### PR TITLE
fix(cli): pass stream_callback=None in /image flow to match event-dri…

### DIFF
--- a/penguin/cli/old_cli.py
+++ b/penguin/cli/old_cli.py
@@ -2245,7 +2245,7 @@ TIP: Use Alt+Enter for new lines, Enter to submit"""
                                 # normal streaming / action-result handling is reused
                                 response = await self.interface.process_input(
                                     {"text": description, "image_path": image_path},
-                                    stream_callback=self.stream_callback,
+                                    stream_callback=None,
                                 )
 
                                 # Finalise any streaming still active


### PR DESCRIPTION
pass stream_callback=None in /image flow to match event-driven streaming 0 [fix/cli-image-stream-callback f61c7e3] fix(cli): pass stream_callback=None in /image flow to match event-driven streaming. 

Surprisingly Penguin only offered a one line change so I'm going to test it out in a workspace before proceeding. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `penguin/cli/old_cli.py`, the `/image` command now calls `interface.process_input` with `stream_callback=None` instead of a streaming callback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61c7e38293258b03b6f3bb2f335e050a4b3b26d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->