### PR TITLE
Honor exact workspace paths in project create

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -332,6 +332,11 @@ ProjectManager:
   └── Event Integration (progress events)
 ```
 
+Current runtime truth also includes:
+- task lifecycle state split across `status` and `phase`
+- typed dependency policies / artifact evidence carried on task records where relevant
+- clarification-aware execution that can pause in `waiting_input` and resume through `RunMode`, web routes, or `PenguinAPI`
+
 **Task Execution Flow:**
 1. Task created with dependencies
 2. Resources allocated

--- a/context/archive/reports/runmode-project-ituv-pr-summary.md
+++ b/context/archive/reports/runmode-project-ituv-pr-summary.md
@@ -1,0 +1,49 @@
+# RunMode / Project / ITUV Branch Summary
+
+## What This Branch Fixed
+
+- restored stricter task/runtime truth across RunMode, project orchestration, and ITUV-related flows
+- hardened clarification handling so non-terminal outcomes like `waiting_input` are preserved instead of flattened
+- improved status/phase visibility in task/web surfaces
+- added richer task/project payload truth for web/API consumers
+- fixed CLI/root normalization and related surface correctness issues
+- restored honest project/task listing behavior and related storage plumbing
+
+## What This Branch Verified
+
+### CLI surface
+- scripted verification for project/task help and lifecycle wording
+- status filter behavior
+- active-state start semantics
+- pending-review approval semantics
+- execution-root consistency across nested CLI commands
+
+### Web/API surface
+- scripted verification for health/task/project routes
+- richer task payload truth (`status`, `phase`, dependencies, dependency specs, artifact evidence, clarification metadata)
+- execute route preserving non-terminal `waiting_input` outcomes
+- clarification resume route behavior
+- clarification-related SSE/session visibility support
+
+### Clarification happy path
+- deterministic proof that a task can:
+  - execute
+  - reach `waiting_input`
+  - accept a clarification answer
+  - resume to a truthful post-clarification result
+
+## What This Branch Explicitly Deferred
+
+- deeper PenguinAPI surface refresh / ergonomics audit
+- CLI workspace semantics and broader interface ergonomics
+- project bootstrap workflow (`project init`, `project start`)
+- RunMode command / loop ownership audit (`--run`, `--247`, `--continuous`, RunMode vs Engine loop boundaries)
+- deeper verification hardening / reliability pass 2
+
+## Why The Deferred Split Matters
+
+This branch is the core-truth / verification pass.
+It should not keep expanding into CLI redesign, Python library refresh, or broader ergonomics work.
+
+The follow-up backlog for those areas lives in:
+- `context/tasks/todo.md`

--- a/context/process/blueprint.template.md
+++ b/context/process/blueprint.template.md
@@ -97,7 +97,12 @@ Rules:
 2) Indent subtasks by two spaces beneath their parent; importer treats them as child tasks.
 3) Use one or more "Acceptance:" bullets under a task for criteria (feeds VERIFY gate).
 4) Use a "Depends:" bullet listing upstream task idents (comma-separated) for DAG edges.
-5) Use a "Recipe:" bullet to reference a usage recipe by name (feeds USE gate).
+5) If you need typed dependency behavior, add a `Dependency Specs:` subsection with one entry per dependency, e.g.:
+   - `- task_id: <KEY-1>`
+     `  policy: artifact_ready`
+     `  artifact_key: client_bundle`
+6) Use a "Recipe:" bullet to reference a usage recipe by name (feeds USE gate).
+7) Expect structured Blueprint diagnostics/linting to flag missing acceptance criteria, missing dependencies, duplicate task IDs, and dependency cycles.
 -->
 
 - [ ] <KEY-1> Short, actionable task title {estimate=2, priority=medium, labels=backend, effort=2, value=4}
@@ -110,6 +115,10 @@ Rules:
 - [ ] <KEY-2> Another task title {estimate=3, priority=high, labels=api,security, assignees=@you, agent_role=implementer, skills=python,fastapi}
   - Acceptance: ...
   - Depends: <KEY-1>
+  - Dependency Specs:
+    - task_id: <KEY-1>
+      policy: artifact_ready
+      artifact_key: auth_openapi
   - Recipe: auth-flow
   - Description: ...
   

--- a/context/tasks/cli-refactor-and-bootstrap-audit.md
+++ b/context/tasks/cli-refactor-and-bootstrap-audit.md
@@ -1,0 +1,335 @@
+# CLI Refactor and Bootstrap Audit
+
+## Purpose
+
+This file defines the audit pass that should happen **before** deeper CLI ergonomics work,
+project bootstrap workflow work, or any serious decomposition of `penguin/cli/cli.py`.
+
+The goal is simple:
+- understand the current CLI structure
+- map the safest extraction seams
+- identify the highest-leverage UX fixes
+- sequence follow-up PRs without destabilizing working behavior
+
+This is not a rewrite plan disguised as an audit.
+It is the anti-chaos step that should happen before we start cutting up `cli.py`.
+
+## Why This Audit Exists
+
+The current CLI file is too large and too mixed in responsibility.
+
+Observed state:
+- `penguin/cli/cli.py` is ~4600 lines
+- top-level callback, environment setup, root/workspace handling, project/task commands,
+  runmode commands, formatting, and helper logic all live in one file
+- project bootstrap improvements (`project init`, `project start`) will become harder and riskier
+  if added directly into the current structure without a seam map first
+
+This creates three risks:
+1. **Behavioral drift** — new commands subtly break already-verified command paths
+2. **Scope sprawl** — ergonomics fixes quietly turn into a giant CLI rewrite
+3. **Review pain** — too many structural and semantic changes get mixed together
+
+## Current Constraints
+
+### Do Not Do First
+- do not rewrite `cli.py` wholesale
+- do not fold bootstrap workflow work into a broad refactor branch
+- do not extract modules speculatively without tests
+- do not change core RunMode / ITUV truth in the name of “nicer UX”
+
+### Preserve
+- current verified CLI surface truth
+- current root/workspace normalization behavior
+- active vs running wording corrections
+- pending-review approval semantics
+- clarification-related runtime truth
+
+## Files To Audit
+
+### Primary
+- `penguin/cli/cli.py`
+- `context/tasks/cli-interface-ergonomics-plan.md`
+- `context/tasks/project-bootstrap-workflow.md`
+- `context/tasks/cli-surface-audit.md`
+- `context/tasks/todo.md`
+
+### Secondary
+- `penguin/run_mode.py`
+- `penguin/engine.py`
+- `penguin/project/manager.py`
+- `penguin/web/routes.py`
+- CLI-related tests under `tests/`
+
+## Audit Findings
+
+### Structural map
+Current high-value landmarks in `penguin/cli/cli.py`:
+- global Typer app setup around `cli.py:305`
+- top-level callback / main entrypoint at `cli.py:831-980`
+- global initialization helper at `cli.py:419-560`
+- runmode dispatch helper at `cli.py:1234-1354`
+- `project create` at `cli.py:2568-2606`
+- `project list` at `cli.py:2609-2663`
+- `task create` at `cli.py:2827-2868`
+- `task list` at `cli.py:2871-2915`
+- legacy/interactive `PenguinCLI` class at `cli.py:3096+`
+
+### Current public-surface shape
+- There is no dedicated runmode command group today.
+- Runmode is exposed via top-level flags on `main_entry(...)`:
+  - `--run`
+  - `--247`
+  - `--continuous`
+- Project/task commands exist as Typer command groups, but bootstrap workflow commands do not yet exist.
+
+### Confirmed pain points
+#### 1. `project create --workspace` honesty gap is real
+- `project create` exposes `--workspace` at `cli.py:2573-2575`
+- implementation ignores it and relies on manager-controlled workspace behavior at `cli.py:2590-2593`
+- this is a surface-contract lie, not just missing polish
+
+#### 2. Execution root vs project workspace remains muddy
+- top-level callback normalizes execution root/workspace before initialization
+- project creation output prints only the resulting project workspace path
+- users do not get a clear explanation of the difference between:
+  - execution root
+  - managed Penguin workspace
+  - project workspace path
+
+#### 3. Help/discoverability is still weaker than it should be
+- runmode is hidden behind top-level flags instead of an obvious command group
+- project/task commands exist, but the likely happy-path workflow is not obvious from the command surface
+
+#### 4. Some command help text still carries stale semantics
+- `task list` still advertises old status examples in its help text (`pending, running, completed, failed`) instead of the fuller current lifecycle vocabulary
+
+#### 5. `project list` does N+1 task counting
+- current implementation fetches task lists per project row to compute task counts
+- this is not the highest-priority ergonomics problem, but it is a cleanup target once semantics are stable
+
+## Known CLI Hotspots
+
+From current inspection:
+- `@app.callback(...)` / main entrypoint around `cli.py:831`
+- `_handle_run_mode(...)` around `cli.py:1234`
+- `project create` around `cli.py:2568`
+- `project list` around `cli.py:2609`
+- `task create` around `cli.py:2827`
+- `task list` around `cli.py:2871`
+- `PenguinCLI` class around `cli.py:3096`
+
+These are likely seam candidates, but the audit should confirm what is actually safe.
+
+## Audit Questions
+
+### 1. Command Surface Questions
+- What commands are truly public and actively supported today?
+- Which documented commands are just design residue or compatibility scaffolding?
+- Where are command semantics duplicated across top-level mode, project commands, and task commands?
+- Which commands have hidden workspace/root assumptions?
+
+### 2. Bootstrap Workflow Questions
+- What should `penguin project init "name" --blueprint ./blueprint.md` actually do step-by-step?
+- What should happen when Blueprint parse, sync, or diagnostics fail?
+- How should project selection work for `project start <project-id|name>`?
+- How should pending-review and clarification outcomes be surfaced in a high-level workflow command?
+
+### 3. Decomposition Questions
+- What helper logic can move safely without changing command behavior?
+- Which rendering/printing logic is duplicated and worth extracting?
+- Which parts of `cli.py` are tied to Typer decorators and should remain stable for now?
+- Which environment/root/workspace helpers should be isolated first?
+
+### 4. Testing Questions
+- Which current tests already protect CLI behavior?
+- What regression tests are missing for project creation location semantics?
+- What tests are needed before extracting command helpers?
+- What should be verified before adding bootstrap commands?
+
+## Audit Deliverables
+
+### Deliverable 1: CLI Structure Map
+A short file section or companion note that identifies:
+- command groups
+- helper clusters
+- initialization flow
+- root/workspace semantics flow
+- output/rendering helper opportunities
+
+### Deliverable 2: Extraction Seam Map
+Explicitly classify seams as:
+- **Safe now**
+- **Safe with tests first**
+- **Leave alone for now**
+
+### Deliverable 3: Bootstrap Workflow Contract
+Define the minimum user-visible contract for:
+- `project init`
+- `project start`
+
+This should be honest about:
+- project creation location
+- Blueprint validation/sync failures
+- deterministic selection rules
+- clarification / pending-review outcomes
+
+### Deliverable 4: PR Sequence
+Recommend the smallest safe order of follow-up work.
+
+## Extraction Seam Map
+
+These are not commands from God. They are the current best classification from the audit.
+
+### Safe now
+- project/task output formatting helpers
+- status/phase wording helpers
+- project/workspace path display helpers
+- project selection resolver helper(s)
+- argument-to-runtime normalization helpers that do not alter init order
+
+### Safe with tests first
+- project command bodies behind stable Typer decorators
+- task command bodies behind stable Typer decorators
+- shared command error/reporting helpers
+- project/task list rendering helpers
+- lightweight command-discoverability/help-text cleanup
+
+### Leave alone for now
+- `_initialize_core_components_globally(...)`
+- top-level callback/init ordering in `main_entry(...)`
+- root/workspace environment normalization
+- `_handle_run_mode(...)`
+- `PenguinCLI` interactive shell / streaming display machinery
+- command-group registration structure itself
+
+## Exact Scope For PR 1: Workspace Semantics + Honesty Fixes
+
+### Goal
+Fix the highest-value CLI surface lies without starting the broader bootstrap or decomposition work yet.
+
+### In scope
+1. Resolve the `project create --workspace` honesty gap
+   - either honor the option for real
+   - or remove/hide it until supported
+2. Clarify execution root vs project workspace behavior
+   - improve wording/output so users can predict where a project lives
+3. Improve project creation output
+   - distinguish execution root, managed workspace root, and resulting project workspace when relevant
+4. Tighten stale task/project help text where it conflicts with current truth
+   - especially lifecycle/status wording
+5. Add regression tests for:
+   - project creation location semantics
+   - `--workspace` behavior (or explicit non-support)
+   - create/list/help output truth on workspace semantics
+
+### Explicitly out of scope
+- `project init`
+- `project start`
+- broader bootstrap workflow behavior
+- major `cli.py` extraction
+- runmode command redesign
+- large-scale help overhaul beyond direct truth fixes
+
+### Acceptance criteria
+- `project create --workspace` is no longer misleading
+- users can tell the difference between execution root and project workspace from command output
+- help text no longer teaches stale task lifecycle/status examples
+- existing verified CLI behavior remains intact
+- new regression tests protect the workspace/location contract
+
+### Suggested implementation strategy
+- keep Typer decorators where they are
+- patch behavior inside the existing project command implementations first
+- extract only tiny display/helper functions if needed for testability or output reuse
+- do not touch top-level init order unless a test proves it is necessary
+
+## Bootstrap Workflow Contract (Pre-Implementation)
+
+### `penguin project init "name" --blueprint ./blueprint.md`
+Minimum honest contract:
+1. create or allocate the project
+2. resolve workspace semantics honestly
+3. parse the Blueprint
+4. run Blueprint diagnostics / validation
+5. sync/import tasks only if validation is acceptable
+6. report:
+   - project id
+   - project workspace
+   - Blueprint sync result
+   - diagnostics/errors/warnings
+
+If Blueprint parse or validation fails, the command must say so plainly. It must not imply that the project graph is ready when it is not.
+
+### `penguin project start <project-id|name>`
+Minimum honest contract:
+1. resolve the project deterministically
+2. refuse ambiguous name matches unless the user disambiguates
+3. route into orchestrated runtime truth, not shortcuts
+4. surface non-terminal outcomes honestly, including:
+   - `waiting_input`
+   - `pending_review`
+   - blocked/no-ready-task conditions
+
+## Recommended Implementation Order
+
+### PR 1: Workspace semantics + honesty fixes
+- resolve `project create --workspace` gap
+- clarify execution root vs project workspace
+- improve create output
+- tighten stale task/project help wording
+- add regression tests
+
+### PR 2: Help/discoverability cleanup
+- improve help text and examples
+- improve project/task workflow discoverability
+- tighten errors for ambiguous selection
+
+### PR 3: Bootstrap workflow MVP
+- `project init`
+- `project start`
+- deterministic selection
+- truthful reporting for Blueprint and runtime outcomes
+
+### PR 4: Safe decomposition
+- extract low-risk helpers
+- reduce duplication in rendering and command support logic
+- keep tests ahead of movement
+
+### PR 5: RunMode/loop ergonomics follow-on
+- audit `--run`, `--247`, and `--continuous` in depth
+- revisit loop ownership boundaries between `RunMode` and `Engine`
+
+## Acceptance Criteria
+
+This audit is complete when:
+- `cli.py` has a documented structure/seam map
+- bootstrap workflow commands have a clear contract before implementation
+- `project create --workspace` is identified in the right PR bucket, not left vague
+- extraction work is sequenced by risk instead of by emotional desire to rewrite the file
+- required regression tests are listed before decomposition work starts
+
+## Relationship To Existing Plans
+
+- `context/tasks/cli-interface-ergonomics-plan.md`
+  - defines the user-facing ergonomics goals
+- `context/tasks/project-bootstrap-workflow.md`
+  - defines the intended bootstrap workflow direction
+- `context/tasks/cli-surface-audit.md`
+  - captures earlier correctness issues and CLI truth fixes
+- `context/tasks/todo.md`
+  - tracks the follow-up PR sequence
+
+## Bottom Line
+
+The CLI absolutely needs decomposition.
+
+But the next smart move is not “rewrite the blob.”
+The next smart move is:
+- map it
+- define the seams
+- fix the highest-value user lies first
+- add bootstrap workflow on top of honest semantics
+- then decompose safely
+
+That is how you make the CLI usable again without turning it into a fresh pile of rubble.

--- a/context/tasks/cli-workspace-semantics-pr1-checklist.md
+++ b/context/tasks/cli-workspace-semantics-pr1-checklist.md
@@ -1,0 +1,199 @@
+# PR 1 Checklist: CLI Workspace Semantics and Honesty Fixes
+
+## Purpose
+
+This file defines the exact implementation checklist for the first follow-up CLI PR.
+
+This PR is intentionally narrow.
+It should fix the highest-value user-facing honesty problems in the CLI without
+turning into a broader bootstrap workflow PR or a premature `cli.py` rewrite.
+
+## Primary Goal
+
+Make project creation and related CLI messaging honest and predictable.
+
+That means:
+- no lying `--workspace` flag
+- no muddy execution-root vs project-workspace output
+- no stale task/project help text that teaches outdated lifecycle truth
+- regression tests protecting the new contract
+
+## Behavior Decision
+
+### Decision: **Honor `--workspace`**
+
+Do **not** remove or hide it in PR 1.
+
+### Why
+
+- users already see and reasonably expect this flag to work
+- the current behavior is a surface-contract lie
+- honoring the option is better than deleting functionality users want
+- bootstrap workflow work (`project init`) will be cleaner if workspace semantics are already real
+
+### Required behavior
+
+If the user runs:
+
+```bash
+penguin project create MyProject --workspace /some/path
+```
+
+then the created project should record a workspace path rooted at `/some/path`
+(or a clearly documented derived child path if that is the chosen contract).
+
+### Constraint
+
+This PR must **not** introduce hidden behavior.
+If the chosen workspace resolution logic is:
+- exact path
+- normalized path
+- project-subdirectory path
+
+then that rule must be explicit in:
+- command output
+- help text
+- tests
+
+## Scope
+
+### In Scope
+- `project create --workspace` semantics
+- project creation output wording
+- execution root vs project workspace clarity
+- stale task/project help text cleanup where it conflicts with current truth
+- regression tests for workspace/location behavior
+
+### Out of Scope
+- `project init`
+- `project start`
+- broader bootstrap workflow logic
+- large CLI help overhaul
+- broad CLI decomposition
+- runmode command redesign
+- `PenguinAPI` surface work
+
+## Files To Touch
+
+### Required
+- `penguin/cli/cli.py`
+  - `project create`
+  - possibly shared project/workspace output helpers
+  - task/project help wording cleanup
+- `penguin/project/manager.py`
+  - if needed to actually honor explicit project workspace paths cleanly
+- `penguin/project/models.py`
+  - only if model-level clarification/documentation of workspace semantics is needed
+- `docs/docs/usage/project_management.md`
+  - update CLI semantics after implementation
+- `docs/docs/usage/cli_commands.md`
+  - update help/examples if behavior changes materially
+
+### Possibly touched
+- `penguin/project/storage.py`
+  - only if persistence behavior needs a small update for explicit workspace path storage
+- `context/tasks/cli-interface-ergonomics-plan.md`
+  - only if the plan should record the final chosen workspace contract
+- `context/tasks/cli-refactor-and-bootstrap-audit.md`
+  - optional note that PR 1 behavior decision is now implemented
+
+### Should Avoid If Possible
+- top-level callback/init ordering in `main_entry(...)`
+- `_initialize_core_components_globally(...)`
+- `_handle_run_mode(...)`
+- `PenguinCLI` interactive shell class
+
+## Implementation Checklist
+
+### 1. Define the concrete workspace contract
+Pick and implement one explicit rule:
+- [ ] `--workspace` means **use this exact path as the project workspace**
+- [ ] or `--workspace` means **create/use a deterministic child path under this directory**
+- [ ] document the rule in code comments/help/output
+- [ ] ensure path is normalized (`expanduser`, resolve where appropriate)
+
+### 2. Update `project create`
+- [ ] pass the workspace choice through instead of ignoring it
+- [ ] remove the misleading `workspace_path is managed internally` behavior/comment
+- [ ] fail cleanly if the provided workspace path is invalid or unusable
+- [ ] keep project creation output concise but explicit
+
+### 3. Clarify command output
+After project creation, output should clearly distinguish:
+- [ ] execution root
+- [ ] managed Penguin workspace root, if relevant
+- [ ] resulting project workspace
+- [ ] whether the project workspace came from `--workspace` or default behavior
+
+### 4. Tighten help text
+- [ ] `project create --help` reflects real workspace semantics
+- [ ] `task list --help` no longer advertises outdated lifecycle examples
+- [ ] project/task help avoids implying commands/features that do not exist
+
+### 5. Keep behavior honest under defaults
+When `--workspace` is omitted:
+- [ ] output should still explain where the project was created
+- [ ] default project workspace behavior should be predictable
+- [ ] current execution root should not be confused with stored project workspace
+
+## Tests To Add / Update
+
+### Required regression tests
+- [ ] `project create --workspace <PATH>` creates a project with the expected recorded workspace path
+- [ ] project creation output reflects explicit workspace usage honestly
+- [ ] project creation output reflects default workspace behavior honestly
+- [ ] `project create --help` documents real workspace semantics
+- [ ] `task list --help` / related help text reflects current lifecycle truth
+
+### Good candidates for existing test files
+- `tests/test_cli_surface_audit_regressions.py`
+- `tests/test_cli_integration.py`
+- `tests/test_cli_entrypoint_dispatcher.py`
+- any project-manager tests if manager-level workspace semantics change
+
+### Optional but useful
+- [ ] test invalid/unusable `--workspace` path failure message
+- [ ] test that project listing still shows the created project cleanly after explicit workspace selection
+- [ ] test that no stale repo/workspace env leak changes the chosen project workspace unexpectedly
+
+## Suggested Implementation Order
+
+1. define the workspace contract
+2. patch manager/create path behavior
+3. patch CLI output/help wording
+4. add/update regression tests
+5. update docs
+6. rerun the CLI verification subset most likely to regress
+
+## Verification Commands
+
+Run at minimum:
+
+```bash
+pytest -q \
+  tests/test_cli_surface_audit_regressions.py \
+  tests/test_cli_integration.py \
+  tests/test_cli_entrypoint_dispatcher.py
+```
+
+If project-manager semantics change, also run the relevant project tests.
+
+## Acceptance Criteria
+
+This PR is done when:
+- `project create --workspace` is no longer misleading
+- users can distinguish execution root from project workspace from CLI output alone
+- stale help text is corrected
+- regression tests protect the workspace/location contract
+- docs reflect the new truth
+
+## Non-Goals Reminder
+
+This PR is **not** the place to:
+- add `project init`
+- add `project start`
+- redesign runmode flags
+- refactor half of `cli.py`
+- solve all discoverability issues in one shot
+
+Do the honest thing first. Fancy comes later.

--- a/context/tasks/testing_scenarios.md
+++ b/context/tasks/testing_scenarios.md
@@ -12,6 +12,8 @@ Penguin-mode/OpenCode-TUI workflows.
 
 Clarification/task-orchestration scenarios live elsewhere. This document is intentionally about multi/sub-agent behavior, not the newer task clarification / dependency-policy / diagnostic flows.
 
+CLI workspace-semantics and bootstrap ergonomics scenarios also live elsewhere; those should be tracked with the dedicated CLI ergonomics / bootstrap workflow plans rather than mixed into this multi-agent pack.
+
 ## Canonical Tool Surface (Current)
 
 ### ActionXML tags (supported)

--- a/context/tasks/testing_scenarios.md
+++ b/context/tasks/testing_scenarios.md
@@ -10,6 +10,8 @@ Penguin-mode/OpenCode-TUI workflows.
 - Secondary: inter-agent messaging/channels and delegation behavior.
 - Surfaces: ActionXML parser path, tool-calling path, and API/session event path.
 
+Clarification/task-orchestration scenarios live elsewhere. This document is intentionally about multi/sub-agent behavior, not the newer task clarification / dependency-policy / diagnostic flows.
+
 ## Canonical Tool Surface (Current)
 
 ### ActionXML tags (supported)

--- a/context/tasks/todo.md
+++ b/context/tasks/todo.md
@@ -16,11 +16,11 @@ These are still reasonable to finish inside the current PR because they are
 directly tied to the runtime refactor and would be redundant as a standalone PR.
 
 ### Category: Current PR / Docs Alignment
-- [ ] Update public docs for typed dependencies, diagnostics, and clarification handling
-- [ ] Review `context/process/blueprint.template.md` for typed dependency and diagnostics drift
-- [ ] Review `context/tasks/testing_scenarios.md` for stale scenarios after clarification, diagnostics, and dependency-policy changes
-- [ ] Final docs pass for README / architecture / surface docs so they match current branch truth
-- [ ] PR write-up: summarize what this branch fixed, what it verified, and what is explicitly deferred
+- [x] Update public docs for typed dependencies, diagnostics, and clarification handling
+- [x] Review `context/process/blueprint.template.md` for typed dependency and diagnostics drift
+- [x] Review `context/tasks/testing_scenarios.md` for stale scenarios after clarification, diagnostics, and dependency-policy changes
+- [x] Final docs pass for README / architecture / surface docs so they match current branch truth
+- [x] PR write-up: summarize what this branch fixed, what it verified, and what is explicitly deferred
 
 ## Follow-Up PRs
 
@@ -60,6 +60,23 @@ Reference:
 Reference:
 - `context/tasks/project-bootstrap-workflow.md`
 
+### Category: RunMode UX and Loop Architecture
+
+#### PR: RunMode Commands and Loop Ownership Audit
+- [ ] Audit `--run`, `--247`, and `--continuous` semantics for current truth and usability
+- [ ] Decide whether `--247` remains a public alias, hidden alias, or internal-only compatibility flag
+- [ ] Clarify no-task continuous mode behavior and shutdown/idle semantics
+- [ ] Review `RunMode.start(...)` vs `RunMode.start_continuous(...)` command affordances
+- [ ] Audit loop ownership boundaries between `RunMode` and `Engine`
+- [ ] Decide what should remain in `RunMode` versus what should be unified into engine loop configuration
+- [ ] Reduce duplicated or overlapping termination/progress concepts where safe
+- [ ] Add targeted docs/tests for the final command and loop contract
+
+Reference:
+- `penguin/run_mode.py`
+- `penguin/engine.py`
+- `penguin/cli/cli.py`
+
 ### Category: Verification Hardening
 
 #### PR: Reliability Pass 2
@@ -79,7 +96,8 @@ Reference:
 2. PenguinAPI Surface Refresh
 3. CLI Workspace Semantics and Ergonomics
 4. Project Bootstrap Workflow MVP
-5. Reliability Pass 2
+5. RunMode Commands and Loop Ownership Audit
+6. Reliability Pass 2
 
 ## Notes
 

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -12,23 +12,29 @@ Welcome! This guide will get you up and running with Penguin v0.4.0, featuring a
 
 ### Core Installation
 ```bash
-pip install penguin-ai            # CLI + Python API
+uv tool install penguin-ai        # recommended: installs the main CLI/TUI entrypoints
+
+# Alternative: plain pip still works
+pip install penguin-ai            # Python package + CLI/TUI + web runtime
 ```
 
 ### Feature-Rich Installation
 ```bash
-pip install "penguin-ai[full]"   # All features including web interface
+pip install "penguin-ai[all]"    # Optional extras for memory/browser/legacy UI features
 ```
 
 ### Installation Options
-* `pip install "penguin-ai[web]"` – adds FastAPI server with web interface
+* `pip install "penguin-ai[web]"` – compatibility alias; base install already includes the web runtime
+* `pip install "penguin-ai[tui]"` – compatibility alias; base install already includes the OpenCode-style TUI launcher
+* `pip install "penguin-ai[legacy_tui]"` – installs the older Textual prototype / experimental UI
 * `pip install "penguin-ai[minimal]"` – lightweight library-only installation
 * `pip install "penguin-ai[dev]"` – development dependencies for contributors
 
 ### What's Included
 
 **Core Features:**
-- Enhanced CLI interface with TUI (`penguin` command)
+- Interactive TUI launcher via `penguin`, `ptui`, or `penguin-tui`
+- Headless/scriptable CLI via `penguin-cli`
 - Python API for programmatic use
 - Advanced conversation management with checkpoints
 - Real-time streaming with event-driven architecture
@@ -36,23 +42,19 @@ pip install "penguin-ai[full]"   # All features including web interface
 - Enhanced token management with category-based budgets
 - Runtime model switching capabilities
 
-**Optional Features:**
-- Web interface with REST API (`penguin-web`)
-- Performance monitoring and diagnostics
-- Comprehensive error handling and recovery
-- Fast startup optimization
-
 ## 2. Verify Installation
 ```bash
 penguin --version     # prints version string
-penguin --help        # shows CLI options
+penguin --help        # shows the default launcher options
+ptui --help           # direct TUI alias
+penguin-cli --help    # headless/scriptable CLI entrypoint
 ```
 
 ### Check Configuration
 ```bash
-penguin config check  # validates required keys are present
-penguin config debug  # prints extended diagnostic info
-penguin config edit   # open the config file in your editor
+penguin-cli config check  # validates required keys are present
+penguin config debug      # prints extended diagnostic info
+penguin config edit       # open the config file in your editor
 ```
 
 ---
@@ -61,14 +63,16 @@ penguin config edit   # open the config file in your editor
 
 ### Enhanced Interactive Chat
 ```bash
-penguin               # opens advanced TUI with real-time streaming
-penguin --no-tui      # CLI mode without graphical interface
+penguin               # launches the default terminal UI
+ptui                  # same TUI, explicit alias
+penguin-tui           # same TUI, explicit alias matching the split runtime naming
 ```
 
-### Streaming and Checkpoint Features
+Use `penguin-cli` for non-interactive automation and scripts:
+
 ```bash
-penguin -p "Help me debug this Python function"  # one-off prompt
-# penguin chat                                     # explicit synonym for interactive chat
+penguin-cli -p "Help me debug this Python function"  # one-off prompt
+penguin-cli chat                                     # explicit synonym for interactive chat
 ```
 
 <!-- TODO: Checkpointing command support -->
@@ -79,24 +83,32 @@ Model subcommands are not yet exposed via CLI. Use defaults in config for now.
 ### Advanced Project & Task Management
 ```bash
 # Create a project
-penguin project create "AI Assistant Demo" -d "Demonstrating new features"
+penguin-cli project create "AI Assistant Demo" -d "Demonstrating new features"
 
 # List projects (note the ID from the table)
-penguin project list
+penguin-cli project list
 
 # Create a task for that project (replace <PROJECT_ID>)
-penguin project task create <PROJECT_ID> "Implement streaming chat"
+penguin-cli project task create <PROJECT_ID> "Implement streaming chat"
 
 # View tasks (optionally filtered by project)
-penguin project task list [<PROJECT_ID>]
+penguin-cli project task list [<PROJECT_ID>]
 ```
 
 ### Enhanced Web Interface (optional)
 ```bash
-pip install "penguin-ai[web]"
-penguin-web   # Enhanced web interface at http://localhost:8000
+pip install "penguin-ai[web]"   # compatibility alias; base install already includes this runtime
+penguin-web                      # Enhanced web interface at http://localhost:8000
 # API docs at http://localhost:8000/api/docs
 ```
+
+### TUI Runtime Notes
+
+The terminal UI now lives in the OpenCode-derived `penguin-tui/` workspace inside this repository.
+
+- In a source checkout, Penguin prefers local `penguin-tui/packages/opencode` sources.
+- Outside a source checkout, it can bootstrap a cached sidecar binary under `~/.cache/penguin/tui`.
+- Advanced overrides: `PENGUIN_OPENCODE_DIR`, `PENGUIN_TUI_BIN_PATH`, and `PENGUIN_TUI_RELEASE_URL`.
 
 ### Programmatic API with Streaming
 ```python
@@ -221,15 +233,15 @@ memory:
 - [Event System](advanced/events.md) - Working with the event-driven architecture
 
 ### Troubleshooting
-
 **Common Issues:**
 
 1. **Command not found**: Ensure you installed with `pip install penguin-ai`, not the minimal option
-2. **Web interface not starting**: Install with `pip install "penguin-ai[web]"` and check port 8000
+2. **Web interface not starting**: Base install already includes the runtime; `pip install "penguin-ai[web]"` is only a compatibility alias. Then check port 8000.
 3. **API errors**: Verify API keys and use `penguin config debug` for configuration issues
 4. **Streaming not working**: Ensure your model supports streaming and check client preference settings
 5. **Checkpoint errors**: Check disk space and file permissions for the workspace directory
 6. **Performance issues**: Try `fast_startup=true` in config or use `penguin profile` / `penguin perf-test` for profiling
+7. **TUI bootstrap problems**: If sidecar download or source auto-detection fails, set `PENGUIN_OPENCODE_DIR` or `PENGUIN_TUI_BIN_PATH` explicitly.
 
 ### Getting Help
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -36,41 +36,46 @@ Welcome to the documentation for Penguin! Penguin v0.4.0 is a modular, extensibl
 
 ### Installation Options
 
-**Default Installation (includes CLI tools):**
+**Recommended Installation (default runtime):**
 ```bash
+uv tool install penguin-ai
+
+# Alternative
 pip install penguin-ai
 ```
 
-**With Web Interface:**
+**Compatibility aliases / optional extras:**
 ```bash
-pip install penguin-ai[web]
-```
-
-**Minimal Installation (library only):**
-```bash
-pip install penguin-ai[minimal]
+pip install "penguin-ai[web]"         # compatibility alias; base install already includes web runtime
+pip install "penguin-ai[tui]"         # compatibility alias; base install already includes TUI runtime
+pip install "penguin-ai[legacy_tui]"  # old Textual prototype / experimental UI
+pip install "penguin-ai[minimal]"     # library-only footprint
 ```
 
 ### Basic Usage
 
-**Command Line Interface:**
+**Terminal Interfaces:**
 ```bash
-# Interactive chat
+# Default terminal UI
 penguin
 
-# Direct commands
-penguin "Write a hello world script"
+# Explicit TUI aliases
+ptui
+penguin-tui
 
-# Project management
-penguin project create "My Project"
-penguin task create "Implement authentication"
+# Headless/scriptable CLI
+penguin-cli -p "Write a hello world script"
+
+# Project management via CLI
+penguin-cli project create "My Project"
+penguin-cli project task create <PROJECT_ID> "Implement authentication"
 ```
 
-Tip: Inside the interactive chat, type `/help` to see in‑chat commands for models, streaming, checkpoints, context files, and Run Mode. See also: Usage → CLI Commands.
+Tip: Inside the interactive chat, type `/help` to see in-chat commands for models, streaming, checkpoints, context files, and Run Mode. See also: Usage → CLI Commands.
 
 **Web Interface:**
 ```bash
-# Start web server (requires [web] extra)
+# Start web server (already included in the base install)
 penguin-web
 ```
 

--- a/docs/docs/usage/automode.md
+++ b/docs/docs/usage/automode.md
@@ -1,4 +1,16 @@
-# Automode
+# Automode / RunMode
 
-Coming Soon!
+Penguin does support autonomous execution today, but this surface is still being cleaned up and audited.
 
+Current public CLI truth:
+- `--run <TASK_OR_PROJECT>` starts RunMode for a specific task/project target
+- `--247` / `--continuous` runs continuous mode until manually stopped
+- continuous mode can also be entered without an explicit task target
+
+Important caveat:
+- command ergonomics and loop ownership between `RunMode` and `Engine` are tracked as follow-up work
+- this page is intentionally minimal until that audit lands, so we do not teach command semantics that may still change
+
+For current command syntax, prefer:
+- `docs/docs/usage/cli_commands.md`
+- `context/tasks/todo.md` (follow-up PR map)

--- a/docs/docs/usage/cli_commands.md
+++ b/docs/docs/usage/cli_commands.md
@@ -1,36 +1,49 @@
 # Penguin CLI – Command Reference (v0.6.x)
 
-Penguin’s CLI supports both traditional sub‑commands (via Typer) and rich in‑chat commands inside the interactive session. This page documents what’s currently implemented and commonly used.
+Penguin now exposes multiple terminal entrypoints on top of the same runtime:
+
+- `penguin` — default launcher for the interactive TUI
+- `ptui` / `penguin-tui` — explicit aliases for the same TUI runtime
+- `penguin-cli` — headless/scriptable CLI for prompts, config, projects, and automation
+
+This page documents the currently implemented command surface and calls out where older docs were too optimistic.
 
 ---
 
 ## Getting help
 ```bash
-# Global help
+# Default launcher help
 penguin --help
 
+# Headless CLI help
+penguin-cli --help
+
 # Help for a specific sub-command
-penguin project --help
-penguin project task --help
-penguin config --help
+penguin-cli project --help
+penguin-cli project task --help
+penguin-cli config --help
 ```
 
 ---
 
 ## Quick start
-### 1. Interactive chat (default)
+### 1. Interactive chat (default TUI)
 ```bash
 # Start an interactive chat session
 penguin
+
+# Equivalent explicit TUI aliases
+ptui
+penguin-tui
 ```
 
 ### 2. One-off prompts (non-interactive)
 ```bash
 # Ask a single question (prints assistant reply and exits)
-penguin -p "Explain async/await in Python"
+penguin-cli -p "Explain async/await in Python"
 
 # Read the prompt from stdin (use "-" as the placeholder)
-echo "Give me a limerick about penguins" | penguin -p -
+echo "Give me a limerick about penguins" | penguin-cli -p -
 ```
 
 The following global flags can be combined with either interactive or non-interactive mode:
@@ -50,47 +63,57 @@ The following global flags can be combined with either interactive or non-intera
 
 ---
 
-## Sub-commands (Typer)
+## Sub-commands (Typer / headless CLI)
+
+Most sub-commands are exposed through `penguin-cli`. If you are scripting Penguin, use that binary instead of assuming the interactive TUI launcher will behave like a classic CLI.
 
 ### `project`
 Project management helpers (backed by `ProjectManager`).
 
 | Command | Summary |
 |---------|---------|
-| `penguin project create <NAME> [--description/-d TEXT]` | Create a new project |
-| `penguin project list` | List existing projects |
-| `penguin project delete <PROJECT_ID> [--force/-f]` | Delete a project |
+| `penguin-cli project create <NAME> [--description/-d TEXT]` | Create a new project using Penguin's managed default workspace |
+| `penguin-cli project create <NAME> --workspace /exact/path` | Create a new project using the exact workspace path you provide |
+| `penguin-cli project list` | List existing projects |
+| `penguin-cli project delete <PROJECT_ID> [--force/-f]` | Delete a project |
+
+Workspace semantics for project creation:
+- `--workspace` uses the **exact provided path**. Penguin does not silently create a child directory under that path.
+- When `--workspace` is omitted, Penguin uses its managed default workspace path.
+- Project creation output distinguishes:
+  - `Workspace (explicit): ...`
+  - `Workspace (default): ...`
+  - `Execution root: ...`
 
 Tasks are namespaced under a project:
 
 | Command | Summary |
 |---------|---------|
-| `penguin project task create <PROJECT_ID> <TITLE>` | Create a task |
-| `penguin project task list [<PROJECT_ID>] [--status/-s STATUS]` | List tasks (optionally filtered) |
-| `penguin project task start <TASK_ID>` | Move task into the **active** state |
-| `penguin project task complete <TASK_ID>` | Approve a task that is **pending review** and mark it completed |
-| `penguin project task delete <TASK_ID> [--force/-f]` | Delete task |
+| `penguin-cli project task create <PROJECT_ID> <TITLE>` | Create a task |
+| `penguin-cli project task list [<PROJECT_ID>] [--status/-s STATUS]` | List tasks (optionally filtered) |
+| `penguin-cli project task start <TASK_ID>` | Move task into the **active** state |
+| `penguin-cli project task complete <TASK_ID>` | Approve a task that is **pending review** and mark it completed |
+| `penguin-cli project task delete <TASK_ID> [--force/-f]` | Delete task |
 
-Status filters are case-insensitive and use the current task lifecycle values: `active`, `running`, `pending_review`, `completed`, `cancelled`, `failed`, and `archived`.
+Status filters are case-insensitive and use the current task lifecycle values: `active`, `running`, `pending_review`, `completed`, `failed`, `blocked`, and `cancelled`.
 
 ### `config`
 Manage the Penguin configuration file and first-run setup wizard.
 
 | Command | What it does |
 |---------|--------------|
-| `penguin config setup`        | Run (or re-run) the interactive setup wizard |
-| `penguin config edit`         | Open the config file in your default editor |
-| `penguin config check`        | Validate that required keys are present |
-| `penguin config test-routing` | Debug provider/model routing logic |
-| `penguin config debug`        | Print an extended diagnostic report |
+| `penguin-cli config setup`        | Run (or re-run) the interactive setup wizard |
+| `penguin-cli config edit`         | Open the config file in your default editor |
+| `penguin-cli config check`        | Validate that required keys are present |
+| `penguin-cli config test-routing` | Debug provider/model routing logic |
+| `penguin-cli config debug`        | Print an extended diagnostic report |
 
 ### Developer utilities
 | Command | Purpose |
 |---------|---------|
-| `penguin perf-test [-i N]` | Benchmark startup time with and without *fast-startup* |
-| `penguin profile [-o FILE] [--view]` | Launch Penguin under `cProfile` and save results |
-| `penguin chat` | Explicit synonym for starting interactive chat (identical to running `penguin` with no arguments) |
-
+| `penguin-cli perf-test [-i N]` | Benchmark startup time with and without *fast-startup* |
+| `penguin-cli profile [-o FILE] [--view]` | Launch Penguin under `cProfile` and save results |
+| `penguin-cli chat` | Explicit synonym for starting interactive chat |
 ---
 
 ## In‑Chat Commands (Interactive Session)
@@ -161,22 +184,26 @@ That keeps the pause/resume loop visible instead of making the CLI look stuck.
 ## Examples
 ```bash
 # Create a project and a task, then start the task
-penguin project create "Demo" -d "Playground project"
+penguin-cli project create "Demo" -d "Playground project"
+
+# Create a project with an explicit exact-path workspace
+penguin-cli project create "Demo" --workspace /tmp/demo-workspace
 
 # List projects and copy the ID from the table
-penguin project list
+penguin-cli project list
 
-# Create and start a task (replace <PROJECT_ID> and <TASK_ID>)
-penguin project task create <PROJECT_ID> "Research llama models"
-penguin project task list <PROJECT_ID>
-penguin project task start <TASK_ID>
+# Create and start a task (replace <PROJECT_ID> and <TASK_ID>).
+# Task commands are namespaced under `project task`, not top-level `task`.
+penguin-cli project task create <PROJECT_ID> "Research llama models"
+penguin-cli project task list <PROJECT_ID>
+penguin-cli project task start <TASK_ID>
 ```
 
 ---
 
 ## Missing features
-Earlier versions of the docs referenced commands such as `penguin memory`, `penguin db`, advanced task dependency graphs, and full web-server management.  These features are **work-in-progress** and are **not** available in the current release.  Attempting to run them will result in a "No such command" error.
+Earlier versions of the docs referenced commands such as `penguin memory`, `penguin db`, advanced task dependency graphs, and full web-server management. These features are **work-in-progress** and are **not** available in the current release. Attempting to run them will result in a "No such command" error.
 ---
 
-*Last updated: November 16, 2025*  
+*Last updated: April 15, 2026*  
 If you find inaccuracies, please open an issue.

--- a/docs/docs/usage/project_management.md
+++ b/docs/docs/usage/project_management.md
@@ -11,7 +11,7 @@ The project management system offers:
 - **Real-time status tracking** with automatic checkpointing
 - **Resource constraints** for budget and time management
 - **EventBus integration** for real-time updates across CLI and web interfaces
-- **Dual sync/async APIs** for flexible integration
+- **CLI, web/API, and Python surfaces** for interacting with the same underlying project/task runtime
 
 ## Core Concepts
 
@@ -34,11 +34,11 @@ Tasks are individual work items with:
 
 ### Dependencies
 Tasks can depend on other tasks with:
-- **Blocking dependencies** - task cannot start until dependencies complete
-- **Soft dependencies** - preferences for execution order
-- **Cross-project dependencies** - tasks can depend on tasks in other projects
+- **Completion-required dependencies** - the default scheduling gate
+- **Typed dependency policies** - Blueprint-driven dependency specs can express stricter semantics such as `artifact_ready`
+- **Structured Blueprint diagnostics** - missing dependencies, duplicate IDs, missing acceptance criteria, and cycles are now surfaced explicitly during Blueprint parse/lint flows
 
-## CLI Usage (Status as of v0.1.x)
+## CLI Usage (Current Public Surface)
 
 ### Implemented Commands
 
@@ -74,154 +74,53 @@ Task status filters are case-insensitive and follow the current lifecycle values
 
 ---
 
-### Blueprint Commands
 
-Blueprints enable spec-driven development where documentation drives task creation:
+### Blueprint / orchestration notes
 
-```bash
-# Sync a blueprint file to create/update tasks
-/blueprint sync context/specs/auth-system.md [project_id]
+Blueprint parsing, dependency DAG construction, diagnostics, recipes, and ITUV orchestration exist in the backend/runtime, but they are **not all exposed as stable first-class CLI commands yet**.
 
-# View blueprint sync status
-/blueprint status <project_id>
-```
+Current truth:
+- Blueprint import/sync and dependency-policy support are runtime/backend capabilities.
+- Structured diagnostics exist for duplicate task IDs, missing dependencies, cycles, missing acceptance criteria, and related authoring issues.
+- Public CLI exposure is intentionally narrower than the backend capability set.
 
-### DAG and Dependency Commands
-
-When tasks are created from blueprints, they form a dependency graph (DAG):
-
-```bash
-# View task dependencies
-/task deps <task_id>
-
-# Export dependency graph (DOT format for Graphviz)
-/task graph <project_id>
-
-# List tasks ready to execute (no pending dependencies)
-/task ready <project_id>
-
-# Get execution frontier (next tasks based on tie-breakers)
-/task frontier <project_id>
-```
-
-### Workflow Commands (ITUV Orchestration)
-
-Execute tasks through the ITUV (Implement, Test, Use, Verify) lifecycle:
-
-```bash
-# Start ITUV workflow for a task
-/workflow start <task_id>
-
-# Check workflow status
-/workflow status <workflow_id>
-
-# Control workflows
-/workflow pause <workflow_id>
-/workflow resume <workflow_id>
-/workflow cancel <workflow_id>
-
-# List workflows
-/workflow list [project_id]
-```
-
-### Planned Extensions (not yet implemented)
-These commands are design-level only.  Attempting to run them will produce a "No such command" error:
-
-* `penguin project show`, `project stats`, `project archive/restore`, export/import
-* `penguin project task update`, `task show`, bulk ops
-* Memory/database/workspace sub-apps
-* Advanced filters (`--tree`, etc.)
-
-Refer to the roadmap for progress.
+Treat older examples of `/blueprint`, `/task graph`, or `/workflow ...` commands as design/history material unless they are explicitly listed in the implemented CLI section above.
 
 ## Python API
 
 ### Basic Project Management
 ```python
-from penguin.project import ProjectManager, TaskStatus
+from pathlib import Path
 
-# Initialize manager
-pm = ProjectManager()
+from penguin.project.manager import ProjectManager
+from penguin.project.models import TaskStatus
 
-# Create project
+workspace = Path("./penguin-workspace")
+pm = ProjectManager(workspace)
+
 project = pm.create_project(
     name="Web Application",
     description="Full-stack web app",
-    workspace="./webapp"
 )
 
-# Create tasks
-task1 = pm.create_task(
-    project_id=project.id,
+task = pm.create_task(
     title="Setup FastAPI backend",
-    description="Initialize FastAPI project with basic structure"
-)
-
-task2 = pm.create_task(
+    description="Initialize FastAPI project with basic structure",
     project_id=project.id,
-    title="Create React frontend",
-    description="Initialize React app with TypeScript",
-    depends_on=[task1.id]  # Depends on backend setup
+    dependencies=[],
+    acceptance_criteria=["Backend scaffold exists"],
 )
 
-# List projects and tasks
 projects = pm.list_projects()
 tasks = pm.list_tasks(project_id=project.id)
-```
-
-### Advanced Task Management
-```python
-from penguin.project import TaskPriority, ResourceConstraints
-
-# Create task with constraints
-task = pm.create_task(
-    project_id=project.id,
-    title="Generate API documentation",
-    description="Create comprehensive API docs",
-    priority=TaskPriority.HIGH,
-    resource_constraints=ResourceConstraints(
-        max_output_tokens=15000,
-        max_duration_minutes=120,
-        allowed_tools=["file_operations", "web_search"]
-    )
-)
-
-# Update task status
 pm.update_task_status(task.id, TaskStatus.ACTIVE)
-
-# Add execution record
-from penguin.project import ExecutionRecord
-record = ExecutionRecord(
-    task_id=task.id,
-    agent_id="gpt-4",
-    tokens_used=1200,
-    duration_seconds=45,
-    status=TaskStatus.COMPLETED,
-    output="API documentation generated successfully"
-)
-pm.add_execution_record(record)
 ```
 
-### Async API
-```python
-import asyncio
-from penguin.project import AsyncProjectManager
-
-async def main():
-    apm = AsyncProjectManager()
-    
-    # All operations available as async
-    project = await apm.create_project("Async Project")
-    tasks = await apm.list_tasks(project_id=project.id)
-    
-    # Batch operations
-    await apm.bulk_update_tasks(
-        task_ids=[1, 2, 3],
-        status=TaskStatus.COMPLETED
-    )
-
-asyncio.run(main())
-```
+### Notes on current Python surface truth
+- `ProjectManager` is the real project/task entry point documented today.
+- Project workspaces are managed under the manager workspace root; `create_project(...)` does **not** currently accept a separate `workspace=` keyword.
+- There is no public `AsyncProjectManager`, `TaskManager`, or `AgentMatcher` API shipped today.
+- Dependency-policy semantics, Blueprint diagnostics, recipes, and clarification-aware task execution exist in the runtime/backend, but the broader Python embedding surface still needs its own dedicated refresh pass.
 
 ## Web/API Interface
 
@@ -247,268 +146,30 @@ The web/API surface is still being audited, but it now reflects current runtime 
 
 ## Advanced Features
 
-### Automated Task Execution
+### Clarification-aware task execution
 ```python
-from penguin import PenguinAgent
-from penguin.project import TaskManager
+from penguin.web.app import PenguinAPI
 
-# Create agent and task manager
-agent = PenguinAgent()
-tm = TaskManager()
+api = PenguinAPI()
+result = await api.run_task("Implement auth flow")
 
-# Execute task with agent
-async def execute_task(task_id):
-    task = tm.get_task(task_id)
-    
-    # Start task
-    tm.update_task_status(task_id, TaskStatus.IN_PROGRESS)
-    
-    try:
-        # Run agent on task
-        result = await agent.run_task(
-            prompt=task.description,
-            max_iterations=task.resource_constraints.max_iterations
-        )
-        
-        # Record completion
-        tm.complete_task(task_id, result=result)
-        
-    except Exception as e:
-        tm.fail_task(task_id, error=str(e))
-
-# Execute pending tasks
-pending_tasks = tm.list_tasks(status=TaskStatus.PENDING)
-for task in pending_tasks:
-    await execute_task(task.id)
+if result.get("status") == "waiting_input":
+    resumed = await api.resume_with_clarification(
+        task_id=result["task_id"],
+        answer="Use rotating refresh tokens",
+        answered_by="human",
+    )
 ```
 
-### Event-Driven Architecture
-```python
-from penguin.project import EventBus, TaskEvent
+This Python embedding surface is usable, but it still has a dedicated follow-up plan because it has not received the same depth of audit/ergonomics cleanup as the CLI and web/API surfaces.
 
-# Subscribe to task events
-def on_task_completed(event: TaskEvent):
-    print(f"Task {event.task_id} completed: {event.data}")
-
-EventBus.subscribe("task.completed", on_task_completed)
-
-# Custom event handlers
-@EventBus.handler("task.started")
-async def send_notification(event):
-    # Send Slack notification, update external systems, etc.
-    pass
-```
-
-### Project Templates
-```yaml
-# project-template.yml
-name: "Web Application Template"
-description: "Standard full-stack web application"
-
-tasks:
-  - title: "Project Setup"
-    description: "Initialize project structure and dependencies"
-    subtasks:
-      - "Create repository"
-      - "Setup CI/CD pipeline"
-      - "Configure development environment"
-  
-  - title: "Backend Development"
-    description: "Implement server-side functionality"
-    depends_on: ["Project Setup"]
-    subtasks:
-      - "Design database schema"
-      - "Implement API endpoints"
-      - "Add authentication"
-      - "Write unit tests"
-  
-  - title: "Frontend Development"
-    description: "Build user interface"
-    depends_on: ["Backend Development"]
-    subtasks:
-      - "Create React components"
-      - "Implement routing"
-      - "Add state management"
-      - "Style with CSS/Tailwind"
-
-constraints:
-  max_duration_days: 30
-  budget_tokens: 100000
-  allowed_tools: ["file_operations", "web_search", "code_execution"]
-```
-
-Load template:
-```bash
-penguin project create-from-template --template web-app-template.yml "My New Project"
-```
+### Additional notes
+Project templates, richer event-driven integrations, and other higher-level orchestration surfaces remain active design/runtime territory. Prefer the explicit CLI and web/API surfaces documented above when you need current public behavior.
 
 ## Database Schema
 
-The project management system uses SQLite with the following key tables:
-
-```sql
--- Projects table
-CREATE TABLE projects (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL UNIQUE,
-    description TEXT,
-    workspace_path TEXT,
-    status TEXT DEFAULT 'active',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- Tasks table
-CREATE TABLE tasks (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    project_id INTEGER REFERENCES projects(id),
-    parent_task_id INTEGER REFERENCES tasks(id),
-    title TEXT NOT NULL,
-    description TEXT,
-    status TEXT DEFAULT 'pending',
-    priority TEXT DEFAULT 'medium',
-    assigned_to TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- Task dependencies
-CREATE TABLE task_dependencies (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    task_id INTEGER REFERENCES tasks(id),
-    depends_on_task_id INTEGER REFERENCES tasks(id),
-    dependency_type TEXT DEFAULT 'blocking',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- Execution records
-CREATE TABLE execution_records (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    task_id INTEGER REFERENCES tasks(id),
-    agent_id TEXT,
-    status TEXT,
-    tokens_used INTEGER,
-    duration_seconds INTEGER,
-    started_at TIMESTAMP,
-    completed_at TIMESTAMP,
-    output TEXT,
-    error_message TEXT
-);
-```
+The project/task storage layer is SQLite-backed, but the exact schema is an implementation detail and may evolve. Prefer the Python and CLI/web surfaces documented above over relying on copied table layouts from older docs.
 
 ## Performance and Scaling
 
-### Database Optimization
-```yaml
-# config.yml
-project:
-  storage:
-    # Enable WAL mode for better concurrency
-    journal_mode: WAL
-    
-    # Optimize for read-heavy workloads
-    synchronous: NORMAL
-    cache_size: 10000
-    
-    # Connection pooling
-    max_connections: 20
-    timeout: 30
-```
-
-### Batch Operations
-```python
-# Efficient bulk task creation
-tasks_data = [
-    {"title": f"Task {i}", "project_id": project_id}
-    for i in range(100)
-]
-pm.bulk_create_tasks(tasks_data)
-
-# Batch status updates
-pm.bulk_update_task_status(
-    task_ids=list(range(1, 101)),
-    status=TaskStatus.COMPLETED
-)
-```
-
-### Memory Management
-```python
-# Use pagination for large datasets
-tasks = pm.list_tasks(
-    project_id=project_id,
-    limit=50,
-    offset=0
-)
-
-# Stream large queries
-for task in pm.stream_tasks(project_id=project_id):
-    process_task(task)
-```
-
-## Best Practices
-
-### Project Organization
-1. **Use clear, descriptive names** for projects and tasks
-2. **Break large tasks into subtasks** for better tracking
-3. **Set realistic resource constraints** to prevent runaway execution
-4. **Use dependencies** to model real workflow constraints
-5. **Regular checkpointing** for long-running tasks
-
-### Task Design
-1. **Atomic tasks** that can be completed independently
-2. **Clear acceptance criteria** in task descriptions
-3. **Appropriate time/token budgets** based on complexity
-4. **Tool restrictions** to prevent unauthorized operations
-5. **Regular status updates** for monitoring progress
-
-### Error Handling
-```python
-from penguin.project import ProjectError, TaskError
-
-try:
-    project = pm.create_project("Test Project")
-except ProjectError as e:
-    logger.error(f"Failed to create project: {e}")
-    
-try:
-    task = pm.start_task(task_id)
-except TaskError as e:
-    logger.error(f"Cannot start task: {e}")
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**Database locked errors:**
-```bash
-# Check for long-running transactions
-penguin project diagnose --check-locks
-
-# Force unlock (use carefully)
-penguin project unlock-database
-```
-
-**Performance issues:**
-```bash
-# Analyze database performance
-penguin project analyze --performance
-
-# Optimize database
-penguin project optimize-database
-
-# Check index usage
-penguin project explain-query "SELECT * FROM tasks WHERE status = 'pending'"
-```
-
-**Circular dependencies:**
-```bash
-# Detect circular dependencies
-penguin task validate-dependencies --all-projects
-
-# Visualize dependency graph
-penguin task graph --project "Web Application" --output deps.svg
-```
-
-For additional support, see the [API Reference](../api_reference/project_api.md) or [GitHub Issues](https://github.com/Maximooch/penguin/issues).
-
+Operational tuning details are still evolving. Treat older examples of WAL toggles, template loaders, or higher-level orchestration helpers as implementation notes rather than stable public APIs unless they are explicitly documented in the current CLI/web/Python sections above.

--- a/docs/docs/usage/project_management.md
+++ b/docs/docs/usage/project_management.md
@@ -173,3 +173,15 @@ The project/task storage layer is SQLite-backed, but the exact schema is an impl
 ## Performance and Scaling
 
 Operational tuning details are still evolving. Treat older examples of WAL toggles, template loaders, or higher-level orchestration helpers as implementation notes rather than stable public APIs unless they are explicitly documented in the current CLI/web/Python sections above.
+
+
+## Workspace Semantics
+
+- `--workspace` uses the **exact provided path**. Penguin does not silently create a child directory under that path.
+- When `--workspace` is omitted, Penguin uses its managed default workspace path.
+- Project creation output now distinguishes:
+  - `Workspace (explicit): ...`
+  - `Workspace (default): ...`
+  - `Execution root: ...`
+
+This separation is intentional: the execution root and the stored project workspace are related concepts, but they are not the same thing.

--- a/docs/docs/usage/project_management.md
+++ b/docs/docs/usage/project_management.md
@@ -45,27 +45,27 @@ Tasks can depend on other tasks with:
 #### Project
 ```bash
 # Create a project
-penguin project create "My Project" [--description/-d TEXT]
+penguin-cli project create "My Project" [--description/-d TEXT]
 
 # List projects
-penguin project list
+penguin-cli project list
 
 # Delete a project
-penguin project delete <PROJECT_ID> [--force/-f]
+penguin-cli project delete <PROJECT_ID> [--force/-f]
 ```
 
 #### Task (within a project)
 ```bash
 # Create a task
-penguin project task create <PROJECT_ID> "Task title" [--description/-d TEXT]
+penguin-cli project task create <PROJECT_ID> "Task title" [--description/-d TEXT]
 
 # List tasks
-penguin project task list [<PROJECT_ID>] [--status/-s STATUS]
+penguin-cli project task list [<PROJECT_ID>] [--status/-s STATUS]
 
 # Start / approve / delete
-penguin project task start <TASK_ID>      # moves task into the active state
-penguin project task complete <TASK_ID>   # approves a task that is pending review
-penguin project task delete <TASK_ID> [--force/-f]
+penguin-cli project task start <TASK_ID>      # moves task into the active state
+penguin-cli project task complete <TASK_ID>   # approves a task that is pending review
+penguin-cli project task delete <TASK_ID> [--force/-f]
 ```
 
 Task status filters are case-insensitive and follow the current lifecycle values (`active`, `running`, `pending_review`, `completed`, `cancelled`, `failed`, `archived`).

--- a/docs/docs/usage/python_api_reference.md
+++ b/docs/docs/usage/python_api_reference.md
@@ -1,4 +1,4 @@
-# Penguin Python API Reference (v0.1.x)
+# Penguin Python API Reference
 
 This page documents the **public APIs that ship today**.  Anything not listed here is work-in-progress and tracked in the [future considerations](../advanced/future_considerations.md) roadmap.
 
@@ -28,6 +28,7 @@ print(agent.chat("Hello Penguin!"))
 | `penguin.agent.PenguinAgent` | ✅ | Synchronous wrapper around `PenguinCore` – chat, stream, run_task |
 | `penguin.agent.PenguinAgentAsync` | ✅ | Async variant with identical method names (returning coroutines) |
 | `penguin.project.manager.ProjectManager` | ✅ | SQLite-backed project CRUD and basic task helpers |
+| `penguin.web.app.PenguinAPI` | ✅ | Programmatic wrapper aligned with current RunMode/task clarification truth |
 | `penguin.core.PenguinCore` | ✅ | Low-level orchestrator (conversation, tools, run-mode) |
 | `penguin.tools.ToolManager` | ✅ | Runtime registry & execution of tools |
 
@@ -72,32 +73,58 @@ agent = await PenguinAgentAsync.create()
 
 ---
 
-## ProjectManager
-Basic project / task operations.  All methods are **sync and async** twins (`ProjectManager` / `AsyncProjectManager`).
+## PenguinAPI
 
 ```python
-from penguin.project import ProjectManager, TaskStatus
+from penguin.web.app import PenguinAPI
 
-pm = ProjectManager()
+api = PenguinAPI()
+```
+
+### Methods
+| Method | Description |
+|--------|-------------|
+| `chat(...) -> dict` | Chat through the same backend core used by the web surface. |
+| `run_task(task_description: str, max_iterations: int | None = None, project_id: str | None = None) -> dict` | Run a task through `RunMode`; non-terminal outcomes like `waiting_input` are preserved. |
+| `resume_with_clarification(task_id: str, answer: str, answered_by: str | None = None) -> dict` | Answer the latest open clarification and resume execution through `RunMode`. |
+
+This is the current lightweight Python embedding surface for clarification-aware task execution. A deeper audit/ergonomics pass is intentionally tracked separately because this surface is still thinner and less polished than the CLI and web/API paths.
+
+---
+
+## ProjectManager
+Basic project / task operations. `ProjectManager` is the current documented entry point; earlier references to `AsyncProjectManager` were premature and should not be treated as shipped public API.
+
+```python
+from pathlib import Path
+
+from penguin.project.manager import ProjectManager
+from penguin.project.models import TaskStatus
+
+pm = ProjectManager(Path("./penguin-workspace"))
 project = pm.create_project(name="Demo", description="Example project")
 print("Project id:", project.id)
 
 # Tasks
-task = pm.create_task(project_id=project.id, title="Initial research")
+task = pm.create_task(
+    title="Initial research",
+    description="Map the repository and identify entry points",
+    project_id=project.id,
+)
 pm.update_task_status(task.id, TaskStatus.ACTIVE)
 pm.update_task_status(task.id, TaskStatus.COMPLETED)
 ```
 
 Implemented high-level methods:
-* `create_project(name, description="")`
+* `create_project(name, description="", ...)`
 * `list_projects(status: str | None = None)`
 * `delete_project(project_id)`
-* `create_task(project_id, title, description="", parent_task_id=None, priority=1)`
+* `create_task(title, description, project_id=None, parent_task_id=None, priority=0, ...)`
 * `list_tasks(project_id: str | None = None, status: TaskStatus | None = None)`
 * `update_task_status(task_id, status: TaskStatus)`
 * `delete_task(task_id)`
 
-Anything else (dependency graphs, bulk updates, Gantt charts, etc.) is future work.
+Dependency graphs, Blueprint diagnostics, typed dependency policies, and clarification-aware execution exist deeper in the runtime/backend, but the Python library surface for them is intentionally narrower today. Broader library-surface polish is tracked separately.
 
 ---
 
@@ -138,7 +165,7 @@ def my_tool(**kwargs):
 ---
 
 ## Deprecated / Future APIs
-The following names appeared in earlier documentation but **do not exist in v0.1.x**.  They are tracked on the roadmap and should not be imported yet:
+The following names appeared in earlier documentation but **do not exist in the current public release**. They are tracked on the roadmap and should not be imported yet:
 
 * `BatchProcessor`
 * `PerformanceMonitor`

--- a/docs/docs/usage/web_interface.md
+++ b/docs/docs/usage/web_interface.md
@@ -1,12 +1,18 @@
-# Web Interface / API Server Guide (v0.1.x)
+# Web Interface / API Server Guide (v0.6.x)
 
-Penguin currently includes a **FastAPI-based HTTP server** that exposes core functionality (projects, tasks, chat) as a REST/WS API.  A rich graphical UI is planned (see [future considerations](../advanced/future_considerations.md)), but not available yet.
+Penguin ships with a **FastAPI-based HTTP server** that exposes core functionality (projects, tasks, chat, SSE/WS streaming) as a REST/WS API. That server is also the backend surface used by the OpenCode-derived terminal UI that now lives in the repository's `penguin-tui/` workspace.
 
 ---
 
 ## Installation
 ```bash
-# Install Penguin with web extras
+# Recommended: base install already includes the web runtime
+uv tool install penguin-ai
+
+# Alternative: plain pip
+pip install penguin-ai
+
+# Compatibility alias for older install docs
 pip install "penguin-ai[web]"
 ```
 
@@ -19,7 +25,7 @@ penguin-web
 penguin-web --host 0.0.0.0 --port 9000
 ```
 
-The command is a thin wrapper around `penguin.web.app:app` (FastAPI) using `uvicorn`.
+The command is a thin wrapper around `penguin.web.server:main`, which serves the FastAPI app used by both API consumers and the modern TUI bridge.
 
 Optional flags:
 | Flag | Description |

--- a/docs/docs/usage/web_interface.md
+++ b/docs/docs/usage/web_interface.md
@@ -41,6 +41,14 @@ Key route groups:
 4. `/api/v1/chat/stream` – WebSocket for streaming chat responses
 5. `/api/v1/*` status/session endpoints for path, VCS, formatter, and LSP
 
+### Task / Clarification Surface Truth
+
+The task/project web surface is no longer just legacy CRUD sugar. Current behavior includes:
+- richer task payloads that expose lifecycle truth such as `status`, `phase`, dependencies, dependency specs, artifact evidence, recipe references, and clarification metadata
+- `POST /api/v1/tasks/{task_id}/execute` routing through `RunMode`, so non-terminal outcomes like `waiting_input` survive to clients
+- `POST /api/v1/tasks/{task_id}/clarification/resume` to answer the latest open clarification and resume execution
+- `GET /api/v1/events/sse` including clarification-related session status visibility for compatible clients
+
 For full path details, inspect the live Swagger page or read `penguin/penguin/web/routes.py`.
 
 > Example – list projects:

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -2574,7 +2574,7 @@ def project_create(
         None, "--workspace", "-w", help="Project workspace path"
     ),
 ):
-    """Create a new project"""
+    """Create a new project. `--workspace` uses the exact provided path."""
 
     async def _async_project_create():
         console.print(f"[bold cyan]🐧 Creating project:[/bold cyan] {name}")
@@ -2587,17 +2587,27 @@ def project_create(
             raise typer.Exit(code=1)
 
         try:
-            # Note: workspace_path is managed internally by ProjectManager
+            resolved_workspace = None
+            if workspace_path:
+                resolved_workspace = Path(workspace_path).expanduser().resolve()
+
             project = await _core.project_manager.create_project_async(
-                name=name, description=description or f"Project: {name}"
+                name=name,
+                description=description or f"Project: {name}",
+                workspace_path=resolved_workspace,
             )
 
             console.print("[green]✓ Project created successfully![/green]")
             console.print(f"  ID: {project.id}")
             console.print(f"  Name: {project.name}")
             console.print(f"  Description: {project.description}")
-            if project.workspace_path:
-                console.print(f"  Workspace: {project.workspace_path}")
+            if resolved_workspace:
+                console.print(f"  Workspace (explicit): {resolved_workspace}")
+            elif project.workspace_path:
+                console.print(f"  Workspace (default): {project.workspace_path}")
+            current_root = os.environ.get("PENGUIN_CWD")
+            if current_root:
+                console.print(f"  Execution root: {current_root}")
 
         except Exception as e:
             console.print(f"[red]Error creating project: {e}[/red]")
@@ -2875,7 +2885,7 @@ def task_list(
         None,
         "--status",
         "-s",
-        help="Filter by status (pending, running, completed, failed)",
+        help="Filter by status (active, running, pending_review, completed, failed, blocked, cancelled)",
     ),
 ):
     """List tasks, optionally filtered by project or status"""

--- a/penguin/project/manager.py
+++ b/penguin/project/manager.py
@@ -92,12 +92,13 @@ class ProjectManager:
     # ==================== Project Operations ====================
     
     def create_project(
-        self, 
-        name: str, 
+        self,
+        name: str,
         description: str,
         tags: Optional[List[str]] = None,
         budget_tokens: Optional[int] = None,
         budget_minutes: Optional[int] = None,
+        workspace_path: Optional[Union[str, Path]] = None,
         **metadata
     ) -> Project:
         """Create a new project.
@@ -129,7 +130,11 @@ class ProjectManager:
         project_id = self._generate_id(name)
         
         # Set up workspace paths
-        workspace_path = self.workspace_path / "projects" / project_id
+        if workspace_path is not None:
+            explicit_workspace_path = Path(workspace_path).expanduser().resolve()
+            workspace_path = explicit_workspace_path
+        else:
+            workspace_path = self.workspace_path / "projects" / project_id
         context_path = workspace_path / "context"
         
         project = Project(
@@ -163,12 +168,13 @@ class ProjectManager:
         return project
     
     async def create_project_async(
-        self, 
-        name: str, 
+        self,
+        name: str,
         description: str,
         tags: Optional[List[str]] = None,
         budget_tokens: Optional[int] = None,
         budget_minutes: Optional[int] = None,
+        workspace_path: Optional[Union[str, Path]] = None,
         **metadata
     ) -> Project:
         """Async version of create_project."""
@@ -179,6 +185,7 @@ class ProjectManager:
                 tags=tags,
                 budget_tokens=budget_tokens,
                 budget_minutes=budget_minutes,
+                workspace_path=workspace_path,
                 **metadata
             )
         return await asyncio.get_event_loop().run_in_executor(None, _create_project)

--- a/tests/test_cli_surface_audit_regressions.py
+++ b/tests/test_cli_surface_audit_regressions.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 import importlib
 import os
-
-import click
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import click
+from click.testing import CliRunner
 import pytest
 
 from penguin.cli.event_manager import EventManager
@@ -67,7 +67,11 @@ async def test_project_status_summary_counts_lowercase_task_status_values():
 
 def test_event_manager_surfaces_clarification_answered_status():
     display_manager = SimpleNamespace(display_message=Mock())
-    streaming_display = SimpleNamespace(is_active=False, set_status=Mock(), clear_status=Mock())
+    streaming_display = SimpleNamespace(
+        is_active=False,
+        set_status=Mock(),
+        clear_status=Mock(),
+    )
     streaming_manager = SimpleNamespace(
         finalize_streaming=Mock(),
         _active_stream_id=None,
@@ -111,9 +115,9 @@ def test_task_list_accepts_uppercase_status_filter_and_shows_real_options():
         )
     )
 
-    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), \
-         patch.object(cli_module, "_core", core), \
-         patch.object(cli_module, "console") as console_mock:
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.object(cli_module, "console") as console_mock:
         cli_module.task_list(project_id="project-1", status="RUNNING")
 
     core.project_manager.list_tasks_async.assert_awaited_once()
@@ -121,12 +125,14 @@ def test_task_list_accepts_uppercase_status_filter_and_shows_real_options():
     assert kwargs["project_id"] == "project-1"
     assert kwargs["status"] == TaskStatus.RUNNING
     assert not console_mock.print.call_args_list or all(
-        "Invalid status" not in str(call.args[0]) for call in console_mock.print.call_args_list if call.args
+        "Invalid status" not in str(call.args[0])
+        for call in console_mock.print.call_args_list
+        if call.args
     )
 
-    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), \
-         patch.object(cli_module, "_core", core), \
-         patch.object(cli_module, "console") as console_mock:
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.object(cli_module, "console") as console_mock:
         with pytest.raises(click.exceptions.Exit):
             cli_module.task_list(project_id=None, status="not-a-status")
 
@@ -147,9 +153,9 @@ def test_task_start_reports_active_state_honestly():
         )
     )
 
-    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), \
-         patch.object(cli_module, "_core", core), \
-         patch.object(cli_module, "console") as console_mock:
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.object(cli_module, "console") as console_mock:
         cli_module.task_start("task-1")
 
     printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
@@ -170,9 +176,9 @@ def test_task_complete_docstring_and_message_reflect_review_approval():
         )
     )
 
-    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), \
-         patch.object(cli_module, "_core", core), \
-         patch.object(cli_module, "console") as console_mock:
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.object(cli_module, "console") as console_mock:
         cli_module.task_complete("task-1")
 
     printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
@@ -217,4 +223,86 @@ def test_preconfigure_cli_environment_clears_stale_root_hints(tmp_path, monkeypa
     finally:
         cli_module.WORKSPACE_PATH = original_cli_workspace
         config_module.WORKSPACE_PATH = original_config_workspace
+
+
+def test_project_create_honors_explicit_workspace_path(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    explicit_workspace = (tmp_path / "explicit-workspace").resolve()
+    project = Project(
+        id="project-1",
+        name="Project 1",
+        description="Project description",
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+        status="active",
+        workspace_path=explicit_workspace,
+        context_path=explicit_workspace / "context",
+    )
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+        )
+    )
+
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.dict(os.environ, {"PENGUIN_CWD": str(tmp_path / "repo-root")}, clear=False), patch.object(
+        cli_module, "console"
+    ) as console_mock:
+        cli_module.project_create(
+            name="Project 1",
+            description="Project description",
+            workspace_path=str(explicit_workspace),
+        )
+
+    core.project_manager.create_project_async.assert_awaited_once()
+    _, kwargs = core.project_manager.create_project_async.await_args
+    assert kwargs["workspace_path"] == explicit_workspace
+
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
+    assert "Workspace (explicit):" in printed
+    assert str(explicit_workspace) in printed
+    assert "Execution root:" in printed
+
+
+def test_project_create_reports_default_workspace_honestly(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    default_workspace = (tmp_path / "managed-root" / "projects" / "project-1").resolve()
+    project = Project(
+        id="project-1",
+        name="Project 1",
+        description="Project description",
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+        status="active",
+        workspace_path=default_workspace,
+        context_path=default_workspace / "context",
+    )
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+        )
+    )
+
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()), patch.object(
+        cli_module, "_core", core
+    ), patch.dict(os.environ, {"PENGUIN_CWD": str(tmp_path / "repo-root")}, clear=False), patch.object(
+        cli_module, "console"
+    ) as console_mock:
+        cli_module.project_create(
+            name="Project 1",
+            description="Project description",
+            workspace_path=None,
+        )
+
+    _, kwargs = core.project_manager.create_project_async.await_args
+    assert kwargs["workspace_path"] is None
+
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
+    assert "Workspace (default):" in printed
+    assert str(default_workspace) in printed
+    assert "Execution root:" in printed
+
 


### PR DESCRIPTION
## Summary

This PR implements **PR 1: CLI Workspace Semantics + Honesty Fixes**.

It tightens the project-creation contract so the CLI tells the truth about where projects live and how task workflow commands are exposed.

### What changed
- honor exact-path `--workspace` for `penguin project create`
- thread explicit `workspace_path` through `ProjectManager.create_project(...)` and the async path
- improve project creation output so it distinguishes:
  - `Workspace (explicit): ...`
  - `Workspace (default): ...`
  - `Execution root: ...`
- update stale task-list lifecycle help text to current values
- add regression coverage for:
  - explicit workspace behavior
  - default workspace behavior
  - current help output / lifecycle wording
- add planning artifacts for the broader CLI audit and bootstrap work
- refresh CLI/project docs and testing-scenario notes to match current truth

## Why

Before this PR, `penguin project create --workspace ...` exposed a flag that did not actually control the created project workspace path. That was a surface-contract lie.

This PR fixes the contract in the simplest honest way:
- `--workspace` means the **exact provided path**
- Penguin does not silently reinterpret it into a child directory
- omission of `--workspace` still uses Penguin's managed default workspace behavior

## Verification

Targeted CLI regression suite:

```bash
pytest -q \
  tests/test_cli_surface_audit_regressions.py \
  tests/test_cli_integration.py \
  tests/test_cli_entrypoint_dispatcher.py
```

Result:
- `63 passed`

Manual smoke check also confirmed the new contract in a real repo/worktree-style path:

```bash
penguin project create PenguinChess --workspace /Users/maximusputnam/code/games/penguin-chess
```

Observed output included:
- `Workspace (explicit): /Users/maximusputnam/code/games/penguin-chess`
- `Execution root: /Users/maximusputnam/Code/Games/penguin-chess`

## Scope boundaries

This PR intentionally does **not** try to solve:
- broader CLI decomposition
- `project init` / `project start`
- deeper RunMode command/loop ergonomics
- `make-cli-useable.md` long-term CLI work

Those remain follow-up work.

## Related planning artifacts
- `context/tasks/cli-refactor-and-bootstrap-audit.md`
- `context/tasks/cli-workspace-semantics-pr1-checklist.md`
- `context/tasks/cli-interface-ergonomics-plan.md`
- `context/tasks/project-bootstrap-workflow.md`

