### PR TITLE
Harden web auth, uploads, and webhook handling

### DIFF
--- a/context/tasks/web-security-hardening-plan.md
+++ b/context/tasks/web-security-hardening-plan.md
@@ -1,0 +1,77 @@
+# Web Security Hardening Plan
+
+Date: 2026-04-16
+Branch: `fix/web-security-hardening`
+Worktree: `../penguin-web-security-hardening`
+
+## Objective
+Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface with minimal, test-backed changes.
+
+## Scope
+- `penguin/web/middleware/auth.py`
+- `penguin/web/routes.py`
+- `penguin/web/server.py`
+- `tests/` additions and updates for auth + WebSocket behavior
+
+## Findings Confirmed
+1. Public endpoint matching bug can bypass auth because `/` is treated as a prefix.
+2. WebSocket endpoints do not enforce auth before `accept()`.
+3. API key auth currently accepts `api_key` via query string.
+4. Server startup posture is permissive by default when bound broadly.
+5. Upload endpoint lacks size/type/quota controls.
+
+## Execution Plan
+
+### P0: Authentication correctness
+- Fix public endpoint matching so `/` is exact-match only.
+- Support explicit prefix-only public paths such as `/static/`.
+- Remove query-parameter API key authentication.
+- Add focused unit tests for:
+  - `/` exact match
+  - `/api/v1/capabilities` not public when auth enabled
+  - header auth succeeds
+  - query-param auth rejected
+
+### P0: WebSocket authentication
+- Add a shared WebSocket auth guard reusable across all protected WS handlers.
+- Enforce auth before `websocket.accept()` for:
+  - `/api/v1/events/ws`
+  - `/api/v1/ws/messages`
+  - `/api/v1/ws/telemetry`
+  - `/api/v1/chat/stream`
+  - `/api/v1/tasks/stream`
+- Add tests proving unauthorized WS handshakes are rejected and authorized handshakes succeed.
+
+### P1: Startup hardening
+- Add a startup/deployment guard for insecure broad binds without auth.
+- Keep localhost/dev workflow working.
+- Add tests for broad-bind + auth-disabled rejection behavior.
+
+### P1: Upload hardening
+- Add file size limits.
+- Add allowlist for file types/extensions if the endpoint is image-focused.
+- Return clear 4xx responses for rejected uploads.
+- Add tests for oversized and disallowed uploads.
+
+### P2: Follow-up items
+- Replay defense for GitHub webhook deliveries.
+- Secret-store backend for provider credentials.
+- Docs updates for hardened deployment profile.
+
+## Verification
+- Use the dedicated worktree only.
+- Prefer local web verification on port `9000` per `AGENTS.md`.
+- Run targeted pytest coverage first.
+- Run live server checks against `http://127.0.0.1:9000`.
+
+## Acceptance Criteria
+- Auth-enabled HTTP protected endpoints require valid header auth.
+- Query-string API key auth no longer works.
+- Protected WebSocket endpoints reject unauthenticated connections before accept.
+- Local verification on port `9000` passes targeted checks.
+- No unrelated behavior churn.
+
+## Notes
+This should likely be split into at least two commits:
+1. auth correctness + WS auth
+2. startup/upload hardening

--- a/context/tasks/web-security-hardening-plan.md
+++ b/context/tasks/web-security-hardening-plan.md
@@ -54,9 +54,11 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 - Add tests for oversized and disallowed uploads.
 
 ### P2: Follow-up items
-- Replay defense for GitHub webhook deliveries.
-- Secret-store backend for provider credentials.
-- Docs updates for hardened deployment profile.
+- Replay defense for GitHub webhook deliveries using a process-local TTL cache.
+- Document the replay-cache limitation for multi-instance deployments.
+- Prefer operator-managed environment variables for provider credentials.
+- Keep legacy plaintext JSON only as a compatibility fallback with loud warnings.
+- Document credential precedence and deprecate plaintext persistence as the primary path.
 
 ## Verification
 - Use the dedicated worktree only.
@@ -72,6 +74,7 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 - No unrelated behavior churn.
 
 ## Notes
-This should likely be split into at least two commits:
+This should likely be split into at least three commits:
 1. auth correctness + WS auth
 2. startup/upload hardening
+3. webhook replay defense + credential precedence/docs

--- a/docs/docs/advanced/future_considerations.md
+++ b/docs/docs/advanced/future_considerations.md
@@ -186,6 +186,25 @@ flowchart TD
 - Tailored resource suggestions for team members
 - Skill development tracking and integration with project planning
 
+
+## Web Server and Deployment Hardening Roadmap
+
+Some web-surface hardening now exists, but several follow-up items are intentionally still future work:
+
+- **Browser-friendly WebSocket auth**
+  - current backend behavior is secure, but browser UX still needs a cleaner strategy such as short-lived WS tickets or cookie/session auth
+- **Shared webhook replay cache**
+  - current GitHub webhook replay defense is process-local only
+  - multi-instance deployments will need Redis or equivalent shared state
+- **Rate limiting and quotas**
+  - request throttling, auth brute-force protection, and per-user/per-route quotas are still missing
+- **Keyring-backed local credential storage**
+  - environment variables are the preferred default now
+  - optional local keyring support remains a future convenience feature for desktop users
+- **Frontend rewrite alignment**
+  - the legacy dashboard/static surface should be replaced, not incrementally polished forever
+  - frontend auth, upload UX, and streaming contracts should be designed around the hardened backend instead of relying on old shortcuts
+
 ## Error Recovery and Safety
 
 ```mermaid

--- a/docs/docs/advanced/security.md
+++ b/docs/docs/advanced/security.md
@@ -538,3 +538,31 @@ Then check logs:
 tail -f .penguin/permission_audit.log | jq .
 ```
 
+## Web Server Hardening Notes
+
+### Provider Credential Precedence
+
+Penguin now prefers **operator-managed environment variables** for provider credentials.
+Legacy plaintext JSON credential files remain a compatibility fallback only.
+
+Precedence order:
+1. Environment variables (recommended for CI, containers, servers, and headless usage)
+2. Legacy local JSON credential store (deprecated fallback)
+3. Future local-only secret backends such as OS keyring integrations may be added later
+
+Important notes:
+- Environment variables are the recommended default because they work consistently across platforms and deployment targets.
+- The legacy JSON provider credential store is still readable for compatibility, but Penguin emits warnings when it is used.
+- Plaintext credential persistence should not be treated as the primary security posture for production deployments.
+
+### GitHub Webhook Replay Defense
+
+Penguin's GitHub webhook endpoint now rejects duplicate `X-GitHub-Delivery` IDs using a process-local in-memory TTL cache.
+
+When HTTP auth is enabled, the webhook route must also be intentionally exposed (for example via `PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook`) or otherwise fronted by an authenticated relay, because GitHub will not send Penguin API keys.
+
+This is effective for a **single-process / single-instance deployment**.
+It is **not sufficient for multi-instance deployments** because delivery IDs are not shared across processes or hosts.
+
+For horizontally scaled deployments, move replay tracking to shared state such as Redis or another low-latency shared cache.
+

--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -219,11 +219,14 @@ Stream chat responses in real-time with support for reasoning models and multipl
 
 **Authentication note:**
 - when web auth is enabled, protected WebSocket routes now enforce authentication during the handshake before `accept()`
-- header-based API key or bearer-token auth is supported for clients that can send them
+- header-based API key or bearer-token auth is supported only for clients that can send auth headers as part of the WebSocket handshake
+- native browser `WebSocket(...)` clients cannot attach arbitrary `Authorization` or `X-API-Key` headers, so the example below only works for public routes or routes intentionally exposed via `PENGUIN_PUBLIC_ENDPOINTS`
 - query-string API key auth is not supported
+- for authenticated connections, use a server-side or Node-based WebSocket client that can set headers, or introduce an authenticated upgrade/ticket flow in front of the browser client
 
 **Connection:**
 ```javascript
+// Works for public or intentionally exposed routes only.
 const ws = new WebSocket('ws://localhost:8000/api/v1/chat/stream');
 ```
 

--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -45,7 +45,12 @@ def create_app() -> FastAPI:
 
     # Configure CORS with environment-based origins
     origins_env = os.getenv("PENGUIN_CORS_ORIGINS", "").strip()
-    origins_list = [o.strip() for o in origins_env.split(",") if o.strip()] or ["*"]
+    origins_list = [o.strip() for o in origins_env.split(",") if o.strip()] or [
+        "http://localhost:8000",
+        "http://127.0.0.1:8000",
+        "http://localhost:9000",
+        "http://127.0.0.1:9000",
+    ]
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins_list,

--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -550,7 +550,7 @@ Register an existing agent with a coordinator role.
 
 Penguin includes built-in GitHub webhook support for automated workflows.
 
-#### POST `/api/v1/github/webhook`
+#### POST `/api/v1/integrations/github/webhook`
 
 Receive GitHub webhook events (configured in GitHub repository settings).
 
@@ -1628,7 +1628,7 @@ By default, the server runs on port 8000 and provides:
 - **Web UI**: http://localhost:8000/
 - **API Documentation (Swagger)**: http://localhost:8000/api/docs
 - **API Documentation (ReDoc)**: http://localhost:8000/api/redoc
-- **GitHub Webhook**: http://localhost:8000/api/v1/github/webhook
+- **GitHub Webhook**: http://localhost:8000/api/v1/integrations/github/webhook
 - **WebSocket Events**: ws://localhost:8000/api/v1/events/ws
 - **WebSocket Chat**: ws://localhost:8000/api/v1/chat/stream
 

--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -71,6 +71,15 @@ def create_app() -> FastAPI:
     return app
 ```
 
+### Startup and CORS Hardening
+
+Current server behavior is slightly stricter than older examples on this page:
+
+- if `PENGUIN_CORS_ORIGINS` is unset, Penguin now uses a small localhost-only development allowlist instead of `"*"`
+- if the server binds to a non-local interface such as `0.0.0.0` while auth is disabled, startup is blocked unless `PENGUIN_ALLOW_INSECURE_NO_AUTH=true` is set explicitly
+
+That startup check exists to reduce accidental exposure of an unauthenticated development server.
+
 ### Core Instance Management
 
 The server uses a global core instance pattern for efficient resource usage:
@@ -202,6 +211,11 @@ Process a chat message with optional conversation support, multi-modal capabilit
 #### WebSocket `/api/v1/chat/stream`
 
 Stream chat responses in real-time with support for reasoning models and multiple agents.
+
+**Authentication note:**
+- when web auth is enabled, protected WebSocket routes now enforce authentication during the handshake before `accept()`
+- header-based API key or bearer-token auth is supported for clients that can send them
+- query-string API key auth is not supported
 
 **Connection:**
 ```javascript
@@ -1194,6 +1208,29 @@ Get comprehensive model and system capabilities.
 
 ### Security & Permissions
 
+The web server now has active auth controls instead of relying entirely on network trust.
+
+**Current behavior:**
+- protected HTTP routes can require API-key or JWT authentication
+- protected WebSocket routes require explicit auth checks before connection acceptance
+- query-parameter API keys are not accepted
+- additional unauthenticated routes can be exposed intentionally with `PENGUIN_PUBLIC_ENDPOINTS`
+
+**Default public routes include:**
+- `/`
+- `/api/docs`
+- `/api/redoc`
+- `/api/openapi.json`
+- `/api/v1/health`
+- `/static/...`
+
+**GitHub webhook note:**
+When global auth is enabled, GitHub webhook delivery usually requires either:
+- exposing `/api/v1/integrations/github/webhook` through `PENGUIN_PUBLIC_ENDPOINTS`, or
+- placing Penguin behind a relay/gateway that handles the trust boundary
+
+GitHub will not send Penguin API keys on webhook delivery.
+
 Penguin provides security endpoints for managing permissions, approvals, and audit logs.
 
 :::note Migration Status
@@ -1372,6 +1409,12 @@ After approval/denial:
 ### File Upload and Multi-Modal Support
 
 #### POST `/api/v1/upload`
+
+**Security notes:**
+- this endpoint is currently restricted to image uploads
+- empty uploads are rejected
+- server-side size enforcement is controlled by `PENGUIN_MAX_UPLOAD_BYTES`
+- partially written files are removed if validation fails
 
 Upload files (primarily images) for use in conversations.
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -85,9 +85,9 @@ PENGUIN_WRITE_ROOT=project                     # Initial execution mode (project
 TASK_COMPLETION_PHRASE=TASK_COMPLETED
 
 # Web server
-WEB_HOST=127.0.0.1
-WEB_PORT=9000
-WEB_DEBUG=false
+HOST=127.0.0.1
+PORT=9000
+DEBUG=false
 
 # Web auth and exposure controls
 PENGUIN_AUTH_ENABLED=true
@@ -128,8 +128,8 @@ The web server now has explicit startup and auth hardening behavior that operato
 
 ```bash
 PENGUIN_AUTH_ENABLED=false
-WEB_HOST=127.0.0.1
-WEB_PORT=9000
+HOST=127.0.0.1
+PORT=9000
 ```
 
 #### Exposed deployment
@@ -138,8 +138,8 @@ WEB_PORT=9000
 PENGUIN_AUTH_ENABLED=true
 PENGUIN_API_KEYS=replace-me
 PENGUIN_CORS_ORIGINS=https://penguin.example.com
-WEB_HOST=0.0.0.0
-WEB_PORT=9000
+HOST=0.0.0.0
+PORT=9000
 ```
 
 #### GitHub webhooks with auth enabled
@@ -149,8 +149,8 @@ PENGUIN_AUTH_ENABLED=true
 PENGUIN_API_KEYS=replace-me
 PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook
 GITHUB_WEBHOOK_SECRET=replace-me
-WEB_HOST=0.0.0.0
-WEB_PORT=9000
+HOST=0.0.0.0
+PORT=9000
 ```
 
 Environment variables are now the preferred credential path for provider secrets in headless/server/container usage. Legacy plaintext JSON credential persistence remains compatibility fallback only.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Configuring Penguin AI Assistant
 
-Penguin AI Assistant v0.2.0 can be configured through environment variables and YAML configuration files. This guide explains all available options for core functionality, project management, web interface, and advanced features.
+Penguin can be configured through environment variables and YAML configuration files. This guide explains current options for core functionality, project management, the web server, and advanced features.
 
 Simpliest way is to just do `penguin config setup`
 
@@ -84,10 +84,21 @@ PENGUIN_WRITE_ROOT=project                     # Initial execution mode (project
 # Task Management
 TASK_COMPLETION_PHRASE=TASK_COMPLETED
 
-# Web Interface (if using penguin-ai[web])
-WEB_HOST=localhost
-WEB_PORT=8000
+# Web server
+WEB_HOST=127.0.0.1
+WEB_PORT=9000
 WEB_DEBUG=false
+
+# Web auth and exposure controls
+PENGUIN_AUTH_ENABLED=true
+PENGUIN_API_KEYS=replace-me
+PENGUIN_JWT_SECRET=replace-me
+PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook
+PENGUIN_CORS_ORIGINS=https://penguin.example.com
+PENGUIN_ALLOW_INSECURE_NO_AUTH=false
+PENGUIN_MAX_UPLOAD_BYTES=10737418240
+PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS=600
+GITHUB_WEBHOOK_SECRET=replace-me
 
 # Project Management
 PROJECT_AUTO_CHECKPOINT=true
@@ -98,6 +109,51 @@ MEMORY_PROVIDER=sqlite
 MEMORY_STORAGE_PATH=./memory
 EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 ```
+
+## Web Server Configuration Notes
+
+The web server now has explicit startup and auth hardening behavior that operators should understand:
+
+- `PENGUIN_AUTH_ENABLED` protects HTTP and protected WebSocket endpoints
+- `PENGUIN_API_KEYS` defines accepted header-based API keys
+- `PENGUIN_PUBLIC_ENDPOINTS` exposes additional routes without auth when needed
+- `PENGUIN_ALLOW_INSECURE_NO_AUTH=true` bypasses the startup block on non-local bind without auth
+- `PENGUIN_CORS_ORIGINS` should be set explicitly for exposed deployments
+- `PENGUIN_MAX_UPLOAD_BYTES` controls the server-side upload cap
+- `PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS` controls the in-memory replay-defense TTL
+
+### Recommended deployment defaults
+
+#### Local development
+
+```bash
+PENGUIN_AUTH_ENABLED=false
+WEB_HOST=127.0.0.1
+WEB_PORT=9000
+```
+
+#### Exposed deployment
+
+```bash
+PENGUIN_AUTH_ENABLED=true
+PENGUIN_API_KEYS=replace-me
+PENGUIN_CORS_ORIGINS=https://penguin.example.com
+WEB_HOST=0.0.0.0
+WEB_PORT=9000
+```
+
+#### GitHub webhooks with auth enabled
+
+```bash
+PENGUIN_AUTH_ENABLED=true
+PENGUIN_API_KEYS=replace-me
+PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook
+GITHUB_WEBHOOK_SECRET=replace-me
+WEB_HOST=0.0.0.0
+WEB_PORT=9000
+```
+
+Environment variables are now the preferred credential path for provider secrets in headless/server/container usage. Legacy plaintext JSON credential persistence remains compatibility fallback only.
 
 ### 2. YAML Configuration File
 

--- a/docs/docs/usage/web_interface.md
+++ b/docs/docs/usage/web_interface.md
@@ -1,91 +1,214 @@
 # Web Interface / API Server Guide (v0.6.x)
 
-Penguin ships with a **FastAPI-based HTTP server** that exposes core functionality (projects, tasks, chat, SSE/WS streaming) as a REST/WS API. That server is also the backend surface used by the OpenCode-derived terminal UI that now lives in the repository's `penguin-tui/` workspace.
+Penguin ships with a **FastAPI-based HTTP server** that exposes chat, projects, tasks, SSE/WS streaming, uploads, and integration routes. That server is also the backend surface used by the OpenCode-derived terminal UI in `penguin-tui/`.
+
+This page focuses on **how to run and expose the web server safely**.
 
 ---
 
-## Installation
-```bash
-# Recommended: base install already includes the web runtime
-uv tool install penguin-ai
-
-# Alternative: plain pip
-pip install penguin-ai
-
-# Compatibility alias for older install docs
-pip install "penguin-ai[web]"
-```
-
 ## Starting the server
+
 ```bash
-# Default → http://localhost:8000
+# Local development
 penguin-web
 
-# Custom host/port
+# Explicit host/port
+penguin-web --host 127.0.0.1 --port 9000
+
+# Exposed host (requires auth unless explicitly overridden)
 penguin-web --host 0.0.0.0 --port 9000
 ```
 
-The command is a thin wrapper around `penguin.web.server:main`, which serves the FastAPI app used by both API consumers and the modern TUI bridge.
+The command is a thin wrapper around `penguin.web.server:main`.
 
 Optional flags:
+
 | Flag | Description |
 |------|-------------|
-| `--debug` | Enable reload & verbose logging |
-| `--workers N` | Run with a process pool (production) |
+| `--debug` | Enable reload and verbose logging |
+| `--workers N` | Run with a process pool |
 
 ---
 
-## API Overview
-The OpenAPI / Swagger UI is served at:
-```
-GET http://<host>:<port>/docs
-```
-Key route groups:
-1. `/api/v1/projects` – CRUD for projects
-2. `/api/v1/tasks` – CRUD & execution for tasks
-3. `/api/v1/chat/message` – Chat endpoint (POST message, returns assistant reply)
-4. `/api/v1/chat/stream` – WebSocket for streaming chat responses
-5. `/api/v1/*` status/session endpoints for path, VCS, formatter, and LSP
+## Current Security Posture
 
-### Task / Clarification Surface Truth
+The web server is no longer “wide open unless you remember to harden it later.” Current behavior:
 
-The task/project web surface is no longer just legacy CRUD sugar. Current behavior includes:
-- richer task payloads that expose lifecycle truth such as `status`, `phase`, dependencies, dependency specs, artifact evidence, recipe references, and clarification metadata
-- `POST /api/v1/tasks/{task_id}/execute` routing through `RunMode`, so non-terminal outcomes like `waiting_input` survive to clients
-- `POST /api/v1/tasks/{task_id}/clarification/resume` to answer the latest open clarification and resume execution
-- `GET /api/v1/events/sse` including clarification-related session status visibility for compatible clients
+- protected HTTP routes can require API-key or JWT auth
+- protected WebSocket routes also require auth before `accept()`
+- query-string API keys are not accepted
+- CORS no longer defaults to `*`
+- non-local bind without auth is blocked at startup unless explicitly overridden
+- upload handling is restricted to image MIME types/extensions
+- GitHub webhook replay defense rejects duplicate `X-GitHub-Delivery` IDs within a process-local TTL window
 
-For full path details, inspect the live Swagger page or read `penguin/penguin/web/routes.py`.
+### Public routes
 
-> Example – list projects:
-> ```bash
-> curl http://localhost:8000/api/v1/projects
-> ```
+Some routes remain public by design, including:
 
-### Session + Directory Isolation
+- `/`
+- `/api/docs`
+- `/api/redoc`
+- `/api/openapi.json`
+- `/api/v1/health`
+- `/static/...`
 
-For OpenCode-compatible multi-session workflows, chat requests support:
-- `session_id` and/or `conversation_id`
-- `directory` (repo root for tool execution)
-
-Behavior:
-- The first valid directory bound to a session is immutable by default.
-- Rebinding a session to a different directory returns `409`.
-- Invalid directories return `400`.
-- Request execution is context-scoped so parallel sessions can run safely across different repos.
+Additional public routes can be exposed explicitly with `PENGUIN_PUBLIC_ENDPOINTS`.
 
 ---
 
 ## Authentication
-Authentication is **not** yet implemented.  The server should only be exposed on trusted networks.
+
+Authentication is controlled by `PENGUIN_AUTH_ENABLED`.
+
+When enabled, protected routes accept:
+
+- `X-API-Key: <key>`
+- `X-Link-API-Key: <key>`
+- `Authorization: Bearer <jwt>`
+
+### Example: authenticated HTTP request
+
+```bash
+curl http://127.0.0.1:9000/api/v1/capabilities \
+  -H "X-API-Key: your-key"
+```
+
+### Example: unauthenticated request
+
+```bash
+curl http://127.0.0.1:9000/api/v1/capabilities
+```
+
+That now returns `401 Unauthorized`, not a misleading `500`.
+
+### WebSocket auth
+
+Protected WebSocket endpoints must authenticate during connection setup.
+
+Important constraint: browser JavaScript cannot cleanly set arbitrary custom WebSocket headers in the same way as backend clients. That means browser-facing WS auth ergonomics are still a design concern for the future UI rewrite.
+
+For now:
+- backend clients should use headers
+- browser-facing improvements likely need short-lived WS tickets or cookie/session auth later
+
+---
+
+## Startup Hardening
+
+If you bind Penguin to a non-local interface such as `0.0.0.0` while auth is disabled, startup is blocked by default.
+
+This prevents the easiest “accidentally exposed dev server on the internet” failure mode.
+
+Override only if you really mean it:
+
+```bash
+PENGUIN_ALLOW_INSECURE_NO_AUTH=true penguin-web --host 0.0.0.0 --port 9000
+```
+
+That override exists for edge cases, not because it is a good idea.
+
+---
+
+## CORS Behavior
+
+If `PENGUIN_CORS_ORIGINS` is unset, Penguin now defaults to a small development allowlist instead of wildcard origins.
+
+Default dev origins:
+
+- `http://localhost:8000`
+- `http://127.0.0.1:8000`
+- `http://localhost:9000`
+- `http://127.0.0.1:9000`
+
+Set an explicit allowlist for real deployments:
+
+```bash
+PENGUIN_CORS_ORIGINS=https://penguin.example.com,https://admin.example.com
+```
+
+---
+
+## Upload Behavior
+
+`POST /api/v1/upload` is currently intended for image-style uploads.
+
+Current behavior:
+- image MIME types/extensions only
+- empty uploads rejected
+- size limit enforced server-side
+- max size controlled by `PENGUIN_MAX_UPLOAD_BYTES`
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:9000/api/v1/upload \
+  -H "X-API-Key: your-key" \
+  -F "file=@screenshot.png;type=image/png"
+```
+
+If you need generic large-object upload semantics later, that should be designed explicitly instead of pretending this endpoint is already that.
+
+---
+
+## GitHub Webhooks Under Auth
+
+GitHub does not send Penguin API keys.
+
+So if global Penguin auth is enabled, the webhook route must either:
+
+1. be explicitly exposed as public, or
+2. sit behind a relay/gateway that handles the trust boundary
+
+Example:
+
+```bash
+PENGUIN_AUTH_ENABLED=true \
+PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook \
+penguin-web --host 127.0.0.1 --port 9000
+```
+
+Penguin still verifies the webhook HMAC signature and now also rejects replayed delivery IDs, but the route has to be reachable first.
+
+---
+
+## Recommended Deployment Profiles
+
+### Local development
+
+```bash
+PENGUIN_AUTH_ENABLED=false
+penguin-web --host 127.0.0.1 --port 9000
+```
+
+### Hardened exposed deployment
+
+```bash
+PENGUIN_AUTH_ENABLED=true
+PENGUIN_API_KEYS=replace-me
+PENGUIN_CORS_ORIGINS=https://penguin.example.com
+penguin-web --host 0.0.0.0 --port 9000
+```
+
+### GitHub webhook with auth enabled
+
+```bash
+PENGUIN_AUTH_ENABLED=true
+PENGUIN_API_KEYS=replace-me
+PENGUIN_PUBLIC_ENDPOINTS=/api/v1/integrations/github/webhook
+GITHUB_WEBHOOK_SECRET=replace-me
+penguin-web --host 0.0.0.0 --port 9000
+```
 
 ---
 
 ## Known Limitations
-* No HTML UI – interaction is via REST/WS or the CLI.  
-* Auth/RBAC, CORS, and HTTPS termination are future work.  
-* API surface may change without notice until v1.0.
+
+- The legacy dashboard/static UI is not the strategic frontend path and should not be treated as a polished product surface.
+- WebSocket auth is correct, but browser-native auth ergonomics still need a better long-term design.
+- GitHub webhook replay defense is process-local only; multi-instance deployments need shared replay state.
+- Rate limiting and per-user/per-route quotas are still future work.
 
 ---
 
-*Last updated: February 16th 2026* 
+*Last updated: April 16, 2026*

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -33,6 +33,13 @@ logger = logging.getLogger(__name__)
 # Global core instance for reuse
 _core_instance: Optional[PenguinCore] = None
 
+DEFAULT_DEV_CORS_ORIGINS = [
+    "http://127.0.0.1:8000",
+    "http://localhost:8000",
+    "http://127.0.0.1:9000",
+    "http://localhost:9000",
+]
+
 
 def get_or_create_core() -> PenguinCore:
     """Get the global core instance or create it if it doesn't exist."""
@@ -180,7 +187,7 @@ def create_app() -> "FastAPI":
 
     # Configure CORS
     origins_env = os.getenv("PENGUIN_CORS_ORIGINS", "").strip()
-    origins_list = [o.strip() for o in origins_env.split(",") if o.strip()] or ["*"]
+    origins_list = [o.strip() for o in origins_env.split(",") if o.strip()] or DEFAULT_DEV_CORS_ORIGINS
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins_list,

--- a/penguin/web/integrations/github_webhook.py
+++ b/penguin/web/integrations/github_webhook.py
@@ -678,9 +678,6 @@ async def github_webhook(request: Request, background_tasks: BackgroundTasks):
     if not delivery_id:
         logger.warning("Missing X-GitHub-Delivery header")
         raise HTTPException(status_code=400, detail="Missing delivery id")
-    if not remember_github_delivery(delivery_id):
-        logger.warning("Rejected replayed GitHub delivery: %s", delivery_id)
-        raise HTTPException(status_code=409, detail="Duplicate delivery")
 
     # Get event type
     event_type = request.headers.get("X-GitHub-Event", "unknown")
@@ -704,6 +701,10 @@ async def github_webhook(request: Request, background_tasks: BackgroundTasks):
     if allowed_repo and repo_name and repo_name != allowed_repo:
         logger.warning(f"Webhook from unauthorized repo: {repo_name} (allowed: {allowed_repo})")
         raise HTTPException(status_code=403, detail="Unauthorized repository")
+
+    if not remember_github_delivery(delivery_id):
+        logger.warning("Rejected replayed GitHub delivery: %s", delivery_id)
+        raise HTTPException(status_code=409, detail="Duplicate delivery")
 
     # Route event to appropriate handler
     # Process in background to avoid timeout

--- a/penguin/web/integrations/github_webhook.py
+++ b/penguin/web/integrations/github_webhook.py
@@ -52,10 +52,10 @@ def _delivery_cache_ttl_seconds() -> float:
 
 
 def remember_github_delivery(delivery_id: str, *, now: float | None = None) -> bool:
-    """Return True when delivery is new, False when it is a replay."""
+    """Return True when delivery is new, False when it is blank or a replay."""
     normalized = delivery_id.strip()
     if not normalized:
-        return True
+        return False
 
     current_time = now if isinstance(now, (int, float)) else time.monotonic()
     ttl_seconds = _delivery_cache_ttl_seconds()

--- a/penguin/web/integrations/github_webhook.py
+++ b/penguin/web/integrations/github_webhook.py
@@ -3,12 +3,16 @@
 Handles GitHub webhook events for @Penguin mentions, PR events, and issue events.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import hmac
 import logging
 import os
 import re
+import time
+from threading import RLock
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Request, HTTPException, BackgroundTasks
@@ -21,6 +25,60 @@ from penguin.constants import DEFAULT_PATCH_TRUNCATION_LIMIT
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/integrations/github", tags=["integrations"])
+
+
+_DEFAULT_DELIVERY_CACHE_TTL_SECONDS = 10 * 60
+_DELIVERY_CACHE_TTL_ENV = "PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS"
+_DELIVERY_CACHE_LOCK = RLock()
+_SEEN_DELIVERY_IDS: dict[str, float] = {}
+
+
+def _delivery_cache_ttl_seconds() -> float:
+    raw = os.getenv(
+        _DELIVERY_CACHE_TTL_ENV,
+        str(_DEFAULT_DELIVERY_CACHE_TTL_SECONDS),
+    ).strip()
+    try:
+        ttl = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %s seconds",
+            _DELIVERY_CACHE_TTL_ENV,
+            raw,
+            _DEFAULT_DELIVERY_CACHE_TTL_SECONDS,
+        )
+        return float(_DEFAULT_DELIVERY_CACHE_TTL_SECONDS)
+    return max(ttl, 0.0)
+
+
+def remember_github_delivery(delivery_id: str, *, now: float | None = None) -> bool:
+    """Return True when delivery is new, False when it is a replay."""
+    normalized = delivery_id.strip()
+    if not normalized:
+        return True
+
+    current_time = now if isinstance(now, (int, float)) else time.monotonic()
+    ttl_seconds = _delivery_cache_ttl_seconds()
+    with _DELIVERY_CACHE_LOCK:
+        expired = [
+            seen_id
+            for seen_id, seen_at in _SEEN_DELIVERY_IDS.items()
+            if current_time - seen_at > ttl_seconds
+        ]
+        for seen_id in expired:
+            _SEEN_DELIVERY_IDS.pop(seen_id, None)
+
+        if normalized in _SEEN_DELIVERY_IDS:
+            return False
+
+        _SEEN_DELIVERY_IDS[normalized] = current_time
+        return True
+
+
+def reset_github_delivery_cache() -> None:
+    """Reset the in-memory replay cache. Intended for tests."""
+    with _DELIVERY_CACHE_LOCK:
+        _SEEN_DELIVERY_IDS.clear()
 
 
 async def post_github_comment(repo_name: str, issue_number: int, comment_body: str) -> bool:
@@ -615,6 +673,14 @@ async def github_webhook(request: Request, background_tasks: BackgroundTasks):
     except Exception as e:
         logger.error(f"Failed to parse webhook payload: {e}")
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    delivery_id = request.headers.get("X-GitHub-Delivery", "").strip()
+    if not delivery_id:
+        logger.warning("Missing X-GitHub-Delivery header")
+        raise HTTPException(status_code=400, detail="Missing delivery id")
+    if not remember_github_delivery(delivery_id):
+        logger.warning("Rejected replayed GitHub delivery: %s", delivery_id)
+        raise HTTPException(status_code=409, detail="Duplicate delivery")
 
     # Get event type
     event_type = request.headers.get("X-GitHub-Event", "unknown")

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -98,6 +98,71 @@ class AuthConfig:
         return any(path.startswith(prefix) for prefix in self.public_endpoint_prefixes)
 
 
+# Public-endpoint matching convention:
+# - entries ending with "/" (except "/" itself) are treated as prefix matches
+# - all other entries require exact path equality
+# `is_public_endpoint()` checks exact matches first, then falls back to prefix matching.
+
+def extract_api_key(connection: Any) -> Optional[str]:
+    """Extract API key from request or websocket headers."""
+    headers = connection.headers
+
+    api_key = headers.get("X-API-Key")
+    if api_key:
+        return api_key
+
+    link_key = headers.get("X-Link-API-Key")
+    if link_key:
+        return link_key
+
+    return None
+
+
+def extract_bearer_token(connection: Any) -> Optional[str]:
+    """Extract Bearer token from Authorization header."""
+    auth_header = connection.headers.get("Authorization")
+    if not auth_header:
+        return None
+
+    parts = auth_header.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+
+    return parts[1]
+
+
+def validate_api_key(api_key: str, config: AuthConfig) -> bool:
+    """Validate an API key against configured keys."""
+    if not api_key:
+        return False
+    return api_key in config.api_keys
+
+
+def validate_jwt(token: str, config: AuthConfig) -> dict:
+    """Validate and decode a JWT token using the provided config."""
+    if not config.jwt_secret:
+        raise AuthenticationError("JWT authentication not configured")
+
+    try:
+        claims = jwt.decode(
+            token,
+            config.jwt_secret,
+            algorithms=[config.jwt_algorithm]
+        )
+
+        if "exp" in claims:
+            exp_timestamp = claims["exp"]
+            if datetime.utcfromtimestamp(exp_timestamp) < datetime.utcnow():
+                raise AuthenticationError("Token has expired")
+
+        return claims
+
+    except jwt.ExpiredSignatureError:
+        raise AuthenticationError("Token has expired")
+    except jwt.InvalidTokenError as e:
+        raise AuthenticationError(f"Invalid token: {str(e)}")
+
+
 class AuthenticationMiddleware(BaseHTTPMiddleware):
     """Middleware for authenticating API requests."""
 
@@ -133,8 +198,8 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 },
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        except Exception as e:
-            logger.error(f"Unexpected error in authentication: {str(e)}")
+        except Exception:
+            logger.exception("Unexpected error in authentication")
             return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content={
@@ -159,89 +224,24 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     async def _authenticate_request(self, request: Request) -> dict:
         """Authenticate a request using available methods."""
-        # Try API key authentication first (faster)
-        api_key = self._extract_api_key(request)
-        if api_key and self._validate_api_key(api_key):
+        api_key = extract_api_key(request)
+        if api_key and validate_api_key(api_key, self.config):
             return {
                 "method": "api_key",
                 "subject": "api_client",
                 "metadata": {"key_prefix": api_key[:8] + "..."}
             }
 
-        # Try JWT authentication
-        token = self._extract_bearer_token(request)
+        token = extract_bearer_token(request)
         if token:
-            claims = self._validate_jwt(token)
+            claims = validate_jwt(token, self.config)
             return {
                 "method": "jwt",
                 "subject": claims.get("sub", "unknown"),
                 "metadata": claims
             }
 
-        # No valid authentication found
         raise AuthenticationError("No valid authentication credentials provided")
-
-    def _extract_api_key(self, connection: Any) -> Optional[str]:
-        """Extract API key from request or websocket headers."""
-        headers = connection.headers
-
-        # Check X-API-Key header
-        api_key = headers.get("X-API-Key")
-        if api_key:
-            return api_key
-
-        # Check X-Link-API-Key header (Link-specific)
-        link_key = headers.get("X-Link-API-Key")
-        if link_key:
-            return link_key
-
-        return None
-
-    def _extract_bearer_token(self, connection: Any) -> Optional[str]:
-        """Extract Bearer token from Authorization header."""
-        auth_header = connection.headers.get("Authorization")
-        if not auth_header:
-            return None
-
-        parts = auth_header.split()
-        if len(parts) != 2 or parts[0].lower() != "bearer":
-            return None
-
-        return parts[1]
-
-    def _validate_api_key(self, api_key: str) -> bool:
-        """Validate an API key."""
-        if not api_key:
-            return False
-
-        # Check against configured keys
-        return api_key in self.config.api_keys
-
-    def _validate_jwt(self, token: str) -> dict:
-        """Validate and decode a JWT token."""
-        if not self.config.jwt_secret:
-            raise AuthenticationError("JWT authentication not configured")
-
-        try:
-            # Decode and validate token
-            claims = jwt.decode(
-                token,
-                self.config.jwt_secret,
-                algorithms=[self.config.jwt_algorithm]
-            )
-
-            # Check expiration
-            if "exp" in claims:
-                exp_timestamp = claims["exp"]
-                if datetime.utcfromtimestamp(exp_timestamp) < datetime.utcnow():
-                    raise AuthenticationError("Token has expired")
-
-            return claims
-
-        except jwt.ExpiredSignatureError:
-            raise AuthenticationError("Token has expired")
-        except jwt.InvalidTokenError as e:
-            raise AuthenticationError(f"Invalid token: {str(e)}")
 
     def create_jwt(self, subject: str, metadata: Optional[dict] = None) -> str:
         """Create a JWT token for a subject.
@@ -316,19 +316,18 @@ def authenticate_connection(
 ) -> dict:
     """Authenticate an HTTP or WebSocket connection using shared auth rules."""
     auth_config = config or AuthConfig()
-    middleware = AuthenticationMiddleware(app=lambda scope, receive, send: None, config=auth_config)
 
-    api_key = middleware._extract_api_key(connection)
-    if api_key and middleware._validate_api_key(api_key):
+    api_key = extract_api_key(connection)
+    if api_key and validate_api_key(api_key, auth_config):
         return {
             "method": "api_key",
             "subject": "api_client",
             "metadata": {"key_prefix": api_key[:8] + "..."},
         }
 
-    token = middleware._extract_bearer_token(connection)
+    token = extract_bearer_token(connection)
     if token:
-        claims = middleware._validate_jwt(token)
+        claims = validate_jwt(token, auth_config)
         return {
             "method": "jwt",
             "subject": claims.get("sub", "unknown"),

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -116,19 +116,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         try:
-            # Attempt to authenticate the request
             auth_result = await self._authenticate_request(request)
-
-            # Add auth info to request state
-            request.state.authenticated = True
-            request.state.auth_method = auth_result["method"]
-            request.state.auth_subject = auth_result.get("subject", "unknown")
-            request.state.auth_metadata = auth_result.get("metadata", {})
-
-            # Process request
-            response = await call_next(request)
-            return response
-
         except AuthenticationError as e:
             logger.warning(f"Authentication failed for {request.url.path}: {str(e)}")
             return JSONResponse(
@@ -160,6 +148,14 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                     }
                 },
             )
+
+        # Add auth info to request state
+        request.state.authenticated = True
+        request.state.auth_method = auth_result["method"]
+        request.state.auth_subject = auth_result.get("subject", "unknown")
+        request.state.auth_metadata = auth_result.get("metadata", {})
+
+        return await call_next(request)
 
     async def _authenticate_request(self, request: Request) -> dict:
         """Authenticate a request using available methods."""

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -6,10 +6,11 @@ and other external clients.
 
 import logging
 import os
-from typing import Optional, Callable, Awaitable
+from typing import Any, Optional
 from datetime import datetime, timedelta
 
-from fastapi import Request, HTTPException, status
+from fastapi import HTTPException, Request, WebSocket, WebSocketException, status
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette.middleware.base import BaseHTTPMiddleware
 import jwt
@@ -69,7 +70,7 @@ class AuthConfig:
             "/api/redoc",
             "/api/openapi.json",
             "/api/v1/health",
-            "/static",
+            "/static/",
         }
 
         # Load additional public endpoints from environment
@@ -79,12 +80,22 @@ class AuthConfig:
 
         return public
 
+    @property
+    def public_endpoint_prefixes(self) -> set[str]:
+        """Return public endpoints that should be treated as prefixes."""
+        return {path for path in self.public_endpoints if path.endswith("/") and path != "/"}
+
+    @property
+    def public_endpoint_exact_matches(self) -> set[str]:
+        """Return public endpoints that require exact path matches."""
+        return self.public_endpoints - self.public_endpoint_prefixes
+
     def is_public_endpoint(self, path: str) -> bool:
         """Check if an endpoint is public (doesn't require auth)."""
-        for public_path in self.public_endpoints:
-            if path.startswith(public_path):
-                return True
-        return False
+        if path in self.public_endpoint_exact_matches:
+            return True
+
+        return any(path.startswith(prefix) for prefix in self.public_endpoint_prefixes)
 
 
 class AuthenticationMiddleware(BaseHTTPMiddleware):
@@ -120,30 +131,34 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
         except AuthenticationError as e:
             logger.warning(f"Authentication failed for {request.url.path}: {str(e)}")
-            raise HTTPException(
+            return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail={
-                    "error": {
-                        "code": "AUTHENTICATION_FAILED",
-                        "message": str(e),
-                        "recoverable": False,
-                        "suggested_action": "check_credentials"
+                content={
+                    "detail": {
+                        "error": {
+                            "code": "AUTHENTICATION_FAILED",
+                            "message": str(e),
+                            "recoverable": False,
+                            "suggested_action": "check_credentials",
+                        }
                     }
                 },
                 headers={"WWW-Authenticate": "Bearer"},
             )
         except Exception as e:
             logger.error(f"Unexpected error in authentication: {str(e)}")
-            raise HTTPException(
+            return JSONResponse(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail={
-                    "error": {
-                        "code": "AUTHENTICATION_ERROR",
-                        "message": "Internal authentication error",
-                        "recoverable": True,
-                        "suggested_action": "retry"
+                content={
+                    "detail": {
+                        "error": {
+                            "code": "AUTHENTICATION_ERROR",
+                            "message": "Internal authentication error",
+                            "recoverable": True,
+                            "suggested_action": "retry",
+                        }
                     }
-                }
+                },
             )
 
     async def _authenticate_request(self, request: Request) -> dict:
@@ -170,29 +185,25 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         # No valid authentication found
         raise AuthenticationError("No valid authentication credentials provided")
 
-    def _extract_api_key(self, request: Request) -> Optional[str]:
-        """Extract API key from request headers."""
+    def _extract_api_key(self, connection: Any) -> Optional[str]:
+        """Extract API key from request or websocket headers."""
+        headers = connection.headers
+
         # Check X-API-Key header
-        api_key = request.headers.get("X-API-Key")
+        api_key = headers.get("X-API-Key")
         if api_key:
             return api_key
 
         # Check X-Link-API-Key header (Link-specific)
-        link_key = request.headers.get("X-Link-API-Key")
+        link_key = headers.get("X-Link-API-Key")
         if link_key:
             return link_key
 
-        # Check query parameter (less secure, but supported)
-        api_key_param = request.query_params.get("api_key")
-        if api_key_param:
-            logger.warning("API key provided via query parameter (insecure)")
-            return api_key_param
-
         return None
 
-    def _extract_bearer_token(self, request: Request) -> Optional[str]:
+    def _extract_bearer_token(self, connection: Any) -> Optional[str]:
         """Extract Bearer token from Authorization header."""
-        auth_header = request.headers.get("Authorization")
+        auth_header = connection.headers.get("Authorization")
         if not auth_header:
             return None
 
@@ -301,3 +312,56 @@ async def require_auth(
         "subject": request.state.auth_subject,
         "metadata": request.state.auth_metadata
     }
+
+
+def authenticate_connection(
+    connection: Any,
+    config: Optional[AuthConfig] = None,
+) -> dict:
+    """Authenticate an HTTP or WebSocket connection using shared auth rules."""
+    auth_config = config or AuthConfig()
+    middleware = AuthenticationMiddleware(app=lambda scope, receive, send: None, config=auth_config)
+
+    api_key = middleware._extract_api_key(connection)
+    if api_key and middleware._validate_api_key(api_key):
+        return {
+            "method": "api_key",
+            "subject": "api_client",
+            "metadata": {"key_prefix": api_key[:8] + "..."},
+        }
+
+    token = middleware._extract_bearer_token(connection)
+    if token:
+        claims = middleware._validate_jwt(token)
+        return {
+            "method": "jwt",
+            "subject": claims.get("sub", "unknown"),
+            "metadata": claims,
+        }
+
+    raise AuthenticationError("No valid authentication credentials provided")
+
+
+async def require_websocket_auth(
+    websocket: WebSocket,
+    config: Optional[AuthConfig] = None,
+) -> dict:
+    """Authenticate a WebSocket connection before accept()."""
+    auth_config = config or AuthConfig()
+    if not auth_config.auth_enabled or auth_config.is_public_endpoint(websocket.url.path):
+        return {"method": "anonymous", "subject": "public", "metadata": {}}
+
+    try:
+        auth_result = authenticate_connection(websocket, auth_config)
+    except AuthenticationError as exc:
+        logger.warning("WebSocket authentication failed for %s: %s", websocket.url.path, exc)
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason=str(exc),
+        ) from exc
+
+    websocket.state.authenticated = True
+    websocket.state.auth_method = auth_result["method"]
+    websocket.state.auth_subject = auth_result.get("subject", "unknown")
+    websocket.state.auth_metadata = auth_result.get("metadata", {})
+    return auth_result

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -24,6 +24,7 @@ import mimetypes
 import os
 from pathlib import Path
 import re
+from contextlib import suppress
 import shutil
 import tempfile
 import time
@@ -157,6 +158,20 @@ def _serialize_task_payload(task: Any, *, include_metadata: bool = True) -> Dict
 
 
 MAX_IMAGES_PER_REQUEST = 10
+DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024 * 1024
+ALLOWED_UPLOAD_CONTENT_TYPES = {
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+}
+ALLOWED_UPLOAD_EXTENSIONS = {".gif", ".jpeg", ".jpg", ".png", ".webp"}
+
+
+def _max_upload_bytes() -> int:
+    """Return the configured upload size limit in bytes."""
+    return int(os.getenv("PENGUIN_MAX_UPLOAD_BYTES", str(DEFAULT_MAX_UPLOAD_BYTES)))
+
 
 _FIND_FILE_CACHE_TTL_SECONDS = 5.0
 _FIND_FILE_CACHE_MAX_DIRECTORIES = 16
@@ -5600,27 +5615,60 @@ async def load_context_file(
 async def upload_file(
     file: UploadFile = File(...), core: PenguinCore = Depends(get_core)
 ):
-    """Upload a file (primarily images) to be used in conversations."""
+    """Upload an image file to be used in conversations."""
     try:
-        # Create uploads directory if it doesn't exist
+        if not file.filename:
+            raise HTTPException(status_code=400, detail="Filename is required")
+
+        content_type = (file.content_type or "").lower()
+        if content_type not in ALLOWED_UPLOAD_CONTENT_TYPES:
+            raise HTTPException(
+                status_code=415,
+                detail="Unsupported media type. Allowed types: GIF, JPEG, PNG, WEBP.",
+            )
+
+        extension = Path(file.filename).suffix.lower()
+        if extension not in ALLOWED_UPLOAD_EXTENSIONS:
+            raise HTTPException(
+                status_code=415,
+                detail="Unsupported file extension. Allowed extensions: .gif, .jpeg, .jpg, .png, .webp.",
+            )
+
         uploads_dir = Path(WORKSPACE_PATH) / "uploads"
         uploads_dir.mkdir(exist_ok=True)
 
-        # Generate a unique filename
-        file_extension = file.filename.split(".")[-1] if "." in file.filename else ""
-        unique_filename = f"{uuid.uuid4()}.{file_extension}"
+        unique_filename = f"{uuid.uuid4()}{extension}"
         file_path = uploads_dir / unique_filename
+        max_upload_bytes = _max_upload_bytes()
+        bytes_written = 0
 
-        # Save the file
         with open(file_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                bytes_written += len(chunk)
+                if bytes_written > max_upload_bytes:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"File exceeds upload size limit of {max_upload_bytes} bytes",
+                    )
+                buffer.write(chunk)
 
-        # Return the path that can be referenced in future requests
+        if bytes_written == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
         return {
             "path": str(file_path),
             "filename": file.filename,
-            "content_type": file.content_type,
+            "content_type": content_type,
+            "size_bytes": bytes_written,
         }
+    except HTTPException:
+        if 'file_path' in locals() and file_path.exists():
+            with suppress(FileNotFoundError):
+                file_path.unlink()
+        raise
     except Exception as e:
         logger.error(f"Error uploading file: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error uploading file: {str(e)}")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -73,6 +73,7 @@ from penguin.web.services.session_view import (
 from penguin.web.services.session_fork import fork_session
 from penguin.web.services.session_revert import revert_session, unrevert_session
 from penguin.web.services.session_summary import summarize_session_title
+from penguin.web.middleware.auth import require_websocket_auth
 from penguin.web.services.system_status import (
     get_formatter_status,
     get_lsp_status,
@@ -2079,6 +2080,7 @@ async def events_ws(websocket: WebSocket, core: PenguinCore = Depends(get_core))
       - include_ui: 'true'|'false' (default 'true')
       - include_bus: 'true'|'false' (default 'true')
     """
+    await require_websocket_auth(websocket)
     await websocket.accept()
     params = websocket.query_params
     agent_filter = params.get("agent_id")
@@ -2296,6 +2298,7 @@ async def telemetry_ws(
     websocket: WebSocket,
     core: PenguinCore = Depends(get_core),
 ):
+    await require_websocket_auth(websocket)
     await websocket.accept()
     params = websocket.query_params
     agent_filter = params.get("agent_id")
@@ -3816,6 +3819,7 @@ async def handle_chat_message(
 @router.websocket("/api/v1/chat/stream")
 async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core)):
     """Stream chat responses in real-time using a queue."""
+    await require_websocket_auth(websocket)
     await websocket.accept()
     _setup_approval_websocket_callbacks()
     _setup_question_event_callbacks()
@@ -5673,6 +5677,7 @@ async def get_capabilities(core: PenguinCore = Depends(get_core)):
 @router.websocket("/api/v1/tasks/stream")
 async def stream_task(websocket: WebSocket, core: PenguinCore = Depends(get_core)):
     """Stream run mode task execution events in real-time."""
+    await require_websocket_auth(websocket)
     await websocket.accept()
     task_execution = None
     run_mode_callback_task = None

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -33,6 +33,7 @@ import uuid
 from urllib.parse import unquote, urlparse
 import websockets
 import httpx
+from PIL import Image, UnidentifiedImageError
 
 from penguin.config import WORKSPACE_PATH
 from penguin.core import PenguinCore
@@ -166,11 +167,55 @@ ALLOWED_UPLOAD_CONTENT_TYPES = {
     "image/webp",
 }
 ALLOWED_UPLOAD_EXTENSIONS = {".gif", ".jpeg", ".jpg", ".png", ".webp"}
+VALIDATED_UPLOAD_IMAGE_FORMATS = {
+    "GIF": ("image/gif", {".gif"}),
+    "JPEG": ("image/jpeg", {".jpeg", ".jpg"}),
+    "PNG": ("image/png", {".png"}),
+    "WEBP": ("image/webp", {".webp"}),
+}
 
 
 def _max_upload_bytes() -> int:
     """Return the configured upload size limit in bytes."""
     return int(os.getenv("PENGUIN_MAX_UPLOAD_BYTES", str(DEFAULT_MAX_UPLOAD_BYTES)))
+
+
+def _validate_saved_upload_image(
+    file_path: Path,
+    *,
+    declared_content_type: str,
+    declared_extension: str,
+) -> str:
+    """Validate a saved upload against actual image bytes on disk."""
+    try:
+        with Image.open(file_path) as image:
+            detected_format = (image.format or "").upper()
+            image.verify()
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError) as exc:
+        raise HTTPException(
+            status_code=415,
+            detail="Uploaded file is not a valid supported image.",
+        ) from exc
+
+    detected = VALIDATED_UPLOAD_IMAGE_FORMATS.get(detected_format)
+    if detected is None:
+        raise HTTPException(
+            status_code=415,
+            detail="Unsupported image format. Allowed formats: GIF, JPEG, PNG, WEBP.",
+        )
+
+    detected_content_type, valid_extensions = detected
+    if declared_content_type != detected_content_type:
+        raise HTTPException(
+            status_code=415,
+            detail="Uploaded file content does not match declared MIME type.",
+        )
+    if declared_extension not in valid_extensions:
+        raise HTTPException(
+            status_code=415,
+            detail="Uploaded file content does not match the file extension.",
+        )
+    return detected_content_type
 
 
 _FIND_FILE_CACHE_TTL_SECONDS = 5.0
@@ -5616,6 +5661,7 @@ async def upload_file(
     file: UploadFile = File(...), core: PenguinCore = Depends(get_core)
 ):
     """Upload an image file to be used in conversations."""
+    file_path: Path | None = None
     try:
         if not file.filename:
             raise HTTPException(status_code=400, detail="Filename is required")
@@ -5658,18 +5704,27 @@ async def upload_file(
         if bytes_written == 0:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
 
+        validated_content_type = _validate_saved_upload_image(
+            file_path,
+            declared_content_type=content_type,
+            declared_extension=extension,
+        )
+
         return {
             "path": str(file_path),
             "filename": file.filename,
-            "content_type": content_type,
+            "content_type": validated_content_type,
             "size_bytes": bytes_written,
         }
     except HTTPException:
-        if 'file_path' in locals() and file_path.exists():
+        if file_path and file_path.exists():
             with suppress(FileNotFoundError):
                 file_path.unlink()
         raise
     except Exception as e:
+        if file_path and file_path.exists():
+            with suppress(FileNotFoundError):
+                file_path.unlink()
         logger.error(f"Error uploading file: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error uploading file: {str(e)}")
 

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -6,8 +6,49 @@ It uses the app factory from app.py to create and configure the FastAPI applicat
 
 import logging
 import os
+from ipaddress import ip_address
 
 logger = logging.getLogger(__name__)
+
+LOCAL_ONLY_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _is_local_host(host: str) -> bool:
+    """Return whether the bind host is limited to local access."""
+    normalized = (host or "").strip().lower()
+    if normalized in LOCAL_ONLY_HOSTS:
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_startup_security(host: str) -> None:
+    """Fail fast for insecure broad-bind deployments unless explicitly allowed."""
+    if _is_local_host(host):
+        return
+
+    auth_enabled = os.environ.get("PENGUIN_AUTH_ENABLED", "false").lower() == "true"
+    if auth_enabled:
+        return
+
+    allow_insecure = (
+        os.environ.get("PENGUIN_ALLOW_INSECURE_NO_AUTH", "false").lower() == "true"
+    )
+    if allow_insecure:
+        logger.warning(
+            "Starting Penguin web server without auth on non-local host %s because "
+            "PENGUIN_ALLOW_INSECURE_NO_AUTH=true",
+            host,
+        )
+        return
+
+    raise RuntimeError(
+        "Refusing to bind Penguin web server to a non-local host without authentication. "
+        "Set PENGUIN_AUTH_ENABLED=true or explicitly override with "
+        "PENGUIN_ALLOW_INSECURE_NO_AUTH=true."
+    )
 
 
 def create_app_factory():
@@ -53,6 +94,7 @@ def main():
     debug = os.environ.get("DEBUG", "false").lower() == "true"
 
     try:
+        validate_startup_security(host)
         if debug:
             create_app_factory()
             app = None
@@ -94,6 +136,7 @@ def start_server(host: str = "0.0.0.0", port: int = 8000, debug: bool = False):
             "Web dependencies not available. Install with: pip install penguin-ai[web]"
         ) from exc
 
+    validate_startup_security(host)
     if debug:
         uvicorn.run(
             "penguin.web.server:create_app_factory",

--- a/penguin/web/services/provider_credentials.py
+++ b/penguin/web/services/provider_credentials.py
@@ -112,7 +112,7 @@ def _load_store() -> dict[str, Any]:
 
     providers = primary.get("providers")
     if isinstance(providers, dict) and providers:
-        if path != _default_store_path() or os.getenv(_STORE_ENV) or os.getenv(_LEGACY_STORE_ENV):
+        if os.getenv(_LEGACY_STORE_ENV) or path == _legacy_default_store_path():
             _warn_legacy_store_usage(path)
         return primary
 
@@ -209,7 +209,6 @@ def get_provider_credentials() -> dict[str, dict[str, Any]]:
             "openrouter",
             "anthropic",
             "google",
-            "ollama",
         })
 
         for provider_id in provider_ids:
@@ -301,7 +300,6 @@ def _provider_env_candidates(provider_id: str) -> list[str]:
         "openai": ["OPENAI_API_KEY"],
         "anthropic": ["ANTHROPIC_API_KEY"],
         "google": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
-        "ollama": ["OLLAMA_HOST"],
     }
     if pid in mapping:
         return mapping[pid]
@@ -313,6 +311,9 @@ def _provider_env_candidates(provider_id: str) -> list[str]:
 def _credential_record_from_environment(provider_id: str) -> dict[str, Any] | None:
     pid = provider_id.strip().lower()
     if not pid:
+        return None
+
+    if pid == "ollama":
         return None
 
     if pid == "openai":
@@ -394,6 +395,8 @@ def apply_credentials_to_environment(
     )
 
     if auth_type == "api":
+        if pid == "ollama":
+            return
         key = credential_record.get("key")
         if not isinstance(key, str) or not key:
             return
@@ -406,6 +409,9 @@ def apply_credentials_to_environment(
             return
         if pid == "openai":
             os.environ["OPENAI_API_KEY"] = key
+            return
+        if pid == "ollama":
+            os.environ["OLLAMA_HOST"] = key
             return
 
         os.environ[f"{pid.upper()}_API_KEY"] = key

--- a/penguin/web/services/provider_credentials.py
+++ b/penguin/web/services/provider_credentials.py
@@ -410,9 +410,6 @@ def apply_credentials_to_environment(
         if pid == "openai":
             os.environ["OPENAI_API_KEY"] = key
             return
-        if pid == "ollama":
-            os.environ["OLLAMA_HOST"] = key
-            return
 
         os.environ[f"{pid.upper()}_API_KEY"] = key
         return

--- a/penguin/web/services/provider_credentials.py
+++ b/penguin/web/services/provider_credentials.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import time
+import warnings
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -28,6 +29,13 @@ _PLACEHOLDER_API_KEYS = {
     "placeholder",
     "test",
 }
+
+
+_LEGACY_STORE_WARNING = (
+    "Provider credentials loaded from legacy plaintext JSON store. Prefer environment "
+    "variables for headless/server deployments; plaintext persistence is deprecated."
+)
+_WARNED_LEGACY_PATHS: set[Path] = set()
 
 
 def _default_store_path() -> Path:
@@ -56,6 +64,15 @@ def _legacy_store_path() -> Path:
     if legacy:
         return Path(legacy).expanduser().resolve()
     return _legacy_default_store_path()
+
+
+def _warn_legacy_store_usage(path: Path) -> None:
+    resolved = path.expanduser().resolve()
+    if resolved in _WARNED_LEGACY_PATHS:
+        return
+    _WARNED_LEGACY_PATHS.add(resolved)
+    logger.warning("%s path=%s", _LEGACY_STORE_WARNING, resolved)
+    warnings.warn(_LEGACY_STORE_WARNING, UserWarning, stacklevel=2)
 
 
 def _ensure_parent(path: Path) -> None:
@@ -95,6 +112,8 @@ def _load_store() -> dict[str, Any]:
 
     providers = primary.get("providers")
     if isinstance(providers, dict) and providers:
+        if path != _default_store_path() or os.getenv(_STORE_ENV) or os.getenv(_LEGACY_STORE_ENV):
+            _warn_legacy_store_usage(path)
         return primary
 
     if path == _default_store_path():
@@ -103,6 +122,7 @@ def _load_store() -> dict[str, Any]:
             legacy_payload = _read_store(legacy_path)
             legacy_providers = legacy_payload.get("providers")
             if isinstance(legacy_providers, dict) and legacy_providers:
+                _warn_legacy_store_usage(legacy_path)
                 return legacy_payload
 
     return primary
@@ -173,16 +193,30 @@ def _sanitize_record(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def get_provider_credentials() -> dict[str, dict[str, Any]]:
-    """Return provider credential records."""
+    """Return provider credential records with env values taking precedence."""
     with _CREDENTIALS_LOCK:
         providers = _load_store().get("providers")
-        if not isinstance(providers, dict):
-            return {}
-        return {
+        records = {
             str(key): value
             for key, value in providers.items()
             if isinstance(key, str) and isinstance(value, dict)
-        }
+        } if isinstance(providers, dict) else {}
+
+        merged = dict(records)
+        provider_ids = set(records.keys())
+        provider_ids.update({
+            "openai",
+            "openrouter",
+            "anthropic",
+            "google",
+            "ollama",
+        })
+
+        for provider_id in provider_ids:
+            env_record = _credential_record_from_environment(provider_id)
+            if env_record is not None:
+                merged[provider_id] = env_record
+        return merged
 
 
 def get_provider_credential(provider_id: str) -> dict[str, Any] | None:
@@ -274,6 +308,41 @@ def _provider_env_candidates(provider_id: str) -> list[str]:
     if pid:
         return [f"{pid.upper()}_API_KEY"]
     return []
+
+
+def _credential_record_from_environment(provider_id: str) -> dict[str, Any] | None:
+    pid = provider_id.strip().lower()
+    if not pid:
+        return None
+
+    if pid == "openai":
+        access = os.getenv("OPENAI_OAUTH_ACCESS_TOKEN", "").strip()
+        refresh = os.getenv("OPENAI_OAUTH_REFRESH_TOKEN", "").strip()
+        expires_raw = os.getenv("OPENAI_OAUTH_EXPIRES_AT_MS", "").strip()
+        if access and refresh and expires_raw:
+            try:
+                expires = int(expires_raw)
+            except ValueError:
+                logger.warning(
+                    "Ignoring OPENAI OAuth environment credentials due to invalid expiry"
+                )
+            else:
+                record: dict[str, Any] = {
+                    "type": "oauth",
+                    "access": access,
+                    "refresh": refresh,
+                    "expires": expires,
+                }
+                account_id = os.getenv("OPENAI_ACCOUNT_ID", "").strip()
+                if account_id:
+                    record["accountId"] = account_id
+                return record
+
+    for env_name in _provider_env_candidates(pid):
+        value = os.getenv(env_name, "").strip()
+        if value and not _is_placeholder_api_key(value):
+            return {"type": "api", "key": value}
+    return None
 
 
 def _is_placeholder_api_key(value: Any) -> bool:

--- a/tests/api/test_github_webhook_security.py
+++ b/tests/api/test_github_webhook_security.py
@@ -99,3 +99,37 @@ def test_github_webhook_requires_delivery_id(webhook_client: TestClient) -> None
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Missing delivery id"
+
+
+def test_github_webhook_transient_failure_does_not_poison_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    github_router.core = None
+    app = FastAPI()
+    app.include_router(github_router)
+    client = TestClient(app)
+
+    payload = _payload_bytes()
+    headers = {
+        "X-Hub-Signature-256": _signature("super-secret", payload),
+        "X-GitHub-Event": "ping",
+        "X-GitHub-Delivery": "delivery-transient",
+        "Content-Type": "application/json",
+    }
+
+    first = client.post(
+        "/api/v1/integrations/github/webhook",
+        data=payload,
+        headers=headers,
+    )
+    assert first.status_code == 500
+
+    github_router.core = SimpleNamespace()
+    second = client.post(
+        "/api/v1/integrations/github/webhook",
+        data=payload,
+        headers=headers,
+    )
+    assert second.status_code == 200

--- a/tests/api/test_github_webhook_security.py
+++ b/tests/api/test_github_webhook_security.py
@@ -29,10 +29,13 @@ def clear_webhook_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def webhook_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    original_core = getattr(github_router, "core", None)
     github_router.core = SimpleNamespace()
     app = FastAPI()
     app.include_router(github_router)
-    return TestClient(app)
+    with TestClient(app) as client:
+        yield client
+    github_router.core = original_core
 
 
 def _signature(secret: str, payload: bytes) -> str:
@@ -53,6 +56,7 @@ def _payload_bytes() -> bytes:
 def test_remember_github_delivery_rejects_replay(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS", "60")
 
+    assert remember_github_delivery("", now=100.0) is False
     assert remember_github_delivery("delivery-1", now=100.0) is True
     assert remember_github_delivery("delivery-1", now=120.0) is False
     assert remember_github_delivery("delivery-1", now=161.0) is True
@@ -106,6 +110,7 @@ def test_github_webhook_transient_failure_does_not_poison_delivery(
 ) -> None:
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
     monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    original_core = getattr(github_router, "core", None)
     github_router.core = None
     app = FastAPI()
     app.include_router(github_router)
@@ -132,4 +137,5 @@ def test_github_webhook_transient_failure_does_not_poison_delivery(
         data=payload,
         headers=headers,
     )
+    github_router.core = original_core
     assert second.status_code == 200

--- a/tests/api/test_github_webhook_security.py
+++ b/tests/api/test_github_webhook_security.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from penguin.web.integrations.github_webhook import (
+    github_webhook,
+    remember_github_delivery,
+    reset_github_delivery_cache,
+    router as github_router,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_webhook_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS", raising=False)
+    reset_github_delivery_cache()
+
+
+@pytest.fixture
+def webhook_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "super-secret")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    github_router.core = SimpleNamespace()
+    app = FastAPI()
+    app.include_router(github_router)
+    return TestClient(app)
+
+
+def _signature(secret: str, payload: bytes) -> str:
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _payload_bytes() -> bytes:
+    return json.dumps(
+        {
+            "repository": {"full_name": "owner/repo"},
+            "action": "opened",
+            "pull_request": {"number": 7},
+        }
+    ).encode("utf-8")
+
+
+def test_remember_github_delivery_rejects_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENGUIN_GITHUB_WEBHOOK_DELIVERY_TTL_SECONDS", "60")
+
+    assert remember_github_delivery("delivery-1", now=100.0) is True
+    assert remember_github_delivery("delivery-1", now=120.0) is False
+    assert remember_github_delivery("delivery-1", now=161.0) is True
+
+
+def test_github_webhook_rejects_duplicate_delivery(webhook_client: TestClient) -> None:
+    payload = _payload_bytes()
+    headers = {
+        "X-Hub-Signature-256": _signature("super-secret", payload),
+        "X-GitHub-Event": "ping",
+        "X-GitHub-Delivery": "delivery-1",
+        "Content-Type": "application/json",
+    }
+
+    first = webhook_client.post(
+        "/api/v1/integrations/github/webhook",
+        data=payload,
+        headers=headers,
+    )
+    second = webhook_client.post(
+        "/api/v1/integrations/github/webhook",
+        data=payload,
+        headers=headers,
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+    assert second.json()["detail"] == "Duplicate delivery"
+
+
+def test_github_webhook_requires_delivery_id(webhook_client: TestClient) -> None:
+    payload = _payload_bytes()
+    headers = {
+        "X-Hub-Signature-256": _signature("super-secret", payload),
+        "X-GitHub-Event": "ping",
+        "Content-Type": "application/json",
+    }
+
+    response = webhook_client.post(
+        "/api/v1/integrations/github/webhook",
+        data=payload,
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing delivery id"

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,6 +17,7 @@ from penguin.web.middleware.auth import (
     require_websocket_auth,
 )
 from penguin.web.routes import ALLOWED_UPLOAD_CONTENT_TYPES, router
+from penguin.web.services import provider_credentials as provider_credentials_service
 
 
 @pytest.fixture(autouse=True)
@@ -26,6 +28,19 @@ def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
     monkeypatch.delenv("PENGUIN_CORS_ORIGINS", raising=False)
     monkeypatch.delenv("PENGUIN_MAX_UPLOAD_BYTES", raising=False)
+    monkeypatch.delenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", raising=False)
+    monkeypatch.delenv("PENGUIN_PROVIDER_AUTH_STORE", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.delenv("OPENAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_OAUTH_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_OAUTH_EXPIRES_AT_MS", raising=False)
+    monkeypatch.delenv("OPENAI_ACCOUNT_ID", raising=False)
+    provider_credentials_service._WARNED_LEGACY_PATHS.clear()
 
 
 @pytest.fixture
@@ -206,6 +221,41 @@ def test_upload_accepts_supported_image(
     assert payload["content_type"] in ALLOWED_UPLOAD_CONTENT_TYPES
     assert payload["size_bytes"] == 7
     assert Path(payload["path"]).exists()
+
+
+def test_provider_credentials_prefer_environment_over_legacy_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store_path = tmp_path / "providers.json"
+    store_path.write_text(
+        json.dumps({"version": 1, "providers": {"openai": {"type": "api", "key": "file-key"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+
+    records = provider_credentials_service.get_provider_credentials()
+
+    assert records["openai"]["type"] == "api"
+    assert records["openai"]["key"] == "env-key"
+
+
+def test_provider_credentials_warn_on_legacy_store_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store_path = tmp_path / "providers.json"
+    store_path.write_text(
+        json.dumps({"version": 1, "providers": {"anthropic": {"type": "api", "key": "file-key"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
+
+    with pytest.warns(UserWarning, match="plaintext JSON store"):
+        records = provider_credentials_service.get_provider_credentials()
+
+    assert records["anthropic"]["key"] == "file-key"
 
 
 def test_http_auth_returns_401_without_credentials(

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, WebSocketException
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from penguin.web.middleware.auth import (
+    AuthConfig,
+    AuthenticationError,
+    authenticate_connection,
+    require_websocket_auth,
+)
+from penguin.web.routes import router
+
+
+@pytest.fixture(autouse=True)
+def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PENGUIN_JWT_SECRET", raising=False)
+    monkeypatch.delenv("PENGUIN_PUBLIC_ENDPOINTS", raising=False)
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+
+
+@pytest.fixture
+def auth_config(monkeypatch: pytest.MonkeyPatch) -> AuthConfig:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "test-key-123")
+    return AuthConfig()
+
+
+def test_public_endpoint_root_is_exact_match_only(auth_config: AuthConfig) -> None:
+    assert auth_config.is_public_endpoint("/") is True
+    assert auth_config.is_public_endpoint("/api/v1/health") is True
+    assert auth_config.is_public_endpoint("/api/v1/capabilities") is False
+    assert auth_config.is_public_endpoint("/static/index.html") is True
+    assert auth_config.is_public_endpoint("/static-assets") is False
+
+
+def test_authenticate_connection_rejects_query_param_api_keys(
+    auth_config: AuthConfig,
+) -> None:
+    connection = SimpleNamespace(
+        headers={},
+        query_params={"api_key": "test-key-123"},
+    )
+
+    with pytest.raises(AuthenticationError, match="No valid authentication"):
+        authenticate_connection(connection, auth_config)
+
+
+@pytest.mark.asyncio
+async def test_require_websocket_auth_accepts_header_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ws-test-key")
+    websocket = SimpleNamespace(
+        url=SimpleNamespace(path="/api/v1/events/ws"),
+        headers={"X-API-Key": "ws-test-key"},
+        state=SimpleNamespace(),
+    )
+
+    result = await require_websocket_auth(websocket)
+
+    assert result["method"] == "api_key"
+    assert websocket.state.authenticated is True
+    assert websocket.state.auth_method == "api_key"
+
+
+@pytest.mark.asyncio
+async def test_require_websocket_auth_rejects_missing_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ws-test-key")
+    websocket = SimpleNamespace(
+        url=SimpleNamespace(path="/api/v1/events/ws"),
+        headers={},
+        state=SimpleNamespace(),
+    )
+
+    with pytest.raises(WebSocketException) as exc_info:
+        await require_websocket_auth(websocket)
+
+    assert exc_info.value.code == 1008
+
+
+@pytest.fixture
+def websocket_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ws-test-key")
+    router.core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(current_agent_id=None),
+        get_telemetry_summary=None,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_events_websocket_rejects_unauthenticated_client(
+    websocket_app: FastAPI,
+) -> None:
+    client = TestClient(websocket_app)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/api/v1/events/ws"):
+            pass
+
+    assert exc_info.value.code == 1008
+
+
+def test_events_websocket_accepts_authenticated_client(
+    websocket_app: FastAPI,
+) -> None:
+    client = TestClient(websocket_app)
+
+    with client.websocket_connect(
+        "/api/v1/events/ws",
+        headers={"X-API-Key": "ws-test-key"},
+    ) as websocket:
+        assert websocket is not None
+
+
+def test_chat_stream_websocket_rejects_query_param_api_key(
+    websocket_app: FastAPI,
+) -> None:
+    client = TestClient(websocket_app)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            "/api/v1/chat/stream?api_key=ws-test-key",
+        ):
+            pass
+
+    assert exc_info.value.code == 1008
+
+
+
+def test_http_auth_returns_401_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "http-test-key")
+
+    from penguin.web.app import create_app
+
+    client = TestClient(create_app())
+    response = client.get("/api/v1/capabilities")
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"]["code"] == "AUTHENTICATION_FAILED"

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -13,7 +15,7 @@ from penguin.web.middleware.auth import (
     authenticate_connection,
     require_websocket_auth,
 )
-from penguin.web.routes import router
+from penguin.web.routes import ALLOWED_UPLOAD_CONTENT_TYPES, router
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +24,8 @@ def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PENGUIN_PUBLIC_ENDPOINTS", raising=False)
     monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
     monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_CORS_ORIGINS", raising=False)
+    monkeypatch.delenv("PENGUIN_MAX_UPLOAD_BYTES", raising=False)
 
 
 @pytest.fixture
@@ -138,6 +142,70 @@ def test_chat_stream_websocket_rejects_query_param_api_key(
 
     assert exc_info.value.code == 1008
 
+
+def test_default_cors_origins_do_not_use_wildcard(monkeypatch: pytest.MonkeyPatch) -> None:
+    from penguin.web.app import DEFAULT_DEV_CORS_ORIGINS, create_app
+
+    app = create_app()
+    cors_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls.__name__ == "CORSMiddleware"
+    )
+
+    assert cors_middleware.kwargs["allow_origins"] == DEFAULT_DEV_CORS_ORIGINS
+    assert "*" not in cors_middleware.kwargs["allow_origins"]
+
+
+def test_upload_rejects_non_image_content_type() -> None:
+    router.core = SimpleNamespace()
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/upload",
+        files={"file": ("notes.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+
+    assert response.status_code == 415
+
+
+def test_upload_rejects_oversized_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PENGUIN_MAX_UPLOAD_BYTES", "8")
+    router.core = SimpleNamespace()
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/upload",
+        files={"file": ("image.png", io.BytesIO(b"123456789"), "image/png")},
+    )
+
+    assert response.status_code == 413
+
+
+def test_upload_accepts_supported_image(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr("penguin.web.routes.WORKSPACE_PATH", str(tmp_path))
+    router.core = SimpleNamespace()
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/upload",
+        files={"file": ("image.png", io.BytesIO(b"pngdata"), "image/png")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content_type"] in ALLOWED_UPLOAD_CONTENT_TYPES
+    assert payload["size_bytes"] == 7
+    assert Path(payload["path"]).exists()
 
 
 def test_http_auth_returns_401_without_credentials(

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import io
 import json
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from PIL import Image
 from fastapi import FastAPI, WebSocketException
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
@@ -201,6 +203,12 @@ def test_upload_rejects_oversized_file(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.status_code == 413
 
 
+def _png_1x1_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (1, 1), color=(255, 0, 0)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
 def test_upload_accepts_supported_image(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -213,13 +221,13 @@ def test_upload_accepts_supported_image(
 
     response = client.post(
         "/api/v1/upload",
-        files={"file": ("image.png", io.BytesIO(b"pngdata"), "image/png")},
+        files={"file": ("image.png", io.BytesIO(_png_1x1_bytes()), "image/png")},
     )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["content_type"] in ALLOWED_UPLOAD_CONTENT_TYPES
-    assert payload["size_bytes"] == 7
+    assert payload["size_bytes"] == len(_png_1x1_bytes())
     assert Path(payload["path"]).exists()
 
 
@@ -245,12 +253,12 @@ def test_provider_credentials_warn_on_legacy_store_usage(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    store_path = tmp_path / "providers.json"
+    store_path = tmp_path / "provider_auth.json"
     store_path.write_text(
         json.dumps({"version": 1, "providers": {"anthropic": {"type": "api", "key": "file-key"}}}),
         encoding="utf-8",
     )
-    monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
+    monkeypatch.setenv("PENGUIN_PROVIDER_AUTH_STORE", str(store_path))
 
     with pytest.warns(UserWarning, match="plaintext JSON store"):
         records = provider_credentials_service.get_provider_credentials()
@@ -271,3 +279,73 @@ def test_http_auth_returns_401_without_credentials(
 
     assert response.status_code == 401
     assert response.json()["detail"]["error"]["code"] == "AUTHENTICATION_FAILED"
+
+
+def test_upload_rejects_spoofed_image_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("penguin.web.routes.WORKSPACE_PATH", str(tmp_path))
+    router.core = SimpleNamespace()
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/upload",
+        files={"file": ("fake.png", io.BytesIO(b"not-a-real-image"), "image/png")},
+    )
+
+    assert response.status_code == 415
+    uploads_dir = tmp_path / "uploads"
+    assert not uploads_dir.exists() or list(uploads_dir.iterdir()) == []
+
+
+def test_provider_credentials_custom_store_path_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store_path = tmp_path / "providers.json"
+    store_path.write_text(
+        json.dumps({"version": 1, "providers": {"anthropic": {"type": "api", "key": "file-key"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        records = provider_credentials_service.get_provider_credentials()
+
+    assert records["anthropic"]["key"] == "file-key"
+    assert not caught
+
+
+def test_provider_credentials_do_not_treat_ollama_host_as_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+
+    records = provider_credentials_service.get_provider_credentials()
+
+    assert "ollama" not in records
+
+
+def test_http_auth_does_not_mask_downstream_exceptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "http-test-key")
+
+    from penguin.web.app import create_app
+
+    app = create_app()
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("boom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/boom", headers={"X-API-Key": "http-test-key"})
+
+    assert response.status_code == 500
+    assert "AUTHENTICATION_ERROR" not in response.text

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -15,6 +15,7 @@ def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     monkeypatch.setenv("HOST", "0.0.0.0")
     monkeypatch.setenv("PORT", "8080")
     monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
 
     assert server.main() == 0
 
@@ -42,3 +43,36 @@ def test_start_server_non_debug_uses_app_instance(monkeypatch):
     assert calls[0][1]["host"] == "127.0.0.1"
     assert calls[0][1]["port"] == 9000
     assert calls[0][1]["reload"] is False
+
+
+def test_validate_startup_security_allows_local_without_auth(monkeypatch):
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
+
+    server.validate_startup_security("127.0.0.1")
+
+
+def test_validate_startup_security_blocks_non_local_without_auth(monkeypatch):
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
+
+    try:
+        server.validate_startup_security("0.0.0.0")
+    except RuntimeError as exc:
+        assert "PENGUIN_AUTH_ENABLED=true" in str(exc)
+    else:
+        raise AssertionError("Expected insecure startup to be blocked")
+
+
+def test_validate_startup_security_allows_non_local_with_auth(monkeypatch):
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
+
+    server.validate_startup_security("0.0.0.0")
+
+
+def test_validate_startup_security_allows_override(monkeypatch):
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.setenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", "true")
+
+    server.validate_startup_security("0.0.0.0")


### PR DESCRIPTION
## Summary
- fix the public-endpoint auth bypass and enforce auth on protected WebSocket routes
- harden startup/CORS behavior and restrict upload handling to validated image uploads
- prefer environment-managed provider credentials, add GitHub webhook replay defense, and update docs

## Testing
- pytest tests/api/test_web_auth_hardening.py tests/api/test_github_webhook_security.py tests/test_web_server.py -xvs
- live server checks on 127.0.0.1:9000 for auth, websocket, upload, and webhook replay behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced WebSocket handshake auth; GitHub webhook replay protection; strict image-only uploads with size/type/extension checks and normalized response metadata; default CORS limited to local dev origins; explicit public-endpoint controls and startup exposure validation.

* **Bug Fixes**
  * Removed query-string API key auth; partially written uploads cleaned on error; clearer auth/error responses and startup blocking for insecure non-local binds (opt-in override).

* **Documentation**
  * Expanded security hardening roadmap, server/CORS/auth/upload guidance, credential precedence, and webhook endpoint/path updates.

* **Tests**
  * New suites for webhook replay, web auth hardening, uploads, provider credential behavior, and startup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->