### PR TITLE
Add native Ollama adapter

### DIFF
--- a/penguin/llm/adapters/__init__.py
+++ b/penguin/llm/adapters/__init__.py
@@ -1,9 +1,18 @@
-from .base import BaseAdapter
-from .anthropic import AnthropicAdapter
 # Import other adapters as they're implemented
 import logging
+
+__all__ = [
+    "AnthropicAdapter",
+    "BaseAdapter",
+    "OllamaAdapter",
+    "get_adapter",
+]
+
 from ..provider_adapters import get_provider_adapter
-from typing import Optional
+from .anthropic import AnthropicAdapter
+from .base import BaseAdapter
+from .ollama import OllamaAdapter
+
 
 def get_adapter(provider: str, model_config):
     """
@@ -15,20 +24,26 @@ def get_adapter(provider: str, model_config):
         # Map provider names to module & class names
         provider_mapping = {
             "anthropic": ("anthropic", "AnthropicAdapter"),
+            "ollama": ("ollama", "OllamaAdapter"),
             # "openai": ("openai", "OpenAIAdapter"), # TODO: Add OpenAI adapter
             # Add more mappings as needed
         }
-        
+
         # Check if we should use native adapter based on client_preference
-        if getattr(model_config, 'client_preference', 'native') == 'native' and provider in provider_mapping:
+        if (
+            getattr(model_config, "client_preference", "native") == "native"
+            and provider in provider_mapping
+        ):
             module_name, class_name = provider_mapping[provider]
-            adapter_module = __import__(f"penguin.llm.adapters.{module_name}", fromlist=[class_name])
+            adapter_module = __import__(
+                f"penguin.llm.adapters.{module_name}", fromlist=[class_name]
+            )
             adapter_class = getattr(adapter_module, class_name)
             logging.info(f"Using native {provider} adapter")
             return adapter_class(model_config)
     except (ImportError, AttributeError) as e:
         logging.warning(f"Native adapter for {provider} not available: {e}")
-    
+
     # Fall back to provider_adapters.py implementation
     logging.info(f"Using generic adapter for {provider} via provider_adapters")
-    return get_provider_adapter(provider, model_config) 
+    return get_provider_adapter(provider, model_config)

--- a/penguin/llm/adapters/ollama.py
+++ b/penguin/llm/adapters/ollama.py
@@ -1,0 +1,101 @@
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import ollama  # type: ignore
+
+from ..model_config import ModelConfig
+from ..utils.diagnostics import diagnostics
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaAdapter(BaseAdapter):
+    """Native adapter using the official `ollama` Python library."""
+
+    def __init__(self, model_config: ModelConfig):
+        self.model_config = model_config
+        base_url = model_config.api_base or "http://localhost:11434"
+        self.client = ollama.AsyncClient(host=base_url)
+
+    @property
+    def provider(self) -> str:
+        return "ollama"
+
+    def format_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        # Ollama accepts OpenAI style chat messages
+        return messages
+
+    def process_response(self, response: Any) -> Tuple[str, List[Any]]:
+        if isinstance(response, dict) and "message" in response:
+            return str(response["message"].get("content", "")), []
+        if isinstance(response, str):
+            return response, []
+        return str(response), []
+
+    def count_tokens(self, text: str) -> int:
+        return diagnostics.count_tokens(text)
+
+    async def create_completion(
+        self,
+        messages: List[Dict[str, Any]],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        stream_callback: Optional[Callable[[str], None]] = None,
+    ) -> Any:
+        options: Dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if max_tokens is not None:
+            options["num_predict"] = max_tokens
+
+        params = {
+            "model": self.model_config.model,
+            "messages": self.format_messages(messages),
+            "stream": stream,
+            "options": options or None,
+        }
+
+        if stream:
+            async for chunk in self.client.chat(**params):
+                text = chunk.get("message", {}).get("content", "")
+                if stream_callback:
+                    await stream_callback(text)
+            return chunk
+        else:
+            return await self.client.chat(**params)
+
+    async def get_response(
+        self,
+        messages: List[Dict[str, Any]],
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        stream_callback: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        if stream:
+            collected: List[str] = []
+
+            async def _cb(chunk: str):
+                collected.append(chunk)
+                if stream_callback:
+                    await stream_callback(chunk)
+
+            await self.create_completion(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                stream=True,
+                stream_callback=_cb,
+            )
+            return "".join(collected)
+        else:
+            resp = await self.create_completion(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                stream=False,
+            )
+            text, _ = self.process_response(resp)
+            return text

--- a/tests/test_ollama_adapter.py
+++ b/tests/test_ollama_adapter.py
@@ -1,0 +1,130 @@
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_tiktoken(monkeypatch):
+    mock_encoding = MagicMock()
+    mock_encoding.encode = lambda s: list(range(len(str(s))))
+    monkeypatch.setattr("tiktoken.get_encoding", lambda _: mock_encoding)
+
+    # Reload diagnostics to apply patch before adapter import
+    import importlib
+
+    import penguin.utils.diagnostics as diagnostics_module
+    importlib.reload(diagnostics_module)
+
+    yield
+
+    importlib.reload(diagnostics_module)
+
+
+@pytest.fixture(autouse=True)
+def stub_penguin_modules(monkeypatch):
+    import types
+    # Provide minimal stubs to satisfy package imports
+    monkeypatch.setitem(
+        sys.modules,
+        "penguin.penguin.core",
+        types.ModuleType("penguin.penguin.core"),
+    )
+    monkeypatch.setitem(
+        sys.modules, "penguin.config", types.ModuleType("penguin.config")
+    )
+    yield
+
+
+
+@pytest.mark.asyncio
+async def test_ollama_adapter_get_response_non_stream():
+    import importlib.util
+    from pathlib import Path
+
+    adapter_spec = importlib.util.spec_from_file_location(
+        "ollama_adapter",
+        Path(__file__).resolve().parent.parent / "penguin/llm/adapters/ollama.py",
+    )
+    adapter_mod = importlib.util.module_from_spec(adapter_spec)
+    assert adapter_spec and adapter_spec.loader
+    adapter_spec.loader.exec_module(adapter_mod)
+    OllamaAdapter = adapter_mod.OllamaAdapter
+
+    model_config_spec = importlib.util.spec_from_file_location(
+        "model_config",
+        Path(__file__).resolve().parent.parent / "penguin/llm/model_config.py",
+    )
+    model_mod = importlib.util.module_from_spec(model_config_spec)
+    assert model_config_spec and model_config_spec.loader
+    model_config_spec.loader.exec_module(model_mod)
+    ModelConfig = model_mod.ModelConfig
+
+    model_config = ModelConfig(model="mistral", provider="ollama")
+    adapter = OllamaAdapter(model_config)
+
+    fake_response = {"message": {"content": "hello"}}
+
+    with patch.object(
+        adapter.client,
+        "chat",
+        AsyncMock(return_value=fake_response),
+    ) as mock_chat:
+        result = await adapter.get_response([
+            {"role": "user", "content": "hi"}
+        ])
+        assert result == "hello"
+        mock_chat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ollama_adapter_get_response_stream():
+    import importlib.util
+    from pathlib import Path
+
+    adapter_spec = importlib.util.spec_from_file_location(
+        "ollama_adapter",
+        Path(__file__).resolve().parent.parent / "penguin/llm/adapters/ollama.py",
+    )
+    adapter_mod = importlib.util.module_from_spec(adapter_spec)
+    assert adapter_spec and adapter_spec.loader
+    adapter_spec.loader.exec_module(adapter_mod)
+    OllamaAdapter = adapter_mod.OllamaAdapter
+
+    model_config_spec = importlib.util.spec_from_file_location(
+        "model_config",
+        Path(__file__).resolve().parent.parent / "penguin/llm/model_config.py",
+    )
+    model_mod = importlib.util.module_from_spec(model_config_spec)
+    assert model_config_spec and model_config_spec.loader
+    model_config_spec.loader.exec_module(model_mod)
+    ModelConfig = model_mod.ModelConfig
+
+    model_config = ModelConfig(model="mistral", provider="ollama")
+    adapter = OllamaAdapter(model_config)
+
+    async def stream_gen(*args, **kwargs):
+        for part in [
+            {"message": {"content": "hel"}},
+            {"message": {"content": "lo"}},
+        ]:
+            yield part
+
+    with patch.object(
+        adapter.client,
+        "chat",
+        AsyncMock(return_value=stream_gen()),
+    ) as mock_chat:
+        collected = []
+
+        async def cb(chunk: str):
+            collected.append(chunk)
+
+        result = await adapter.get_response(
+            [{"role": "user", "content": "hi"}],
+            stream=True,
+            stream_callback=cb,
+        )
+        assert result == "hello"
+        assert collected == ["hel", "lo"]
+        mock_chat.assert_awaited_once()


### PR DESCRIPTION
## Summary
- implement `OllamaAdapter` using the official library
- register the adapter in `get_adapter`
- add unit tests for the new adapter

## Testing
- `ruff check --fix penguin/llm/adapters/ollama.py penguin/llm/adapters/__init__.py tests/test_ollama_adapter.py`
- `pytest tests/test_ollama_adapter.py -q` *(fails: ModuleNotFoundError: No module named 'penguin.config')*

------
https://chatgpt.com/codex/tasks/task_e_6880586c31288331ada9a28043b175e4