### PR TITLE
Update engine and project docs

### DIFF
--- a/docs/docs/api_reference/engine.md
+++ b/docs/docs/api_reference/engine.md
@@ -25,9 +25,16 @@ If the `Engine` fails to initialize, `PenguinCore` falls back to its legacy inte
 
 ## Key Methods
 
--   `async run_single_turn(prompt: str, *, tools_enabled: bool = True, streaming: Optional[bool] = None)`: Executes a single cycle: user prompt -> LLM reasoning -> optional tool execution -> response. Returns a dictionary containing the assistant's response and any action results.
--   `async run_task(task_prompt: str, max_iterations: Optional[int] = None) -> str`: Runs a multi-step reasoning/action loop. It starts with the `task_prompt` and continues iteratively until a `StopCondition` is met, the maximum iterations are reached, or a task completion phrase is detected. Returns the final assistant response.
--   `async stream(prompt: str)`: Initiates a streaming response for the given prompt, yielding chunks as they arrive.
+- `async run_single_turn(prompt: str, *, tools_enabled: bool = True, streaming: Optional[bool] = None)`
+  Executes a single cycle: user prompt → LLM reasoning → optional tool execution → response. Returns a dictionary containing the assistant's response and any action results.
+- `async run_response(prompt: str, *, image_path: Optional[str] = None, max_iterations: Optional[int] = None, streaming: Optional[bool] = None, stream_callback: Optional[Callable[[str], None]] = None) -> Dict[str, Any]`
+  Conversational helper that loops until the model stops taking actions. Useful for natural chat flows where each iteration is saved as a separate message.
+- `async run_task(task_prompt: str, *, image_path: Optional[str] = None, max_iterations: Optional[int] = None, task_context: Optional[Dict[str, Any]] = None, task_id: Optional[str] = None, task_name: Optional[str] = None, completion_phrases: Optional[List[str]] = None, on_completion: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None, enable_events: bool = True, message_callback: Optional[Callable[[str, str], Awaitable[None]]] = None) -> Dict[str, Any]`
+  Runs a multi-step reasoning/action loop with optional EventBus integration. The loop stops when a `StopCondition` triggers, `completion_phrases` are detected, or the maximum iterations are reached.
+- `async stream(prompt: str)`
+  Initiates a streaming response for the given prompt, yielding chunks as they arrive.
+- `async spawn_child(purpose: str = "child", inherit_tools: bool = False, shared_conversation: bool = False) -> Engine`
+  Spawns a child engine (currently runs in-process) with optional tool and conversation sharing.
 
 ## Stop Conditions
 
@@ -36,6 +43,10 @@ The `run_task` loop can be controlled by `StopCondition` objects passed during i
 -   `TokenBudgetStop`: Stops if the conversation context exceeds a token limit.
 -   `WallClockStop`: Stops if the task runs longer than a specified duration.
 -   `ExternalCallbackStop`: Stops based on the result of a custom asynchronous callback function.
+
+## Events and Callbacks
+
+`run_task` publishes progress via an optional EventBus. Callbacks (`message_callback`, `on_completion`) allow real‑time streaming of tool output and custom handling of task completion.
 
 ## Integration with Core and RunMode
 

--- a/docs/docs/api_reference/project_api.md
+++ b/docs/docs/api_reference/project_api.md
@@ -1,6 +1,6 @@
 # Project Management API Reference (v0.1.x)
 
-Penguin's project subsystem is under active development.  The current release ships **minimal but functional** CRUD helpers backed by SQLite.  Anything not mentioned here (advanced dependency graphs, event bus, async streaming, etc.) is planned—see the roadmap in [future considerations](../advanced/future_considerations.md).
+Penguin's project subsystem manages projects and tasks with a simple SQLite backend.  Recent releases add **EventBus integration** so task execution can emit real‑time progress updates.  Advanced features like dependency graphs are still on the roadmap—see [future considerations](../advanced/future_considerations.md).
 
 ---
 
@@ -69,11 +69,11 @@ Current implementation **does not** support:
 * Hierarchical subtasks beyond parent_task_id linkage
 * Dependency management / graphs
 * Bulk operations
-* EventBus or real-time updates
-* Resource constraints or execution records
+* Resource constraints beyond basic execution recording
+* Execution recording can be toggled with `ProjectManager.disable_execution_recording()`
 
 These items are tracked in the roadmap.
 
 ---
 
-*Last updated: June 13 2025* 
+*Last updated: July 30 2025*


### PR DESCRIPTION
## Summary
- document new Engine methods and EventBus callbacks
- refresh Project API docs with EventBus details

## Testing
- `pytest -q` *(fails: HTTPSConnectionPool host='openaipublic.blob.core.windows.net' 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889624658e88331adb1fb8c280091f4