### PR TITLE
Add checkpointing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Penguin is a modular, extensible AI coding assistant powered by LLMs, enabling s
   - Interactive CLI with slash commands
   - PyDoll browser tools and Chrome debugger
   - Memory search across conversations
+  - Automatic checkpoints with branching and rollback
 
 ## Prerequisites
 

--- a/docs/docs/advanced/future_considerations.md
+++ b/docs/docs/advanced/future_considerations.md
@@ -64,6 +64,8 @@ flowchart TD
 - Implement hierarchical session structures (project→task→subtask)
 - Allow multiple active sessions with context switching
 - Add branching/forking of conversations
+- Automatic checkpoint creation with rollback support
+- Conversation tree UI for managing branches
 - Implement proper version control for sessions
 
 ## Performance and Storage

--- a/docs/docs/usage/checkpointing.md
+++ b/docs/docs/usage/checkpointing.md
@@ -1,0 +1,25 @@
+# Checkpointing and Branching
+
+Penguin supports saving conversation checkpoints so you can easily return to a previous state or explore alternate approaches on a new branch.
+
+## Creating Checkpoints
+
+- **Automatic**: Penguin can create checkpoints every few messages. Configure the interval in your `.penguin/config.yaml`.
+- **Manual**: Use `/checkpoint` in chat or `penguin checkpoint` on the CLI to save the current state.
+
+## Listing Checkpoints
+
+- `/checkpoints` or `penguin checkpoints` shows recent checkpoints.
+- Each checkpoint is referenced by the message ID at which it was created.
+
+## Branching and Rollback
+
+- `/branch <msg_id>` or `penguin branch <msg_id>` forks a new conversation starting from that checkpoint.
+- `/rollback <msg_id>` or `penguin rollback <msg_id>` rewinds the main thread to an earlier checkpoint.
+- View the conversation tree with `/tree` or `penguin tree` to see all branches.
+
+## Configuration Tips
+
+Adjust checkpoint frequency and retention in the configuration file. You can also choose which data to capture (conversation, tasks, or code) for each checkpoint.
+
+For design mockups of the checkpoint UI, see [UI Mockups](../../misc/UI_mockups_checkpointing.md).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -31,9 +31,10 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Usage Guide',
       items: [
-        'usage/basic_usage', 
-        'usage/automode', 
-        'usage/task_management', 
+        'usage/basic_usage',
+        'usage/automode',
+        'usage/task_management',
+        'usage/checkpointing',
         'usage/project_management',
         'usage/api_usage',
       ],


### PR DESCRIPTION
## Summary
- document checkpointing and branching controls
- add bullet to advanced roadmap on checkpointing UI
- expose checkpointing page in docs sidebar
- mention checkpointing in README feature list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6848eb2464fc8331ba9d0101367f9dbb