### PR TITLE
Fix/UI bleed finalize scoping

### DIFF
--- a/context/tasks/multi-session-regression.md
+++ b/context/tasks/multi-session-regression.md
@@ -1,0 +1,55 @@
+# Multi-Session Regression
+
+Date: 2026-04-04
+
+## Summary
+
+This note tracks the current regression and fix work for OpenCode/Penguin multi-session
+handling on the shared web server path.
+
+The immediate problem is that chat isolation was restored recently, but session-scoped
+tooling, directory resolution, and some persistence/finalization paths can still bleed
+across concurrent sessions.
+
+## Current Decisions
+
+- Isolation boundary is exact directory/worktree, not just same git repository.
+- `session_id` is authoritative for session-scoped routes such as `find/file`.
+- When `session_id` and `directory` disagree, the server should reject the request
+  instead of silently trusting the raw directory.
+
+## Immediate Fix Scope
+
+- Make `find/file` and related lookup paths prefer session binding over remembered or
+  caller-provided directory state.
+- Remove session listing behavior that groups different directories/worktrees together
+  under the same git root/common-dir identity.
+- Reduce cross-session persistence/finalization races where shared conversation objects
+  are reloaded and saved for the wrong session under concurrency.
+- Add focused regression tests for mismatched `session_id` and `directory`, exact-dir
+  filtering, and cross-session finalize behavior.
+
+## Known Short-Term Risks
+
+- The web layer still sits on shared mutable conversation/session-manager state.
+- `ConversationSystem.load()` and `SessionManager.current_session` are still mutable and
+  request-global within an agent scope.
+- Per-session request gating helps, but it does not fully isolate all session state once
+  multiple requests can touch the same agent-backed conversation object.
+
+## Longer-Term Considerations
+
+- Move away from mutating shared `ConversationSystem` / `SessionManager` objects on the
+  hot request path.
+- Prefer request-local session handles or a stronger session-scoped serialization model
+  around load/add/save/finalize operations.
+- Audit remaining server-wide caches and remembered state for session leakage, including
+  directory fallbacks, stream state, and any persistence helpers that infer session from
+  mutable globals.
+
+## Working Notes
+
+- Latest commit restored message/history/SSE isolation more effectively than tool and
+  directory isolation.
+- Current unstaged work is correctly aimed at autocomplete/tag lookup and finalization,
+  but needs stricter session authority and race-proof persistence behavior.

--- a/context/tasks/multi-session-regression.md
+++ b/context/tasks/multi-session-regression.md
@@ -7,9 +7,14 @@ Date: 2026-04-04
 This note tracks the current regression and fix work for OpenCode/Penguin multi-session
 handling on the shared web server path.
 
-The immediate problem is that chat isolation was restored recently, but session-scoped
-tooling, directory resolution, and some persistence/finalization paths can still bleed
-across concurrent sessions.
+The original regression is now mostly resolved: concurrent OpenCode/TUI sessions on the
+same Penguin web server no longer appear to bleed chat history, tool roots, directory
+scope, or active request model/runtime state into each other during normal operation.
+
+The remaining work is narrower and should be treated as follow-up hardening rather than
+the original isolation failure. Current rough edges are around post-processing/runtime
+polish, model-specific tool-call quality, and a few stale global-state fallbacks still
+visible in diagnostics.
 
 ## Current Decisions
 
@@ -18,24 +23,50 @@ across concurrent sessions.
 - When `session_id` and `directory` disagree, the server should reject the request
   instead of silently trusting the raw directory.
 
+## Current Status
+
+- Main multi-session request isolation appears fixed on the web server path.
+- Session-local conversation state is now handed off into the engine instead of being
+  re-derived from stale shared conversation state mid-request.
+- Request-local model/runtime selection is now isolated, so one tab no longer appears to
+  switch another tab's in-flight model.
+- Session metadata now carries `providerID`, `modelID`, and `variant`, and the TUI now
+  restores model selection from session info before falling back to message/global state.
+- Transcript/event metadata and session title generation now prefer session-scoped model
+  state over global `core.model_config` fallback.
+
 ## Immediate Fix Scope
 
-- Make `find/file` and related lookup paths prefer session binding over remembered or
+- Completed:
+- `find/file` and related lookup paths now prefer session binding over remembered or
   caller-provided directory state.
-- Remove session listing behavior that groups different directories/worktrees together
-  under the same git root/common-dir identity.
-- Reduce cross-session persistence/finalization races where shared conversation objects
-  are reloaded and saved for the wrong session under concurrency.
-- Add focused regression tests for mismatched `session_id` and `directory`, exact-dir
-  filtering, and cross-session finalize behavior.
+- Session listing no longer groups different directories/worktrees together under the
+  same git root/common-dir identity.
+- Cross-session persistence/finalization races were reduced by persisting finalized
+  messages directly to the target session store instead of reloading shared conversation
+  state first.
+- Request-local engine state now reuses the already-loaded session-scoped conversation
+  manager instead of rebuilding from stale shared base state.
+- Per-session model/provider/variant metadata is now persisted and surfaced through
+  session info for TUI restoration.
+- Added focused regression coverage for mismatched `session_id` and `directory`,
+  exact-dir filtering, request-scoped engine reuse, malformed tool-output repair, and
+  session model metadata round-trip.
 
 ## Known Short-Term Risks
 
 - The web layer still sits on shared mutable conversation/session-manager state.
 - `ConversationSystem.load()` and `SessionManager.current_session` are still mutable and
-  request-global within an agent scope.
-- Per-session request gating helps, but it does not fully isolate all session state once
-  multiple requests can touch the same agent-backed conversation object.
+  request-global within an agent scope, even though request-local handoff now avoids the
+  worst observed bleed.
+- Some diagnostics still reveal stale shared-session pointers (`current_conv_session`)
+  even when the actual persisted output is correct because the direct session-store path
+  is winning.
+- Model/provider-specific behavior is still jagged in some cases:
+  - OpenRouter/Kimi can fail on max-context/max-output negotiation.
+  - Some models still emit malformed partial tool syntax and rely on repair turns.
+  - Timeouts or abrupt stream endings can still produce rough UX even without session
+    bleed.
 
 ## Longer-Term Considerations
 
@@ -46,10 +77,30 @@ across concurrent sessions.
 - Audit remaining server-wide caches and remembered state for session leakage, including
   directory fallbacks, stream state, and any persistence helpers that infer session from
   mutable globals.
+- Consider reducing dependence on legacy global fallbacks in transcript/event shaping so
+  diagnostics and replay metadata line up more closely with the request-scoped runtime.
+
+## Open Follow-Ups
+
+- Clean up or eliminate stale `current_conv_session` diagnostics where possible.
+- Review provider/model-specific robustness:
+  - timeouts
+  - context/max-output negotiation
+  - malformed tool-call emission
+- Improve graceful handling when a stream ends abruptly or the user aborts during a long
+  request.
+- Decide whether any remaining TUI oddities are server bugs, model-quality issues, or
+  frontend UX issues before doing more structural work.
 
 ## Working Notes
 
-- Latest commit restored message/history/SSE isolation more effectively than tool and
+- Previous commit restored message/history/SSE isolation more effectively than tool and
   directory isolation.
-- Current unstaged work is correctly aimed at autocomplete/tag lookup and finalization,
-  but needs stricter session authority and race-proof persistence behavior.
+- Follow-up work fixed the deeper runtime issues that previous surface-level isolation did
+  not cover:
+  - request-scoped conversation handoff
+  - request-scoped model runtime
+  - stricter session directory authority
+  - per-session model metadata persistence/restoration
+- Latest live repros indicate the original multi-session bleed is no longer the primary
+  problem area.

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-tag.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-tag.tsx
@@ -2,10 +2,12 @@ import { createMemo, createResource } from "solid-js"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
 import { createStore } from "solid-js/store"
 
 export function DialogTag(props: { onSelect?: (value: string) => void }) {
   const sdk = useSDK()
+  const sync = useSync()
   const dialog = useDialog()
 
   const [store] = createStore({
@@ -15,9 +17,16 @@ export function DialogTag(props: { onSelect?: (value: string) => void }) {
   const [files] = createResource(
     () => [store.filter],
     async () => {
-      const result = await sdk.client.find.files({
+      const params = {
         query: store.filter,
-      })
+        directory: sdk.sessionID
+          ? sync.session.get(sdk.sessionID)?.directory ?? sdk.directory
+          : sdk.directory,
+        session_id: sdk.sessionID,
+      } as Parameters<typeof sdk.client.find.files>[0] & {
+        session_id?: string
+      }
+      const result = await sdk.client.find.files(params)
       if (result.error) return []
       const sliced = (result.data ?? []).slice(0, 5)
       return sliced

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -213,11 +213,18 @@ export function Autocomplete(props: {
       if (!store.visible || store.visible === "/") return []
 
       const { lineRange, baseQuery } = extractLineRange(query ?? "")
+      const params = {
+        query: baseQuery,
+        directory: sdk.sessionID
+          ? sync.session.get(sdk.sessionID)?.directory ?? sdk.directory
+          : sdk.directory,
+        session_id: sdk.sessionID,
+      } as Parameters<typeof sdk.client.find.files>[0] & {
+        session_id?: string
+      }
 
       // Get files from SDK
-      const result = await sdk.client.find.files({
-        query: baseQuery,
-      })
+      const result = await sdk.client.find.files(params)
 
       const options: AutocompleteOption[] = []
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -207,23 +207,50 @@ export function Prompt(props: PromptProps) {
     setStore("pendingSeenBusy", false)
   })
 
-  // Initialize agent/model/variant from last user message when session changes
+  // Initialize agent/model/variant from session info first, then last user message fallback.
   let syncedSessionID: string | undefined
   createEffect(() => {
     const sessionID = props.sessionID
     const msg = lastUserMessage()
+    const session = sessionID
+      ? (sync.session.get(sessionID) as {
+          agent_id?: string
+          providerID?: string
+          modelID?: string
+          variant?: string
+        } | undefined)
+      : undefined
 
     if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
+      if (!sessionID) return
 
       syncedSessionID = sessionID
 
+      const sessionAgent = session?.agent_id
+      const messageAgent = msg?.agent
+      const nextAgent = typeof sessionAgent === "string" && sessionAgent ? sessionAgent : messageAgent
+
       // Only set agent if it's a primary agent (not a subagent)
-      const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
-      if (msg.agent && isPrimaryAgent) {
-        local.agent.set(msg.agent)
-        if (msg.model) local.model.set(msg.model)
-        if (msg.variant) local.model.variant.set(msg.variant)
+      const isPrimaryAgent = nextAgent ? local.agent.list().some((x) => x.name === nextAgent) : false
+      if (nextAgent && isPrimaryAgent) {
+        local.agent.set(nextAgent)
+      }
+
+      const sessionModel =
+        session?.providerID && session?.modelID
+          ? { providerID: session.providerID, modelID: session.modelID }
+          : undefined
+      const messageModel = msg?.model
+      const nextModel = sessionModel ?? messageModel
+      if (nextModel) {
+        local.model.set(nextModel)
+      }
+
+      const nextVariant = session?.variant ?? msg?.variant
+      if (typeof nextVariant === "string") {
+        local.model.variant.set(nextVariant)
+      } else if (nextModel) {
+        local.model.variant.set(undefined)
       }
     }
   })
@@ -618,6 +645,9 @@ export function Prompt(props: PromptProps) {
       promptModelWarning()
       return
     }
+    const currentMode = store.mode
+    const variant = local.model.variant.current()
+    const agent = local.agent.current()
     const sessionID = await iife(async () => {
       if (props.sessionID) return props.sessionID
       if (sdk.sessionID) return sdk.sessionID
@@ -632,7 +662,12 @@ export function Prompt(props: PromptProps) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ agent_mode: agentMode() }),
+          body: JSON.stringify({
+            agent_mode: agentMode(),
+            providerID: selectedModel.providerID,
+            modelID: selectedModel.modelID,
+            variant,
+          }),
         }).then(async (res) => {
           if (!res.ok) {
             const details = await res.text().catch(() => "")
@@ -701,11 +736,6 @@ export function Prompt(props: PromptProps) {
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
-
-    // Capture mode before it gets reset
-    const currentMode = store.mode
-    const variant = local.model.variant.current()
-    const agent = local.agent.current()
 
     if (sdk.penguin) {
       const firstLine = inputText.split("\n", 1)[0].trim()

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -147,6 +147,23 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         })
 
       const args = useArgs()
+      const sessionModel = createMemo(() => {
+        const sessionID = sdk.sessionID
+        const session = sessionID
+          ? (sync.session.get(sessionID) as
+              | {
+                  providerID?: string
+                  modelID?: string
+                }
+              | undefined)
+          : undefined
+        if (!session?.providerID || !session?.modelID) return undefined
+        const candidate = {
+          providerID: session.providerID,
+          modelID: session.modelID,
+        }
+        if (isModelValid(candidate)) return candidate
+      })
       const fallbackModel = createMemo(() => {
         if (args.model) {
           const { providerID, modelID } = Provider.parseModel(args.model)
@@ -156,6 +173,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               modelID,
             }
           }
+        }
+
+        const activeSessionModel = sessionModel()
+        if (activeSessionModel) {
+          return activeSessionModel
         }
 
         if (sync.data.config.model) {

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -1,7 +1,8 @@
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
 import { createSimpleContext } from "./helper"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
-import { batch, onCleanup, onMount } from "solid-js"
+import { batch, createEffect, onCleanup, onMount } from "solid-js"
+import { useRoute } from "./route"
 
 export type EventSource = {
   on: (handler: (event: Event) => void) => () => void
@@ -25,7 +26,8 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       fetch: props.fetch,
     })
     const penguin = !!props.penguin
-    const sessionID = props.sessionID
+    const route = useRoute()
+    const sessionID = () => (route.data.type === "session" ? route.data.sessionID : props.sessionID)
 
     const emitter = createGlobalEmitter<{
       [key in Event["type"]]: Extract<Event, { type: key }>
@@ -34,6 +36,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     let queue: Event[] = []
     let timer: Timer | undefined
     let last = 0
+    let streamAbort: AbortController | undefined
 
     const flush = () => {
       if (queue.length === 0) return
@@ -96,9 +99,15 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     const streamPenguin = async () => {
       const base = new URL("/api/v1/events/sse", props.url)
+      const activeSessionID = sessionID()
+      if (activeSessionID) base.searchParams.set("session_id", activeSessionID)
       if (props.directory) base.searchParams.set("directory", props.directory)
+
+      streamAbort = new AbortController()
+      const currentStreamAbort = streamAbort
+
       const reader = await (props.fetch ?? fetch)(base, {
-        signal: abort.signal,
+        signal: currentStreamAbort.signal,
         headers: {
           Accept: "text/event-stream",
         },
@@ -112,8 +121,18 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       const state = { buffer: "" }
 
       while (true) {
+        if (abort.signal.aborted || currentStreamAbort.signal.aborted) break
+
         const chunk = await reader.read()
         if (chunk.done) break
+
+        if (sessionID() !== activeSessionID) {
+          try {
+            await reader.cancel()
+          } catch {}
+          break
+        }
+
         state.buffer += decoder.decode(chunk.value, { stream: true })
         const parts = state.buffer.split("\n\n")
         state.buffer = parts.pop() ?? ""
@@ -124,6 +143,12 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         }
       }
     }
+
+    createEffect(() => {
+      if (!penguin) return
+      sessionID()
+      streamAbort?.abort()
+    })
 
     onMount(async () => {
       // If an event source is provided, use it instead of SSE
@@ -172,6 +197,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     onCleanup(() => {
       abort.abort()
+      streamAbort?.abort()
       if (timer) clearTimeout(timer)
     })
 
@@ -181,7 +207,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       url: props.url,
       directory: props.directory,
       penguin,
-      sessionID,
+      get sessionID() {
+        return sessionID()
+      },
     }
   },
 })

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -51,6 +51,9 @@ type PenguinSession = Session & {
   agent_mode?: string
   agent_id?: string
   parent_agent_id?: string
+  providerID?: string
+  modelID?: string
+  variant?: string
 }
 
 const parseUsage = (raw: unknown): SessionUsage | undefined => {
@@ -98,7 +101,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         [sessionID: string]: QuestionRequest[]
       }
       config: Config
-      session: Session[]
+      session: PenguinSession[]
       session_status: {
         [sessionID: string]: SessionStatus
       }
@@ -894,6 +897,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (sessionMode) {
             payload.agent_mode = sessionMode
           }
+          const providerID = typeof item.providerID === "string" ? item.providerID : undefined
+          if (providerID) payload.providerID = providerID
+          const modelID = typeof item.modelID === "string" ? item.modelID : undefined
+          if (modelID) payload.modelID = modelID
+          const variant = typeof item.variant === "string" ? item.variant : undefined
+          if (variant) payload.variant = variant
           const agentID = typeof item.agent_id === "string" ? item.agent_id : undefined
           if (agentID) payload.agent_id = agentID
           const parentAgentID = typeof item.parent_agent_id === "string" ? item.parent_agent_id : undefined

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -333,20 +333,37 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         const sid = eventSessionID(event)
         const dir = normalizeDirectory(eventDirectory(event))
         const baseDir = appDirectory()
-        if (sid) {
-          const sidDir = sessionDirectory(sid)
-          if (sidDir && baseDir && sidDir !== baseDir) return
-          if (!sidDir && dir && baseDir && dir !== baseDir) return
-        }
-        if (!sid) {
-          if (dir && baseDir && dir !== baseDir) return
-          if (
-            !dir &&
-            (event.type === "lsp.updated" ||
-              event.type === "lsp.client.diagnostics" ||
-              event.type === "vcs.branch.updated")
-          ) {
-            return
+        const activeSessionID = route.data.type === "session" ? route.data.sessionID : undefined
+        if (activeSessionID) {
+          if (sid && sid !== activeSessionID) return
+          const activeDir = sessionDirectory(activeSessionID) ?? baseDir
+          if (!sid) {
+            if (dir && activeDir && dir !== activeDir) return
+            if (
+              !dir &&
+              (event.type === "lsp.updated" ||
+                event.type === "lsp.client.diagnostics" ||
+                event.type === "vcs.branch.updated")
+            ) {
+              return
+            }
+          }
+        } else {
+          if (sid) {
+            const sidDir = sessionDirectory(sid)
+            if (sidDir && baseDir && sidDir !== baseDir) return
+            if (!sidDir && dir && baseDir && dir !== baseDir) return
+          }
+          if (!sid) {
+            if (dir && baseDir && dir !== baseDir) return
+            if (
+              !dir &&
+              (event.type === "lsp.updated" ||
+                event.type === "lsp.client.diagnostics" ||
+                event.type === "vcs.branch.updated")
+            ) {
+              return
+            }
           }
         }
       }

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -234,6 +234,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 console = Console()
 
+_SESSION_MODEL_ID_KEY = "_opencode_model_id_v1"
+_SESSION_PROVIDER_ID_KEY = "_opencode_provider_id_v1"
+_SESSION_VARIANT_KEY = "_opencode_variant_v1"
+
 
 def _trace_log_info(message: str, *args: Any) -> None:
     """Mirror core trace logs to uvicorn for live server debugging."""
@@ -4627,12 +4631,15 @@ class PenguinCore:
             state["active"] = True
             state["stream_id"] = stream_id
 
+            model_state = self._resolve_opencode_model_state(session_id=session_id)
+
             # Create message and text part
             try:
                 message_id, part_id = await adapter.on_stream_start(
                     agent_id=agent_id,
-                    model_id=getattr(self.model_config, "model", None),
-                    provider_id=getattr(self.model_config, "provider", None),
+                    model_id=model_state.get("modelID"),
+                    provider_id=model_state.get("providerID"),
+                    variant=model_state.get("variant"),
                 )
                 state["message_id"] = message_id
                 state["part_id"] = part_id
@@ -5774,6 +5781,59 @@ class PenguinCore:
 
         return None, None
 
+    def _resolve_opencode_model_state(
+        self,
+        *,
+        session_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
+        variant: Optional[str] = None,
+    ) -> Dict[str, Optional[str]]:
+        """Resolve model/provider/variant for OpenCode event persistence."""
+
+        def _normalize(value: Any) -> Optional[str]:
+            if not isinstance(value, str):
+                return None
+            stripped = value.strip()
+            return stripped or None
+
+        normalized_session_id = _normalize(session_id)
+        session_meta: Dict[str, Any] = {}
+        if normalized_session_id:
+            session, _ = self._find_session_store(normalized_session_id)
+            metadata = (
+                getattr(session, "metadata", None) if session is not None else None
+            )
+            if isinstance(metadata, dict):
+                session_meta = metadata
+
+        resolved_provider = (
+            _normalize(provider_id)
+            or _normalize(session_meta.get(_SESSION_PROVIDER_ID_KEY))
+            or _normalize(session_meta.get("providerID"))
+            or _normalize(session_meta.get("provider_id"))
+            or _normalize(
+                getattr(getattr(self, "model_config", None), "provider", None)
+            )
+        )
+        resolved_model = (
+            _normalize(model_id)
+            or _normalize(session_meta.get(_SESSION_MODEL_ID_KEY))
+            or _normalize(session_meta.get("modelID"))
+            or _normalize(session_meta.get("model_id"))
+            or _normalize(getattr(getattr(self, "model_config", None), "model", None))
+        )
+        resolved_variant = (
+            _normalize(variant)
+            or _normalize(session_meta.get(_SESSION_VARIANT_KEY))
+            or _normalize(session_meta.get("variant"))
+        )
+        return {
+            "providerID": resolved_provider,
+            "modelID": resolved_model,
+            "variant": resolved_variant,
+        }
+
     async def _persist_opencode_event(
         self, event_type: str, properties: Dict[str, Any]
     ) -> None:
@@ -5874,6 +5934,7 @@ class PenguinCore:
                     or os.getenv("PENGUIN_CWD")
                     or os.getcwd()
                 )
+                model_state = self._resolve_opencode_model_state(session_id=session_id)
                 entry = {
                     "info": {
                         "id": message_id,
@@ -5881,10 +5942,8 @@ class PenguinCore:
                         "role": "assistant",
                         "time": {"created": int(time.time() * 1000)},
                         "parentID": "root",
-                        "modelID": getattr(
-                            self.model_config, "model", "penguin-default"
-                        ),
-                        "providerID": getattr(self.model_config, "provider", "penguin"),
+                        "modelID": model_state.get("modelID") or "penguin-default",
+                        "providerID": model_state.get("providerID") or "penguin",
                         "mode": "chat",
                         "agent": "default",
                         "path": {"cwd": fallback_directory, "root": fallback_directory},
@@ -5895,6 +5954,11 @@ class PenguinCore:
                             "reasoning": 0,
                             "cache": {"read": 0, "write": 0},
                         },
+                        **(
+                            {"variant": model_state.get("variant")}
+                            if model_state.get("variant")
+                            else {}
+                        ),
                     },
                     "parts": {},
                     "part_order": [],
@@ -5974,8 +6038,16 @@ class PenguinCore:
             current_session = self.conversation_manager.get_current_session()
             session_id = current_session.id if current_session else "unknown"
         adapter = self._get_tui_adapter(session_id)
+        model_state = self._resolve_opencode_model_state(
+            session_id=session_id,
+            model_id=model_id,
+            provider_id=provider_id,
+        )
         message_id, part_id = await adapter.on_stream_start(
-            agent_id, model_id, provider_id
+            agent_id,
+            model_state.get("modelID"),
+            model_state.get("providerID"),
+            model_state.get("variant"),
         )
         self._opencode_message_adapters[message_id] = adapter
         return message_id, part_id

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -104,6 +104,7 @@ See Also:
 """
 
 import asyncio
+import copy
 import inspect
 import logging
 import time
@@ -232,6 +233,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 console = Console()
+
+
+def _trace_log_info(message: str, *args: Any) -> None:
+    """Mirror core trace logs to uvicorn for live server debugging."""
+    logger.info(message, *args)
+    uvicorn_logger = logging.getLogger("uvicorn.error")
+    if uvicorn_logger is not logger:
+        uvicorn_logger.info(message, *args)
 
 
 # ---------------------------------------------------------------------------
@@ -802,6 +811,7 @@ class PenguinCore:
                 stop_conditions=default_stops,
             )
             try:
+                self.engine.model_config = self.model_config  # type: ignore[attr-defined]
                 self.engine.coordinator = self.get_coordinator()
                 self.engine.telemetry = getattr(self, "telemetry", None)
                 # Setup MessageBus integration for inter-agent communication
@@ -2554,11 +2564,13 @@ class PenguinCore:
         context: Optional[Dict[str, Any]] = None,
         conversation_id: Optional[str] = None,
         agent_id: Optional[str] = None,
-        max_iterations: int = MAX_TASK_ITERATIONS,  # Use config value (default 5000)
+        max_iterations: int = MAX_TASK_ITERATIONS,  # Use config value (default 5000) #TODO:247 mode and other loops need to be infinite.
         context_files: Optional[List[str]] = None,
         streaming: Optional[bool] = None,
         stream_callback: Optional[Callable[[str], None]] = None,
         multi_step: bool = True,
+        api_client_override: Optional[APIClient] = None,
+        model_config_override: Optional[ModelConfig] = None,
     ) -> Dict[str, Any]:
         """
         Process a message with Penguin.
@@ -2575,7 +2587,7 @@ class PenguinCore:
             context: Optional additional context for processing
             conversation_id: Optional ID for conversation continuity
             agent_id: Optional agent identifier to scope the request
-            max_iterations: Maximum reasoning-action cycles (default: 5)
+            max_iterations: Maximum reasoning-action cycles (default: 5) #TODO:247 mode and other loops need to be infinite.
             context_files: Optional list of context files to load
             streaming: Whether to use streaming mode for responses.
             stream_callback: Optional callback function for handling streaming output chunks.
@@ -2634,6 +2646,25 @@ class PenguinCore:
             if execution_context and execution_context.session_id
             else conversation_id
         )
+        scoped_conversation = getattr(conversation_manager, "conversation", None)
+        scoped_session_before = getattr(
+            getattr(scoped_conversation, "session", None), "id", None
+        )
+        _trace_log_info(
+            "core.process.trace.start request=%s session=%s conversation=%s agent=%s cm=%s conv=%s conv_session=%s msg_len=%s context_files=%s images=%s streaming=%s multi_step=%s",
+            execution_context.request_id if execution_context else "unknown",
+            request_session_id or "unknown",
+            conversation_id or "",
+            agent_id or "default",
+            hex(id(conversation_manager)),
+            hex(id(scoped_conversation)) if scoped_conversation is not None else "none",
+            scoped_session_before or "unknown",
+            len(message or ""),
+            len(context_files or []),
+            len(image_paths or []),
+            streaming,
+            multi_step,
+        )
         request_task = asyncio.current_task()
         request_tracked = False
         if isinstance(request_session_id, str) and request_session_id:
@@ -2659,13 +2690,37 @@ class PenguinCore:
                 scoped_conversation = getattr(
                     conversation_manager, "conversation", None
                 )
+                load_ok = True
+                load_via = "conversation"
                 if scoped_conversation is not None and hasattr(
                     scoped_conversation, "load"
                 ):
-                    if not scoped_conversation.load(conversation_id):
+                    load_ok = bool(scoped_conversation.load(conversation_id))
+                    if not load_ok:
                         logger.warning(f"Failed to load conversation {conversation_id}")
-                elif not conversation_manager.load(conversation_id):
-                    logger.warning(f"Failed to load conversation {conversation_id}")
+                else:
+                    load_via = "manager"
+                    load_ok = bool(conversation_manager.load(conversation_id))
+                    if not load_ok:
+                        logger.warning(f"Failed to load conversation {conversation_id}")
+                scoped_session_after_load = getattr(
+                    getattr(
+                        getattr(conversation_manager, "conversation", None),
+                        "session",
+                        None,
+                    ),
+                    "id",
+                    None,
+                )
+                _trace_log_info(
+                    "core.process.trace.load request=%s session=%s conversation=%s via=%s ok=%s conv_session=%s",
+                    execution_context.request_id if execution_context else "unknown",
+                    request_session_id or "unknown",
+                    conversation_id,
+                    load_via,
+                    load_ok,
+                    scoped_session_after_load or "unknown",
+                )
 
             # Load context files if specified
             if context_files:
@@ -2679,6 +2734,13 @@ class PenguinCore:
                         scoped_conversation.load_context_file(file_path)
                     else:
                         conversation_manager.load_context_file(file_path)
+                _trace_log_info(
+                    "core.process.trace.context request=%s session=%s conversation=%s count=%s",
+                    execution_context.request_id if execution_context else "unknown",
+                    request_session_id or "unknown",
+                    conversation_id or "",
+                    len(context_files),
+                )
 
             # Add user message to conversation explicitly
             user_message_dict = {
@@ -2723,6 +2785,15 @@ class PenguinCore:
                         scoped_session_id = None
                 if not scoped_conversation_id:
                     scoped_conversation_id = scoped_session_id
+
+                prime_agent_id = agent_id or getattr(
+                    self.engine, "default_agent_id", "default"
+                )
+                if hasattr(self.engine, "prime_scoped_conversation_manager"):
+                    self.engine.prime_scoped_conversation_manager(
+                        prime_agent_id,
+                        conversation_manager,
+                    )
 
                 async def _scoped_stream_callback(
                     chunk: str,
@@ -2787,6 +2858,31 @@ class PenguinCore:
                 if multi_step:
                     # Check if this is a formal task (RunMode) or conversational multi-step
                     is_formal_task = context and context.get("task_mode", False)
+                    _trace_log_info(
+                        "core.process.trace.engine request=%s session=%s conversation=%s agent=%s formal_task=%s cm=%s conv=%s conv_session=%s",
+                        execution_context.request_id
+                        if execution_context
+                        else "unknown",
+                        request_session_id or "unknown",
+                        scoped_conversation_id or "",
+                        agent_id or "default",
+                        bool(is_formal_task),
+                        hex(id(conversation_manager)),
+                        hex(id(getattr(conversation_manager, "conversation", None)))
+                        if getattr(conversation_manager, "conversation", None)
+                        is not None
+                        else "none",
+                        getattr(
+                            getattr(
+                                getattr(conversation_manager, "conversation", None),
+                                "session",
+                                None,
+                            ),
+                            "id",
+                            None,
+                        )
+                        or "unknown",
+                    )
 
                     if is_formal_task:
                         # Bridge the simple stream_callback to the Engine's richer message_callback
@@ -2817,6 +2913,8 @@ class PenguinCore:
                             task_context=context,
                             message_callback=engine_message_callback,
                             agent_id=agent_id,
+                            api_client_override=api_client_override,
+                            model_config_override=model_config_override,
                         )
                     else:
                         # Use the new conversational multi-step engine
@@ -2827,6 +2925,8 @@ class PenguinCore:
                             streaming=streaming,
                             stream_callback=engine_stream_callback,
                             agent_id=agent_id,
+                            api_client_override=api_client_override,
+                            model_config_override=model_config_override,
                         )
                 else:
                     # Use the single-turn conversational engine
@@ -2836,7 +2936,24 @@ class PenguinCore:
                         streaming=streaming,
                         stream_callback=engine_stream_callback,
                         agent_id=agent_id,
+                        api_client_override=api_client_override,
+                        model_config_override=model_config_override,
                     )
+                _trace_log_info(
+                    "core.process.trace.done request=%s session=%s conversation=%s status=%s iterations=%s actions=%s usage=%s response_len=%s",
+                    execution_context.request_id if execution_context else "unknown",
+                    request_session_id or "unknown",
+                    scoped_conversation_id if self.engine else (conversation_id or ""),
+                    response.get("status") if isinstance(response, dict) else None,
+                    response.get("iterations") if isinstance(response, dict) else None,
+                    len(response.get("action_results", []) or [])
+                    if isinstance(response, dict)
+                    else None,
+                    response.get("usage") if isinstance(response, dict) else None,
+                    len(response.get("assistant_response", "") or "")
+                    if isinstance(response, dict)
+                    else None,
+                )
             else:
                 # ---------- Legacy path (fallback) ----------
                 # Prepare conversation and call get_response directly
@@ -3293,6 +3410,142 @@ class PenguinCore:
                     f"Failed to propagate new model config to ContextWindowManager: {e}"
                 )
 
+        if getattr(self, "engine", None) is not None:
+            try:
+                self.engine.model_config = new_model_config  # type: ignore[attr-defined]
+            except Exception as e:
+                logger.warning(f"Failed to propagate new model config to Engine: {e}")
+
+    async def _build_model_config_for_model(
+        self, model_id: str
+    ) -> tuple[ModelConfig, Optional[int]]:
+        """Resolve a runtime model id into a concrete ModelConfig without mutating global state."""
+
+        def _coerce_optional_int(value: Any) -> Optional[int]:
+            try:
+                parsed = int(value)
+            except Exception:
+                return None
+            return parsed if parsed > 0 else None
+
+        provider, client_pref = self._resolve_model_provider(model_id)
+        if not provider:
+            raise ValueError(f"Could not resolve provider for model '{model_id}'")
+
+        provider_value = provider.strip().lower()
+        client_value = client_pref.strip().lower()
+        runtime_model_id = self._canonicalize_runtime_model_id(
+            model_id,
+            provider_value,
+            client_value,
+        )
+
+        model_configs = getattr(self.config, "model_configs", None)
+        if not isinstance(model_configs, dict):
+            model_configs = {}
+        model_lookup_id = (
+            runtime_model_id
+            if runtime_model_id in model_configs and model_id not in model_configs
+            else model_id
+        )
+
+        requires_openrouter_specs = bool(
+            provider_value == "openrouter" or client_value == "openrouter"
+        )
+        model_specs: Dict[str, Any] = {}
+        spec_model_id = runtime_model_id if provider_value == "openrouter" else model_id
+
+        if requires_openrouter_specs:
+            model_specs = await fetch_model_specs(spec_model_id)
+            if not model_specs:
+                raise ValueError(
+                    f"Could not fetch specifications for model '{spec_model_id}'"
+                )
+            logger.info(f"Fetched specs for {spec_model_id}: {model_specs}")
+
+        model_specific = model_configs.get(model_lookup_id, {})
+        if not isinstance(model_specific, dict):
+            model_specific = {}
+
+        context_length = _coerce_optional_int(model_specs.get("context_length"))
+        if context_length is None:
+            context_length = _coerce_optional_int(
+                model_specific.get("context_window")
+                or model_specific.get("max_context_window_tokens")
+            )
+
+        safe_window = safe_context_window(context_length)
+        max_output = _coerce_optional_int(model_specs.get("max_output_tokens"))
+        if max_output is None:
+            max_output = _coerce_optional_int(
+                model_specific.get("max_output_tokens")
+                or model_specific.get("max_tokens")
+            )
+        if max_output is None:
+            max_output = safe_window
+
+        new_model_config = ModelConfig.for_model(
+            model_name=model_lookup_id,
+            provider=provider,
+            client_preference=client_pref,
+            model_configs=model_configs,
+        )
+
+        new_model_config.model = runtime_model_id
+        if context_length is not None:
+            new_model_config.max_context_window_tokens = context_length
+            new_model_config.max_history_tokens = safe_window
+        if max_output is not None:
+            new_model_config.max_output_tokens = max_output
+
+        user_explicit_vision = model_specific.get("vision_enabled")
+        if user_explicit_vision is not None:
+            new_model_config.vision_enabled = bool(user_explicit_vision)
+            logger.info(
+                f"Model '{runtime_model_id}' vision set to {new_model_config.vision_enabled} (user config)"
+            )
+        elif model_specs.get("supports_vision"):
+            new_model_config.vision_enabled = True
+            logger.info(f"Model '{runtime_model_id}' supports vision (auto-detected)")
+
+        return new_model_config, safe_window
+
+    async def resolve_request_runtime(
+        self,
+        model_id: Optional[str] = None,
+    ) -> tuple[ModelConfig, APIClient]:
+        """Build a request-scoped model config and API client without mutating global state."""
+        current_model = (
+            self.get_current_model() if hasattr(self, "get_current_model") else {}
+        )
+        current_raw = (
+            str(current_model.get("model") or "").strip()
+            if isinstance(current_model, dict)
+            else ""
+        )
+        current_provider = (
+            str(current_model.get("provider") or "").strip()
+            if isinstance(current_model, dict)
+            else ""
+        )
+        current_qualified = (
+            f"{current_provider}/{current_raw}"
+            if current_provider and current_raw
+            else ""
+        )
+
+        requested_model = model_id.strip() if isinstance(model_id, str) else ""
+        if requested_model and requested_model not in {current_raw, current_qualified}:
+            new_model_config, _ = await self._build_model_config_for_model(
+                requested_model
+            )
+        else:
+            new_model_config = copy.deepcopy(self.model_config)
+
+        api_client = APIClient(model_config=new_model_config)
+        api_client.set_system_prompt(self.system_prompt)
+        return new_model_config, api_client
+
     async def load_model(self, model_id: str) -> bool:
         """Replace the active model at runtime.
 
@@ -3304,115 +3557,16 @@ class PenguinCore:
         """
         self._last_model_load_error = None
 
-        def _coerce_optional_int(value: Any) -> Optional[int]:
-            try:
-                parsed = int(value)
-            except Exception:
-                return None
-            return parsed if parsed > 0 else None
-
         try:
-            # Resolve provider and client preference
-            provider, client_pref = self._resolve_model_provider(model_id)
-            if not provider:
-                self._last_model_load_error = (
-                    f"Could not resolve provider for model '{model_id}'"
-                )
-                return False
-
-            provider_value = provider.strip().lower()
-            client_value = client_pref.strip().lower()
-            runtime_model_id = self._canonicalize_runtime_model_id(
-                model_id,
-                provider_value,
-                client_value,
+            new_model_config, safe_window = await self._build_model_config_for_model(
+                model_id
             )
-
-            model_configs = getattr(self.config, "model_configs", None)
-            if not isinstance(model_configs, dict):
-                model_configs = {}
-            model_lookup_id = (
-                runtime_model_id
-                if runtime_model_id in model_configs and model_id not in model_configs
-                else model_id
-            )
-
-            requires_openrouter_specs = bool(
-                provider_value == "openrouter" or client_value == "openrouter"
-            )
-            model_specs: Dict[str, Any] = {}
-            spec_model_id = (
-                runtime_model_id if provider_value == "openrouter" else model_id
-            )
-
-            if requires_openrouter_specs:
-                model_specs = await fetch_model_specs(spec_model_id)
-                if not model_specs:
-                    self._last_model_load_error = (
-                        f"Could not fetch specifications for model '{spec_model_id}'"
-                    )
-                    logger.error(self._last_model_load_error)
-                    return False
-                logger.info(f"Fetched specs for {spec_model_id}: {model_specs}")
-
-            model_specific = model_configs.get(model_lookup_id, {})
-            if not isinstance(model_specific, dict):
-                model_specific = {}
-
-            context_length = _coerce_optional_int(model_specs.get("context_length"))
-            if context_length is None:
-                context_length = _coerce_optional_int(
-                    model_specific.get("context_window")
-                    or model_specific.get("max_context_window_tokens")
-                )
-
-            safe_window = safe_context_window(context_length)
-            max_output = _coerce_optional_int(model_specs.get("max_output_tokens"))
-            if max_output is None:
-                max_output = _coerce_optional_int(
-                    model_specific.get("max_output_tokens")
-                    or model_specific.get("max_tokens")
-                )
-            if max_output is None:
-                max_output = safe_window
-
-            # Build and apply new ModelConfig
-            new_model_config = ModelConfig.for_model(
-                model_name=model_lookup_id,
-                provider=provider,
-                client_preference=client_pref,
-                model_configs=model_configs,
-            )
-
-            new_model_config.model = runtime_model_id
-            if context_length is not None:
-                new_model_config.max_context_window_tokens = context_length
-                new_model_config.max_history_tokens = safe_window
-            if max_output is not None:
-                new_model_config.max_output_tokens = max_output
-
-            # Apply vision support from actual model specs, but respect explicit user config.
-            # Only auto-enable if user hasn't explicitly set vision_enabled in model_configs.
-            user_explicit_vision = model_specific.get("vision_enabled")
-            if user_explicit_vision is not None:
-                # User explicitly configured vision - respect their choice
-                new_model_config.vision_enabled = bool(user_explicit_vision)
-                logger.info(
-                    f"Model '{runtime_model_id}' vision set to {new_model_config.vision_enabled} (user config)"
-                )
-            elif model_specs.get("supports_vision"):
-                # No explicit user config, auto-enable based on model capability
-                new_model_config.vision_enabled = True
-                logger.info(
-                    f"Model '{runtime_model_id}' supports vision (auto-detected)"
-                )
-
             self._apply_new_model_config(
                 new_model_config, context_window_tokens=safe_window
             )
 
             logger.info(
-                f"Switched to model '{runtime_model_id}' (context: {safe_window} tokens, vision: {new_model_config.vision_enabled})"
+                f"Switched to model '{new_model_config.model}' (context: {safe_window} tokens, vision: {new_model_config.vision_enabled})"
             )
             return True
 
@@ -3911,25 +4065,74 @@ class PenguinCore:
 
         # Add to the correct agent's conversation
         if hasattr(self, "conversation_manager") and self.conversation_manager:
+            target_session_id = (
+                resolved_session_id
+                if isinstance(resolved_session_id, str) and resolved_session_id
+                else None
+            )
+            persisted = self._persist_finalized_message(
+                agent_id=resolved_agent_id,
+                session_id=target_session_id,
+                message=message,
+                category=category,
+            )
             try:
                 # Try to get agent-specific conversation if available
                 conv = self.conversation_manager.get_agent_conversation(
                     resolved_agent_id
                 )
-                conv.add_message(
-                    role=message.role,
-                    content=message.content,
-                    category=category,
-                    metadata=message.metadata,
+                current_session_id = getattr(getattr(conv, "session", None), "id", None)
+                _trace_log_info(
+                    "core.stream.finalize request=%s session=%s conversation=%s agent=%s current_conv_session=%s persisted=%s message_len=%s events=%s empty=%s",
+                    execution_context.request_id if execution_context else "unknown",
+                    target_session_id or "unknown",
+                    resolved_conversation_id or "",
+                    resolved_agent_id,
+                    current_session_id or "unknown",
+                    persisted,
+                    len(message.content or ""),
+                    len(events),
+                    bool(message.was_empty),
                 )
+                if not persisted:
+                    if target_session_id and current_session_id != target_session_id:
+                        logger.warning(
+                            "Skipping shared-conversation finalize persistence for agent '%s': target session '%s' != current session '%s'",
+                            resolved_agent_id,
+                            target_session_id,
+                            current_session_id,
+                        )
+                    else:
+                        conv.add_message(
+                            role=message.role,
+                            content=message.content,
+                            category=category,
+                            metadata=message.metadata,
+                        )
+                        if hasattr(conv, "save"):
+                            conv.save()
             except (KeyError, AttributeError):
                 # Fallback to current conversation
-                self.conversation_manager.conversation.add_message(
-                    role=message.role,
-                    content=message.content,
-                    category=category,
-                    metadata=message.metadata,
-                )
+                if not persisted:
+                    conv = self.conversation_manager.conversation
+                    current_session_id = getattr(
+                        getattr(conv, "session", None), "id", None
+                    )
+                    if target_session_id and current_session_id != target_session_id:
+                        logger.warning(
+                            "Skipping fallback finalize persistence: target session '%s' != current session '%s'",
+                            target_session_id,
+                            current_session_id,
+                        )
+                    else:
+                        conv.add_message(
+                            role=message.role,
+                            content=message.content,
+                            category=category,
+                            metadata=message.metadata,
+                        )
+                        if hasattr(conv, "save"):
+                            conv.save()
 
             # For WebSocket streaming (RunMode), emit a message event
             if hasattr(self, "_temp_ws_callback") and self._temp_ws_callback:
@@ -3991,6 +4194,54 @@ class PenguinCore:
                 )
 
         return message.to_dict()
+
+    def _persist_finalized_message(
+        self,
+        *,
+        agent_id: str,
+        session_id: Optional[str],
+        message: Message,
+        category: MessageCategory,
+    ) -> bool:
+        """Persist a finalized streaming message without reloading shared conversations."""
+        target_session_id = session_id.strip() if isinstance(session_id, str) else ""
+        if not target_session_id:
+            return False
+
+        session, manager = self._find_session_store(target_session_id)
+        if session is None or manager is None:
+            _trace_log_info(
+                "core.stream.persist session=%s agent=%s status=missing_store",
+                target_session_id,
+                agent_id,
+            )
+            return False
+
+        persisted_message = Message(
+            role=message.role,
+            content=message.content,
+            category=category,
+            id=getattr(message, "id", None) or f"msg_{datetime.now().timestamp()}",
+            timestamp=getattr(message, "timestamp", None) or datetime.now().isoformat(),
+            metadata=dict(getattr(message, "metadata", {}) or {}),
+            tokens=int(getattr(message, "tokens", 0) or 0),
+            agent_id=getattr(message, "agent_id", None) or agent_id,
+            recipient_id=getattr(message, "recipient_id", None),
+            message_type=getattr(message, "message_type", "message") or "message",
+        )
+        session.add_message(persisted_message)
+        saved = bool(manager.save_session(session))
+        _trace_log_info(
+            "core.stream.persist session=%s agent=%s manager=%s message_id=%s saved=%s message_len=%s category=%s",
+            target_session_id,
+            agent_id,
+            hex(id(manager)),
+            persisted_message.id,
+            saved,
+            len(persisted_message.content or ""),
+            category,
+        )
+        return saved
 
     def _prepare_runmode_stream_callback(
         self,

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -12,6 +12,7 @@ remains test‑friendly and avoids hidden globals.
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import asyncio
+import copy
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from penguin.constants import UI_ASYNC_SLEEP_SECONDS
@@ -34,7 +35,12 @@ from typing import (
 from penguin.utils.errors import LLMEmptyResponseError
 
 from penguin.system.conversation_manager import ConversationManager  # type: ignore
-from penguin.utils.parser import parse_action, CodeActAction, ActionExecutor  # type: ignore
+from penguin.utils.parser import (  # type: ignore
+    ActionExecutor,
+    ActionType,
+    CodeActAction,
+    parse_action,
+)
 from penguin.system.state import MessageCategory  # type: ignore
 from penguin.llm.api_client import APIClient  # type: ignore
 from penguin.tools import ToolManager  # type: ignore
@@ -52,6 +58,17 @@ except ImportError:
     ProtocolMessage = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+def _trace_log_info(message: str, *args: Any) -> None:
+    """Mirror engine trace logs to uvicorn for live server debugging."""
+    logger.info(message, *args)
+    uvicorn_logger = logging.getLogger("uvicorn.error")
+    if uvicorn_logger is not logger:
+        uvicorn_logger.info(message, *args)
+
+
+_ACTION_TAG_NAME_PATTERN = "|".join(action_type.value for action_type in ActionType)
 
 # ---------------------------------------------------------------------------
 # Settings & Stop‑conditions
@@ -247,6 +264,11 @@ class EngineRunState:
     current_iteration: int = 0
     start_time: datetime = field(default_factory=datetime.utcnow)
     loop_state: LoopState = field(default_factory=LoopState)
+    scoped_conversation_managers: Dict[tuple[int, str], Any] = field(
+        default_factory=dict
+    )
+    api_client: Optional[Any] = None
+    model_config: Optional[Any] = None
 
 
 _CURRENT_ENGINE_RUN_STATE: ContextVar[Optional[EngineRunState]] = ContextVar(
@@ -269,7 +291,30 @@ class _ScopedConversationManager:
             )
         if conversation is None:
             conversation = getattr(base_manager, "conversation", None)
-        self._conversation = conversation
+        self._conversation = self._clone_conversation(conversation)
+
+    def _clone_conversation(self, conversation: Any) -> Any:
+        if conversation is None:
+            return None
+        try:
+            cloned = copy.copy(conversation)
+        except Exception:
+            return conversation
+
+        session = getattr(conversation, "session", None)
+        if session is None:
+            return cloned
+
+        try:
+            cloned_session = copy.copy(session)
+            if isinstance(getattr(session, "messages", None), list):
+                cloned_session.messages = list(session.messages)
+            if isinstance(getattr(session, "metadata", None), dict):
+                cloned_session.metadata = dict(session.metadata)
+            cloned.session = cloned_session
+        except Exception:
+            return cloned
+        return cloned
 
     @property
     def conversation(self) -> Any:
@@ -364,12 +409,63 @@ class Engine:
 
         # Light run‑time state
         self._interrupted: bool = False
+        self._pending_scoped_conversation_managers: Dict[tuple[str, str], Any] = {}
+
+    @staticmethod
+    def _trace_preview(value: Any, limit: int = 120) -> str:
+        text = str(value or "")
+        text = text.replace("\n", "\\n")
+        if len(text) <= limit:
+            return text
+        return text[: max(limit - 3, 0)] + "..."
+
+    def _trace_request_fields(self) -> tuple[str, str]:
+        execution_context = get_current_execution_context()
+        request_id = (
+            execution_context.request_id
+            if execution_context and execution_context.request_id
+            else "unknown"
+        )
+        session_id = (
+            execution_context.session_id
+            if execution_context and execution_context.session_id
+            else (
+                execution_context.conversation_id
+                if execution_context and execution_context.conversation_id
+                else ""
+            )
+        )
+        return request_id, session_id
+
+    @staticmethod
+    def _conversation_session_id(cm: Any) -> Optional[str]:
+        try:
+            session = (
+                cm.get_current_session() if hasattr(cm, "get_current_session") else None
+            )
+        except Exception:
+            session = None
+        if session is None:
+            session = getattr(getattr(cm, "conversation", None), "session", None)
+        return getattr(session, "id", None) if session is not None else None
 
     def _get_loop_state(self) -> LoopState:
         run_state = _CURRENT_ENGINE_RUN_STATE.get()
         if run_state is not None:
             return run_state.loop_state
         return self._default_run_state.loop_state
+
+    def _get_runtime_api_client(self) -> Any:
+        run_state = _CURRENT_ENGINE_RUN_STATE.get()
+        if run_state is not None and run_state.api_client is not None:
+            return run_state.api_client
+        return self.api_client
+
+    def _get_runtime_model_config(self) -> Any:
+        run_state = _CURRENT_ENGINE_RUN_STATE.get()
+        if run_state is not None and run_state.model_config is not None:
+            return run_state.model_config
+        return getattr(self, "model_config", None)
 
     @property
     def current_agent_id(self) -> Optional[str]:
@@ -477,7 +573,7 @@ class Engine:
             return None
         if resolved_agent_id:
             try:
-                return _ScopedConversationManager(
+                return self._get_scoped_conversation_manager(
                     agent.conversation_manager,
                     resolved_agent_id,
                 )
@@ -681,7 +777,7 @@ class Engine:
             cm = self.conversation_manager
             if agent_id:
                 try:
-                    cm = _ScopedConversationManager(cm, agent_id)
+                    cm = self._get_scoped_conversation_manager(cm, agent_id)
                 except Exception:
                     logger.exception(
                         "Failed to build scoped conversation manager for agent '%s'",
@@ -689,14 +785,14 @@ class Engine:
                     )
             return (
                 cm,
-                self.api_client,
+                self._get_runtime_api_client(),
                 self.tool_manager,
                 self.action_executor,
             )
         cm = agent.conversation_manager
         if agent_id:
             try:
-                cm = _ScopedConversationManager(cm, agent_id)
+                cm = self._get_scoped_conversation_manager(cm, agent_id)
             except Exception:
                 logger.exception(
                     "Failed to build scoped conversation manager for agent '%s'",
@@ -704,9 +800,101 @@ class Engine:
                 )
         return (
             cm,
-            agent.api_client or self.api_client,
+            agent.api_client or self._get_runtime_api_client(),
             agent.tool_manager or self.tool_manager,
             agent.action_executor or self.action_executor,
+        )
+
+    def _get_scoped_conversation_manager(
+        self,
+        base_manager: ConversationManager,
+        agent_id: str,
+    ) -> _ScopedConversationManager:
+        """Return a request-scoped conversation view reused within the same run."""
+        request_id, session_id = self._trace_request_fields()
+        run_state = _CURRENT_ENGINE_RUN_STATE.get()
+        if run_state is None:
+            scoped = _ScopedConversationManager(base_manager, agent_id)
+            _trace_log_info(
+                "engine.scope.create request=%s session=%s agent=%s cache=none base_cm=%s scoped_cm=%s scoped_session=%s",
+                request_id,
+                session_id or "unknown",
+                agent_id,
+                hex(id(base_manager)),
+                hex(id(scoped)),
+                self._conversation_session_id(scoped) or "unknown",
+            )
+            return scoped
+
+        key = (id(base_manager), agent_id)
+        cached = run_state.scoped_conversation_managers.get(key)
+        if isinstance(cached, _ScopedConversationManager):
+            _trace_log_info(
+                "engine.scope.reuse request=%s session=%s agent=%s cache=%s base_cm=%s scoped_cm=%s scoped_session=%s",
+                request_id,
+                session_id or "unknown",
+                agent_id,
+                len(run_state.scoped_conversation_managers),
+                hex(id(base_manager)),
+                hex(id(cached)),
+                self._conversation_session_id(cached) or "unknown",
+            )
+            return cached
+
+        pending_key = (request_id, agent_id)
+        pending = self._pending_scoped_conversation_managers.pop(pending_key, None)
+        if pending is not None:
+            run_state.scoped_conversation_managers[key] = pending
+            _trace_log_info(
+                "engine.scope.adopt request=%s session=%s agent=%s cache=%s base_cm=%s scoped_cm=%s scoped_session=%s",
+                request_id,
+                session_id or "unknown",
+                agent_id,
+                len(run_state.scoped_conversation_managers),
+                hex(id(base_manager)),
+                hex(id(pending)),
+                self._conversation_session_id(pending) or "unknown",
+            )
+            return pending
+
+        scoped = _ScopedConversationManager(base_manager, agent_id)
+        run_state.scoped_conversation_managers[key] = scoped
+        _trace_log_info(
+            "engine.scope.create request=%s session=%s agent=%s cache=%s base_cm=%s scoped_cm=%s scoped_session=%s",
+            request_id,
+            session_id or "unknown",
+            agent_id,
+            len(run_state.scoped_conversation_managers),
+            hex(id(base_manager)),
+            hex(id(scoped)),
+            self._conversation_session_id(scoped) or "unknown",
+        )
+        return scoped
+
+    def prime_scoped_conversation_manager(
+        self,
+        agent_id: str,
+        conversation_manager: Any,
+    ) -> None:
+        """Prime the next request-local engine run with a preloaded scoped manager."""
+        execution_context = get_current_execution_context()
+        request_id = (
+            execution_context.request_id
+            if execution_context and execution_context.request_id
+            else None
+        )
+        if not request_id:
+            return
+        self._pending_scoped_conversation_managers[(request_id, agent_id)] = (
+            conversation_manager
+        )
+        _trace_log_info(
+            "engine.scope.prime request=%s session=%s agent=%s scoped_cm=%s scoped_session=%s",
+            request_id,
+            execution_context.session_id if execution_context else "unknown",
+            agent_id,
+            hex(id(conversation_manager)),
+            self._conversation_session_id(conversation_manager) or "unknown",
         )
 
     def _extract_usage_from_api_client(self, api_client: Any) -> Dict[str, Any]:
@@ -747,6 +935,12 @@ class Engine:
         """
         # Check for no-action completion (models that don't use CodeAct format)
         if not iteration_results and last_response:
+            if self._looks_like_malformed_action_output(last_response):
+                logger.warning(
+                    "[WALLET_GUARD] Suppressing implicit completion for malformed %s response",
+                    mode,
+                )
+                return False, None
             has_action_tags = bool(
                 re.search(r"<\w+>.*?</\w+>", last_response, re.DOTALL)
             )
@@ -800,6 +994,78 @@ class Engine:
             return True, "implicit_completion" if mode == "task" else None
 
         return False, None
+
+    def _looks_like_malformed_action_output(self, response: str) -> bool:
+        """Return whether text looks like a partial or malformed tool call."""
+        if not isinstance(response, str) or not response.strip():
+            return False
+        if parse_action(response):
+            return False
+
+        stripped = response.strip()
+        if re.search(rf"</(?:{_ACTION_TAG_NAME_PATTERN})>", stripped, re.IGNORECASE):
+            return True
+        if re.search(
+            rf"<(?:{_ACTION_TAG_NAME_PATTERN})>(?:(?!</).)*$",
+            stripped,
+            re.DOTALL | re.IGNORECASE,
+        ):
+            return True
+        if re.search(
+            rf"<(?:{_ACTION_TAG_NAME_PATTERN})?[^>]*$", stripped, re.IGNORECASE
+        ):
+            return True
+        return False
+
+    def _queue_malformed_action_repair_note(
+        self,
+        cm: Any,
+        response: str,
+        *,
+        mode: str,
+    ) -> bool:
+        """Add a repair note when the model emits broken tool syntax."""
+        if not self._looks_like_malformed_action_output(response):
+            return False
+
+        request_id, session_id = self._trace_request_fields()
+        preview = self._trace_preview(response)
+        logger.warning(
+            "[WALLET_GUARD] Malformed action syntax in %s response request=%s session=%s preview=%r",
+            mode,
+            request_id,
+            session_id or "unknown",
+            preview,
+        )
+        try:
+            cm.conversation.add_message(
+                role="system",
+                content=(
+                    "The previous assistant response ended with malformed or partial tool syntax. "
+                    "Do not treat it as complete. Repair by continuing with either plain assistant text "
+                    "or one complete valid tool tag. Do not emit dangling XML-like fragments."
+                ),
+                category=MessageCategory.SYSTEM_OUTPUT,
+                metadata={
+                    "type": "malformed_action_output",
+                    "mode": mode,
+                    "preview": preview,
+                },
+                message_type="status",
+            )
+        except Exception:
+            logger.exception("Failed to record malformed action repair note")
+            return False
+
+        _trace_log_info(
+            "engine.action.repair request=%s session=%s mode=%s conv_session=%s preview=%r",
+            request_id,
+            session_id or "unknown",
+            mode,
+            self._conversation_session_id(cm) or "unknown",
+            preview,
+        )
+        return True
 
     async def _iteration_loop(
         self,
@@ -968,6 +1234,19 @@ class Engine:
                         f"Preview: {last_response[:100]}..."
                     )
 
+                if not iteration_results and self._queue_malformed_action_repair_note(
+                    cm,
+                    last_response,
+                    mode=config.mode,
+                ):
+                    await self._save_conversation(cm, async_save=config.async_save)
+                    if config.message_callback:
+                        await config.message_callback(
+                            "Assistant returned malformed tool syntax; requesting a repair turn.",
+                            "system_output",
+                        )
+                    continue
+
                 # WALLET_GUARD: Consolidated termination checks
                 should_break, guard_status = self._check_wallet_guard_termination(
                     last_response, iteration_results, mode=config.mode
@@ -1109,6 +1388,8 @@ class Engine:
         stream_callback: Optional[Callable[[str], None]] = None,
         agent_id: Optional[str] = None,
         agent_role: Optional[str] = None,
+        api_client_override: Optional[Any] = None,
+        model_config_override: Optional[Any] = None,
     ):
         """Run a single reasoning cycle for the requested agent/role."""
         selected, lite_output = await self._resolve_agent(
@@ -1124,7 +1405,11 @@ class Engine:
             }
 
         token: Token[Optional[EngineRunState]] = _CURRENT_ENGINE_RUN_STATE.set(
-            EngineRunState(current_agent_id=selected)
+            EngineRunState(
+                current_agent_id=selected,
+                api_client=api_client_override,
+                model_config=model_config_override,
+            )
         )
         try:
             cm, _api, _tm, _ae = self._resolve_components(self.current_agent_id)
@@ -1154,6 +1439,8 @@ class Engine:
         stream_callback: Optional[Callable[[str], None]] = None,
         agent_id: Optional[str] = None,
         agent_role: Optional[str] = None,
+        api_client_override: Optional[Any] = None,
+        model_config_override: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Multi-step conversational loop for natural conversation flow.
@@ -1198,7 +1485,11 @@ class Engine:
             }
 
         token: Token[Optional[EngineRunState]] = _CURRENT_ENGINE_RUN_STATE.set(
-            EngineRunState(current_agent_id=selected)
+            EngineRunState(
+                current_agent_id=selected,
+                api_client=api_client_override,
+                model_config=model_config_override,
+            )
         )
         all_action_results: List[Dict[str, Any]] = []
         try:
@@ -1297,6 +1588,14 @@ class Engine:
                         f"[LOOP DEBUG] Response contains 'finish_response' text but wasn't parsed as action. Response preview: {last_response[:100]}..."
                     )
 
+                if not iteration_results and self._queue_malformed_action_repair_note(
+                    cm,
+                    last_response,
+                    mode="response",
+                ):
+                    await self._save_conversation(cm, async_save=True)
+                    continue
+
                 # WALLET_GUARD: Consolidated termination checks
                 should_break, _ = self._check_wallet_guard_termination(
                     last_response, iteration_results, mode="response"
@@ -1345,6 +1644,8 @@ class Engine:
         message_callback: Optional[Callable[[str, str], Awaitable[None]]] = None,
         agent_id: Optional[str] = None,
         agent_role: Optional[str] = None,
+        api_client_override: Optional[Any] = None,
+        model_config_override: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Multi-step reasoning loop with comprehensive task handling.
@@ -1383,7 +1684,11 @@ class Engine:
             selected = self.default_agent_id
 
         token: Token[Optional[EngineRunState]] = _CURRENT_ENGINE_RUN_STATE.set(
-            EngineRunState(current_agent_id=selected)
+            EngineRunState(
+                current_agent_id=selected,
+                api_client=api_client_override,
+                model_config=model_config_override,
+            )
         )
         self.current_iteration = 0
         self.start_time = datetime.utcnow()
@@ -1574,6 +1879,19 @@ class Engine:
                             logger.debug("EventBus not available for completion event")
                     break
 
+                if not iteration_results and self._queue_malformed_action_repair_note(
+                    cm,
+                    last_response,
+                    mode="task",
+                ):
+                    await self._save_conversation(cm, async_save=True)
+                    if message_callback:
+                        await message_callback(
+                            "Assistant returned malformed tool syntax; requesting a repair turn.",
+                            "system_output",
+                        )
+                    continue
+
                 # WALLET_GUARD: Consolidated termination checks
                 should_break, guard_status = self._check_wallet_guard_termination(
                     last_response, iteration_results, mode="task"
@@ -1733,7 +2051,7 @@ class Engine:
         """
         extra_kwargs = {}
         try:
-            model_cfg = getattr(self, "model_config", None)
+            model_cfg = self._get_runtime_model_config()
             uses_openai_native_responses = bool(
                 model_cfg
                 and getattr(model_cfg, "provider", "") == "openai"
@@ -1921,16 +2239,44 @@ class Engine:
         Raises:
             LLMEmptyResponseError: If response is empty after retry
         """
+        streamed_assistant_chunk = False
+
+        async def _tracked_stream_callback(
+            chunk: str,
+            message_type: str = "assistant",
+        ) -> None:
+            nonlocal streamed_assistant_chunk
+            if chunk and message_type == "assistant":
+                streamed_assistant_chunk = True
+            if stream_callback is None:
+                return
+            if asyncio.iscoroutinefunction(stream_callback):
+                await stream_callback(chunk, message_type)
+                return
+            try:
+                stream_callback(chunk, message_type)
+            except TypeError:
+                stream_callback(chunk)
+
         # First attempt – honour requested streaming setting
         assistant_response = await api_client.get_response(
             messages,
             stream=streaming,
-            stream_callback=stream_callback,
+            stream_callback=(
+                _tracked_stream_callback
+                if streaming and stream_callback
+                else stream_callback
+            ),
             **extra_kwargs,
         )
 
         # If empty, retry once with stream=False (some providers fail in streaming mode)
         if not assistant_response or not assistant_response.strip():
+            if streamed_assistant_chunk:
+                logger.info(
+                    "_llm_step received empty final text after streaming assistant chunks; skipping non-stream retry."
+                )
+                return assistant_response or ""
             if self._handler_has_pending_tool_call(api_client):
                 logger.info(
                     "_llm_step received empty text because handler captured a tool call; skipping empty-response retry."
@@ -2099,6 +2445,16 @@ class Engine:
         Returns:
             Finalized response text (may be updated from streaming buffer)
         """
+        request_id, request_session_id = self._trace_request_fields()
+        _trace_log_info(
+            "engine.stream.finalize.start request=%s session=%s agent=%s conv_session=%s streaming=%s response_len=%s",
+            request_id,
+            request_session_id or "unknown",
+            agent_id or self.current_agent_id or self.default_agent_id,
+            self._conversation_session_id(cm) or "unknown",
+            streaming,
+            len(assistant_response or ""),
+        )
         if not streaming:
             # Non-streaming: check if message already added, add if not
             try:
@@ -2125,6 +2481,16 @@ class Engine:
                 logger.debug(
                     f"Added assistant message to conversation ({len(assistant_response)} chars)"
                 )
+
+            _trace_log_info(
+                "engine.stream.finalize.done request=%s session=%s agent=%s conv_session=%s response_len=%s finalized=%s",
+                request_id,
+                request_session_id or "unknown",
+                agent_id or self.current_agent_id or self.default_agent_id,
+                self._conversation_session_id(cm) or "unknown",
+                len(assistant_response or ""),
+                False,
+            )
 
             return assistant_response
 
@@ -2185,6 +2551,16 @@ class Engine:
                     "Persisted non-chunk streaming response as assistant message (%s chars)",
                     len(assistant_response),
                 )
+
+        _trace_log_info(
+            "engine.stream.finalize.done request=%s session=%s agent=%s conv_session=%s response_len=%s finalized=%s",
+            request_id,
+            request_session_id or "unknown",
+            agent_id or self.current_agent_id or self.default_agent_id,
+            self._conversation_session_id(cm) or "unknown",
+            len(assistant_response or ""),
+            bool(finalized_content),
+        )
 
         return assistant_response
 
@@ -2321,6 +2697,28 @@ class Engine:
         )
         messages = cm.conversation.get_formatted_messages()
         messages = self._apply_agent_mode_notice(messages)
+        request_id, session_id = self._trace_request_fields()
+        last_message = messages[-1] if messages else {}
+        _trace_log_info(
+            "engine.llm_step.start request=%s session=%s agent=%s cm=%s conv=%s conv_session=%s msgs=%s last_role=%s last_preview=%r streaming=%s tools=%s",
+            request_id,
+            session_id or "unknown",
+            agent_id or self.current_agent_id or self.default_agent_id,
+            hex(id(cm)),
+            hex(id(getattr(cm, "conversation", None)))
+            if getattr(cm, "conversation", None) is not None
+            else "none",
+            self._conversation_session_id(cm) or "unknown",
+            len(messages),
+            last_message.get("role") if isinstance(last_message, dict) else None,
+            self._trace_preview(
+                last_message.get("content", "")
+                if isinstance(last_message, dict)
+                else ""
+            ),
+            streaming,
+            tools_enabled,
+        )
 
         # Step 1: Prepare Responses API tools if enabled
         extra_kwargs = self._prepare_responses_tools(tool_manager)
@@ -2349,6 +2747,16 @@ class Engine:
             )
 
         usage = self._extract_usage_from_api_client(api_client)
+        _trace_log_info(
+            "engine.llm_step.done request=%s session=%s agent=%s conv_session=%s response_len=%s actions=%s usage=%s",
+            request_id,
+            session_id or "unknown",
+            agent_id or self.current_agent_id or self.default_agent_id,
+            self._conversation_session_id(cm) or "unknown",
+            len(assistant_response or ""),
+            len(action_results),
+            usage,
+        )
 
         # Note: cm.save() removed - caller (run_response/run_task) handles persistence
         # This avoids redundant saves per iteration

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -535,10 +535,23 @@ class APIClient:
         )
         prepared_messages = self._prepare_messages_with_system_prompt(messages)
 
-        # <<<--- ADD THIS LOGGING for PREPARED MESSAGES ---<<<
-        request_id_api = os.urandom(4).hex()  # Simple ID for this layer
+        try:
+            from penguin.system.execution_context import get_current_execution_context
+
+            execution_context = get_current_execution_context()
+            request_id_ctx = execution_context.request_id if execution_context else None
+            session_id_ctx = (
+                execution_context.session_id or execution_context.conversation_id
+                if execution_context
+                else None
+            )
+        except Exception:
+            request_id_ctx = None
+            session_id_ctx = None
+
+        request_id_api = request_id_ctx or os.urandom(4).hex()
         self.logger.info(
-            f"[Request:{request_id_api}] APIClient calling handler {type(self.client_handler).__name__}.get_response"
+            f"[Request:{request_id_api}] APIClient calling handler {type(self.client_handler).__name__}.get_response session={session_id_ctx} model={getattr(self.model_config, 'model', None)} stream={use_streaming}"
         )
         try:
             safe_msgs_for_log = []

--- a/penguin/tui_adapter/part_events.py
+++ b/penguin/tui_adapter/part_events.py
@@ -48,6 +48,7 @@ class Message:
     time_completed: Optional[float] = None
     model_id: Optional[str] = None
     provider_id: Optional[str] = None
+    variant: Optional[str] = None
     agent_id: str = "default"
     parent_id: str = "root"
     path: Dict[str, str] = field(default_factory=dict)
@@ -312,6 +313,7 @@ class PartEventAdapter:
         agent_id: str = "default",
         model_id: Optional[str] = None,
         provider_id: Optional[str] = None,
+        variant: Optional[str] = None,
     ) -> Tuple[str, str]:
         """Called when streaming starts - creates Message and initial TextPart.
 
@@ -331,6 +333,7 @@ class PartEventAdapter:
             time_created=time.time(),
             model_id=model_id,
             provider_id=provider_id,
+            variant=variant,
             agent_id=agent_id,
             parent_id="root",
             path=self._path(),
@@ -694,6 +697,7 @@ class PartEventAdapter:
                 "parentID": msg.parent_id,
                 "modelID": msg.model_id,
                 "providerID": msg.provider_id,
+                "variant": msg.variant,
                 "mode": msg.mode,
                 "agent": msg.agent_id,
                 "path": msg.path or self._path(),

--- a/penguin/tui_adapter/part_events.py
+++ b/penguin/tui_adapter/part_events.py
@@ -160,7 +160,11 @@ class PartEventAdapter:
             self._last_id_ts = ts
             self._last_id_inc = 0
         stamp = str(ts).rjust(13, "0")
-        return f"{prefix}_{stamp}_{self._last_id_inc:02d}"
+        session_fragment = (
+            re.sub(r"[^a-zA-Z0-9]+", "_", self._session_id or "unknown").strip("_")
+            or "unknown"
+        )
+        return f"{prefix}_{session_fragment}_{stamp}_{self._last_id_inc:02d}"
 
     def _strip_action_tags_keep_whitespace(self, text: str) -> str:
         if not text:

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -149,6 +149,42 @@ def _get_last_scoped_directory(core: PenguinCore) -> Optional[str]:
     return normalize_directory(getattr(core, "_opencode_last_scoped_directory", None))
 
 
+def _directories_match(left: Optional[str], right: Optional[str]) -> bool:
+    """Return whether two directory values resolve to the same location."""
+    left_normalized = normalize_directory(left)
+    right_normalized = normalize_directory(right)
+    if not left_normalized or not right_normalized:
+        return False
+    if left_normalized == right_normalized:
+        return True
+    try:
+        return Path(left_normalized).samefile(right_normalized)
+    except Exception:
+        return False
+
+
+def _get_bound_session_directory(
+    core: PenguinCore, session_id: Optional[str]
+) -> Optional[str]:
+    """Return the authoritative directory for a known session, if any."""
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+
+    normalized_session_id = session_id.strip()
+    session_dirs = _ensure_session_directory_map(core)
+    mapped = normalize_directory(session_dirs.get(normalized_session_id))
+    if mapped:
+        return mapped
+
+    info = get_session_info(core, normalized_session_id)
+    info_directory = (
+        normalize_directory(info.get("directory")) if isinstance(info, dict) else None
+    )
+    if info_directory:
+        session_dirs[normalized_session_id] = info_directory
+    return info_directory
+
+
 def _resolve_scoped_directory_for_find(
     core: PenguinCore,
     *,
@@ -157,10 +193,7 @@ def _resolve_scoped_directory_for_find(
     conversation_id: Optional[str],
 ) -> Optional[str]:
     """Resolve find scope using explicit, session, remembered, and runtime roots."""
-    explicit = _remember_last_scoped_directory(core, directory)
-    if explicit:
-        return explicit
-
+    explicit = normalize_directory(directory)
     effective_session = (
         session_id.strip()
         if isinstance(session_id, str) and session_id.strip()
@@ -170,15 +203,73 @@ def _resolve_scoped_directory_for_find(
             else None
         )
     )
+
     if effective_session:
-        session_dirs = _ensure_session_directory_map(core)
-        mapped = normalize_directory(session_dirs.get(effective_session))
+        mapped = _get_bound_session_directory(core, effective_session)
         if mapped:
+            if explicit and not _directories_match(mapped, explicit):
+                _request_log_info(
+                    "find.scope.conflict session=%s explicit=%s mapped=%s conversation=%s",
+                    effective_session,
+                    explicit,
+                    mapped,
+                    conversation_id or "",
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Session '{effective_session}' is bound to '{mapped}' and "
+                        f"cannot be searched via '{explicit}'"
+                    ),
+                )
             _remember_last_scoped_directory(core, mapped)
+            _request_log_debug(
+                "find.scope.resolve session=%s conversation=%s source=session_binding explicit=%s resolved=%s",
+                effective_session,
+                conversation_id or "",
+                explicit,
+                mapped,
+            )
             return mapped
+
+        if explicit:
+            resolved = _bind_session_directory(core, effective_session, explicit)
+            _request_log_debug(
+                "find.scope.resolve session=%s conversation=%s source=explicit_bind explicit=%s resolved=%s",
+                effective_session,
+                conversation_id or "",
+                explicit,
+                resolved,
+            )
+            return resolved
+
+        _request_log_debug(
+            "find.scope.resolve session=%s conversation=%s source=missing_binding explicit=%s resolved=%s",
+            effective_session,
+            conversation_id or "",
+            explicit,
+            None,
+        )
+        return None
+
+    explicit = _remember_last_scoped_directory(core, directory)
+    if explicit:
+        _request_log_debug(
+            "find.scope.resolve session=%s conversation=%s source=explicit resolved=%s",
+            session_id or "",
+            conversation_id or "",
+            explicit,
+        )
+        return explicit
 
     remembered = _get_last_scoped_directory(core)
     if remembered:
+        _request_log_debug(
+            "find.scope.resolve session=%s conversation=%s source=remembered resolved=%s",
+            session_id or "",
+            conversation_id or "",
+            remembered,
+        )
         return remembered
 
     runtime = getattr(core, "runtime_config", None)
@@ -189,11 +280,23 @@ def _resolve_scoped_directory_for_find(
     )
     if runtime_fallback:
         _remember_last_scoped_directory(core, runtime_fallback)
+        _request_log_debug(
+            "find.scope.resolve session=%s conversation=%s source=runtime resolved=%s",
+            session_id or "",
+            conversation_id or "",
+            runtime_fallback,
+        )
         return runtime_fallback
 
     workspace_fallback = normalize_directory(WORKSPACE_PATH)
     if workspace_fallback:
         _remember_last_scoped_directory(core, workspace_fallback)
+        _request_log_debug(
+            "find.scope.resolve session=%s conversation=%s source=workspace resolved=%s",
+            session_id or "",
+            conversation_id or "",
+            workspace_fallback,
+        )
     return workspace_fallback
 
 
@@ -206,7 +309,9 @@ def _ensure_session_directory_map(core: PenguinCore) -> dict[str, str]:
     return session_dirs
 
 
-def _get_session_request_gate(core: PenguinCore, session_id: Optional[str]) -> asyncio.Lock:
+def _get_session_request_gate(
+    core: PenguinCore, session_id: Optional[str]
+) -> asyncio.Lock:
     """Return a REST request gate scoped to one session."""
     gate_key = session_id or "__default__"
     request_gates = getattr(core, "_opencode_request_gates", None)
@@ -229,7 +334,14 @@ def _bind_session_directory(
         )
 
     if not session_id:
-        return _remember_last_scoped_directory(core, directory)
+        resolved = _remember_last_scoped_directory(core, directory)
+        _request_log_debug(
+            "session.directory.bind session=%s source=no_session requested=%s resolved=%s",
+            "",
+            directory,
+            resolved,
+        )
+        return resolved
 
     session_dirs = _ensure_session_directory_map(core)
     existing = normalize_directory(session_dirs.get(session_id))
@@ -240,9 +352,22 @@ def _bind_session_directory(
             try:
                 if Path(existing).samefile(requested):
                     _remember_last_scoped_directory(core, existing)
+                    _request_log_debug(
+                        "session.directory.bind session=%s source=reuse_samefile requested=%s existing=%s resolved=%s",
+                        session_id,
+                        requested,
+                        existing,
+                        existing,
+                    )
                     return existing
             except Exception:
                 pass
+            _request_log_info(
+                "session.directory.bind_conflict session=%s requested=%s existing=%s",
+                session_id,
+                requested,
+                existing,
+            )
             raise HTTPException(
                 status_code=409,
                 detail=(
@@ -251,13 +376,33 @@ def _bind_session_directory(
                 ),
             )
         _remember_last_scoped_directory(core, existing)
+        _request_log_debug(
+            "session.directory.bind session=%s source=existing requested=%s existing=%s resolved=%s",
+            session_id,
+            requested,
+            existing,
+            existing,
+        )
         return existing
 
     if requested:
         session_dirs[session_id] = requested
         _remember_last_scoped_directory(core, requested)
+        _request_log_info(
+            "session.directory.bind session=%s source=new requested=%s resolved=%s total=%s",
+            session_id,
+            requested,
+            requested,
+            len(session_dirs),
+        )
         return requested
 
+    _request_log_debug(
+        "session.directory.bind session=%s source=empty requested=%s resolved=%s",
+        session_id,
+        requested,
+        None,
+    )
     return None
 
 
@@ -372,6 +517,43 @@ async def _persist_session_agent_mode(
         return
 
     updated = update_session_info(core, session_id, agent_mode=normalized_mode)
+    if isinstance(updated, dict):
+        await _emit_session_updated_event(core, updated)
+
+
+async def _persist_session_model_selection(
+    core: PenguinCore,
+    session_id: Optional[str],
+    *,
+    provider_id: Optional[str],
+    model_id: Optional[str],
+    variant: Optional[str],
+) -> None:
+    if not isinstance(session_id, str) or not session_id:
+        return
+    normalized_provider = provider_id.strip() if isinstance(provider_id, str) else ""
+    normalized_model = model_id.strip() if isinstance(model_id, str) else ""
+    normalized_variant = variant.strip() if isinstance(variant, str) else ""
+    if not normalized_provider or not normalized_model:
+        return
+
+    existing = get_session_info(core, session_id)
+    if not isinstance(existing, dict):
+        return
+    if (
+        existing.get("providerID") == normalized_provider
+        and existing.get("modelID") == normalized_model
+        and (existing.get("variant") or "") == normalized_variant
+    ):
+        return
+
+    updated = update_session_info(
+        core,
+        session_id,
+        provider_id=normalized_provider,
+        model_id=normalized_model,
+        variant=normalized_variant or None,
+    )
     if isinstance(updated, dict):
         await _emit_session_updated_event(core, updated)
 
@@ -641,8 +823,10 @@ _INLINE_FILE_REFERENCE_PATTERN = re.compile(
 def _apply_reasoning_variant_override(
     core: PenguinCore,
     variant: Optional[str],
+    *,
+    model_config: Optional[Any] = None,
 ) -> Optional[Dict[str, Any]]:
-    model_config = getattr(core, "model_config", None)
+    model_config = model_config or getattr(core, "model_config", None)
     if model_config is None:
         return None
 
@@ -713,11 +897,13 @@ def _apply_reasoning_variant_override(
 def _restore_reasoning_variant_override(
     core: PenguinCore,
     snapshot: Optional[Dict[str, Any]],
+    *,
+    model_config: Optional[Any] = None,
 ) -> None:
     if not isinstance(snapshot, dict):
         return
 
-    model_config = getattr(core, "model_config", None)
+    model_config = model_config or getattr(core, "model_config", None)
     if model_config is None:
         return
 
@@ -732,6 +918,77 @@ def _restore_reasoning_variant_override(
             delattr(model_config, "supports_reasoning")
         except Exception:
             pass
+
+
+async def _resolve_request_runtime_for_model(
+    core: Any,
+    requested_model: Optional[str],
+) -> tuple[Optional[Any], Optional[Any]]:
+    """Resolve request-scoped model runtime with backwards-compatible fallback."""
+    requested = requested_model.strip() if isinstance(requested_model, str) else ""
+    resolver = getattr(core, "resolve_request_runtime", None)
+    if callable(resolver):
+        return await resolver(requested or None)
+
+    if not requested:
+        return getattr(core, "model_config", None), None
+
+    current_model = (
+        core.get_current_model() if hasattr(core, "get_current_model") else None
+    )
+    current_raw = ""
+    current_provider = ""
+    if isinstance(current_model, dict):
+        raw_model = current_model.get("model")
+        raw_provider = current_model.get("provider")
+        if isinstance(raw_model, str):
+            current_raw = raw_model.strip()
+        if isinstance(raw_provider, str):
+            current_provider = raw_provider.strip()
+    current_qualified = (
+        f"{current_provider}/{current_raw}" if current_provider and current_raw else ""
+    )
+
+    if requested in {current_raw, current_qualified}:
+        return getattr(core, "model_config", None), None
+
+    candidates: list[str] = [requested]
+    if "/" in requested:
+        _, remainder = requested.split("/", 1)
+        if remainder and remainder not in candidates:
+            candidates.append(remainder)
+
+    model_configs = getattr(getattr(core, "config", None), "model_configs", {})
+    if isinstance(model_configs, dict) and len(candidates) == 2:
+        full = candidates[0]
+        short = candidates[1]
+        if short in model_configs and full not in model_configs:
+            candidates = [short, full]
+
+    loader = getattr(core, "load_model", None)
+    if not callable(loader):
+        raise ValueError(f"Failed to resolve model runtime '{requested}'")
+
+    last_reason: Optional[str] = None
+    for candidate in candidates:
+        loaded = await loader(candidate)
+        if loaded:
+            return getattr(core, "model_config", None), None
+        reason = getattr(core, "_last_model_load_error", None)
+        if isinstance(reason, str) and reason.strip():
+            last_reason = reason.strip()
+        _request_log_info(
+            "chat.model.load_failed session=%s requested=%s candidate=%s reason=%s",
+            "unknown",
+            requested,
+            candidate,
+            last_reason or "unknown",
+        )
+
+    detail = f"Failed to load model '{requested}'"
+    if last_reason:
+        detail = f"{detail}: {last_reason}"
+    raise ValueError(detail)
 
 
 def _resolve_context_file_path(
@@ -2523,6 +2780,16 @@ async def opencode_find_files(
     conversation_id: Optional[str] = Query(None),
 ) -> List[str]:
     """OpenCode-compatible file/directory search endpoint."""
+    _request_log_debug(
+        "find.request session=%s conversation=%s query=%r directory=%s dirs=%s type=%s limit=%s",
+        session_id or "",
+        conversation_id or "",
+        query,
+        directory,
+        dirs,
+        entry_type,
+        limit,
+    )
     type_value = entry_type.strip().lower() if isinstance(entry_type, str) else None
     if type_value not in {None, "file", "directory"}:
         raise HTTPException(
@@ -2549,11 +2816,30 @@ async def opencode_find_files(
 
     files, directories = _get_find_file_index(resolved_directory)
     kind = type_value or ("file" if not dirs_enabled else "all")
+    _request_log_debug(
+        "find.index session=%s query=%r resolved=%s files=%s dirs=%s kind=%s",
+        session_id or conversation_id or "",
+        query_value,
+        resolved_directory,
+        len(files),
+        len(directories),
+        kind,
+    )
 
     if not query_value:
         if kind == "file":
-            return _sort_hidden_last(files, query_value)[:limit_value]
-        return _sort_hidden_last(directories, query_value)[:limit_value]
+            result = _sort_hidden_last(files, query_value)[:limit_value]
+        else:
+            result = _sort_hidden_last(directories, query_value)[:limit_value]
+        _request_log_debug(
+            "find.result session=%s query=%r resolved=%s count=%s sample=%s",
+            session_id or conversation_id or "",
+            query_value,
+            resolved_directory,
+            len(result),
+            result[:5],
+        )
+        return result
 
     items = (
         files
@@ -2570,7 +2856,16 @@ async def opencode_find_files(
     matched = _search_find_file_items(
         items, query_value, max(search_limit, limit_value)
     )
-    return _sort_hidden_last(matched, query_value)[:limit_value]
+    result = _sort_hidden_last(matched, query_value)[:limit_value]
+    _request_log_debug(
+        "find.result session=%s query=%r resolved=%s count=%s sample=%s",
+        session_id or conversation_id or "",
+        query_value,
+        resolved_directory,
+        len(result),
+        result[:5],
+    )
+    return result
 
 
 @router.get("/config")
@@ -3091,6 +3386,8 @@ async def handle_chat_message(
     request_task: Optional[asyncio.Task[Any]] = None
     request_tracked = False
     reasoning_variant_snapshot: Optional[Dict[str, Any]] = None
+    request_model_config: Optional[Any] = None
+    request_api_client: Optional[Any] = None
     try:
         _setup_approval_websocket_callbacks()
         _setup_question_event_callbacks()
@@ -3150,6 +3447,16 @@ async def handle_chat_message(
                     tasks_map[request_session_id] = tasks
                 tasks.add(request_task)
                 request_tracked = True
+                _request_log_debug(
+                    "chat.trace.track request=%s session=%s task=%s tracked=%s session_tasks=%s",
+                    request_task.get_name()
+                    if hasattr(request_task, "get_name")
+                    else hex(id(request_task)),
+                    request_session_id,
+                    hex(id(request_task)),
+                    True,
+                    len(tasks),
+                )
 
         scope_directory = bound_directory or request.directory
         part_context_files, part_image_paths = _extract_paths_from_parts(
@@ -3211,66 +3518,14 @@ async def handle_chat_message(
         requested_model = (
             request.model.strip() if isinstance(request.model, str) else ""
         )
-        if requested_model:
-            current_model = (
-                core.get_current_model() if hasattr(core, "get_current_model") else None
-            )
-            current_raw = ""
-            current_provider = ""
-            if isinstance(current_model, dict):
-                raw_model = current_model.get("model")
-                raw_provider = current_model.get("provider")
-                if isinstance(raw_model, str):
-                    current_raw = raw_model.strip()
-                if isinstance(raw_provider, str):
-                    current_provider = raw_provider.strip()
-            current_qualified = (
-                f"{current_provider}/{current_raw}"
-                if current_provider and current_raw
-                else ""
-            )
-
-            if requested_model not in {current_raw, current_qualified}:
-                candidates: list[str] = [requested_model]
-                if "/" in requested_model:
-                    _, remainder = requested_model.split("/", 1)
-                    if remainder and remainder not in candidates:
-                        candidates.append(remainder)
-
-                model_configs = getattr(
-                    getattr(core, "config", None), "model_configs", {}
-                )
-                if isinstance(model_configs, dict) and len(candidates) == 2:
-                    full = candidates[0]
-                    short = candidates[1]
-                    if short in model_configs and full not in model_configs:
-                        candidates = [short, full]
-
-                loaded = False
-                last_reason: Optional[str] = None
-                for candidate in candidates:
-                    loaded = await core.load_model(candidate)
-                    if loaded:
-                        break
-                    reason = getattr(core, "_last_model_load_error", None)
-                    if isinstance(reason, str) and reason.strip():
-                        last_reason = reason.strip()
-                    _request_log_info(
-                        "chat.model.load_failed session=%s requested=%s candidate=%s reason=%s",
-                        request_session_id or "unknown",
-                        requested_model,
-                        candidate,
-                        last_reason or "unknown",
-                    )
-
-                if not loaded:
-                    detail = f"Failed to load model '{requested_model}'"
-                    if last_reason:
-                        detail = f"{detail}: {last_reason}"
-                    raise HTTPException(
-                        status_code=400,
-                        detail=detail,
-                    )
+        try:
+            (
+                request_model_config,
+                request_api_client,
+            ) = await _resolve_request_runtime_for_model(core, requested_model or None)
+        except Exception as exc:
+            detail = str(exc) or f"Failed to resolve model runtime '{requested_model}'"
+            raise HTTPException(status_code=400, detail=detail) from exc
 
         # Maybe?
         # # If no conversation_id is provided, try to use the most recent one
@@ -3337,8 +3592,16 @@ async def handle_chat_message(
         reasoning_variant_snapshot = _apply_reasoning_variant_override(
             core,
             request.variant,
+            model_config=request_model_config,
         )
-        model_config = getattr(core, "model_config", None)
+        await _persist_session_model_selection(
+            core,
+            request_session_id,
+            provider_id=getattr(request_model_config, "provider", None),
+            model_id=getattr(request_model_config, "model", None),
+            variant=request.variant,
+        )
+        model_config = request_model_config or getattr(core, "model_config", None)
         variant_value = (
             request.variant.strip().lower()
             if isinstance(request.variant, str) and request.variant.strip()
@@ -3368,11 +3631,21 @@ async def handle_chat_message(
         # Process the message with all available options
         with execution_context_scope(execution_context):
             request_gate = _get_session_request_gate(core, request_session_id)
+            gate_locked_before = request_gate.locked()
+            gate_wait_started = time.perf_counter()
+            active_requests = getattr(core, "_opencode_active_requests", {})
+            active_request_count = (
+                active_requests.get(request_session_id, 0)
+                if isinstance(active_requests, dict) and request_session_id
+                else 0
+            )
             _request_log_debug(
-                "chat.trace.before_process request=%s session=%s gate=%s cm=%s tracked=%s ctx=%s",
+                "chat.trace.before_process request=%s session=%s gate=%s gate_locked=%s active=%s cm=%s tracked=%s ctx=%s",
                 execution_context.request_id or "unknown",
                 request_session_id or "unknown",
                 hex(id(request_gate)),
+                gate_locked_before,
+                active_request_count,
                 hex(id(getattr(core, "conversation_manager", None)))
                 if getattr(core, "conversation_manager", None) is not None
                 else "none",
@@ -3380,6 +3653,16 @@ async def handle_chat_message(
                 execution_context.as_dict(),
             )
             async with request_gate:
+                gate_wait_ms = (time.perf_counter() - gate_wait_started) * 1000
+                _request_log_debug(
+                    "chat.trace.gate_acquired request=%s session=%s gate=%s wait_ms=%.2f tracked=%s",
+                    execution_context.request_id or "unknown",
+                    request_session_id or "unknown",
+                    hex(id(request_gate)),
+                    gate_wait_ms,
+                    bool(request_tracked),
+                )
+                process_started = time.perf_counter()
                 process_result = await core.process(
                     input_data=input_data,
                     context=request.context,
@@ -3389,13 +3672,20 @@ async def handle_chat_message(
                     context_files=context_files,
                     streaming=effective_streaming,
                     stream_callback=stream_cb,
+                    api_client_override=request_api_client,
+                    model_config_override=request_model_config,
                 )
+                process_ms = (time.perf_counter() - process_started) * 1000
             _request_log_debug(
-                "chat.trace.after_process request=%s session=%s response_len=%s actions=%s preview=%r",
+                "chat.trace.after_process request=%s session=%s status=%s iterations=%s response_len=%s actions=%s usage=%s process_ms=%.2f preview=%r",
                 execution_context.request_id or "unknown",
                 request_session_id or "unknown",
+                process_result.get("status"),
+                process_result.get("iterations"),
                 len(process_result.get("assistant_response", "") or ""),
                 len(process_result.get("action_results", []) or []),
+                process_result.get("usage") or {},
+                process_ms,
                 _preview_text(process_result.get("assistant_response", "")),
             )
 
@@ -3414,10 +3704,11 @@ async def handle_chat_message(
         if request.include_reasoning:
             resp["reasoning"] = "".join(reasoning_buf)
         _request_log_debug(
-            "chat.trace.response request=%s session=%s response_len=%s aborted=%s preview=%r",
+            "chat.trace.response request=%s session=%s response_len=%s reasoning_len=%s aborted=%s preview=%r",
             execution_context.request_id or "unknown",
             request_session_id or "unknown",
             len(resp.get("response", "") or ""),
+            len(resp.get("reasoning", "") or ""),
             bool(resp.get("aborted")),
             _preview_text(resp.get("response", "")),
         )
@@ -3425,7 +3716,9 @@ async def handle_chat_message(
     except asyncio.CancelledError:
         _request_log_info(
             "chat.trace.cancelled request=%s session=%s",
-            execution_context.request_id if "execution_context" in locals() else "unknown",
+            execution_context.request_id
+            if "execution_context" in locals()
+            else "unknown",
             request_session_id or "unknown",
         )
         return {"response": "", "action_results": [], "aborted": True}
@@ -3597,9 +3890,12 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
             parts = data.get("parts")
             include_reasoning = bool(data.get("include_reasoning", False))
             variant = data.get("variant")
+            model = data.get("model")
             agent_id = data.get("agent_id")
             agent_mode = data.get("agent_mode")
             directory = data.get("directory")
+            request_model_config = None
+            request_api_client = None
 
             # Prefer explicit session_id when provided; conversation_id is continuity metadata.
             effective_session_id = session_id or conversation_id
@@ -3788,11 +4084,28 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                     except Exception as e:
                         logger.error(f"Error enqueuing stream chunk: {e}")
 
+                requested_model = model.strip() if isinstance(model, str) else ""
+                (
+                    request_model_config,
+                    request_api_client,
+                ) = await _resolve_request_runtime_for_model(
+                    core, requested_model or None
+                )
                 reasoning_variant_snapshot = _apply_reasoning_variant_override(
                     core,
                     variant if isinstance(variant, str) else None,
+                    model_config=request_model_config,
                 )
-                model_config = getattr(core, "model_config", None)
+                await _persist_session_model_selection(
+                    core,
+                    effective_session_id,
+                    provider_id=getattr(request_model_config, "provider", None),
+                    model_id=getattr(request_model_config, "model", None),
+                    variant=variant if isinstance(variant, str) else None,
+                )
+                model_config = request_model_config or getattr(
+                    core, "model_config", None
+                )
                 variant_value = (
                     variant.strip().lower()
                     if isinstance(variant, str) and variant.strip()
@@ -3830,6 +4143,8 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                                 context=context,
                                 streaming=True,
                                 stream_callback=per_request_stream_callback,
+                                api_client_override=request_api_client,
+                                model_config_override=request_model_config,
                             )
                         )
 
@@ -3837,7 +4152,9 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                     process_result = await process_task
                 finally:
                     _restore_reasoning_variant_override(
-                        core, reasoning_variant_snapshot
+                        core,
+                        reasoning_variant_snapshot,
+                        model_config=request_model_config,
                     )
                 logger.info(
                     f"core.process finished. Result keys: {list(process_result.keys())}"
@@ -4556,6 +4873,9 @@ async def session_create(
     parent_id = body.get("parentID")
     permission = body.get("permission")
     agent_mode = body.get("agent_mode")
+    provider_id = body.get("providerID")
+    model_id = body.get("modelID")
+    variant = body.get("variant")
     if agent_mode is None:
         agent_mode = body.get("agentMode")
 
@@ -4565,6 +4885,12 @@ async def session_create(
         raise HTTPException(status_code=400, detail="parentID must be a string")
     if permission is not None and not isinstance(permission, list):
         raise HTTPException(status_code=400, detail="permission must be a list")
+    if provider_id is not None and not isinstance(provider_id, str):
+        raise HTTPException(status_code=400, detail="providerID must be a string")
+    if model_id is not None and not isinstance(model_id, str):
+        raise HTTPException(status_code=400, detail="modelID must be a string")
+    if variant is not None and not isinstance(variant, str):
+        raise HTTPException(status_code=400, detail="variant must be a string")
     normalized_agent_mode = _normalize_agent_mode(agent_mode)
     if agent_mode is not None and normalized_agent_mode is None:
         raise HTTPException(
@@ -4595,6 +4921,9 @@ async def session_create(
             directory=resolved_directory,
             permission=permission if isinstance(permission, list) else None,
             agent_mode=normalized_agent_mode,
+            provider_id=provider_id if isinstance(provider_id, str) else None,
+            model_id=model_id if isinstance(model_id, str) else None,
+            variant=variant if isinstance(variant, str) else None,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -4627,11 +4956,20 @@ async def session_update(
     title = body.get("title")
     archived = None
     agent_mode = body.get("agent_mode")
+    provider_id = body.get("providerID")
+    model_id = body.get("modelID")
+    variant = body.get("variant")
     if agent_mode is None:
         agent_mode = body.get("agentMode")
 
     if title is not None and not isinstance(title, str):
         raise HTTPException(status_code=400, detail="title must be a string")
+    if provider_id is not None and not isinstance(provider_id, str):
+        raise HTTPException(status_code=400, detail="providerID must be a string")
+    if model_id is not None and not isinstance(model_id, str):
+        raise HTTPException(status_code=400, detail="modelID must be a string")
+    if variant is not None and not isinstance(variant, str):
+        raise HTTPException(status_code=400, detail="variant must be a string")
     normalized_agent_mode = _normalize_agent_mode(agent_mode)
     if agent_mode is not None and normalized_agent_mode is None:
         raise HTTPException(
@@ -4655,6 +4993,9 @@ async def session_update(
         title=title if isinstance(title, str) else None,
         archived=archived,
         agent_mode=normalized_agent_mode,
+        provider_id=provider_id if isinstance(provider_id, str) else None,
+        model_id=model_id if isinstance(model_id, str) else None,
+        variant=variant if isinstance(variant, str) else None,
     )
     if updated is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -206,6 +206,16 @@ def _ensure_session_directory_map(core: PenguinCore) -> dict[str, str]:
     return session_dirs
 
 
+def _get_session_request_gate(core: PenguinCore, session_id: Optional[str]) -> asyncio.Lock:
+    """Return a REST request gate scoped to one session."""
+    gate_key = session_id or "__default__"
+    request_gates = getattr(core, "_opencode_request_gates", None)
+    if not isinstance(request_gates, dict):
+        request_gates = {}
+        setattr(core, "_opencode_request_gates", request_gates)
+    return request_gates.setdefault(gate_key, asyncio.Lock())
+
+
 def _bind_session_directory(
     core: PenguinCore,
     session_id: Optional[str],
@@ -444,6 +454,20 @@ def _request_log_info(message: str, *args: Any) -> None:
     uvicorn_logger = logging.getLogger("uvicorn.error")
     if uvicorn_logger is not logger:
         uvicorn_logger.info(message, *args)
+
+
+def _request_log_debug(message: str, *args: Any) -> None:
+    """Log verbose request-level traces via app and uvicorn logger."""
+    logger.info(message, *args)
+    uvicorn_logger = logging.getLogger("uvicorn.error")
+    if uvicorn_logger is not logger:
+        uvicorn_logger.info(message, *args)
+
+
+def _preview_text(value: Any, limit: int = 120) -> str:
+    text = value if isinstance(value, str) else str(value)
+    text = text.replace("\n", "\\n")
+    return text[:limit] + ("..." if len(text) > limit else "")
 
 
 async def _refresh_session_title_if_default(
@@ -3171,6 +3195,18 @@ async def handle_chat_message(
             agent_mode=resolved_agent_mode,
             directory=bound_directory or request.directory,
         )
+        _request_log_debug(
+            "chat.trace.start request=%s session=%s agent=%s mode=%s dir=%s model=%s streaming=%s client_msg=%s prompt=%r",
+            execution_context.request_id or "unknown",
+            request_session_id or "unknown",
+            request.agent_id or "default",
+            resolved_agent_mode,
+            bound_directory or request.directory,
+            request.model or "",
+            bool(request.streaming),
+            request.client_message_id or "",
+            _preview_text(request.text),
+        )
 
         requested_model = (
             request.model.strip() if isinstance(request.model, str) else ""
@@ -3331,11 +3367,18 @@ async def handle_chat_message(
 
         # Process the message with all available options
         with execution_context_scope(execution_context):
-            request_gate = getattr(core, "_opencode_request_gate", None)
-            if not isinstance(request_gate, asyncio.Lock):
-                request_gate = asyncio.Lock()
-                setattr(core, "_opencode_request_gate", request_gate)
-
+            request_gate = _get_session_request_gate(core, request_session_id)
+            _request_log_debug(
+                "chat.trace.before_process request=%s session=%s gate=%s cm=%s tracked=%s ctx=%s",
+                execution_context.request_id or "unknown",
+                request_session_id or "unknown",
+                hex(id(request_gate)),
+                hex(id(getattr(core, "conversation_manager", None)))
+                if getattr(core, "conversation_manager", None) is not None
+                else "none",
+                bool(request_tracked),
+                execution_context.as_dict(),
+            )
             async with request_gate:
                 process_result = await core.process(
                     input_data=input_data,
@@ -3347,6 +3390,14 @@ async def handle_chat_message(
                     streaming=effective_streaming,
                     stream_callback=stream_cb,
                 )
+            _request_log_debug(
+                "chat.trace.after_process request=%s session=%s response_len=%s actions=%s preview=%r",
+                execution_context.request_id or "unknown",
+                request_session_id or "unknown",
+                len(process_result.get("assistant_response", "") or ""),
+                len(process_result.get("action_results", []) or []),
+                _preview_text(process_result.get("assistant_response", "")),
+            )
 
         # Build response
         if request_session_id:
@@ -3362,9 +3413,21 @@ async def handle_chat_message(
         }
         if request.include_reasoning:
             resp["reasoning"] = "".join(reasoning_buf)
+        _request_log_debug(
+            "chat.trace.response request=%s session=%s response_len=%s aborted=%s preview=%r",
+            execution_context.request_id or "unknown",
+            request_session_id or "unknown",
+            len(resp.get("response", "") or ""),
+            bool(resp.get("aborted")),
+            _preview_text(resp.get("response", "")),
+        )
         return resp
     except asyncio.CancelledError:
-        logger.info("Chat request cancelled for session %s", request_session_id)
+        _request_log_info(
+            "chat.trace.cancelled request=%s session=%s",
+            execution_context.request_id if "execution_context" in locals() else "unknown",
+            request_session_id or "unknown",
+        )
         return {"response": "", "action_results": [], "aborted": True}
     except HTTPException:
         raise
@@ -3782,7 +3845,11 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
 
                 # Finalize streaming message (adds to conversation with reasoning)
                 if hasattr(core, "finalize_streaming_message"):
-                    core.finalize_streaming_message()
+                    core.finalize_streaming_message(
+                        agent_id=agent_id,
+                        session_id=effective_session_id,
+                        conversation_id=effective_session_id,
+                    )
                     logger.debug("Finalized streaming message with reasoning")
 
                 # Signal sender task to finish *after* core.process is done

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -3694,6 +3694,8 @@ async def handle_chat_message(
             _queue_session_title_refresh(
                 core,
                 request_session_id,
+                provider_id=getattr(request_model_config, "provider", None),
+                model_id=getattr(request_model_config, "model", None),
                 fallback_text=request.text if isinstance(request.text, str) else None,
             )
 

--- a/penguin/web/services/session_summary.py
+++ b/penguin/web/services/session_summary.py
@@ -241,6 +241,20 @@ async def summarize_session_title(
     if existing is None:
         return None
 
+    effective_provider_id = provider_id
+    if not isinstance(effective_provider_id, str) or not effective_provider_id.strip():
+        session_provider = (
+            existing.get("providerID") if isinstance(existing, dict) else None
+        )
+        effective_provider_id = (
+            session_provider if isinstance(session_provider, str) else None
+        )
+
+    effective_model_id = model_id
+    if not isinstance(effective_model_id, str) or not effective_model_id.strip():
+        session_model = existing.get("modelID") if isinstance(existing, dict) else None
+        effective_model_id = session_model if isinstance(session_model, str) else None
+
     explicit_title = get_session_metadata_title(core, session_id)
     if explicit_title is None:
         return None
@@ -257,8 +271,8 @@ async def summarize_session_title(
     generated = await _generate_title_with_model(
         core,
         snippets=snippets,
-        provider_id=provider_id,
-        model_id=model_id,
+        provider_id=effective_provider_id,
+        model_id=effective_model_id,
     )
     source = "generated" if generated else "heuristic"
     title = generated or _heuristic_title(snippets, session_id)

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -1027,40 +1027,14 @@ def get_session_messages(
             continue
         legacy_rows.append(_legacy_message_to_with_parts(core, session, message))
 
-    if not rows:
-        rows = legacy_rows
-    elif legacy_rows:
-        transcript_by_id: dict[str, dict[str, Any]] = {}
-        for row in rows:
-            info = row.get("info") if isinstance(row, dict) else None
-            message_id = info.get("id") if isinstance(info, dict) else None
-            if isinstance(message_id, str):
-                transcript_by_id[message_id] = row
+    if rows:
+        if limit is not None and limit > 0:
+            return rows[-limit:]
+        return rows
 
-        merged_rows: list[dict[str, Any]] = []
-        merged_ids: set[str] = set()
-        for legacy_row in legacy_rows:
-            info = legacy_row.get("info") if isinstance(legacy_row, dict) else None
-            message_id = info.get("id") if isinstance(info, dict) else None
-            if isinstance(message_id, str) and message_id in transcript_by_id:
-                merged_rows.append(transcript_by_id[message_id])
-                merged_ids.add(message_id)
-                continue
-            merged_rows.append(legacy_row)
-            if isinstance(message_id, str):
-                merged_ids.add(message_id)
-
-        for row in rows:
-            info = row.get("info") if isinstance(row, dict) else None
-            message_id = info.get("id") if isinstance(info, dict) else None
-            if isinstance(message_id, str) and message_id in merged_ids:
-                continue
-            merged_rows.append(row)
-            if isinstance(message_id, str):
-                merged_ids.add(message_id)
-
-        rows = merged_rows
+    rows = legacy_rows
 
     if limit is not None and limit > 0:
         return rows[-limit:]
     return rows
+

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -17,6 +17,9 @@ AGENT_MODE_KEY = "_opencode_agent_mode_v1"
 REVERT_KEY = "_opencode_revert_v1"
 SUMMARY_KEY = "_opencode_summary_v1"
 REVERT_SNAPSHOT_KEY = "_opencode_revert_snapshot_v1"
+MODEL_ID_KEY = "_opencode_model_id_v1"
+PROVIDER_ID_KEY = "_opencode_provider_id_v1"
+VARIANT_KEY = "_opencode_variant_v1"
 
 _TODO_STATUS_VALUES = {"pending", "in_progress", "completed", "cancelled"}
 _TODO_PRIORITY_VALUES = {"high", "medium", "low"}
@@ -29,6 +32,62 @@ def _normalize_agent_mode(value: Any) -> Optional[str]:
     if normalized in {"plan", "build"}:
         return normalized
     return None
+
+
+def _normalize_non_empty_string(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _resolve_session_model_state(
+    core: Any,
+    session: Any,
+    message: Any | None = None,
+) -> dict[str, Optional[str]]:
+    """Resolve model/provider/variant from message, then session, then global fallback."""
+    session_meta_raw = getattr(session, "metadata", None)
+    session_meta = session_meta_raw if isinstance(session_meta_raw, dict) else {}
+    message_meta_raw = (
+        getattr(message, "metadata", None) if message is not None else None
+    )
+    message_meta = message_meta_raw if isinstance(message_meta_raw, dict) else {}
+    message_model = message_meta.get("model")
+    message_model_dict = message_model if isinstance(message_model, dict) else {}
+
+    provider_id = (
+        _normalize_non_empty_string(message_meta.get("providerID"))
+        or _normalize_non_empty_string(message_meta.get("provider_id"))
+        or _normalize_non_empty_string(message_model_dict.get("providerID"))
+        or _normalize_non_empty_string(session_meta.get(PROVIDER_ID_KEY))
+        or _normalize_non_empty_string(session_meta.get("providerID"))
+        or _normalize_non_empty_string(session_meta.get("provider_id"))
+        or _normalize_non_empty_string(
+            getattr(getattr(core, "model_config", None), "provider", None)
+        )
+    )
+    model_id = (
+        _normalize_non_empty_string(message_meta.get("modelID"))
+        or _normalize_non_empty_string(message_meta.get("model_id"))
+        or _normalize_non_empty_string(message_model_dict.get("modelID"))
+        or _normalize_non_empty_string(session_meta.get(MODEL_ID_KEY))
+        or _normalize_non_empty_string(session_meta.get("modelID"))
+        or _normalize_non_empty_string(session_meta.get("model_id"))
+        or _normalize_non_empty_string(
+            getattr(getattr(core, "model_config", None), "model", None)
+        )
+    )
+    variant = (
+        _normalize_non_empty_string(message_meta.get("variant"))
+        or _normalize_non_empty_string(session_meta.get(VARIANT_KEY))
+        or _normalize_non_empty_string(session_meta.get("variant"))
+    )
+    return {
+        "providerID": provider_id,
+        "modelID": model_id,
+        "variant": variant,
+    }
 
 
 def _iso_to_ms(value: Optional[str]) -> int:
@@ -149,6 +208,14 @@ def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]
         },
     }
 
+    model_state = _resolve_session_model_state(core, session)
+    if model_state["providerID"]:
+        payload["providerID"] = model_state["providerID"]
+    if model_state["modelID"]:
+        payload["modelID"] = model_state["modelID"]
+    if model_state["variant"]:
+        payload["variant"] = model_state["variant"]
+
     if isinstance(metadata, dict):
         metadata_agent_mode = _normalize_agent_mode(
             metadata.get(AGENT_MODE_KEY) or metadata.get("agent_mode")
@@ -262,6 +329,9 @@ def create_session_info(
     directory: str | None = None,
     permission: list[dict[str, Any]] | None = None,
     agent_mode: str | None = None,
+    provider_id: str | None = None,
+    model_id: str | None = None,
+    variant: str | None = None,
 ) -> dict[str, Any]:
     """Create a session and return OpenCode Session.Info payload."""
     manager = _manager_for_new_session(core, parent_id=parent_id)
@@ -285,6 +355,15 @@ def create_session_info(
     normalized_agent_mode = _normalize_agent_mode(agent_mode)
     if normalized_agent_mode:
         metadata[AGENT_MODE_KEY] = normalized_agent_mode
+    normalized_provider = _normalize_non_empty_string(provider_id)
+    if normalized_provider:
+        metadata[PROVIDER_ID_KEY] = normalized_provider
+    normalized_model = _normalize_non_empty_string(model_id)
+    if normalized_model:
+        metadata[MODEL_ID_KEY] = normalized_model
+    normalized_variant = _normalize_non_empty_string(variant)
+    if normalized_variant:
+        metadata[VARIANT_KEY] = normalized_variant
 
     manager.mark_session_modified(session.id)
     manager.save_session(session)
@@ -299,6 +378,9 @@ def update_session_info(
     title: str | None = None,
     archived: int | None = None,
     agent_mode: str | None = None,
+    provider_id: str | None = None,
+    model_id: str | None = None,
+    variant: str | None = None,
 ) -> Optional[dict[str, Any]]:
     """Update a session and return OpenCode Session.Info payload."""
     session, manager = _find_session(core, session_id)
@@ -326,6 +408,18 @@ def update_session_info(
     normalized_agent_mode = _normalize_agent_mode(agent_mode)
     if normalized_agent_mode:
         metadata[AGENT_MODE_KEY] = normalized_agent_mode
+    normalized_provider = _normalize_non_empty_string(provider_id)
+    if normalized_provider:
+        metadata[PROVIDER_ID_KEY] = normalized_provider
+    normalized_model = _normalize_non_empty_string(model_id)
+    if normalized_model:
+        metadata[MODEL_ID_KEY] = normalized_model
+    if variant is not None:
+        normalized_variant = _normalize_non_empty_string(variant)
+        if normalized_variant:
+            metadata[VARIANT_KEY] = normalized_variant
+        else:
+            metadata.pop(VARIANT_KEY, None)
 
     manager.mark_session_modified(session.id)
     manager.save_session(session)
@@ -560,42 +654,6 @@ def _directory_matches(left: str, right: str) -> bool:
         return False
 
 
-def _git_project_key(
-    directory: str,
-    cache: dict[str, Optional[str]],
-) -> Optional[str]:
-    """Return stable git/worktree identity key for directory filtering."""
-    cached = cache.get(directory)
-    if cached is not None or directory in cache:
-        return cached
-
-    top_level = _run_git(["rev-parse", "--show-toplevel"], directory)
-    if not top_level:
-        cache[directory] = None
-        return None
-
-    common_dir = _run_git(["rev-parse", "--git-common-dir"], directory)
-    if common_dir:
-        common_path = Path(common_dir)
-        if not common_path.is_absolute():
-            common_path = Path(directory) / common_path
-        try:
-            common_resolved = common_path.expanduser().resolve()
-        except Exception:
-            common_resolved = common_path.expanduser()
-        key = f"git:{common_resolved}"
-        cache[directory] = key
-        return key
-
-    try:
-        top_resolved = Path(top_level).expanduser().resolve()
-    except Exception:
-        top_resolved = Path(top_level).expanduser()
-    key = f"root:{top_resolved}"
-    cache[directory] = key
-    return key
-
-
 def _session_directory(core: Any, session: Any) -> str:
     metadata = getattr(session, "metadata", {})
     if isinstance(metadata, dict):
@@ -701,12 +759,6 @@ def list_session_infos(
     results: list[dict[str, Any]] = []
     lowered_search = search.lower() if search else None
     normalized_directory = _normalize_existing_directory(directory)
-    project_cache: dict[str, Optional[str]] = {}
-    requested_project_key = (
-        _git_project_key(normalized_directory, project_cache)
-        if normalized_directory
-        else None
-    )
 
     for manager in _iter_session_managers(core):
         index = getattr(manager, "session_index", {})
@@ -735,14 +787,7 @@ def list_session_infos(
                 if not session_directory:
                     continue
                 if not _directory_matches(session_directory, normalized_directory):
-                    if not requested_project_key:
-                        continue
-                    session_project_key = _git_project_key(
-                        session_directory,
-                        project_cache,
-                    )
-                    if session_project_key != requested_project_key:
-                        continue
+                    continue
             if start is not None and info["time"]["updated"] < start:
                 continue
             if lowered_search and lowered_search not in info["title"].lower():
@@ -792,22 +837,20 @@ def _default_assistant_info(
     message_id: str,
     *,
     agent_id: str | None = None,
+    session: Any | None = None,
 ) -> dict[str, Any]:
     """Build a minimal valid assistant info envelope."""
     now = int(datetime.now().timestamp() * 1000)
     cwd = str(Path.cwd())
+    model_state = _resolve_session_model_state(core, session or object())
     return {
         "id": message_id,
         "sessionID": session_id,
         "role": "assistant",
         "time": {"created": now},
         "parentID": "root",
-        "modelID": getattr(
-            getattr(core, "model_config", None), "model", "penguin-default"
-        ),
-        "providerID": getattr(
-            getattr(core, "model_config", None), "provider", "penguin"
-        ),
+        "modelID": model_state["modelID"] or "penguin-default",
+        "providerID": model_state["providerID"] or "penguin",
         "mode": "chat",
         "agent": agent_id.strip()
         if isinstance(agent_id, str) and agent_id.strip()
@@ -820,6 +863,7 @@ def _default_assistant_info(
             "reasoning": 0,
             "cache": {"read": 0, "write": 0},
         },
+        **({"variant": model_state["variant"]} if model_state["variant"] else {}),
     }
 
 
@@ -834,6 +878,7 @@ def _legacy_message_to_with_parts(
     created = created or int(datetime.now().timestamp() * 1000)
     content = getattr(message, "content", "")
     text = content if isinstance(content, str) else str(content)
+    model_state = _resolve_session_model_state(core, session, message)
 
     if role == "user":
         info = {
@@ -843,13 +888,10 @@ def _legacy_message_to_with_parts(
             "time": {"created": created},
             "agent": getattr(message, "agent_id", None) or "default",
             "model": {
-                "providerID": getattr(
-                    getattr(core, "model_config", None), "provider", "penguin"
-                ),
-                "modelID": getattr(
-                    getattr(core, "model_config", None), "model", "penguin-default"
-                ),
+                "providerID": model_state["providerID"] or "penguin",
+                "modelID": model_state["modelID"] or "penguin-default",
             },
+            **({"variant": model_state["variant"]} if model_state["variant"] else {}),
         }
     else:
         message_agent = getattr(message, "agent_id", None)
@@ -862,8 +904,15 @@ def _legacy_message_to_with_parts(
             session_id,
             message_id,
             agent_id=message_agent if isinstance(message_agent, str) else None,
+            session=session,
         )
         info["time"] = {"created": created, "completed": created}
+        if model_state["providerID"]:
+            info["providerID"] = model_state["providerID"]
+        if model_state["modelID"]:
+            info["modelID"] = model_state["modelID"]
+        if model_state["variant"]:
+            info["variant"] = model_state["variant"]
 
     part = {
         "id": f"part_{message_id}_0",
@@ -1037,4 +1086,3 @@ def get_session_messages(
     if limit is not None and limit > 0:
         return rows[-limit:]
     return rows
-

--- a/tests/api/test_concurrent_session_isolation.py
+++ b/tests/api/test_concurrent_session_isolation.py
@@ -109,6 +109,11 @@ async def test_parallel_chat_requests_keep_execution_context_isolated(
     repo_b.mkdir()
 
     captured_contexts: list[tuple[str | None, str | None]] = []
+    entered_sessions: list[str] = []
+    both_started = asyncio.Event()
+    release_process = asyncio.Event()
+    active_calls = 0
+    max_active_calls = 0
 
     class _Core:
         def __init__(self) -> None:
@@ -121,11 +126,21 @@ async def test_parallel_chat_requests_keep_execution_context_isolated(
 
         async def process(self, **kwargs):  # type: ignore[no-untyped-def]
             del kwargs
+            nonlocal active_calls, max_active_calls
             current = get_current_execution_context()
             session_id = current.session_id if current else None
             directory = current.directory if current else None
             captured_contexts.append((session_id, directory))
-            await asyncio.sleep(0.02)
+            if isinstance(session_id, str):
+                entered_sessions.append(session_id)
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+            if len(entered_sessions) >= 2:
+                both_started.set()
+            try:
+                await release_process.wait()
+            finally:
+                active_calls -= 1
             return {
                 "assistant_response": f"session={session_id}|dir={directory}",
                 "action_results": [],
@@ -143,10 +158,14 @@ async def test_parallel_chat_requests_keep_execution_context_isolated(
         )
         return await handle_chat_message(request, core=cast(Any, core))
 
-    response_a, response_b = await asyncio.gather(
-        _send("chat_session_a", repo_a),
-        _send("chat_session_b", repo_b),
-    )
+    task_a = asyncio.create_task(_send("chat_session_a", repo_a))
+    task_b = asyncio.create_task(_send("chat_session_b", repo_b))
+    try:
+        await asyncio.wait_for(both_started.wait(), timeout=0.2)
+        assert max_active_calls == 2
+    finally:
+        release_process.set()
+    response_a, response_b = await asyncio.gather(task_a, task_b)
 
     assert str(repo_a.resolve()) in response_a["response"]
     assert str(repo_b.resolve()) in response_b["response"]
@@ -625,7 +644,9 @@ async def test_rest_chat_queued_request_returns_aborted_when_cancelled(
             )
             self._opencode_session_directories: dict[str, str] = {}
             self._opencode_process_tasks: dict[str, set[asyncio.Task[Any]]] = {}
-            self._opencode_request_gate = asyncio.Lock()
+            self._opencode_request_gates = {
+                "session_queued_cancel": asyncio.Lock()
+            }
 
         async def process(self, **kwargs):  # type: ignore[no-untyped-def]
             del kwargs
@@ -633,7 +654,7 @@ async def test_rest_chat_queued_request_returns_aborted_when_cancelled(
             return {"assistant_response": "ok", "action_results": []}
 
     core = _Core()
-    await core._opencode_request_gate.acquire()
+    await core._opencode_request_gates["session_queued_cancel"].acquire()
 
     request = MessageRequest(
         text="queued cancel",
@@ -662,7 +683,7 @@ async def test_rest_chat_queued_request_returns_aborted_when_cancelled(
     tracked_after = core._opencode_process_tasks.get("session_queued_cancel")
     assert not tracked_after or request_task not in tracked_after
 
-    core._opencode_request_gate.release()
+    core._opencode_request_gates["session_queued_cancel"].release()
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_find_file_routes.py
+++ b/tests/api/test_find_file_routes.py
@@ -188,3 +188,47 @@ def test_find_file_uses_session_directory_request_for_fallback(tmp_path: Path) -
         fallback = client.get("/find/file", params={"query": "readme"})
         assert fallback.status_code == 200
         assert "README.md" in fallback.json()
+
+
+def test_find_file_uses_bound_session_directory_over_raw_directory(
+    tmp_path: Path,
+) -> None:
+    _clear_find_cache()
+    repo_a = tmp_path / "repo_find_bound_a"
+    repo_b = tmp_path / "repo_find_bound_b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    (repo_a / "alpha.md").write_text("a", encoding="utf-8")
+    (repo_b / "beta.md").write_text("b", encoding="utf-8")
+
+    core = _Core(tmp_path)
+    core._opencode_session_directories["session_bound"] = str(repo_a)
+    with _build_client(core) as client:
+        response = client.get(
+            "/find/file",
+            params={"session_id": "session_bound", "query": "alpha"},
+        )
+        assert response.status_code == 200
+        assert response.json() == ["alpha.md"]
+
+
+def test_find_file_rejects_mismatched_session_directory(tmp_path: Path) -> None:
+    _clear_find_cache()
+    repo_a = tmp_path / "repo_find_conflict_a"
+    repo_b = tmp_path / "repo_find_conflict_b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+    (repo_a / "alpha.md").write_text("a", encoding="utf-8")
+
+    core = _Core(tmp_path)
+    core._opencode_session_directories["session_conflict"] = str(repo_a)
+    with _build_client(core) as client:
+        response = client.get(
+            "/find/file",
+            params={
+                "session_id": "session_conflict",
+                "directory": str(repo_b),
+                "query": "alpha",
+            },
+        )
+        assert response.status_code == 409

--- a/tests/api/test_opencode_session_routes.py
+++ b/tests/api/test_opencode_session_routes.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, cast
 import pytest
 from fastapi import HTTPException
 
-from penguin.system.state import Session
+from penguin.system.state import Message, MessageCategory, Session
 from penguin.web.routes import (
     api_session_abort,
     api_session_create,
@@ -26,6 +26,7 @@ from penguin.web.routes import (
     session_diff,
     session_get,
     session_list,
+    session_messages,
     session_summarize,
     session_todo,
     session_status,
@@ -245,12 +246,69 @@ async def test_session_alias_endpoints_work(tmp_path: Path) -> None:
     todos = await api_session_todo(session_id, core=typed_core)
     assert len(todos) == 1
     assert todos[0]["content"] == "Verify alias todo endpoint"
-
     diffs = await api_session_diff(session_id, core=typed_core, messageID=None)
     assert isinstance(diffs, list)
 
     deleted = await api_session_delete(session_id, core=typed_core)
     assert deleted is True
+
+
+@pytest.mark.asyncio
+async def test_session_messages_prefer_transcript_over_legacy_rows(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    typed_core = cast(Any, core)
+
+    created = await session_create(
+        payload={"title": "Transcript Wins"},
+        core=typed_core,
+        directory=str(tmp_path),
+    )
+    session_id = created["id"]
+
+    manager = core.conversation_manager.session_manager
+    session_obj = manager.load_session(session_id)
+    assert session_obj is not None
+
+    session_obj.metadata[TRANSCRIPT_KEY] = {
+        "order": ["msg_transcript"],
+        "messages": {
+            "msg_transcript": {
+                "info": {
+                    "id": "msg_transcript",
+                    "sessionID": session_id,
+                    "role": "assistant",
+                    "time": {"created": 1, "completed": 2},
+                },
+                "part_order": ["part_transcript"],
+                "parts": {
+                    "part_transcript": {
+                        "id": "part_transcript",
+                        "sessionID": session_id,
+                        "messageID": "msg_transcript",
+                        "type": "text",
+                        "text": "authoritative transcript response",
+                    }
+                },
+            }
+        },
+    }
+
+    session_obj.messages.append(
+        Message(
+            role="assistant",
+            content="polluted legacy response",
+            category=MessageCategory.DIALOG,
+        )
+    )
+
+    messages = await session_messages(session_id, core=typed_core, limit=None)
+
+    assert messages is not None
+    assert len(messages) == 1
+    assert messages[0]["info"]["id"] == "msg_transcript"
+    assert messages[0]["parts"][0]["text"] == "authoritative transcript response"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -568,6 +568,49 @@ async def test_summarize_session_title_prefers_model_generation(
 
 
 @pytest.mark.asyncio
+async def test_summarize_session_title_prefers_session_model_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _session("session_summary_meta", "Session 1234", "2026-02-03T00:00:00")
+    session.metadata["_opencode_provider_id_v1"] = "openrouter"
+    session.metadata["_opencode_model_id_v1"] = "z-ai/glm-5-turbo"
+    session.messages.append(
+        Message(
+            id="msg_user",
+            role="user",
+            content="Implement session restore parity",
+            category=MessageCategory.DIALOG,
+            timestamp="2026-02-03T00:00:00",
+        )
+    )
+    core = _core([session])
+    core.model_config = SimpleNamespace(model="z-ai/glm-4.7", provider="openrouter")
+    seen_model_config: dict[str, str | None] = {}
+
+    class _FakeAPIClient:
+        def __init__(self, model_config):
+            seen_model_config["model"] = getattr(model_config, "model", None)
+            seen_model_config["provider"] = getattr(model_config, "provider", None)
+
+        async def get_response(self, messages, **kwargs):
+            del messages, kwargs
+            return "Session restore parity"
+
+    monkeypatch.setattr(
+        "penguin.web.services.session_summary.APIClient", _FakeAPIClient
+    )
+
+    result = await summarize_session_title(core, session.id)
+
+    assert result is not None
+    assert result["changed"] is True
+    assert seen_model_config == {
+        "model": "z-ai/glm-5-turbo",
+        "provider": "openrouter",
+    }
+
+
+@pytest.mark.asyncio
 async def test_summarize_session_title_falls_back_to_heuristic(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -12,11 +12,14 @@ import pytest
 from penguin.system.state import Message, MessageCategory, Session
 from penguin.web.services.session_summary import summarize_session_title
 from penguin.web.services.session_view import (
+    MODEL_ID_KEY,
+    PROVIDER_ID_KEY,
     REVERT_KEY,
     SUMMARY_KEY,
     TODO_KEY,
     TRANSCRIPT_KEY,
     USAGE_KEY,
+    VARIANT_KEY,
     create_session_info,
     get_session_diff,
     get_session_info,
@@ -121,7 +124,7 @@ def test_list_session_infos_sorted_and_filtered():
     assert [item["id"] for item in filtered] == ["session_a"]
 
 
-def test_list_session_infos_directory_filter_matches_same_git_project(
+def test_list_session_infos_directory_filter_matches_exact_directory_only(
     tmp_path: Path,
 ):
     project_root = tmp_path / "project"
@@ -164,7 +167,7 @@ def test_list_session_infos_directory_filter_matches_same_git_project(
 
     result = list_session_infos(core, directory=str(alpha_dir))
 
-    assert {item["id"] for item in result} == {"session_alpha", "session_beta"}
+    assert [item["id"] for item in result] == ["session_alpha"]
 
 
 def test_list_session_infos_directory_filter_falls_back_to_exact_directory(
@@ -416,7 +419,7 @@ def test_get_session_messages_legacy_assistant_uses_session_agent_fallback():
     assert messages[0]["info"]["agent"] == "child-fallback"
 
 
-def test_get_session_messages_merges_transcript_with_legacy_rows():
+def test_get_session_messages_prefers_transcript_over_legacy_rows():
     now = datetime.now().isoformat()
     session = _session("session_merge", "Merged Session", now)
     session.messages.append(
@@ -478,9 +481,8 @@ def test_get_session_messages_merges_transcript_with_legacy_rows():
     messages = get_session_messages(core, session.id)
 
     assert messages is not None
-    assert [item["info"]["id"] for item in messages] == ["msg_user", "msg_assistant"]
-    assert messages[0]["parts"][0]["text"] == "hello"
-    assert messages[1]["parts"][0]["text"] == "assistant from transcript"
+    assert [item["info"]["id"] for item in messages] == ["msg_assistant"]
+    assert messages[0]["parts"][0]["text"] == "assistant from transcript"
 
 
 def test_session_todo_round_trip():
@@ -765,12 +767,18 @@ def test_create_update_remove_session_info_round_trip():
                 "action": "allow",
             }
         ],
+        provider_id="openrouter",
+        model_id="z-ai/glm-5-turbo",
+        variant="high",
     )
 
     session_id = created["id"]
     assert created["title"] == "Created Session"
     assert created["directory"] == "/tmp/workspace/project"
     assert created["parentID"] == "parent_1"
+    assert created["providerID"] == "openrouter"
+    assert created["modelID"] == "z-ai/glm-5-turbo"
+    assert created["variant"] == "high"
     assert isinstance(created["time"]["created"], int)
 
     updated = update_session_info(
@@ -778,13 +786,60 @@ def test_create_update_remove_session_info_round_trip():
         session_id,
         title="Renamed Session",
         archived=123456789,
+        provider_id="openrouter",
+        model_id="qwen/qwen3.5-plus-02-15",
+        variant="max",
     )
     assert updated is not None
     assert updated["title"] == "Renamed Session"
     assert updated["time"]["archived"] == 123456789
+    assert updated["providerID"] == "openrouter"
+    assert updated["modelID"] == "qwen/qwen3.5-plus-02-15"
+    assert updated["variant"] == "max"
 
     assert remove_session_info(core, session_id) is True
     assert get_session_info(core, session_id) is None
+
+
+def test_legacy_message_projection_prefers_session_model_metadata() -> None:
+    session = _session("session_model_meta", "Model Metadata", "2026-02-03T00:00:00")
+    session.metadata[PROVIDER_ID_KEY] = "openrouter"
+    session.metadata[MODEL_ID_KEY] = "z-ai/glm-5-turbo"
+    session.metadata[VARIANT_KEY] = "high"
+    session.messages.append(
+        Message(
+            id="msg_user_model_meta",
+            role="user",
+            content="hello",
+            category=MessageCategory.DIALOG,
+            timestamp="2026-02-03T00:00:00",
+        )
+    )
+    session.messages.append(
+        Message(
+            id="msg_assistant_model_meta",
+            role="assistant",
+            content="hi",
+            category=MessageCategory.DIALOG,
+            timestamp="2026-02-03T00:01:00",
+        )
+    )
+    core = _core([session])
+    core.model_config = SimpleNamespace(
+        model="global-model", provider="global-provider"
+    )
+
+    messages = get_session_messages(core, session.id)
+
+    assert messages is not None
+    user = messages[0]["info"]
+    assistant = messages[1]["info"]
+    assert user["model"]["providerID"] == "openrouter"
+    assert user["model"]["modelID"] == "z-ai/glm-5-turbo"
+    assert user["variant"] == "high"
+    assert assistant["providerID"] == "openrouter"
+    assert assistant["modelID"] == "z-ai/glm-5-turbo"
+    assert assistant["variant"] == "high"
 
 
 def test_list_session_statuses_prefers_busy_signals():

--- a/tests/test_core_opencode_stream_fallback.py
+++ b/tests/test_core_opencode_stream_fallback.py
@@ -51,3 +51,47 @@ async def test_on_tui_stream_chunk_synthesizes_final_content_when_no_delta() -> 
     ]
     deltas = [item.get("properties", {}).get("delta") for item in emitted]
     assert "fallback assistant text" in deltas
+
+def test_finalize_streaming_message_loads_target_session_before_persisting() -> None:
+    core = PenguinCore.__new__(PenguinCore)
+
+    finalized_message = SimpleNamespace(
+        role="assistant",
+        content="scoped response",
+        metadata={},
+        was_empty=False,
+        to_dict=lambda: {"content": "scoped response"},
+    )
+    core._stream_manager = SimpleNamespace(
+        finalize=lambda agent_id: (finalized_message, []),
+        get_active_agents=lambda: [],
+    )
+
+    load_calls: list[str] = []
+    add_calls: list[dict[str, object]] = []
+    save_calls: list[str] = []
+
+    conversation = SimpleNamespace(
+        session=SimpleNamespace(id="wrong-session"),
+        load=lambda session_id: load_calls.append(session_id) or True,
+        add_message=lambda **kwargs: add_calls.append(kwargs),
+        save=lambda: save_calls.append("saved") or True,
+    )
+    core.conversation_manager = SimpleNamespace(
+        current_agent_id="default",
+        get_agent_conversation=lambda agent_id: conversation,
+    )
+    core._runmode_stream_callback = None
+    core._filter_internal_markers_from_event = lambda data: data
+
+    result = PenguinCore.finalize_streaming_message(
+        core,
+        agent_id="default",
+        session_id="target-session",
+        conversation_id="target-session",
+    )
+
+    assert result == {"content": "scoped response"}
+    assert load_calls == ["target-session"]
+    assert add_calls and add_calls[0]["content"] == "scoped response"
+    assert save_calls == ["saved"]

--- a/tests/test_core_opencode_stream_fallback.py
+++ b/tests/test_core_opencode_stream_fallback.py
@@ -52,13 +52,20 @@ async def test_on_tui_stream_chunk_synthesizes_final_content_when_no_delta() -> 
     deltas = [item.get("properties", {}).get("delta") for item in emitted]
     assert "fallback assistant text" in deltas
 
-def test_finalize_streaming_message_loads_target_session_before_persisting() -> None:
+
+def test_finalize_streaming_message_persists_to_target_session_store() -> None:
     core = PenguinCore.__new__(PenguinCore)
 
     finalized_message = SimpleNamespace(
+        id="msg_finalized_1",
         role="assistant",
         content="scoped response",
         metadata={},
+        timestamp="2026-04-04T00:00:00",
+        tokens=0,
+        agent_id="default",
+        recipient_id=None,
+        message_type="message",
         was_empty=False,
         to_dict=lambda: {"content": "scoped response"},
     )
@@ -71,15 +78,30 @@ def test_finalize_streaming_message_loads_target_session_before_persisting() -> 
     add_calls: list[dict[str, object]] = []
     save_calls: list[str] = []
 
+    target_session = SimpleNamespace(
+        id="target-session",
+        messages=[],
+        metadata={},
+        add_message=lambda msg: target_session.messages.append(msg),
+    )
+
+    session_manager = SimpleNamespace(
+        sessions={"target-session": (target_session, False)},
+        session_index={"target-session": {}},
+        save_session=lambda session: save_calls.append(session.id) or True,
+    )
+
     conversation = SimpleNamespace(
         session=SimpleNamespace(id="wrong-session"),
         load=lambda session_id: load_calls.append(session_id) or True,
         add_message=lambda **kwargs: add_calls.append(kwargs),
-        save=lambda: save_calls.append("saved") or True,
+        save=lambda: save_calls.append("shared-save") or True,
     )
     core.conversation_manager = SimpleNamespace(
         current_agent_id="default",
         get_agent_conversation=lambda agent_id: conversation,
+        session_manager=session_manager,
+        agent_session_managers={"default": session_manager},
     )
     core._runmode_stream_callback = None
     core._filter_internal_markers_from_event = lambda data: data
@@ -92,6 +114,8 @@ def test_finalize_streaming_message_loads_target_session_before_persisting() -> 
     )
 
     assert result == {"content": "scoped response"}
-    assert load_calls == ["target-session"]
-    assert add_calls and add_calls[0]["content"] == "scoped response"
-    assert save_calls == ["saved"]
+    assert load_calls == []
+    assert add_calls == []
+    assert save_calls == ["target-session"]
+    assert len(target_session.messages) == 1
+    assert target_session.messages[0].content == "scoped response"

--- a/tests/test_core_tool_mapping.py
+++ b/tests/test_core_tool_mapping.py
@@ -872,3 +872,55 @@ async def test_persist_opencode_events_replays_tool_parts_in_order() -> None:
     assert rows is not None
     assert len(rows) == 1
     assert [part["id"] for part in rows[0]["parts"]] == ["part_text", "part_tool"]
+
+
+@pytest.mark.asyncio
+async def test_persist_opencode_event_uses_session_model_metadata_for_new_entry() -> (
+    None
+):
+    session = Session(id="session_track_model_meta")
+    session.metadata["_opencode_provider_id_v1"] = "openrouter"
+    session.metadata["_opencode_model_id_v1"] = "z-ai/glm-5-turbo"
+    session.metadata["_opencode_variant_v1"] = "high"
+    manager = _SessionManager(session)
+    conversation_manager = SimpleNamespace(
+        session_manager=manager,
+        agent_session_managers={"default": manager},
+    )
+
+    core = PenguinCore.__new__(PenguinCore)
+    setattr(core, "conversation_manager", conversation_manager)
+    setattr(
+        core,
+        "model_config",
+        SimpleNamespace(model="z-ai/glm-4.7", provider="openrouter"),
+    )
+    setattr(
+        core,
+        "runtime_config",
+        SimpleNamespace(active_root="/tmp/project", project_root="/tmp/project"),
+    )
+    setattr(core, "_opencode_session_directories", {session.id: "/tmp/project"})
+
+    await core._persist_opencode_event(
+        "message.part.updated",
+        {
+            "part": {
+                "id": "part_text",
+                "sessionID": session.id,
+                "messageID": "msg_1",
+                "type": "text",
+                "text": "hello",
+            }
+        },
+    )
+
+    transcript = session.metadata.get(TRANSCRIPT_KEY)
+    assert isinstance(transcript, dict)
+    message_entry = transcript.get("messages", {}).get("msg_1")
+    assert isinstance(message_entry, dict)
+    info = message_entry.get("info")
+    assert isinstance(info, dict)
+    assert info["providerID"] == "openrouter"
+    assert info["modelID"] == "z-ai/glm-5-turbo"
+    assert info["variant"] == "high"

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -101,9 +101,10 @@ def test_finalize_streaming_response_uses_finalized_content_without_duplicate_sa
     conversation.add_assistant_message.assert_not_called()
 
 
-
 @pytest.mark.asyncio
-async def test_call_llm_with_retry_skips_non_stream_retry_after_streamed_chunks() -> None:
+async def test_call_llm_with_retry_skips_non_stream_retry_after_streamed_chunks() -> (
+    None
+):
     engine = Engine(
         EngineSettings(),
         MagicMock(),
@@ -120,7 +121,9 @@ async def test_call_llm_with_retry_skips_non_stream_retry_after_streamed_chunks(
             assert stream_callback is not None
             await stream_callback("hello", "assistant")
             return ""
-        raise AssertionError("non-stream retry should not happen after streamed assistant chunks")
+        raise AssertionError(
+            "non-stream retry should not happen after streamed assistant chunks"
+        )
 
     api_client = SimpleNamespace(
         get_response=AsyncMock(side_effect=_fake_get_response),
@@ -172,6 +175,75 @@ def test_scoped_conversation_manager_clones_default_agent_session() -> None:
     assert scoped.get_current_session() is not base_session
     assert scoped.get_current_session().id == "session-a"
 
+
+def test_scoped_conversation_manager_is_reused_within_run_state() -> None:
+    base_session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=base_session,
+        save=MagicMock(return_value=True),
+        add_action_result=MagicMock(),
+    )
+    base_manager = SimpleNamespace(
+        core=None,
+        get_agent_conversation=MagicMock(return_value=conversation),
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=base_session),
+        agent_context_windows={},
+    )
+
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, base_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    with engine._run_state_scope("default"):
+        first = engine.get_conversation_manager("default")
+        second = engine.get_conversation_manager("default")
+
+    assert first is not None
+    assert second is not None
+    assert first is second
+
+
+def test_preloaded_scoped_conversation_manager_is_adopted_within_run_state() -> None:
+    base_session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=base_session,
+        save=MagicMock(return_value=True),
+        add_action_result=MagicMock(),
+    )
+    base_manager = SimpleNamespace(
+        core=None,
+        get_agent_conversation=MagicMock(return_value=conversation),
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=base_session),
+        agent_context_windows={},
+    )
+
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, base_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    preloaded = engine.get_conversation_manager("default")
+    assert preloaded is not None
+
+    with execution_context_scope(
+        ExecutionContext(session_id="session-a", request_id="req-1")
+    ):
+        engine.prime_scoped_conversation_manager("default", preloaded)
+        with engine._run_state_scope("default"):
+            adopted = engine.get_conversation_manager("default")
+
+    assert adopted is preloaded
+
+
 @pytest.mark.asyncio
 async def test_llm_step_returns_usage_from_active_api_client() -> None:
     conversation = SimpleNamespace(
@@ -221,6 +293,109 @@ async def test_llm_step_returns_usage_from_active_api_client() -> None:
         "total_tokens": 17,
         "cost": 0.0003,
     }
+
+
+@pytest.mark.asyncio
+async def test_run_response_uses_request_scoped_api_client_override() -> None:
+    session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=session,
+        get_formatted_messages=MagicMock(
+            return_value=[{"role": "user", "content": "hi"}]
+        ),
+        prepare_conversation=MagicMock(),
+        add_assistant_message=MagicMock(),
+        save=MagicMock(return_value=True),
+    )
+    conversation_manager = SimpleNamespace(
+        core=None,
+        conversation=conversation,
+        get_agent_conversation=lambda *args, **kwargs: conversation,
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=session),
+        agent_context_windows={},
+    )
+
+    default_api = SimpleNamespace(
+        get_response=AsyncMock(return_value="default"),
+        client_handler=SimpleNamespace(get_last_usage=MagicMock(return_value={})),
+    )
+    override_api = SimpleNamespace(
+        get_response=AsyncMock(return_value="override"),
+        client_handler=SimpleNamespace(get_last_usage=MagicMock(return_value={})),
+    )
+
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, conversation_manager),
+        cast(Any, default_api),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    result = await engine.run_response(
+        "hi",
+        streaming=False,
+        max_iterations=1,
+        api_client_override=cast(Any, override_api),
+    )
+
+    assert result["assistant_response"] == "override"
+    assert default_api.get_response.await_count == 0
+    assert override_api.get_response.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_response_repairs_malformed_partial_tool_output() -> None:
+    session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=session,
+        prepare_conversation=MagicMock(),
+        add_message=MagicMock(),
+        save=MagicMock(return_value=True),
+    )
+    conversation_manager = SimpleNamespace(
+        core=None,
+        conversation=conversation,
+        get_agent_conversation=lambda *args, **kwargs: conversation,
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=session),
+        agent_context_windows={},
+    )
+
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, conversation_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    engine._llm_step = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            {
+                "assistant_response": '-contract.md","show_line_numbers":true}</read_file>\n\n',
+                "action_results": [],
+                "usage": {},
+            },
+            {
+                "assistant_response": "Recovered answer",
+                "action_results": [
+                    {"action": "finish_response", "result": "", "status": "completed"}
+                ],
+                "usage": {},
+            },
+        ]
+    )
+    engine._save_conversation = AsyncMock()  # type: ignore[method-assign]
+
+    result = await engine.run_response("continue", streaming=False)
+
+    assert result["assistant_response"] == "Recovered answer"
+    assert result["iterations"] == 2
+    conversation.add_message.assert_called()
+    assert conversation.add_message.call_args.kwargs["metadata"]["type"] == (
+        "malformed_action_output"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -101,6 +101,77 @@ def test_finalize_streaming_response_uses_finalized_content_without_duplicate_sa
     conversation.add_assistant_message.assert_not_called()
 
 
+
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_skips_non_stream_retry_after_streamed_chunks() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    streamed: list[tuple[str, str]] = []
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        del messages, kwargs
+        if stream:
+            assert stream_callback is not None
+            await stream_callback("hello", "assistant")
+            return ""
+        raise AssertionError("non-stream retry should not happen after streamed assistant chunks")
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        client_handler=SimpleNamespace(),
+    )
+
+    async def _collector(chunk: str, message_type: str = "assistant") -> None:
+        streamed.append((chunk, message_type))
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=_collector,
+        extra_kwargs={},
+    )
+
+    assert result == ""
+    assert streamed == [("hello", "assistant")]
+    assert api_client.get_response.await_count == 1
+
+
+def test_scoped_conversation_manager_clones_default_agent_session() -> None:
+    base_session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=base_session,
+        save=MagicMock(return_value=True),
+        add_action_result=MagicMock(),
+    )
+    base_manager = SimpleNamespace(
+        core=None,
+        get_agent_conversation=MagicMock(return_value=conversation),
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=base_session),
+        agent_context_windows={},
+    )
+
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, base_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    scoped = engine.get_conversation_manager("default")
+    assert scoped is not None
+    assert scoped.conversation is not conversation
+    assert scoped.get_current_session() is not base_session
+    assert scoped.get_current_session().id == "session-a"
+
 @pytest.mark.asyncio
 async def test_llm_step_returns_usage_from_active_api_client() -> None:
     conversation = SimpleNamespace(

--- a/tests/test_part_event_persist_callback.py
+++ b/tests/test_part_event_persist_callback.py
@@ -125,6 +125,31 @@ async def test_tool_events_attach_to_completed_stream_message_when_available():
 
 
 @pytest.mark.asyncio
+async def test_stream_start_emits_model_provider_and_variant() -> None:
+    bus = _EventBus()
+    adapter = PartEventAdapter(bus)
+    adapter.set_session("session_model_meta")
+
+    await adapter.on_stream_start(
+        agent_id="default",
+        model_id="z-ai/glm-5-turbo",
+        provider_id="openrouter",
+        variant="high",
+    )
+
+    assistant_updates = [
+        item
+        for item in _opencode_events(bus, "message.updated")
+        if item.get("role") == "assistant"
+    ]
+    assert assistant_updates
+    latest = assistant_updates[-1]
+    assert latest["modelID"] == "z-ai/glm-5-turbo"
+    assert latest["providerID"] == "openrouter"
+    assert latest["variant"] == "high"
+
+
+@pytest.mark.asyncio
 async def test_update_assistant_usage_creates_missing_message_and_emits_update():
     bus = _EventBus()
     adapter = PartEventAdapter(bus)

--- a/tests/test_part_event_persist_callback.py
+++ b/tests/test_part_event_persist_callback.py
@@ -186,3 +186,18 @@ async def test_stream_keeps_literal_action_tag_text_without_truncation():
     final_text = text_parts[-1].get("text", "")
     assert "<spawn_sub_agent>" in final_text
     assert "Response should continue after the literal tag." in final_text
+
+
+def test_part_adapter_ids_include_session_scope() -> None:
+    bus = _EventBus()
+    adapter_a = PartEventAdapter(bus)
+    adapter_a.set_session("session-a")
+    adapter_b = PartEventAdapter(bus)
+    adapter_b.set_session("session-b")
+
+    id_a = adapter_a._next_id("msg")
+    id_b = adapter_b._next_id("msg")
+
+    assert id_a != id_b
+    assert "session_a" in id_a
+    assert "session_b" in id_b


### PR DESCRIPTION
## Summary
- Restore and harden OpenCode multi-session isolation on the Penguin web/TUI path.
- Keep session-scoped conversation state, directory scope, event routing, and request-local model/runtime bound to the active session all the way through `routes.py` -> `core.py` -> `engine.py`.
- Persist per-session model metadata so session restore, replay, transcript/event shaping, and title generation stop falling back to global runtime defaults.
## Problem
- Concurrent OpenCode sessions on one Penguin web server could bleed into each other.
- The bleed showed up in several layers:
- Message/event routing could cross session boundaries.
- Engine runs could re-derive conversation state from stale shared session pointers.
- `find/file` and related lookup paths could use the wrong repo/worktree.
- Model/provider selection could drift across sessions or be restored from global config instead of session state.
- Malformed partial tool output could be accepted as a successful completion, leaving a session in a broken state.
## What Changed
- Web/session boundary fixes:
- Narrowed request gating to `session_id` instead of relying on broader shared state.
- Tightened session-bound SSE/event handling and transcript-backed session history.
- Made `find/file` session-authoritative and reject mismatched `session_id` + `directory`.
- Enforced exact directory/worktree isolation instead of same-repo fallback behavior.
- Core/engine runtime fixes:
- Added request-local engine run state for scoped conversation reuse.
- Primed the engine with the already-loaded session conversation from `core.process()` so runs no longer re-enter through stale shared session state.
- Added request-local model/runtime overrides so one session’s active model does not mutate another session’s in-flight request.
- Persisted finalized streamed messages directly to the target session store instead of reloading shared conversation state first.
- TUI/session restore fixes:
- TUI session state now carries `providerID`, `modelID`, and `variant`.
- Session restore prefers session info over global `/config` or last-message heuristics.
- Session creation/update sends model metadata so the server can persist it with the session.
- Session-local model selection is preferred before global config fallback.
- Reliability guards:
- Added malformed partial tool-output detection and repair turns instead of treating dangling tool syntax as a valid completion.
- Added detailed request/session tracing mirrored to `uvicorn.error` for live debugging.
## Verification
- `pytest -q tests/api/test_concurrent_session_isolation.py tests/api/test_find_file_routes.py tests/api/test_opencode_session_routes.py tests/api/test_session_directory_binding.py tests/api/test_session_view_service.py tests/test_core_opencode_stream_fallback.py tests/test_engine_initialization.py tests/test_part_event_persist_callback.py tests/test_core_tool_mapping.py`
- `bun run typecheck`
## Notes
- Latest live repros indicate the original multi-session bleed is resolved on the main request path.
- Some provider-specific rough edges remain separate from session isolation, especially:
- timeouts / cold starts
- context or max-output negotiation failures
- models that emit malformed partial tool syntax and require repair turns
- Those reliability issues are intentionally left as follow-up work rather than folded into this isolation PR.