### PR TITLE
Secure local web auth by default and align browser/TUI bootstrap flows

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -591,7 +591,7 @@ The current TUI architecture is split across the Python runtime and the `penguin
 - `ptui` and `penguin-tui` are direct aliases for the TUI launcher entrypoint.
 - In a source checkout, the launcher prefers local `penguin-tui/packages/opencode` sources.
 - Outside a source checkout, the launcher resolves or downloads a cached sidecar binary under `~/.cache/penguin/tui`.
-- The launcher talks to `penguin-web`, auto-starting a local server when needed.
+- The launcher talks to `penguin-web`, auto-starting a local server at `http://127.0.0.1:9000` when needed unless an explicit `--url` or `PENGUIN_WEB_URL` override is provided.
 
 This matters because the TUI is no longer a Python widget tree embedded inside the runtime. It is a separate frontend path backed by the same Penguin web/core services.
 

--- a/context/tasks/web-security-followup-bugs.md
+++ b/context/tasks/web-security-followup-bugs.md
@@ -5,15 +5,17 @@ Branch: `refactor-web-security-overhaul`
 
 ## Verified Bugs
 
-### High risk
-- Startup-token auth is not scoped tightly enough to loopback peers in `penguin/web/middleware/auth.py`.
-- Auth-failure suppression uses an unbounded in-memory set keyed by raw paths in `penguin/web/middleware/auth.py`.
-- `PORT` parsing in `penguin/web/server.py` can fail with an uncontrolled `ValueError` on malformed input.
-- Local auth token cache writes in `penguin/web/server.py` can abort startup if the filesystem write fails.
+### Fixed high risk
+- Startup-token auth is now scoped to loopback peers in `penguin/web/middleware/auth.py`.
+- Auth-failure suppression is now bounded and path-normalized in `penguin/web/middleware/auth.py`.
+- `PORT` parsing in `penguin/web/server.py` now fails with a controlled startup error path.
+- Local auth token cache writes in `penguin/web/server.py` are now non-fatal.
 
-### Medium risk
-- `task.phase` serialization in `penguin/web/routes.py` can raise `AttributeError` for tasks without a `phase` attribute.
+### Remaining security-relevant
 - The browser auth bootstrap fragment in `penguin/web/static/authorize.html` is only cleared after a successful auth POST.
+
+### Remaining medium risk / reliability
+- `task.phase` serialization in `penguin/web/routes.py` can raise `AttributeError` for tasks without a `phase` attribute.
 - Dashboard websocket reconnect timers in `penguin/web/static/dashboard.html` are not cleaned up on unmount.
 - Chat websocket auth-close handling in `penguin/web/static/index.html` can leave pending send state hanging.
 - TUI prompt send path in `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` only clears pending state on network exceptions, not non-2xx responses.
@@ -31,6 +33,5 @@ Branch: `refactor-web-security-overhaul`
 - Package/static asset relocation discussion for `dashboard.html`.
 
 ## Current Focus
-1. Loopback-only startup-token acceptance.
-2. Bounded auth-failure cache.
-3. Safe startup parsing and cache-write failure handling.
+1. Clear bootstrap fragments before the auth network call.
+2. Defer lower-priority reliability and cleanup items until after the security-sensitive auth flow is settled.

--- a/context/tasks/web-security-followup-bugs.md
+++ b/context/tasks/web-security-followup-bugs.md
@@ -1,0 +1,36 @@
+# Web Security Follow-Up Bugs
+
+Date: 2026-04-18
+Branch: `refactor-web-security-overhaul`
+
+## Verified Bugs
+
+### High risk
+- Startup-token auth is not scoped tightly enough to loopback peers in `penguin/web/middleware/auth.py`.
+- Auth-failure suppression uses an unbounded in-memory set keyed by raw paths in `penguin/web/middleware/auth.py`.
+- `PORT` parsing in `penguin/web/server.py` can fail with an uncontrolled `ValueError` on malformed input.
+- Local auth token cache writes in `penguin/web/server.py` can abort startup if the filesystem write fails.
+
+### Medium risk
+- `task.phase` serialization in `penguin/web/routes.py` can raise `AttributeError` for tasks without a `phase` attribute.
+- The browser auth bootstrap fragment in `penguin/web/static/authorize.html` is only cleared after a successful auth POST.
+- Dashboard websocket reconnect timers in `penguin/web/static/dashboard.html` are not cleaned up on unmount.
+- Chat websocket auth-close handling in `penguin/web/static/index.html` can leave pending send state hanging.
+- TUI prompt send path in `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` only clears pending state on network exceptions, not non-2xx responses.
+- TUI bootstrap fetches in `penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx` still swallow non-OK protected bootstrap responses.
+- Test fixtures in `tests/api/test_web_auth_hardening.py` mutate singleton-ish state without restoring it.
+
+### Low risk / consistency
+- Legacy `8000` values remain in `penguin/run_web.py` and `tests/run_server.py`.
+
+## Non-Bug Cleanup Items
+- `collections.abc.Mapping` / `contextlib.suppress` cleanup in `penguin/local_auth.py`.
+- Missing return annotations in `penguin/web/app.py` and `penguin/web/__init__.py`.
+- `api_auth_session` service extraction in `penguin/web/routes.py`.
+- Task serializer protocol typing in `penguin/web/routes.py`.
+- Package/static asset relocation discussion for `dashboard.html`.
+
+## Current Focus
+1. Loopback-only startup-token acceptance.
+2. Bounded auth-failure cache.
+3. Safe startup parsing and cache-write failure handling.

--- a/context/tasks/web-security-hardening-plan.md
+++ b/context/tasks/web-security-hardening-plan.md
@@ -46,13 +46,18 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 ### Auth model
 - Penguin should not introduce local Penguin accounts.
 - When auth is enabled, Penguin should issue a startup capability token and exchange it once at a local auth endpoint.
+- For local browser/dashboard use, Penguin should offer a one-click bootstrap path instead of requiring manual endpoint calls.
+- The printed local authorization URL should carry the startup token in a URL fragment, not a query parameter, so the token is not sent in request logs or reused as transport auth.
+- The browser dashboard should exchange that token immediately at the local auth endpoint and discard it after the session cookie is set.
 - The auth endpoint should set an `HttpOnly` session cookie for same-origin browser use.
 - Header auth should remain supported for TUI, CLI, and external clients.
 
 ### Browser compatibility
 - Cookie-backed sessions are the recommended browser path because cookies work across normal HTTP, SSE, and WebSocket flows.
+- If Penguin prints a browser bootstrap URL, the token should be placed in the fragment portion of the URL, for example `http://127.0.0.1:9000/#local_token=...`.
 - Do not reintroduce query-string auth for SSE or WebSocket compatibility.
 - Avoid relying on custom request headers for browser `EventSource` or browser-created `WebSocket` auth.
+- Browser users should never need to manually use `curl`, devtools, or raw HTTP calls during the normal local authorization flow.
 
 ### Broad bind policy
 - Non-loopback binds should remain blocked unless auth is enabled or an explicit insecure override is set.
@@ -60,15 +65,20 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 
 ### UX guidance
 - If Penguin is started without auth, emit a clear warning that the local server is unsecured.
+- If Penguin is started with auth enabled for local dashboard use, print a one-click local authorization URL in the console.
 - If Penguin rejects an unauthorized browser/client request, return a short remediation message describing the safe auth flow and the explicit no-auth local-only override.
+- Unauthorized browser/dashboard clients should show a minimal local authorization screen and pause background retries until authorization succeeds.
+- Successful browser authorization should automatically establish the session cookie and resume or reload the dashboard without requiring manual retry steps.
+- Manual token redemption via raw endpoint calls should remain only as a debugging fallback, not the intended user workflow.
 - Avoid repeated noisy auth failures in logs when a single warning plus 401/1008 response is sufficient.
 
 ## Recommended Follow-up Implementation
 - Add startup-token generation when `PENGUIN_AUTH_ENABLED=true` and no explicit API keys are configured.
+- Print a local authorization URL that embeds the startup token in a URL fragment for browser/dashboard bootstrap.
 - Add `POST /api/v1/auth/session` to redeem the startup token or configured API key for a signed session cookie.
 - Add `POST /api/v1/auth/logout` to clear the session cookie.
 - Extend HTTP, SSE, and WebSocket auth checks to accept the signed session cookie.
-- Add a small, explicit unauthorized warning path for browser/local clients instead of silent 401 loops.
+- Add a minimal local authorization dashboard flow that exchanges the startup token automatically instead of requiring manual endpoint calls.
 - Update local verification and docs to prefer `http://127.0.0.1:9000`.
 
 ## Execution Plan
@@ -113,7 +123,8 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 
 ### P3: Local browser session auth
 - Add startup capability-token generation when `PENGUIN_AUTH_ENABLED=true` and no configured API key is present.
-- Print a one-time local authorization message describing how to redeem the startup token.
+- Print a one-time local authorization message that includes a browser-friendly bootstrap URL.
+- The printed browser bootstrap URL should carry the token in a fragment, not a query parameter.
 - Add `POST /api/v1/auth/session` to exchange a startup token or configured API key for a signed `HttpOnly` session cookie.
 - Add `POST /api/v1/auth/logout` to clear the session cookie.
 - Ensure session cookies are loopback-safe and use conservative defaults for expiry, `SameSite`, and path.
@@ -133,15 +144,24 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 - Add concise remediation text for unauthorized browser/local requests instead of repeated noisy log spam.
 
 ### P6: Browser-client polish
-- Add a minimal unauthorized state for local browser clients that explains the instance is protected and how to authorize safely.
+- Add a minimal protected-dashboard authorization screen for local browser clients.
+- If the browser is opened via the printed authorization URL, automatically extract the fragment token, redeem it, clear the fragment, and continue loading.
+- If the dashboard is opened without a token or valid cookie, show the protected local authorization UI instead of looping on repeated `401`s.
 - Avoid building a Penguin account/login concept; keep the flow framed as local instance authorization.
-- Ensure auth-enabled browser clients recover cleanly after successful session creation instead of looping on repeated 401s.
-- Add regression coverage for the protected-browser happy path.
+- Add regression coverage for:
+  - opening the printed authorization URL
+  - automatic token redemption
+  - cookie establishment
+  - dashboard recovery after authorization
+  - unauthorized dashboard state without retry storms
 
 ### P7: TUI, packaging, and architecture alignment
 - Audit `penguin-tui` and launcher flows to ensure they can authenticate cleanly against an auth-enabled local `penguin-web` instance.
 - Keep header-based auth support for TUI/CLI-sidecar flows even after browser cookie auth is added.
 - Decide whether the TUI should redeem a startup token directly, reuse configured API keys, or delegate local authorization through the launcher.
+- TUI and CLI local flows must not depend on a browser authorization step.
+- Launcher-managed local TUI sessions should receive bootstrap auth automatically when using auth-enabled local `penguin-web`.
+- Headless and CI flows should rely on configured API keys, not startup-token copy/paste.
 - Update any TUI/server startup assumptions to prefer `http://127.0.0.1:9000`.
 - Update `pyproject.toml` script/runtime expectations if default port, auth messaging, or launcher assumptions change.
 - Update `architecture.md` so the documented TUI/web topology and local security model match runtime truth.
@@ -149,6 +169,10 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 ### P8: Documentation and operator guidance
 - Update README and web/TUI docs to describe the secure local-default posture.
 - Document the default host/port, the startup-token flow, and the explicit insecure override paths.
+- Document the browser/dashboard auth flow as a one-click local authorization URL plus automatic cookie bootstrap.
+- Document that manual `POST /api/v1/auth/session` redemption is a debugging fallback only.
+- Document TUI/CLI local auth as automatic header-based bootstrap.
+- Document CI/headless auth with `PENGUIN_API_KEYS` as the primary automation path.
 - Document how browser, TUI, CLI, and external clients authenticate against a protected local Penguin instance.
 - Document the difference between local instance authorization and user-account authentication.
 - Add operator guidance for non-loopback deployments, including the requirement for explicit auth.

--- a/context/tasks/web-security-hardening-plan.md
+++ b/context/tasks/web-security-hardening-plan.md
@@ -20,6 +20,57 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 4. Server startup posture is permissive by default when bound broadly.
 5. Upload endpoint lacks size/type/quota controls.
 
+## Reference Comparison
+
+### Codex precedent
+- Codex avoids exposing a local network listener by default and prefers `stdio` transports for rich clients.
+- When Codex exposes a websocket listener, loopback listeners are treated as the normal local path.
+- Non-loopback listeners require explicit token-based auth configuration.
+- For browser-driven OAuth callbacks, Codex binds to `127.0.0.1` by default and only broadens bind scope when explicitly configured.
+- Longer-lived credentials are stored in secure OS-backed storage.
+
+### OpenCode precedent
+- OpenCode defaults to `127.0.0.1` and prefers a local dev port, with fallback if that port is unavailable.
+- OpenCode permits a local/browser-accessible HTTP server as a first-class workflow.
+- Server auth is optional and implemented with simple HTTP Basic Auth when `OPENCODE_SERVER_PASSWORD` is set.
+- OpenCode warns loudly when the server is started without auth.
+- CORS is restricted to local origins, Tauri origins, and an explicit allowlist.
+
+## Penguin Recommendation Matrix
+
+### Safe defaults
+- Default bind host should remain loopback-only: `127.0.0.1`.
+- Default port should move to `9000` to reduce generic-port collisions and match repo guidance.
+- Penguin should never default to `0.0.0.0`.
+
+### Auth model
+- Penguin should not introduce local Penguin accounts.
+- When auth is enabled, Penguin should issue a startup capability token and exchange it once at a local auth endpoint.
+- The auth endpoint should set an `HttpOnly` session cookie for same-origin browser use.
+- Header auth should remain supported for TUI, CLI, and external clients.
+
+### Browser compatibility
+- Cookie-backed sessions are the recommended browser path because cookies work across normal HTTP, SSE, and WebSocket flows.
+- Do not reintroduce query-string auth for SSE or WebSocket compatibility.
+- Avoid relying on custom request headers for browser `EventSource` or browser-created `WebSocket` auth.
+
+### Broad bind policy
+- Non-loopback binds should remain blocked unless auth is enabled or an explicit insecure override is set.
+- Startup messaging should make the safe local path obvious and make insecure overrides feel deliberate.
+
+### UX guidance
+- If Penguin is started without auth, emit a clear warning that the local server is unsecured.
+- If Penguin rejects an unauthorized browser/client request, return a short remediation message describing the safe auth flow and the explicit no-auth local-only override.
+- Avoid repeated noisy auth failures in logs when a single warning plus 401/1008 response is sufficient.
+
+## Recommended Follow-up Implementation
+- Add startup-token generation when `PENGUIN_AUTH_ENABLED=true` and no explicit API keys are configured.
+- Add `POST /api/v1/auth/session` to redeem the startup token or configured API key for a signed session cookie.
+- Add `POST /api/v1/auth/logout` to clear the session cookie.
+- Extend HTTP, SSE, and WebSocket auth checks to accept the signed session cookie.
+- Add a small, explicit unauthorized warning path for browser/local clients instead of silent 401 loops.
+- Update local verification and docs to prefer `http://127.0.0.1:9000`.
+
 ## Execution Plan
 
 ### P0: Authentication correctness
@@ -60,6 +111,49 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 - Keep legacy plaintext JSON only as a compatibility fallback with loud warnings.
 - Document credential precedence and deprecate plaintext persistence as the primary path.
 
+### P3: Local browser session auth
+- Add startup capability-token generation when `PENGUIN_AUTH_ENABLED=true` and no configured API key is present.
+- Print a one-time local authorization message describing how to redeem the startup token.
+- Add `POST /api/v1/auth/session` to exchange a startup token or configured API key for a signed `HttpOnly` session cookie.
+- Add `POST /api/v1/auth/logout` to clear the session cookie.
+- Ensure session cookies are loopback-safe and use conservative defaults for expiry, `SameSite`, and path.
+
+### P4: Cookie auth integration across transports
+- Extend HTTP auth middleware to accept the signed session cookie alongside header auth.
+- Extend SSE auth checks to accept the signed session cookie.
+- Extend protected WebSocket auth guards to accept the signed session cookie during handshake.
+- Add focused tests proving cookie-authenticated HTTP, SSE, and WebSocket flows succeed.
+- Keep query-string auth disabled.
+
+### P5: Defaults and startup UX
+- Move the default web port to `9000`.
+- Keep the default bind host at `127.0.0.1`.
+- Update startup banners, server messages, and docs to consistently point users at `http://127.0.0.1:9000`.
+- Add a clear warning when Penguin is intentionally started without auth.
+- Add concise remediation text for unauthorized browser/local requests instead of repeated noisy log spam.
+
+### P6: Browser-client polish
+- Add a minimal unauthorized state for local browser clients that explains the instance is protected and how to authorize safely.
+- Avoid building a Penguin account/login concept; keep the flow framed as local instance authorization.
+- Ensure auth-enabled browser clients recover cleanly after successful session creation instead of looping on repeated 401s.
+- Add regression coverage for the protected-browser happy path.
+
+### P7: TUI, packaging, and architecture alignment
+- Audit `penguin-tui` and launcher flows to ensure they can authenticate cleanly against an auth-enabled local `penguin-web` instance.
+- Keep header-based auth support for TUI/CLI-sidecar flows even after browser cookie auth is added.
+- Decide whether the TUI should redeem a startup token directly, reuse configured API keys, or delegate local authorization through the launcher.
+- Update any TUI/server startup assumptions to prefer `http://127.0.0.1:9000`.
+- Update `pyproject.toml` script/runtime expectations if default port, auth messaging, or launcher assumptions change.
+- Update `architecture.md` so the documented TUI/web topology and local security model match runtime truth.
+
+### P8: Documentation and operator guidance
+- Update README and web/TUI docs to describe the secure local-default posture.
+- Document the default host/port, the startup-token flow, and the explicit insecure override paths.
+- Document how browser, TUI, CLI, and external clients authenticate against a protected local Penguin instance.
+- Document the difference between local instance authorization and user-account authentication.
+- Add operator guidance for non-loopback deployments, including the requirement for explicit auth.
+- Ensure examples, troubleshooting steps, and startup output snippets consistently use `127.0.0.1:9000`.
+
 ## Verification
 - Use the dedicated worktree only.
 - Prefer local web verification on port `9000` per `AGENTS.md`.
@@ -74,7 +168,11 @@ Close the highest-risk web security gaps in Penguin's HTTP and WebSocket surface
 - No unrelated behavior churn.
 
 ## Notes
-This should likely be split into at least three commits:
+This should likely be split into at least seven commits:
 1. auth correctness + WS auth
 2. startup/upload hardening
 3. webhook replay defense + credential precedence/docs
+4. startup token + session cookie auth
+5. default port/startup UX/docs polish
+6. TUI/launcher + packaging alignment
+7. architecture/docs final pass

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -885,6 +885,8 @@ export function Prompt(props: PromptProps) {
       })
         .then(async (res) => {
           if (res.ok) return
+          // TODO: Reset emitted session busy state here too, not just pending flags,
+          // so a failed send cannot leave the session visually stuck as busy.
           setStore("pending", false)
           setStore("pendingSeenBusy", false)
           const details = await res.text().catch(() => "")
@@ -895,7 +897,9 @@ export function Prompt(props: PromptProps) {
               : `Failed to send message (${res.status})`,
           })
         })
-        .catch(() => {
+        .catch((err) => {
+          // TODO: Surface transport-layer failures with a toast and reset the
+          // session busy state, not only the pending flags.
           setStore("pending", false)
           setStore("pendingSeenBusy", false)
         })

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -882,10 +882,23 @@ export function Prompt(props: PromptProps) {
           client_message_id: messageID,
           parts: nonTextParts,
         }),
-      }).catch(() => {
-        setStore("pending", false)
-        setStore("pendingSeenBusy", false)
       })
+        .then(async (res) => {
+          if (res.ok) return
+          setStore("pending", false)
+          setStore("pendingSeenBusy", false)
+          const details = await res.text().catch(() => "")
+          toast.show({
+            variant: "error",
+            message: details
+              ? `Failed to send message: ${details}`
+              : `Failed to send message (${res.status})`,
+          })
+        })
+        .catch(() => {
+          setStore("pending", false)
+          setStore("pendingSeenBusy", false)
+        })
       return
     }
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -171,7 +171,7 @@ export function Prompt(props: PromptProps) {
 
   function persistAgentMode(sessionID: string, nextMode: "build" | "plan") {
     const modeUrl = new URL(`/session/${encodeURIComponent(sessionID)}`, sdk.url)
-    fetch(modeUrl, {
+    sdk.fetch(modeUrl, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -657,7 +657,7 @@ export function Prompt(props: PromptProps) {
           sync.session.get(props.sessionID ?? sdk.sessionID ?? "")?.directory ?? process.cwd()
         const createUrl = new URL("/session", sdk.url)
         createUrl.searchParams.set("directory", directory)
-        const created = await fetch(createUrl, {
+        const created = await sdk.fetch(createUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -865,7 +865,7 @@ export function Prompt(props: PromptProps) {
       setStore("pending", true)
       setStore("pendingSeenBusy", false)
       const url = new URL("/api/v1/chat/message", sdk.url)
-      fetch(url, {
+      sdk.fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -8,6 +8,12 @@ export type EventSource = {
   on: (handler: (event: Event) => void) => () => void
 }
 
+function getPenguinAuthHeaders() {
+  const token = process.env.PENGUIN_LOCAL_AUTH_TOKEN ?? process.env.PENGUIN_AUTH_STARTUP_TOKEN
+  if (!token) return
+  return { "X-API-Key": token }
+}
+
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
   init: (props: {
@@ -19,11 +25,23 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     sessionID?: string
   }) => {
     const abort = new AbortController()
+    const headers = props.penguin ? getPenguinAuthHeaders() : undefined
+    const request = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const base = props.fetch ?? fetch
+      const next = new Request(input, init)
+      if (headers) {
+        for (const [key, value] of Object.entries(headers)) {
+          next.headers.set(key, value)
+        }
+      }
+      return base(next)
+    }) as typeof fetch
     const sdk = createOpencodeClient({
       baseUrl: props.url,
       signal: abort.signal,
       directory: props.directory,
-      fetch: props.fetch,
+      fetch: request,
+      headers,
     })
     const penguin = !!props.penguin
     const route = useRoute()
@@ -106,7 +124,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       streamAbort = new AbortController()
       const currentStreamAbort = streamAbort
 
-      const reader = await (props.fetch ?? fetch)(base, {
+      const reader = await request(base, {
         signal: currentStreamAbort.signal,
         headers: {
           Accept: "text/event-stream",
@@ -204,6 +222,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     return {
       client: sdk,
       event: emitter,
+      fetch: request,
       url: props.url,
       directory: props.directory,
       penguin,

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -289,7 +289,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       usageRefreshInFlight.add(sessionID)
       usageRefreshAt.set(sessionID, now)
       const url = new URL(`/session/${encodeURIComponent(sessionID)}`, sdk.url)
-      fetch(url)
+      sdk.fetch(url)
         .then((res) => (res.ok ? res.json() : undefined))
         .then((data) => {
           const usage = parseUsage(data)
@@ -671,7 +671,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             if (normalizedScoped && normalizedBase && normalizedScoped !== normalizedBase) break
             const url = new URL("/lsp", sdk.url)
             url.searchParams.set("directory", scopedDirectory)
-            fetch(url)
+            sdk.fetch(url)
               .then((res) => (res.ok ? res.json() : []))
               .then((data) => setStore("lsp", reconcile(Array.isArray(data) ? data : [])))
               .catch(() => undefined)
@@ -771,23 +771,23 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
         const [providersData, providerListData, configData, providerAuthData, sessionsData, roster] = await Promise.all(
           [
-            fetch(new URL("/config/providers", sdk.url))
+            sdk.fetch(new URL("/config/providers", sdk.url))
               .then((res) => (res.ok ? res.json() : undefined))
               .catch(() => undefined),
-            fetch(new URL("/provider", sdk.url))
+            sdk.fetch(new URL("/provider", sdk.url))
               .then((res) => (res.ok ? res.json() : undefined))
               .catch(() => undefined),
-            fetch(new URL("/config", sdk.url))
+            sdk.fetch(new URL("/config", sdk.url))
               .then((res) => (res.ok ? res.json() : undefined))
               .catch(() => undefined),
-            fetch(new URL("/provider/auth", sdk.url))
+            sdk.fetch(new URL("/provider/auth", sdk.url))
               .then((res) => (res.ok ? res.json() : undefined))
               .catch(() => undefined),
-            fetch(sessionsUrl)
+            sdk.fetch(sessionsUrl)
               .then((res) => (res.ok ? res.json() : undefined))
               .then((data) => (Array.isArray(data) ? data : []))
               .catch(() => []),
-            fetch(new URL("/api/v1/agents", sdk.url))
+            sdk.fetch(new URL("/api/v1/agents", sdk.url))
               .then((res) => (res.ok ? res.json() : undefined))
               .then((data) => (Array.isArray(data) ? data : []))
               .catch(() => []),
@@ -1005,16 +1005,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         await Promise.all([
-          fetch(systemUrl("/lsp"))
+          sdk.fetch(systemUrl("/lsp"))
             .then((res) => (res.ok ? res.json() : []))
             .catch(() => []),
-          fetch(systemUrl("/formatter"))
+          sdk.fetch(systemUrl("/formatter"))
             .then((res) => (res.ok ? res.json() : []))
             .catch(() => []),
-          fetch(systemUrl("/vcs"))
+          sdk.fetch(systemUrl("/vcs"))
             .then((res) => (res.ok ? res.json() : undefined))
             .catch(() => undefined),
-          fetch(systemUrl("/path"))
+          sdk.fetch(systemUrl("/path"))
             .then((res) => (res.ok ? res.json() : undefined))
             .catch(() => undefined),
         ]).then((result) => {

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -773,6 +773,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           sdk.fetch(path).then(async (res) => {
             if (res.ok) return res.json().catch(() => undefined)
             const details = await res.text().catch(() => "")
+            // TODO: Revisit whether some bootstrap endpoints should degrade to local
+            // fallbacks instead of failing the whole sync flow on non-2xx responses.
             throw new Error(
               details
                 ? `Bootstrap request failed (${res.status}): ${details}`

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -769,20 +769,22 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           url.searchParams.set("limit", "50")
           return url
         })
+        const bootstrap = (path: string | URL) =>
+          sdk.fetch(path).then(async (res) => {
+            if (res.ok) return res.json().catch(() => undefined)
+            const details = await res.text().catch(() => "")
+            throw new Error(
+              details
+                ? `Bootstrap request failed (${res.status}): ${details}`
+                : `Bootstrap request failed (${res.status})`,
+            )
+          })
         const [providersData, providerListData, configData, providerAuthData, sessionsData, roster] = await Promise.all(
           [
-            sdk.fetch(new URL("/config/providers", sdk.url))
-              .then((res) => (res.ok ? res.json() : undefined))
-              .catch(() => undefined),
-            sdk.fetch(new URL("/provider", sdk.url))
-              .then((res) => (res.ok ? res.json() : undefined))
-              .catch(() => undefined),
-            sdk.fetch(new URL("/config", sdk.url))
-              .then((res) => (res.ok ? res.json() : undefined))
-              .catch(() => undefined),
-            sdk.fetch(new URL("/provider/auth", sdk.url))
-              .then((res) => (res.ok ? res.json() : undefined))
-              .catch(() => undefined),
+            bootstrap(new URL("/config/providers", sdk.url)),
+            bootstrap(new URL("/provider", sdk.url)),
+            bootstrap(new URL("/config", sdk.url)),
+            bootstrap(new URL("/provider/auth", sdk.url)),
             sdk.fetch(sessionsUrl)
               .then((res) => (res.ok ? res.json() : undefined))
               .then((data) => (Array.isArray(data) ? data : []))
@@ -1005,18 +1007,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         await Promise.all([
-          sdk.fetch(systemUrl("/lsp"))
-            .then((res) => (res.ok ? res.json() : []))
-            .catch(() => []),
-          sdk.fetch(systemUrl("/formatter"))
-            .then((res) => (res.ok ? res.json() : []))
-            .catch(() => []),
-          sdk.fetch(systemUrl("/vcs"))
-            .then((res) => (res.ok ? res.json() : undefined))
-            .catch(() => undefined),
-          sdk.fetch(systemUrl("/path"))
-            .then((res) => (res.ok ? res.json() : undefined))
-            .catch(() => undefined),
+          bootstrap(systemUrl("/lsp")),
+          bootstrap(systemUrl("/formatter")),
+          bootstrap(systemUrl("/vcs")),
+          bootstrap(systemUrl("/path")),
         ]).then((result) => {
           const lsp = result[0]
           const formatter = result[1]

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -119,7 +119,7 @@ export const TuiThreadCommand = cmd({
       return piped ? piped + "\n" + args.prompt : args.prompt
     })
 
-    const base = args.url ?? process.env.PENGUIN_WEB_URL ?? "http://localhost:8000"
+    const base = args.url ?? process.env.PENGUIN_WEB_URL ?? "http://127.0.0.1:9000"
     const sessionID = args.session
     const url = base
     const customFetch = undefined

--- a/penguin/cli/opencode_launcher.py
+++ b/penguin/cli/opencode_launcher.py
@@ -13,6 +13,7 @@ import importlib.metadata
 import json
 import os
 import platform
+import secrets
 import shutil
 import subprocess
 import sys
@@ -27,10 +28,17 @@ from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 from .._version import __version__ as PENGUIN_VERSION
+from ..constants import DEFAULT_WEB_PORT
+from ..local_auth import (
+    is_web_auth_enabled,
+    read_local_auth_token,
+    write_local_auth_token,
+)
 
 LOCAL_HOSTS = {"", "localhost", "127.0.0.1", "0.0.0.0", "::1"}
 DEFAULT_TUI_RELEASE_API_ROOT = "https://api.github.com/repos/Maximooch/penguin/releases"
 DEFAULT_TUI_RELEASE_URL = f"{DEFAULT_TUI_RELEASE_API_ROOT}/latest"
+DEFAULT_WEB_URL = f"http://127.0.0.1:{DEFAULT_WEB_PORT}"
 _URL_MODE_CAP_CACHE: dict[str, bool] = {}
 
 
@@ -231,12 +239,62 @@ def _stop_process(proc: subprocess.Popen[str] | None) -> None:
     if proc.poll() is not None:
         return
 
-    proc.terminate()
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        return
+
     try:
         proc.wait(timeout=5)
+    except KeyboardInterrupt:
+        return
     except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait(timeout=5)
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            return
+        try:
+            proc.wait(timeout=5)
+        except (KeyboardInterrupt, ProcessLookupError):
+            return
+
+
+def _prepare_local_auth_env(
+    base_url: str,
+    env: dict[str, str],
+    *,
+    server_running: bool,
+) -> None:
+    """Seed auth env so local TUI sessions can reuse local bootstrap auth."""
+    if not _is_local_url(base_url):
+        return
+    if env.get("PENGUIN_API_KEYS", "").strip():
+        return
+
+    auth_mode = env.get("PENGUIN_AUTH_ENABLED", "").strip().lower()
+    if auth_mode in {"0", "false", "no", "off"}:
+        return
+
+    token = env.get("PENGUIN_LOCAL_AUTH_TOKEN", "").strip()
+    if not token:
+        token = env.get("PENGUIN_AUTH_STARTUP_TOKEN", "").strip()
+    if not token:
+        token = read_local_auth_token(base_url) or ""
+
+    if token:
+        env.setdefault("PENGUIN_LOCAL_AUTH_TOKEN", token)
+        return
+
+    auth_enabled = is_web_auth_enabled(env)
+    if server_running or not auth_enabled:
+        return
+
+    if not token:
+        token = secrets.token_urlsafe(24)
+        env["PENGUIN_AUTH_STARTUP_TOKEN"] = token
+        write_local_auth_token(token, base_url)
+
+    env.setdefault("PENGUIN_LOCAL_AUTH_TOKEN", token)
 
 
 def _find_local_opencode_dir() -> Path | None:
@@ -803,7 +861,7 @@ def _parse_args(
     )
     parser.add_argument(
         "--url",
-        default=os.getenv("PENGUIN_WEB_URL", "http://localhost:8000"),
+        default=os.getenv("PENGUIN_WEB_URL", DEFAULT_WEB_URL),
         help="Penguin web base URL (default: %(default)s).",
     )
     parser.add_argument(
@@ -858,11 +916,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Force it to the requested target project when launched via uvx/tool shims.
     env["PWD"] = str(project_dir)
 
+    server_running = _is_server_running(base_url)
+    _prepare_local_auth_env(base_url, env, server_running=server_running)
+
     server_proc: subprocess.Popen[str] | None = None
     cleanup_registered = False
 
     should_try_web_start = _is_local_url(base_url) and not args.no_web_autostart
-    if not _is_server_running(base_url):
+    if not server_running:
         if should_try_web_start:
             try:
                 _ensure_web_runtime_available()

--- a/penguin/constants.py
+++ b/penguin/constants.py
@@ -38,20 +38,26 @@ DEFAULT_MAX_CONTEXT_IMAGES = int(os.getenv("PENGUIN_MAX_CONTEXT_IMAGES", "5"))
 DEFAULT_SESSION_LIST_LIMIT = int(os.getenv("PENGUIN_SESSION_LIST_LIMIT", "100000"))
 
 # Session manager message limits
-DEFAULT_MAX_MESSAGES_PER_SESSION = int(os.getenv("PENGUIN_MAX_MESSAGES_PER_SESSION", "5000"))
+DEFAULT_MAX_MESSAGES_PER_SESSION = int(
+    os.getenv("PENGUIN_MAX_MESSAGES_PER_SESSION", "5000")
+)
 DEFAULT_MAX_TOTAL_MESSAGES = int(os.getenv("PENGUIN_MAX_TOTAL_MESSAGES", "100000"))
 
 # Memory/chunk size limits
 DEFAULT_MAX_CHUNK_SIZE = int(os.getenv("PENGUIN_MAX_CHUNK_SIZE", "8000"))
 
 # File size threshold for skipping in delegate explore
-DEFAULT_LARGE_FILE_THRESHOLD_BYTES = int(os.getenv("PENGUIN_LARGE_FILE_THRESHOLD_BYTES", "100000"))
+DEFAULT_LARGE_FILE_THRESHOLD_BYTES = int(
+    os.getenv("PENGUIN_LARGE_FILE_THRESHOLD_BYTES", "100000")
+)
 
 # Web/API server defaults
-DEFAULT_WEB_PORT = int(os.getenv("PENGUIN_WEB_PORT", "8000"))
+DEFAULT_WEB_PORT = int(os.getenv("PENGUIN_WEB_PORT", "9000"))
 
 # Patch truncation limit for webhooks
-DEFAULT_PATCH_TRUNCATION_LIMIT = int(os.getenv("PENGUIN_PATCH_TRUNCATION_LIMIT", "5000"))
+DEFAULT_PATCH_TRUNCATION_LIMIT = int(
+    os.getenv("PENGUIN_PATCH_TRUNCATION_LIMIT", "5000")
+)
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -87,7 +93,10 @@ def get_default_max_history_tokens() -> int:
     This should generally be derived from model context window, but several call
     paths still need a stable fallback.
     """
-    return _coerce_int(os.getenv("PENGUIN_MAX_HISTORY_TOKENS", DEFAULT_MAX_HISTORY_TOKENS), DEFAULT_MAX_HISTORY_TOKENS)
+    return _coerce_int(
+        os.getenv("PENGUIN_MAX_HISTORY_TOKENS", DEFAULT_MAX_HISTORY_TOKENS),
+        DEFAULT_MAX_HISTORY_TOKENS,
+    )
 
 
 def get_default_context_window_emergency_fallback_tokens() -> int:

--- a/penguin/local_auth.py
+++ b/penguin/local_auth.py
@@ -1,0 +1,100 @@
+"""Shared local auth helpers for Penguin browser and TUI bootstrap flows."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlparse
+
+from penguin.constants import DEFAULT_WEB_PORT
+
+LOCAL_AUTH_CACHE_DIR_ENV = "PENGUIN_LOCAL_AUTH_CACHE_DIR"
+WEB_AUTH_ENABLED_ENV = "PENGUIN_AUTH_ENABLED"
+
+__all__ = [
+    "WEB_AUTH_ENABLED_ENV",
+    "is_web_auth_enabled",
+    "local_auth_token_path",
+    "read_local_auth_token",
+    "write_local_auth_token",
+]
+
+
+def is_web_auth_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether Penguin web auth should be enabled.
+
+    Web auth is protected-by-default. Only explicit false-like values disable it.
+    """
+    source = os.environ if env is None else env
+    raw = source.get(WEB_AUTH_ENABLED_ENV, "")
+    normalized = raw.strip().lower()
+    if not normalized:
+        return True
+    return normalized not in {"0", "false", "no", "off"}
+
+
+def _normalize_local_auth_host(host: str) -> str:
+    normalized = (host or "").strip().lower()
+    if normalized in {"", "localhost", "127.0.0.1", "0.0.0.0", "::1"}:
+        return "127.0.0.1"
+    return normalized.replace(":", "_")
+
+
+def _local_auth_cache_dir() -> Path:
+    raw = os.getenv(LOCAL_AUTH_CACHE_DIR_ENV, "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path.home() / ".cache" / "penguin" / "auth"
+
+
+def local_auth_token_path(
+    base_url: str | None = None,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> Path:
+    """Return the cache path for a loopback Penguin startup token."""
+    if base_url:
+        parsed = urlparse(base_url)
+        host = parsed.hostname or host or "127.0.0.1"
+        port = parsed.port or port or DEFAULT_WEB_PORT
+    else:
+        host = host or os.getenv("HOST", "127.0.0.1")
+        port = port or int(os.getenv("PORT", str(DEFAULT_WEB_PORT)))
+
+    cache_dir = _local_auth_cache_dir()
+    return cache_dir / f"{_normalize_local_auth_host(host)}-{port}.token"
+
+
+def read_local_auth_token(
+    base_url: str | None = None,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> str | None:
+    """Read a cached local startup token if one exists."""
+    path = local_auth_token_path(base_url, host=host, port=port)
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return token or None
+
+
+def write_local_auth_token(
+    token: str,
+    base_url: str | None = None,
+    *,
+    host: str | None = None,
+    port: int | None = None,
+) -> Path:
+    """Persist a loopback Penguin startup token for local launcher reuse."""
+    path = local_auth_token_path(base_url, host=host, port=port)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token.strip(), encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path

--- a/penguin/web/__init__.py
+++ b/penguin/web/__init__.py
@@ -9,10 +9,10 @@ This module provides web-based interfaces for Penguin, including:
 Example Usage:
     ```python
     from penguin.web import create_app, PenguinAPI
-    
+
     # Create FastAPI application
     app = create_app()
-    
+
     # Or use the API class directly
     api = PenguinAPI()
     await api.chat("Hello, how can you help me?")
@@ -27,12 +27,15 @@ Installation:
 
 from typing import Optional
 
+from penguin.constants import DEFAULT_WEB_PORT
+
 # Web application - will be imported when FastAPI is available
 _web_app: Optional[object] = None
 
+
 def get_web_app():
     """Get the web application instance.
-    
+
     Returns:
         The FastAPI application, or None if web dependencies not available
     """
@@ -40,6 +43,7 @@ def get_web_app():
     if _web_app is None:
         try:
             from .app import create_app
+
             _web_app = create_app()
         except ImportError:
             # Web dependencies not available
@@ -52,17 +56,17 @@ try:
     from .app import create_app, PenguinAPI
     from .routes import router as api_router
     from .server import start_server, main
-    
+
     __all__ = [
         "create_app",
-        "PenguinAPI", 
+        "PenguinAPI",
         "api_router",
         "start_server",
         "main",
         "get_web_app",
-        "PenguinWeb"
+        "PenguinWeb",
     ]
-    
+
 except ImportError:
     # Web dependencies not available (minimal install)
     __all__ = ["get_web_app"]
@@ -70,10 +74,10 @@ except ImportError:
 
 class PenguinWeb:
     """Main web interface class for programmatic access."""
-    
-    def __init__(self, host: str = "localhost", port: int = 8000):
+
+    def __init__(self, host: str = "localhost", port: int = DEFAULT_WEB_PORT):
         """Initialize web interface.
-        
+
         Args:
             host: Host to bind the server to
             port: Port to bind the server to
@@ -85,11 +89,12 @@ class PenguinWeb:
             raise ImportError(
                 "Web dependencies not available. Install with: pip install penguin-ai[web]"
             )
-    
+
     def run(self, **kwargs):
         """Run the web server with uvicorn."""
         try:
             import uvicorn
+
             uvicorn.run(self.app, host=self.host, port=self.port, **kwargs)
         except ImportError:
             raise ImportError(

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 
 # Global core instance for reuse
 _core_instance: Optional[PenguinCore] = None
+NO_CACHE_HEADERS = {
+    "Cache-Control": "no-store, max-age=0",
+    "Pragma": "no-cache",
+}
 
 DEFAULT_DEV_CORS_ORIGINS = [
     "http://127.0.0.1:8000",
@@ -187,7 +191,9 @@ def create_app() -> "FastAPI":
 
     # Configure CORS
     origins_env = os.getenv("PENGUIN_CORS_ORIGINS", "").strip()
-    origins_list = [o.strip() for o in origins_env.split(",") if o.strip()] or DEFAULT_DEV_CORS_ORIGINS
+    origins_list = [
+        o.strip() for o in origins_env.split(",") if o.strip()
+    ] or DEFAULT_DEV_CORS_ORIGINS
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins_list,
@@ -278,16 +284,32 @@ def create_app() -> "FastAPI":
             """Serve the main web UI."""
             index_path = static_dir / "index.html"
             if index_path.exists():
-                return FileResponse(str(index_path))
+                return FileResponse(str(index_path), headers=NO_CACHE_HEADERS)
             return {"message": "Penguin API is running. Web UI not found."}
+
+        @app.get("/chat")
+        async def read_chat():
+            """Serve the legacy chat UI at a stable explicit path."""
+            index_path = static_dir / "index.html"
+            if index_path.exists():
+                return FileResponse(str(index_path), headers=NO_CACHE_HEADERS)
+            return {"message": "Penguin chat UI not found."}
 
         @app.get("/dashboard")
         async def read_dashboard():
             """Serve the dashboard UI."""
             dashboard_path = static_dir / "dashboard.html"
             if dashboard_path.exists():
-                return FileResponse(str(dashboard_path))
+                return FileResponse(str(dashboard_path), headers=NO_CACHE_HEADERS)
             return {"message": "Dashboard not found."}
+
+        @app.get("/authorize")
+        async def read_authorize():
+            """Serve the lightweight local authorization UI."""
+            authorize_path = static_dir / "authorize.html"
+            if authorize_path.exists():
+                return FileResponse(str(authorize_path), headers=NO_CACHE_HEADERS)
+            return {"message": "Authorization UI not found."}
     else:
 
         @app.get("/")
@@ -540,7 +562,10 @@ class PenguinAPI:
         clarification-needed and other non-terminal outcomes should survive instead of being flattened into engine-only semantics.
         """
         try:
-            run_mode = RunMode(core=self.core, max_iterations=max_iterations or get_engine_max_iterations_default())
+            run_mode = RunMode(
+                core=self.core,
+                max_iterations=max_iterations or get_engine_max_iterations_default(),
+            )
             return await run_mode.start(
                 name=task_description,
                 description=None,

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -1,13 +1,16 @@
-"""Authentication middleware for Penguin web API.
+"""Authentication middleware and local session helpers for Penguin web API.
 
-Supports both API key and JWT token authentication for Link integration
-and other external clients.
+Supports API key and JWT authentication for external clients plus a
+startup-token-to-cookie bootstrap flow for local browser sessions.
 """
 
 import logging
 import os
+import secrets
 from typing import Any, Optional
 from datetime import datetime, timedelta
+from ipaddress import ip_address
+from threading import Lock
 
 from fastapi import HTTPException, Request, WebSocket, WebSocketException, status
 from fastapi.responses import JSONResponse
@@ -17,12 +20,21 @@ import jwt
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SESSION_COOKIE_NAME = "penguin_session"
+DEFAULT_SESSION_COOKIE_PATH = "/"
+DEFAULT_SESSION_COOKIE_SAMESITE = "lax"
+DEFAULT_SESSION_EXPIRATION_SECONDS = 12 * 60 * 60
+STARTUP_TOKEN_ENV = "PENGUIN_AUTH_STARTUP_TOKEN"
+SESSION_SECRET_ENV = "PENGUIN_SESSION_SECRET"
+_AUTH_SECRET_LOCK = Lock()
+
 # Security scheme for Bearer token
 security = HTTPBearer(auto_error=False)
 
 
 class AuthenticationError(Exception):
     """Raised when authentication fails."""
+
     pass
 
 
@@ -40,11 +52,30 @@ class AuthConfig:
 
         # Link-specific configuration
         self.link_api_key = os.getenv("LINK_API_KEY")
-        self.link_auth_required = os.getenv("PENGUIN_LINK_AUTH_REQUIRED", "false").lower() == "true"
+        self.link_auth_required = (
+            os.getenv("PENGUIN_LINK_AUTH_REQUIRED", "false").lower() == "true"
+        )
 
         # General auth settings
         self.auth_enabled = os.getenv("PENGUIN_AUTH_ENABLED", "false").lower() == "true"
         self.public_endpoints = self._load_public_endpoints()
+        self.session_cookie_name = os.getenv(
+            "PENGUIN_SESSION_COOKIE_NAME", DEFAULT_SESSION_COOKIE_NAME
+        )
+        self.session_cookie_path = os.getenv(
+            "PENGUIN_SESSION_COOKIE_PATH", DEFAULT_SESSION_COOKIE_PATH
+        )
+        self.session_cookie_samesite = _normalize_samesite(
+            os.getenv(
+                "PENGUIN_SESSION_COOKIE_SAMESITE", DEFAULT_SESSION_COOKIE_SAMESITE
+            )
+        )
+        self.session_expiration_seconds = int(
+            os.getenv(
+                "PENGUIN_SESSION_EXPIRATION_SECONDS",
+                str(DEFAULT_SESSION_EXPIRATION_SECONDS),
+            )
+        )
 
     def _load_api_keys(self) -> set:
         """Load valid API keys from environment."""
@@ -70,6 +101,8 @@ class AuthConfig:
             "/api/redoc",
             "/api/openapi.json",
             "/api/v1/health",
+            "/api/v1/auth/session",
+            "/api/v1/auth/logout",
             "/static/",
         }
 
@@ -83,7 +116,9 @@ class AuthConfig:
     @property
     def public_endpoint_prefixes(self) -> set[str]:
         """Return public endpoints that should be treated as prefixes."""
-        return {path for path in self.public_endpoints if path.endswith("/") and path != "/"}
+        return {
+            path for path in self.public_endpoints if path.endswith("/") and path != "/"
+        }
 
     @property
     def public_endpoint_exact_matches(self) -> set[str]:
@@ -97,11 +132,168 @@ class AuthConfig:
 
         return any(path.startswith(prefix) for prefix in self.public_endpoint_prefixes)
 
+    @property
+    def requires_startup_token(self) -> bool:
+        """Return whether local bootstrap token auth should be enabled."""
+        return self.auth_enabled and not self.api_keys
+
 
 # Public-endpoint matching convention:
 # - entries ending with "/" (except "/" itself) are treated as prefix matches
 # - all other entries require exact path equality
 # `is_public_endpoint()` checks exact matches first, then falls back to prefix matching.
+
+
+def _normalize_samesite(value: str) -> str:
+    """Return a valid cookie SameSite value."""
+    normalized = (value or "").strip().lower()
+    if normalized in {"lax", "strict", "none"}:
+        return normalized
+    return DEFAULT_SESSION_COOKIE_SAMESITE
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return whether the provided host resolves to loopback."""
+    normalized = (host or "").strip().lower()
+    if normalized in {"127.0.0.1", "localhost", "::1"}:
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _load_or_create_secret(env_name: str, *, bytes_length: int) -> str:
+    """Load an auth secret from env or create one for this process tree."""
+    value = os.getenv(env_name, "").strip()
+    if value:
+        return value
+
+    with _AUTH_SECRET_LOCK:
+        value = os.getenv(env_name, "").strip()
+        if value:
+            return value
+
+        generated = secrets.token_urlsafe(bytes_length)
+        os.environ[env_name] = generated
+        return generated
+
+
+def get_startup_auth_token(config: Optional[AuthConfig] = None) -> Optional[str]:
+    """Return the loopback bootstrap token when auth needs local browser bootstrap."""
+    auth_config = config or AuthConfig()
+    if not auth_config.requires_startup_token:
+        return None
+    return _load_or_create_secret(STARTUP_TOKEN_ENV, bytes_length=24)
+
+
+def get_session_secret(config: Optional[AuthConfig] = None) -> str:
+    """Return the signing secret used for Penguin browser session cookies."""
+    auth_config = config or AuthConfig()
+    explicit_secret = os.getenv(SESSION_SECRET_ENV, "").strip()
+    if explicit_secret:
+        return explicit_secret
+    if auth_config.jwt_secret:
+        return auth_config.jwt_secret
+    return _load_or_create_secret(SESSION_SECRET_ENV, bytes_length=32)
+
+
+def authenticate_local_session_token(
+    token: str,
+    config: Optional[AuthConfig] = None,
+) -> dict:
+    """Authenticate a token exchanged for a local browser session."""
+    auth_config = config or AuthConfig()
+    candidate = (token or "").strip()
+    if not candidate:
+        raise AuthenticationError("Local authorization token is required")
+
+    startup_token = get_startup_auth_token(auth_config)
+    if startup_token and secrets.compare_digest(candidate, startup_token):
+        return {
+            "method": "startup_token",
+            "subject": "local_bootstrap",
+            "metadata": {"interactive": True},
+        }
+
+    if validate_api_key(candidate, auth_config):
+        return {
+            "method": "api_key",
+            "subject": "api_client",
+            "metadata": {"key_prefix": candidate[:8] + "..."},
+        }
+
+    raise AuthenticationError("Invalid local authorization token")
+
+
+def create_session_token(
+    subject: str,
+    *,
+    auth_method: str,
+    config: Optional[AuthConfig] = None,
+    metadata: Optional[dict] = None,
+) -> str:
+    """Create a signed browser session token for Penguin local auth."""
+    auth_config = config or AuthConfig()
+    issued_at = datetime.utcnow()
+    claims = {
+        "sub": subject,
+        "type": "session",
+        "auth_method": auth_method,
+        "iat": issued_at,
+        "exp": issued_at + timedelta(seconds=auth_config.session_expiration_seconds),
+    }
+    if metadata:
+        claims["metadata"] = metadata
+
+    return jwt.encode(
+        claims,
+        get_session_secret(auth_config),
+        algorithm=auth_config.jwt_algorithm,
+    )
+
+
+def validate_session_token(token: str, config: Optional[AuthConfig] = None) -> dict:
+    """Validate a signed Penguin browser session token."""
+    auth_config = config or AuthConfig()
+    try:
+        claims = jwt.decode(
+            token,
+            get_session_secret(auth_config),
+            algorithms=[auth_config.jwt_algorithm],
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise AuthenticationError("Session has expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise AuthenticationError(f"Invalid session token: {exc}") from exc
+
+    if claims.get("type") != "session":
+        raise AuthenticationError("Invalid session token type")
+    return claims
+
+
+def build_session_cookie_settings(
+    request: Request,
+    config: Optional[AuthConfig] = None,
+) -> dict[str, Any]:
+    """Build safe cookie settings for Penguin local browser sessions."""
+    auth_config = config or AuthConfig()
+    host = (request.url.hostname or "").strip().lower()
+    secure = request.url.scheme == "https"
+    if not secure and not _is_loopback_host(host):
+        raise AuthenticationError(
+            "Browser session cookies are only issued for loopback hosts or HTTPS origins"
+        )
+
+    return {
+        "expires": auth_config.session_expiration_seconds,
+        "httponly": True,
+        "max_age": auth_config.session_expiration_seconds,
+        "path": auth_config.session_cookie_path,
+        "samesite": auth_config.session_cookie_samesite,
+        "secure": secure,
+    }
+
 
 def extract_api_key(connection: Any) -> Optional[str]:
     """Extract API key from request or websocket headers."""
@@ -135,7 +327,7 @@ def validate_api_key(api_key: str, config: AuthConfig) -> bool:
     """Validate an API key against configured keys."""
     if not api_key:
         return False
-    return api_key in config.api_keys
+    return any(secrets.compare_digest(api_key, key) for key in config.api_keys)
 
 
 def validate_jwt(token: str, config: AuthConfig) -> dict:
@@ -144,11 +336,7 @@ def validate_jwt(token: str, config: AuthConfig) -> dict:
         raise AuthenticationError("JWT authentication not configured")
 
     try:
-        claims = jwt.decode(
-            token,
-            config.jwt_secret,
-            algorithms=[config.jwt_algorithm]
-        )
+        claims = jwt.decode(token, config.jwt_secret, algorithms=[config.jwt_algorithm])
 
         if "exp" in claims:
             exp_timestamp = claims["exp"]
@@ -229,7 +417,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             return {
                 "method": "api_key",
                 "subject": "api_client",
-                "metadata": {"key_prefix": api_key[:8] + "..."}
+                "metadata": {"key_prefix": api_key[:8] + "..."},
             }
 
         token = extract_bearer_token(request)
@@ -238,7 +426,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             return {
                 "method": "jwt",
                 "subject": claims.get("sub", "unknown"),
-                "metadata": claims
+                "metadata": claims,
             }
 
         raise AuthenticationError("No valid authentication credentials provided")
@@ -260,7 +448,8 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         claims = {
             "sub": subject,
             "iat": datetime.utcnow(),
-            "exp": datetime.utcnow() + timedelta(hours=self.config.jwt_expiration_hours)
+            "exp": datetime.utcnow()
+            + timedelta(hours=self.config.jwt_expiration_hours),
         }
 
         # Add metadata
@@ -269,9 +458,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
         # Encode token
         token = jwt.encode(
-            claims,
-            self.config.jwt_secret,
-            algorithm=self.config.jwt_algorithm
+            claims, self.config.jwt_secret, algorithm=self.config.jwt_algorithm
         )
 
         return token
@@ -279,8 +466,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
 # Dependency for route-level auth
 async def require_auth(
-    request: Request,
-    credentials: Optional[HTTPAuthorizationCredentials] = None
+    request: Request, credentials: Optional[HTTPAuthorizationCredentials] = None
 ) -> dict:
     """FastAPI dependency for requiring authentication.
 
@@ -297,7 +483,7 @@ async def require_auth(
                     "code": "AUTHENTICATION_REQUIRED",
                     "message": "Authentication required for this endpoint",
                     "recoverable": False,
-                    "suggested_action": "provide_credentials"
+                    "suggested_action": "provide_credentials",
                 }
             },
             headers={"WWW-Authenticate": "Bearer"},
@@ -306,7 +492,7 @@ async def require_auth(
     return {
         "method": request.state.auth_method,
         "subject": request.state.auth_subject,
-        "metadata": request.state.auth_metadata
+        "metadata": request.state.auth_metadata,
     }
 
 
@@ -343,13 +529,17 @@ async def require_websocket_auth(
 ) -> dict:
     """Authenticate a WebSocket connection before accept()."""
     auth_config = config or AuthConfig()
-    if not auth_config.auth_enabled or auth_config.is_public_endpoint(websocket.url.path):
+    if not auth_config.auth_enabled or auth_config.is_public_endpoint(
+        websocket.url.path
+    ):
         return {"method": "anonymous", "subject": "public", "metadata": {}}
 
     try:
         auth_result = authenticate_connection(websocket, auth_config)
     except AuthenticationError as exc:
-        logger.warning("WebSocket authentication failed for %s: %s", websocket.url.path, exc)
+        logger.warning(
+            "WebSocket authentication failed for %s: %s", websocket.url.path, exc
+        )
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION,
             reason=str(exc),

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Authentication middleware and local session helpers for Penguin web API.
 
 Supports API key and JWT authentication for external clients plus a
@@ -7,11 +9,13 @@ startup-token-to-cookie bootstrap flow for local browser sessions.
 import logging
 import os
 import secrets
-from http.cookies import SimpleCookie
-from typing import Any, Optional
+from collections import OrderedDict
 from datetime import datetime, timedelta
+from http.cookies import SimpleCookie
 from ipaddress import ip_address
+import re
 from threading import Lock
+from typing import Any, Optional
 
 from fastapi import HTTPException, Request, WebSocket, WebSocketException, status
 from fastapi.responses import JSONResponse
@@ -31,7 +35,11 @@ STARTUP_TOKEN_ENV = "PENGUIN_AUTH_STARTUP_TOKEN"
 SESSION_SECRET_ENV = "PENGUIN_SESSION_SECRET"
 _AUTH_SECRET_LOCK = Lock()
 _AUTH_WARNING_LOCK = Lock()
-_SEEN_AUTH_FAILURES: set[tuple[str, str]] = set()
+_AUTH_FAILURE_CACHE_LIMIT = 256
+_DYNAMIC_PATH_SEGMENT = re.compile(
+    r"^(?:[0-9]+|[0-9a-fA-F-]{8,}|session_[A-Za-z0-9_:-]+|msg_[A-Za-z0-9_:-]+|task_[A-Za-z0-9_:-]+)$"
+)
+_SEEN_AUTH_FAILURES: "OrderedDict[tuple[str, str], None]" = OrderedDict()
 
 # Security scheme for Bearer token
 security = HTTPBearer(auto_error=False)
@@ -175,6 +183,37 @@ def _is_loopback_host(host: str) -> bool:
         return False
 
 
+def _connection_host(connection: Any) -> str | None:
+    """Return the peer host for an HTTP or WebSocket connection."""
+    client = getattr(connection, "client", None)
+    if client is None:
+        return None
+    if isinstance(client, (tuple, list)):
+        return str(client[0]) if client else None
+    host = getattr(client, "host", None)
+    return str(host) if host else None
+
+
+def _is_loopback_peer(connection: Any) -> bool:
+    """Return whether the peer connected from a loopback address."""
+    host = _connection_host(connection)
+    return _is_loopback_host(host or "") if host else False
+
+
+def _normalize_auth_failure_path(path: str) -> str:
+    """Bucket dynamic paths so auth-failure suppression stays bounded."""
+    normalized = (path or "/").split("?", 1)[0].strip() or "/"
+    if normalized == "/":
+        return normalized
+
+    parts = [
+        ":id" if _DYNAMIC_PATH_SEGMENT.match(part) else part
+        for part in normalized.split("/")
+        if part
+    ]
+    return "/" + "/".join(parts)
+
+
 def _load_or_create_secret(env_name: str, *, bytes_length: int) -> str:
     """Load an auth secret from env or create one for this process tree."""
     value = os.getenv(env_name, "").strip()
@@ -213,6 +252,7 @@ def get_session_secret(config: Optional[AuthConfig] = None) -> str:
 def authenticate_local_session_token(
     token: str,
     config: Optional[AuthConfig] = None,
+    connection: Any = None,
 ) -> dict:
     """Authenticate a token exchanged for a local browser session."""
     auth_config = config or AuthConfig()
@@ -222,6 +262,10 @@ def authenticate_local_session_token(
 
     startup_token = get_startup_auth_token(auth_config)
     if startup_token and secrets.compare_digest(candidate, startup_token):
+        if not _is_loopback_peer(connection):
+            raise AuthenticationError(
+                "Local startup token is only valid from loopback clients"
+            )
         return {
             "method": "startup_token",
             "subject": "local_bootstrap",
@@ -290,7 +334,7 @@ def build_session_cookie_settings(
 ) -> dict[str, Any]:
     """Build safe cookie settings for Penguin local browser sessions."""
     auth_config = config or AuthConfig()
-    host = (request.url.hostname or "").strip().lower()
+    host = (_connection_host(request) or "").strip().lower()
     secure = request.url.scheme == "https"
     if not secure and not _is_loopback_host(host):
         raise AuthenticationError(
@@ -332,11 +376,13 @@ def log_auth_failure_once(
     transport: str, path: str, config: Optional[AuthConfig] = None
 ) -> None:
     """Warn once per transport/path pair to avoid repeated auth log spam."""
-    key = (transport, path)
+    key = (transport, _normalize_auth_failure_path(path))
     with _AUTH_WARNING_LOCK:
         first_failure = key not in _SEEN_AUTH_FAILURES
         if first_failure:
-            _SEEN_AUTH_FAILURES.add(key)
+            _SEEN_AUTH_FAILURES[key] = None
+            while len(_SEEN_AUTH_FAILURES) > _AUTH_FAILURE_CACHE_LIMIT:
+                _SEEN_AUTH_FAILURES.popitem(last=False)
 
     if first_failure:
         logger.warning(
@@ -412,9 +458,13 @@ def validate_api_key(api_key: str, config: AuthConfig) -> bool:
     return any(secrets.compare_digest(api_key, key) for key in config.api_keys)
 
 
-def validate_startup_token(token: str, config: AuthConfig) -> bool:
+def validate_startup_token(
+    token: str, config: AuthConfig, connection: Any = None
+) -> bool:
     """Validate the process-local startup token for local non-browser clients."""
     if not config.requires_startup_token or not token:
+        return False
+    if not _is_loopback_peer(connection):
         return False
 
     startup_token = get_startup_auth_token(config)
@@ -589,7 +639,7 @@ def authenticate_connection(
                 "metadata": {"key_prefix": api_key[:8] + "..."},
             }
 
-        if validate_startup_token(api_key, auth_config):
+        if validate_startup_token(api_key, auth_config, connection):
             return {
                 "method": "startup_token",
                 "subject": "local_bootstrap",

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -19,6 +19,8 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from starlette.middleware.base import BaseHTTPMiddleware
 import jwt
 
+from penguin.local_auth import is_web_auth_enabled
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_SESSION_COOKIE_NAME = "penguin_session"
@@ -28,6 +30,8 @@ DEFAULT_SESSION_EXPIRATION_SECONDS = 12 * 60 * 60
 STARTUP_TOKEN_ENV = "PENGUIN_AUTH_STARTUP_TOKEN"
 SESSION_SECRET_ENV = "PENGUIN_SESSION_SECRET"
 _AUTH_SECRET_LOCK = Lock()
+_AUTH_WARNING_LOCK = Lock()
+_SEEN_AUTH_FAILURES: set[tuple[str, str]] = set()
 
 # Security scheme for Bearer token
 security = HTTPBearer(auto_error=False)
@@ -58,7 +62,7 @@ class AuthConfig:
         )
 
         # General auth settings
-        self.auth_enabled = os.getenv("PENGUIN_AUTH_ENABLED", "false").lower() == "true"
+        self.auth_enabled = is_web_auth_enabled()
         self.public_endpoints = self._load_public_endpoints()
         self.session_cookie_name = os.getenv(
             "PENGUIN_SESSION_COOKIE_NAME", DEFAULT_SESSION_COOKIE_NAME
@@ -98,12 +102,19 @@ class AuthConfig:
         """Load endpoints that don't require authentication."""
         public = {
             "/",
+            "/authorize",
+            "/chat",
+            "/dashboard",
+            "/openapi.json",
             "/api/docs",
             "/api/redoc",
             "/api/openapi.json",
             "/api/v1/health",
             "/api/v1/auth/session",
             "/api/v1/auth/logout",
+            "/favicon.ico",
+            "/apple-touch-icon.png",
+            "/apple-touch-icon-precomposed.png",
             "/static/",
         }
 
@@ -296,6 +307,48 @@ def build_session_cookie_settings(
     }
 
 
+def build_auth_remediation(config: Optional[AuthConfig] = None) -> str:
+    """Return a concise remediation message for unauthorized local requests."""
+    auth_config = config or AuthConfig()
+    if auth_config.requires_startup_token:
+        return (
+            "Use the startup token in an X-API-Key header or authenticate via "
+            "POST /api/v1/auth/session, or "
+            "restart local-only without auth using PENGUIN_AUTH_ENABLED=false uv run penguin-web."
+        )
+
+    return (
+        "Provide an X-API-Key or Authorization header, or create a local session at "
+        "POST /api/v1/auth/session."
+    )
+
+
+def build_unauthorized_message(config: Optional[AuthConfig] = None) -> str:
+    """Return the user-facing unauthorized message for protected Penguin routes."""
+    return f"This Penguin instance is protected. {build_auth_remediation(config)}"
+
+
+def log_auth_failure_once(
+    transport: str, path: str, config: Optional[AuthConfig] = None
+) -> None:
+    """Warn once per transport/path pair to avoid repeated auth log spam."""
+    key = (transport, path)
+    with _AUTH_WARNING_LOCK:
+        first_failure = key not in _SEEN_AUTH_FAILURES
+        if first_failure:
+            _SEEN_AUTH_FAILURES.add(key)
+
+    if first_failure:
+        logger.warning(
+            "Unauthorized %s request to %s. %s",
+            transport,
+            path,
+            build_auth_remediation(config),
+        )
+    else:
+        logger.debug("Unauthorized %s request to %s", transport, path)
+
+
 def extract_api_key(connection: Any) -> Optional[str]:
     """Extract API key from request or websocket headers."""
     headers = connection.headers
@@ -359,6 +412,18 @@ def validate_api_key(api_key: str, config: AuthConfig) -> bool:
     return any(secrets.compare_digest(api_key, key) for key in config.api_keys)
 
 
+def validate_startup_token(token: str, config: AuthConfig) -> bool:
+    """Validate the process-local startup token for local non-browser clients."""
+    if not config.requires_startup_token or not token:
+        return False
+
+    startup_token = get_startup_auth_token(config)
+    if not startup_token:
+        return False
+
+    return secrets.compare_digest(token, startup_token)
+
+
 def validate_jwt(token: str, config: AuthConfig) -> dict:
     """Validate and decode a JWT token using the provided config."""
     if not config.jwt_secret:
@@ -399,17 +464,17 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
         try:
             auth_result = await self._authenticate_request(request)
-        except AuthenticationError as e:
-            logger.warning(f"Authentication failed for {request.url.path}: {str(e)}")
+        except AuthenticationError:
+            log_auth_failure_once("http", request.url.path, self.config)
             return JSONResponse(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 content={
                     "detail": {
                         "error": {
                             "code": "AUTHENTICATION_FAILED",
-                            "message": str(e),
+                            "message": build_unauthorized_message(self.config),
                             "recoverable": False,
-                            "suggested_action": "check_credentials",
+                            "suggested_action": build_auth_remediation(self.config),
                         }
                     }
                 },
@@ -516,12 +581,20 @@ def authenticate_connection(
     auth_config = config or AuthConfig()
 
     api_key = extract_api_key(connection)
-    if api_key and validate_api_key(api_key, auth_config):
-        return {
-            "method": "api_key",
-            "subject": "api_client",
-            "metadata": {"key_prefix": api_key[:8] + "..."},
-        }
+    if api_key:
+        if validate_api_key(api_key, auth_config):
+            return {
+                "method": "api_key",
+                "subject": "api_client",
+                "metadata": {"key_prefix": api_key[:8] + "..."},
+            }
+
+        if validate_startup_token(api_key, auth_config):
+            return {
+                "method": "startup_token",
+                "subject": "local_bootstrap",
+                "metadata": {"interactive": False},
+            }
 
     token = extract_bearer_token(connection)
     if token:
@@ -558,12 +631,10 @@ async def require_websocket_auth(
     try:
         auth_result = authenticate_connection(websocket, auth_config)
     except AuthenticationError as exc:
-        logger.warning(
-            "WebSocket authentication failed for %s: %s", websocket.url.path, exc
-        )
+        log_auth_failure_once("websocket", websocket.url.path, auth_config)
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION,
-            reason=str(exc),
+            reason=build_unauthorized_message(auth_config),
         ) from exc
 
     websocket.state.authenticated = True

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -7,6 +7,7 @@ startup-token-to-cookie bootstrap flow for local browser sessions.
 import logging
 import os
 import secrets
+from http.cookies import SimpleCookie
 from typing import Any, Optional
 from datetime import datetime, timedelta
 from ipaddress import ip_address
@@ -323,6 +324,34 @@ def extract_bearer_token(connection: Any) -> Optional[str]:
     return parts[1]
 
 
+def extract_session_cookie(
+    connection: Any,
+    config: Optional[AuthConfig] = None,
+) -> Optional[str]:
+    """Extract the Penguin session cookie from an HTTP or WebSocket connection."""
+    auth_config = config or AuthConfig()
+
+    cookies = getattr(connection, "cookies", None)
+    if cookies is not None:
+        try:
+            session_cookie = cookies.get(auth_config.session_cookie_name)
+        except Exception:
+            session_cookie = None
+        if session_cookie:
+            return session_cookie
+
+    cookie_header = connection.headers.get("cookie") or connection.headers.get("Cookie")
+    if not cookie_header:
+        return None
+
+    parsed = SimpleCookie()
+    parsed.load(cookie_header)
+    morsel = parsed.get(auth_config.session_cookie_name)
+    if morsel is None:
+        return None
+    return morsel.value
+
+
 def validate_api_key(api_key: str, config: AuthConfig) -> bool:
     """Validate an API key against configured keys."""
     if not api_key:
@@ -412,24 +441,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     async def _authenticate_request(self, request: Request) -> dict:
         """Authenticate a request using available methods."""
-        api_key = extract_api_key(request)
-        if api_key and validate_api_key(api_key, self.config):
-            return {
-                "method": "api_key",
-                "subject": "api_client",
-                "metadata": {"key_prefix": api_key[:8] + "..."},
-            }
-
-        token = extract_bearer_token(request)
-        if token:
-            claims = validate_jwt(token, self.config)
-            return {
-                "method": "jwt",
-                "subject": claims.get("sub", "unknown"),
-                "metadata": claims,
-            }
-
-        raise AuthenticationError("No valid authentication credentials provided")
+        return authenticate_connection(request, self.config)
 
     def create_jwt(self, subject: str, metadata: Optional[dict] = None) -> str:
         """Create a JWT token for a subject.
@@ -516,6 +528,15 @@ def authenticate_connection(
         claims = validate_jwt(token, auth_config)
         return {
             "method": "jwt",
+            "subject": claims.get("sub", "unknown"),
+            "metadata": claims,
+        }
+
+    session_token = extract_session_cookie(connection, auth_config)
+    if session_token:
+        claims = validate_session_token(session_token, auth_config)
+        return {
+            "method": "session",
             "subject": claims.get("sub", "unknown"),
             "metadata": claims,
         }

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -3233,7 +3233,7 @@ async def api_auth_session(
         )
 
     try:
-        auth_result = authenticate_local_session_token(body.token, auth_config)
+        auth_result = authenticate_local_session_token(body.token, auth_config, request)
         session_token = create_session_token(
             auth_result.get("subject", "unknown"),
             auth_method=auth_result["method"],

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -14,6 +14,7 @@ from fastapi import (
     Query,
 )  # type: ignore
 from pydantic import BaseModel  # type: ignore
+from fastapi.responses import PlainTextResponse
 from dataclasses import asdict  # type: ignore
 from datetime import datetime  # type: ignore
 from collections import OrderedDict
@@ -3251,6 +3252,27 @@ async def api_auth_session(
         }
     except AuthenticationError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+@router.get("/api/v1/auth/session", response_class=PlainTextResponse)
+async def api_auth_session_info() -> str:
+    """Explain how to exchange a local startup token for a browser session."""
+    auth_config = AuthConfig()
+    if not auth_config.auth_enabled:
+        return (
+            "Penguin local session auth is not enabled for this server.\n"
+            "Protected local startup is the default: uv run penguin-web\n"
+            "To keep auth disabled intentionally: PENGUIN_AUTH_ENABLED=false uv run penguin-web\n"
+        )
+
+    return (
+        "Penguin local session bootstrap endpoint.\n"
+        'Use POST /api/v1/auth/session with JSON body: {"token": "<startup token>"}.\n'
+        "Use the startup token printed by penguin-web, or a configured API key if one is set.\n"
+        "TUI/CLI local sessions authenticate automatically.\n"
+        "CI/headless should prefer PENGUIN_API_KEYS plus X-API-Key header auth.\n"
+        "To run local-only without auth: PENGUIN_AUTH_ENABLED=false uv run penguin-web\n"
+    )
 
 
 @router.post("/api/v1/auth/logout")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -6,6 +6,8 @@ from fastapi import (
     WebSocketDisconnect,
     HTTPException,
     BackgroundTasks,
+    Request,
+    Response,
     UploadFile,
     File,
     Form,
@@ -75,7 +77,14 @@ from penguin.web.services.session_view import (
 from penguin.web.services.session_fork import fork_session
 from penguin.web.services.session_revert import revert_session, unrevert_session
 from penguin.web.services.session_summary import summarize_session_title
-from penguin.web.middleware.auth import require_websocket_auth
+from penguin.web.middleware.auth import (
+    AuthenticationError,
+    AuthConfig,
+    authenticate_local_session_token,
+    build_session_cookie_settings,
+    create_session_token,
+    require_websocket_auth,
+)
 from penguin.web.services.system_status import (
     get_formatter_status,
     get_lsp_status,
@@ -121,7 +130,9 @@ def _format_error_response(error: Exception, status_code: int = 500) -> HTTPExce
         )
 
 
-def _serialize_task_payload(task: Any, *, include_metadata: bool = True) -> Dict[str, Any]:
+def _serialize_task_payload(
+    task: Any, *, include_metadata: bool = True
+) -> Dict[str, Any]:
     """Serialize a task for web responses without flattening new runtime state away."""
     # Keep this centralized so task payload fixes land in one place instead of drifting across routes.
     # The web surface should expose current lifecycle truth, including phase and clarification state, not just legacy status fields.
@@ -142,7 +153,9 @@ def _serialize_task_payload(task: Any, *, include_metadata: bool = True) -> Dict
         "title": task.title,
         "description": task.description,
         "status": task.status.value if hasattr(task.status, "value") else task.status,
-        "phase": task.phase.value if hasattr(task.phase, "value") else getattr(task, "phase", None),
+        "phase": task.phase.value
+        if hasattr(task.phase, "value")
+        else getattr(task, "phase", None),
         "priority": getattr(task, "priority", None),
         "parent_task_id": getattr(task, "parent_task_id", None),
         "dependencies": list(getattr(task, "dependencies", []) or []),
@@ -2100,6 +2113,10 @@ class AgentDelegateRequest(BaseModel):
     parent: Optional[str] = None
 
 
+class LocalAuthSessionRequest(BaseModel):
+    token: str
+
+
 class MessageEnvelope(BaseModel):
     recipient: str
     content: Any
@@ -3198,6 +3215,53 @@ async def api_provider_list(core: PenguinCore = Depends(get_core)):
 async def api_provider_auth(core: PenguinCore = Depends(get_core)):
     """Alias for OpenCode-compatible provider auth methods endpoint."""
     return await opencode_provider_auth(core=core)
+
+
+@router.post("/api/v1/auth/session")
+async def api_auth_session(
+    body: LocalAuthSessionRequest,
+    request: Request,
+    response: Response,
+):
+    """Exchange a local bootstrap token or configured API key for a browser session."""
+    auth_config = AuthConfig()
+    if not auth_config.auth_enabled:
+        raise HTTPException(
+            status_code=400,
+            detail="Penguin local session auth is not enabled for this server.",
+        )
+
+    try:
+        auth_result = authenticate_local_session_token(body.token, auth_config)
+        session_token = create_session_token(
+            auth_result.get("subject", "unknown"),
+            auth_method=auth_result["method"],
+            config=auth_config,
+            metadata=auth_result.get("metadata", {}),
+        )
+        response.set_cookie(
+            key=auth_config.session_cookie_name,
+            value=session_token,
+            **build_session_cookie_settings(request, auth_config),
+        )
+        return {
+            "authenticated": True,
+            "method": auth_result["method"],
+            "subject": auth_result.get("subject", "unknown"),
+        }
+    except AuthenticationError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+@router.post("/api/v1/auth/logout")
+async def api_auth_logout(response: Response):
+    """Clear the local Penguin browser session cookie."""
+    auth_config = AuthConfig()
+    response.delete_cookie(
+        key=auth_config.session_cookie_name,
+        path=auth_config.session_cookie_path,
+    )
+    return {"authenticated": False}
 
 
 @router.put("/api/v1/auth/{providerID}")
@@ -4577,10 +4641,7 @@ async def get_project(project_id: str, core: PenguinCore = Depends(get_core)):
             "workspace_path": project.workspace_path,
             "created_at": project.created_at if project.created_at else None,
             "updated_at": project.updated_at if project.updated_at else None,
-            "tasks": [
-                _serialize_task_payload(task)
-                for task in tasks
-            ],
+            "tasks": [_serialize_task_payload(task) for task in tasks],
         }
     except HTTPException:
         raise
@@ -4635,7 +4696,9 @@ async def list_tasks(
                 normalized_status = status.strip().lower()
                 status_filter = TaskStatus(normalized_status)
             except ValueError:
-                valid_options = ", ".join(task_status.value for task_status in TaskStatus)
+                valid_options = ", ".join(
+                    task_status.value for task_status in TaskStatus
+                )
                 raise HTTPException(
                     status_code=400,
                     detail=f"Invalid status: {status}. Valid options: {valid_options}",
@@ -4645,12 +4708,7 @@ async def list_tasks(
             project_id=project_id, status=status_filter
         )
 
-        return {
-            "tasks": [
-                _serialize_task_payload(task)
-                for task in tasks
-            ]
-        }
+        return {"tasks": [_serialize_task_payload(task) for task in tasks]}
     except HTTPException:
         raise
     except Exception as e:
@@ -4695,7 +4753,6 @@ async def resume_task_clarification(
         task = await core.project_manager.get_task_async(task_id)
         if not task:
             raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
-
 
         run_mode = RunMode(core=core)
         result = await run_mode.resume_with_clarification(

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -7,6 +7,10 @@ It uses the app factory from app.py to create and configure the FastAPI applicat
 import logging
 import os
 from ipaddress import ip_address
+from urllib.parse import quote
+
+from penguin.constants import DEFAULT_WEB_PORT
+from penguin.local_auth import is_web_auth_enabled, write_local_auth_token
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +34,7 @@ def validate_startup_security(host: str) -> None:
     if _is_local_host(host):
         return
 
-    auth_enabled = os.environ.get("PENGUIN_AUTH_ENABLED", "false").lower() == "true"
+    auth_enabled = is_web_auth_enabled()
     if auth_enabled:
         return
 
@@ -46,9 +50,9 @@ def validate_startup_security(host: str) -> None:
         return
 
     raise RuntimeError(
-        "Refusing to bind Penguin web server to a non-local host without authentication. "
-        "Set PENGUIN_AUTH_ENABLED=true or explicitly override with "
-        "PENGUIN_ALLOW_INSECURE_NO_AUTH=true."
+        "Refusing to bind Penguin web server to a non-local host with auth disabled. "
+        "Remove PENGUIN_AUTH_ENABLED=false, switch to HOST=127.0.0.1 for local-only use, "
+        "or explicitly override with PENGUIN_ALLOW_INSECURE_NO_AUTH=true."
     )
 
 
@@ -72,13 +76,42 @@ def _display_host(host: str) -> str:
 def _print_startup_banner(host: str, port: int) -> None:
     """Print startup information using the actual configured address."""
     display_host = _display_host(host)
-    print("\n\033[96m=== Penguin AI Server ===\033[0m")
+    print("\n\033[96m=== Penguin Server ===\033[0m")
     print(f"\033[96mVisit http://{display_host}:{port} to start using Penguin!\033[0m")
     print(f"\033[96mAPI documentation: http://{display_host}:{port}/api/docs\033[0m\n")
 
 
+def _print_no_auth_warning(host: str, port: int) -> None:
+    """Print a clear warning when Penguin starts without authentication."""
+    display_host = _display_host(host)
+    if _is_local_host(host):
+        print(
+            "\033[93mWarning: Penguin local web auth is explicitly disabled for this session.\033[0m"
+        )
+        print(
+            f"\033[93mThis instance is reachable at http://{display_host}:{port} without authentication.\033[0m"
+        )
+        print(
+            "\033[93mProtected local startup is the default: uv run penguin-web\033[0m"
+        )
+        print(
+            "\033[93mTo keep auth disabled intentionally: PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
+        )
+        return
+
+    print(
+        "\033[91mWarning: Penguin is exposed on a non-local host without authentication.\033[0m"
+    )
+    print(
+        "\033[91mThis is only allowed because PENGUIN_ALLOW_INSECURE_NO_AUTH=true is set.\033[0m"
+    )
+    print(
+        "\033[93mSafer options: remove PENGUIN_AUTH_ENABLED=false or switch back to HOST=127.0.0.1.\033[0m\n"
+    )
+
+
 def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
-    """Print one-time local authorization instructions when bootstrap auth is enabled."""
+    """Print startup guidance when local web auth is enabled."""
     try:
         from .middleware.auth import AuthConfig, get_startup_auth_token
     except ImportError:
@@ -86,15 +119,27 @@ def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
 
     auth_config = AuthConfig()
     startup_token = get_startup_auth_token(auth_config)
-    if not startup_token:
-        return
-
     display_host = _display_host(host)
-    print("\033[93mLocal Penguin authorization is enabled.\033[0m")
+    print("\033[93mPenguin local web auth is enabled.\033[0m")
+    if startup_token:
+        write_local_auth_token(startup_token, host=host, port=port)
+        bootstrap_url = f"http://{display_host}:{port}/authorize#local_token={quote(startup_token, safe='')}"
+        print(
+            "\033[93mBrowser/dashboard only: open this local authorization URL once for this browser.\033[0m"
+        )
+        print(f"\033[93m  {bootstrap_url}\033[0m")
+        print(f"\033[93mStartup token (debug fallback): {startup_token}\033[0m")
+    else:
+        print(
+            "\033[93mBrowser/dashboard: authorize with a configured API key at /api/v1/auth/session if needed.\033[0m"
+        )
+    print("\033[93mTUI/CLI: local Penguin sessions authenticate automatically.\033[0m")
     print(
-        f"\033[93mRedeem the startup token at http://{display_host}:{port}/api/v1/auth/session\033[0m"
+        "\033[93mCI/headless: use PENGUIN_API_KEYS with X-API-Key header auth.\033[0m"
     )
-    print(f"\033[93mStartup token: {startup_token}\033[0m\n")
+    print(
+        "\033[93mTo explicitly run local-only without auth: PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
+    )
 
 
 def main():
@@ -107,7 +152,7 @@ def main():
         return 1
 
     host = os.environ.get("HOST", DEFAULT_HOST)
-    port = int(os.environ.get("PORT", 8000))
+    port = int(os.environ.get("PORT", DEFAULT_WEB_PORT))
     debug = os.environ.get("DEBUG", "false").lower() == "true"
     app = None
 
@@ -122,7 +167,11 @@ def main():
         return 1
 
     _print_startup_banner(host, port)
-    _print_local_auth_bootstrap_banner(host, port)
+    auth_enabled = is_web_auth_enabled()
+    if auth_enabled:
+        _print_local_auth_bootstrap_banner(host, port)
+    else:
+        _print_no_auth_warning(host, port)
 
     if debug:
         uvicorn.run(
@@ -143,7 +192,9 @@ def main():
     return 0
 
 
-def start_server(host: str = DEFAULT_HOST, port: int = 8000, debug: bool = False):
+def start_server(
+    host: str = DEFAULT_HOST, port: int = DEFAULT_WEB_PORT, debug: bool = False
+):
     """Start the web server programmatically.
 
     Args:

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -10,6 +10,7 @@ from ipaddress import ip_address
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HOST = "127.0.0.1"
 LOCAL_ONLY_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
@@ -72,12 +73,8 @@ def _print_startup_banner(host: str, port: int) -> None:
     """Print startup information using the actual configured address."""
     display_host = _display_host(host)
     print("\n\033[96m=== Penguin AI Server ===\033[0m")
-    print(
-        f"\033[96mVisit http://{display_host}:{port} to start using Penguin!\033[0m"
-    )
-    print(
-        f"\033[96mAPI documentation: http://{display_host}:{port}/api/docs\033[0m\n"
-    )
+    print(f"\033[96mVisit http://{display_host}:{port} to start using Penguin!\033[0m")
+    print(f"\033[96mAPI documentation: http://{display_host}:{port}/api/docs\033[0m\n")
 
 
 def main():
@@ -89,15 +86,15 @@ def main():
         print("Install with: pip install penguin-ai[web]")
         return 1
 
-    host = os.environ.get("HOST", "0.0.0.0")
+    host = os.environ.get("HOST", DEFAULT_HOST)
     port = int(os.environ.get("PORT", 8000))
     debug = os.environ.get("DEBUG", "false").lower() == "true"
+    app = None
 
     try:
         validate_startup_security(host)
         if debug:
             create_app_factory()
-            app = None
         else:
             app = create_app_factory()
     except Exception as e:
@@ -115,13 +112,17 @@ def main():
             reload=True,
             factory=True,
         )
-    else:
-        uvicorn.run(app, host=host, port=port, log_level="info", reload=False)
+        return 0
+
+    if app is None:
+        return 1
+
+    uvicorn.run(app, host=host, port=port, log_level="info", reload=False)
 
     return 0
 
 
-def start_server(host: str = "0.0.0.0", port: int = 8000, debug: bool = False):
+def start_server(host: str = DEFAULT_HOST, port: int = 8000, debug: bool = False):
     """Start the web server programmatically.
 
     Args:

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -77,6 +77,26 @@ def _print_startup_banner(host: str, port: int) -> None:
     print(f"\033[96mAPI documentation: http://{display_host}:{port}/api/docs\033[0m\n")
 
 
+def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
+    """Print one-time local authorization instructions when bootstrap auth is enabled."""
+    try:
+        from .middleware.auth import AuthConfig, get_startup_auth_token
+    except ImportError:
+        return
+
+    auth_config = AuthConfig()
+    startup_token = get_startup_auth_token(auth_config)
+    if not startup_token:
+        return
+
+    display_host = _display_host(host)
+    print("\033[93mLocal Penguin authorization is enabled.\033[0m")
+    print(
+        f"\033[93mRedeem the startup token at http://{display_host}:{port}/api/v1/auth/session\033[0m"
+    )
+    print(f"\033[93mStartup token: {startup_token}\033[0m\n")
+
+
 def main():
     """Entry point for the web server."""
     try:
@@ -102,6 +122,7 @@ def main():
         return 1
 
     _print_startup_banner(host, port)
+    _print_local_auth_bootstrap_banner(host, port)
 
     if debug:
         uvicorn.run(

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -73,6 +73,17 @@ def _display_host(host: str) -> str:
     return "localhost" if host in {"0.0.0.0", "::", ""} else host
 
 
+def _resolve_port() -> int:
+    """Parse the configured web port with a controlled error path."""
+    raw = os.environ.get("PORT", str(DEFAULT_WEB_PORT))
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Invalid PORT value {raw!r}. Set PORT to an integer port number."
+        ) from exc
+
+
 def _print_startup_banner(host: str, port: int) -> None:
     """Print startup information using the actual configured address."""
     display_host = _display_host(host)
@@ -122,7 +133,15 @@ def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
     display_host = _display_host(host)
     print("\033[93mPenguin local web auth is enabled.\033[0m")
     if startup_token:
-        write_local_auth_token(startup_token, host=host, port=port)
+        try:
+            write_local_auth_token(startup_token, host=host, port=port)
+        except Exception as exc:
+            logger.warning(
+                "Failed to write local auth token cache for %s:%s: %s",
+                host,
+                port,
+                exc,
+            )
         bootstrap_url = f"http://{display_host}:{port}/authorize#local_token={quote(startup_token, safe='')}"
         print(
             "\033[93mBrowser/dashboard only: open this local authorization URL once for this browser.\033[0m"
@@ -152,11 +171,10 @@ def main():
         return 1
 
     host = os.environ.get("HOST", DEFAULT_HOST)
-    port = int(os.environ.get("PORT", DEFAULT_WEB_PORT))
-    debug = os.environ.get("DEBUG", "false").lower() == "true"
-    app = None
-
     try:
+        port = _resolve_port()
+        debug = os.environ.get("DEBUG", "false").lower() == "true"
+        app = None
         validate_startup_security(host)
         if debug:
             create_app_factory()

--- a/penguin/web/static/authorize.html
+++ b/penguin/web/static/authorize.html
@@ -295,6 +295,7 @@
 
             setWorking(true)
             setStatus('Authorizing local browser session...')
+            clearBootstrapFragment()
 
             try {
                 const response = await fetch('/api/v1/auth/session', {
@@ -312,7 +313,6 @@
                     return false
                 }
 
-                clearBootstrapFragment()
                 setAuthorized()
                 return true
             } catch (error) {

--- a/penguin/web/static/authorize.html
+++ b/penguin/web/static/authorize.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authorize Penguin</title>
+    <style>
+        :root {
+            --background: 224 71% 4%;
+            --foreground: 213 31% 91%;
+            --primary: 210 40% 98%;
+            --primary-foreground: 222.2 47.4% 1.2%;
+            --muted: 223 47% 11%;
+            --muted-foreground: 215.4 16.3% 56.9%;
+            --border: 216 34% 17%;
+            --accent: 217 91% 60%;
+            --radius: 0.75rem;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background:
+                radial-gradient(circle at top, rgba(59, 130, 246, 0.16), transparent 35%),
+                linear-gradient(180deg, hsl(var(--background)), #020617 60%);
+            color: hsl(var(--foreground));
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+        }
+
+        .shell {
+            width: min(100%, 42rem);
+            background: rgba(15, 23, 42, 0.92);
+            border: 1px solid hsl(var(--border));
+            border-radius: calc(var(--radius) * 1.25);
+            box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+            overflow: hidden;
+        }
+
+        .hero {
+            padding: 1.5rem;
+            border-bottom: 1px solid hsl(var(--border));
+            background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(16, 185, 129, 0.06));
+        }
+
+        .eyebrow {
+            font-size: 0.72rem;
+            letter-spacing: 0.2em;
+            text-transform: uppercase;
+            color: hsl(var(--muted-foreground));
+            margin-bottom: 0.75rem;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: clamp(2rem, 4vw, 2.75rem);
+            line-height: 1.05;
+        }
+
+        .subhead {
+            margin-top: 0.75rem;
+            color: hsl(var(--muted-foreground));
+            line-height: 1.6;
+            font-size: 1rem;
+        }
+
+        .content {
+            padding: 1.5rem;
+            display: grid;
+            gap: 1rem;
+        }
+
+        .panel {
+            background: rgba(15, 23, 42, 0.82);
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+            padding: 1rem;
+        }
+
+        .status {
+            font-size: 0.95rem;
+            line-height: 1.55;
+            color: hsl(var(--foreground));
+        }
+
+        .muted {
+            color: hsl(var(--muted-foreground));
+        }
+
+        .input {
+            width: 100%;
+            border-radius: var(--radius);
+            border: 1px solid hsl(var(--border));
+            background: rgba(2, 6, 23, 0.92);
+            color: hsl(var(--foreground));
+            padding: 0.9rem 1rem;
+            font-size: 1rem;
+        }
+
+        .input:focus {
+            outline: none;
+            border-color: hsl(var(--accent));
+            box-shadow: 0 0 0 1px hsl(var(--accent));
+        }
+
+        .actions {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .button {
+            border: 0;
+            border-radius: var(--radius);
+            background: hsl(var(--primary));
+            color: hsl(var(--primary-foreground));
+            padding: 0.85rem 1.25rem;
+            font-size: 0.95rem;
+            font-weight: 600;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .button.secondary {
+            background: transparent;
+            color: hsl(var(--foreground));
+            border: 1px solid hsl(var(--border));
+        }
+
+        .button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .links {
+            display: none;
+            grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+            gap: 0.75rem;
+        }
+
+        .links.visible {
+            display: grid;
+        }
+
+        .link-card {
+            border: 1px solid hsl(var(--border));
+            border-radius: var(--radius);
+            padding: 1rem;
+            text-decoration: none;
+            color: inherit;
+            background: rgba(2, 6, 23, 0.82);
+        }
+
+        .link-card strong {
+            display: block;
+            margin-bottom: 0.35rem;
+        }
+
+        .progress {
+            height: 0.5rem;
+            border-radius: 999px;
+            overflow: hidden;
+            background: rgba(148, 163, 184, 0.14);
+        }
+
+        .progress > span {
+            display: block;
+            height: 100%;
+            width: 66%;
+            background: linear-gradient(90deg, #3b82f6, #10b981);
+            animation: shimmer 1.2s ease-in-out infinite;
+        }
+
+        @keyframes shimmer {
+            0%, 100% { opacity: 0.7; transform: scaleX(0.97); }
+            50% { opacity: 1; transform: scaleX(1); }
+        }
+    </style>
+</head>
+<body>
+    <main class="shell">
+        <section class="hero">
+            <div class="eyebrow">Protected Local Penguin</div>
+            <h1>Authorize this browser</h1>
+            <p class="subhead">
+                Penguin is running locally with protection enabled. Authorize this browser once and Penguin will set a local session cookie for the dashboard and browser tools.
+            </p>
+        </section>
+
+        <section class="content">
+            <div class="panel" id="status-panel">
+                <p class="status" id="status-text">Paste the startup token printed by <code>penguin-web</code>, or open the full authorization URL from the terminal.</p>
+            </div>
+
+            <div class="panel" id="form-panel">
+                <label class="muted" for="token-input">Startup token</label>
+                <div style="height: 0.5rem"></div>
+                <input id="token-input" class="input" type="password" autocomplete="off" spellcheck="false" placeholder="Paste local startup token" />
+                <div style="height: 1rem"></div>
+                <div class="actions">
+                    <button class="button" id="authorize-button">Authorize browser</button>
+                    <a class="button secondary" href="/api/docs">Open API docs</a>
+                </div>
+            </div>
+
+            <div class="panel" id="working-panel" hidden>
+                <p class="status">Authorizing local browser session...</p>
+                <div style="height: 0.75rem"></div>
+                <div class="progress"><span></span></div>
+            </div>
+
+            <div class="links" id="authorized-links">
+                <a class="link-card" href="/chat">
+                    <strong>Open Chat</strong>
+                    <span class="muted">Use the legacy local chat UI.</span>
+                </a>
+                <a class="link-card" href="/dashboard">
+                    <strong>Open Dashboard</strong>
+                    <span class="muted">View local telemetry and engine state.</span>
+                </a>
+            </div>
+
+            <p class="muted" style="margin: 0; font-size: 0.86rem;">
+                This is local instance authorization, not a Penguin account login. For headless and CI flows, prefer configured <code>PENGUIN_API_KEYS</code>.
+            </p>
+        </section>
+    </main>
+
+    <script>
+        const statusText = document.getElementById('status-text')
+        const formPanel = document.getElementById('form-panel')
+        const workingPanel = document.getElementById('working-panel')
+        const authorizedLinks = document.getElementById('authorized-links')
+        const tokenInput = document.getElementById('token-input')
+        const authorizeButton = document.getElementById('authorize-button')
+
+        const setStatus = (message) => {
+            statusText.textContent = message
+        }
+
+        const setWorking = (active) => {
+            formPanel.hidden = active
+            workingPanel.hidden = !active
+        }
+
+        const setAuthorized = () => {
+            setWorking(false)
+            authorizedLinks.classList.add('visible')
+            setStatus('This browser is authorized. Open Chat or Dashboard below.')
+        }
+
+        const clearBootstrapFragment = () => {
+            if (!window.location.hash) return
+            history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+        }
+
+        const getBootstrapToken = () => {
+            const hash = window.location.hash.startsWith('#')
+                ? window.location.hash.slice(1)
+                : window.location.hash
+            if (!hash) return ''
+            const params = new URLSearchParams(hash)
+            return params.get('local_token') || ''
+        }
+
+        const parseError = async (response) => {
+            try {
+                const data = await response.clone().json()
+                return data?.detail?.error?.message || data?.detail || response.statusText
+            } catch {
+                try {
+                    return await response.clone().text() || response.statusText
+                } catch {
+                    return response.statusText
+                }
+            }
+        }
+
+        const authorize = async (token) => {
+            const value = (token || '').trim()
+            if (!value) {
+                setStatus('Paste the startup token printed by penguin-web to authorize this browser.')
+                return false
+            }
+
+            setWorking(true)
+            setStatus('Authorizing local browser session...')
+
+            try {
+                const response = await fetch('/api/v1/auth/session', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ token: value })
+                })
+
+                if (!response.ok) {
+                    setWorking(false)
+                    setStatus(await parseError(response))
+                    return false
+                }
+
+                clearBootstrapFragment()
+                setAuthorized()
+                return true
+            } catch (error) {
+                setWorking(false)
+                setStatus(error?.message || 'Failed to authorize this browser.')
+                return false
+            }
+        }
+
+        const checkExistingSession = async () => {
+            try {
+                const response = await fetch('/api/v1/capabilities', { credentials: 'same-origin' })
+                if (response.ok) {
+                    setAuthorized()
+                    return true
+                }
+            } catch {
+                // Ignore and fall back to auth form.
+            }
+            return false
+        }
+
+        authorizeButton.addEventListener('click', () => authorize(tokenInput.value))
+        tokenInput.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault()
+                authorize(tokenInput.value)
+            }
+        })
+
+        ;(async () => {
+            const bootstrapToken = getBootstrapToken()
+            if (bootstrapToken) {
+                tokenInput.value = bootstrapToken
+                await authorize(bootstrapToken)
+                return
+            }
+
+            if (await checkExistingSession()) {
+                return
+            }
+
+            tokenInput.focus()
+        })()
+    </script>
+</body>
+</html>

--- a/penguin/web/static/dashboard.html
+++ b/penguin/web/static/dashboard.html
@@ -126,6 +126,24 @@
             color: hsl(var(--primary-foreground));
         }
 
+        .button {
+            background-color: hsl(var(--primary));
+            color: hsl(var(--primary-foreground));
+            border-radius: var(--radius);
+            padding: 0.75rem 1.5rem;
+            font-weight: 500;
+            transition: opacity 0.2s;
+        }
+
+        .button:hover:not(:disabled) {
+            opacity: 0.9;
+        }
+
+        .button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .timeline-item {
             display: grid;
             grid-template-columns: 1fr auto auto;
@@ -193,16 +211,99 @@
             white-space: nowrap;
             z-index: 10;
         }
+
+        .auth-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(2, 6, 23, 0.9);
+            backdrop-filter: blur(6px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            z-index: 60;
+        }
+
+        .auth-card {
+            width: min(100%, 30rem);
+            background-color: hsl(var(--muted));
+            border: 1px solid hsl(var(--border));
+            border-radius: calc(var(--radius) * 1.5);
+            padding: 1.5rem;
+            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+        }
+
+        .auth-input {
+            width: 100%;
+            background-color: hsl(var(--background));
+            border: 1px solid hsl(var(--border));
+            color: hsl(var(--foreground));
+            border-radius: var(--radius);
+            padding: 0.75rem 1rem;
+        }
+
+        .auth-input:focus {
+            outline: none;
+            border-color: hsl(var(--primary));
+            box-shadow: 0 0 0 1px hsl(var(--primary));
+        }
+
+        [v-cloak] {
+            display: none;
+        }
     </style>
 </head>
 <body>
     <div id="app" class="min-h-screen" v-cloak>
+        <div v-if="authRequired || authBusy" class="auth-overlay">
+            <div class="auth-card space-y-4">
+                <div class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Protected Local Dashboard</div>
+                <div>
+                    <h2 class="text-2xl font-semibold">Authorize this browser</h2>
+                    <p class="mt-2 text-sm text-muted-foreground">
+                        {{ authStatus || 'Paste the startup token printed by penguin-web. Penguin will exchange it for a local dashboard session cookie and reload automatically.' }}
+                    </p>
+                </div>
+
+                <div v-if="!authBusy" class="space-y-3">
+                    <label class="block text-sm font-medium text-muted-foreground" for="dashboard-auth-token">Startup token</label>
+                    <input
+                        id="dashboard-auth-token"
+                        v-model="authToken"
+                        @keydown.enter.prevent="submitAuthToken()"
+                        type="password"
+                        autocomplete="off"
+                        spellcheck="false"
+                        placeholder="Paste local startup token"
+                        class="auth-input"
+                    />
+                    <button
+                        @click="submitAuthToken()"
+                        :disabled="!authToken.trim()"
+                        class="button w-full"
+                    >
+                        Authorize dashboard
+                    </button>
+                    <p class="text-xs text-muted-foreground">
+                        This is local instance authorization, not a Penguin account login.
+                    </p>
+                </div>
+
+                <div v-else class="space-y-2">
+                    <div class="text-sm text-foreground">Authorizing local dashboard session...</div>
+                    <div class="progress-bar-bg">
+                        <div class="progress-bar-fill" style="width: 66%; background-color: #3b82f6;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Navigation -->
         <nav class="border-b border-border px-6 py-3 flex items-center justify-between">
             <div class="flex items-center gap-4">
                 <h1 class="text-xl font-semibold">Penguin</h1>
                 <div class="flex gap-2">
-                    <a href="/" class="nav-tab">Chat</a>
+                    <a href="/chat" class="nav-tab">Chat</a>
                     <a href="/dashboard" class="nav-tab active">Dashboard</a>
                 </div>
             </div>
@@ -426,7 +527,121 @@
                 // Connection state
                 const connected = ref(false)
                 const ws = ref(null)
+                const eventsWs = ref(null)
                 const currentModel = ref('Loading...')
+                const authRequired = ref(false)
+                const authBusy = ref(false)
+                const authToken = ref('')
+                const authStatus = ref('')
+
+                const defaultAuthMessage = 'This local Penguin dashboard is protected. Paste the startup token printed by penguin-web to authorize this browser.'
+
+                const closeSockets = () => {
+                    for (const socketRef of [ws, eventsWs]) {
+                        const socket = socketRef.value
+                        if (socket && socket.readyState !== WebSocket.CLOSED && socket.readyState !== WebSocket.CLOSING) {
+                            socket.close()
+                        }
+                    }
+                }
+
+                const setAuthRequired = (message) => {
+                    authRequired.value = true
+                    authBusy.value = false
+                    authStatus.value = message || defaultAuthMessage
+                    connected.value = false
+                    closeSockets()
+                }
+
+                const parseAuthError = async (response) => {
+                    try {
+                        const data = await response.clone().json()
+                        return data?.detail?.error?.message || data?.detail || response.statusText
+                    } catch {
+                        try {
+                            const text = await response.clone().text()
+                            return text || response.statusText
+                        } catch {
+                            return response.statusText
+                        }
+                    }
+                }
+
+                const consumeBootstrapToken = () => {
+                    const hash = window.location.hash.startsWith('#')
+                        ? window.location.hash.slice(1)
+                        : window.location.hash
+                    if (!hash) return ''
+                    const params = new URLSearchParams(hash)
+                    const token = params.get('local_token') || ''
+                    if (!token) return ''
+                    history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+                    return token
+                }
+
+                const requireAuthorizedResponse = async (response) => {
+                    if (response.status !== 401) {
+                        return response
+                    }
+
+                    setAuthRequired(await parseAuthError(response))
+                    throw new Error('Penguin browser authorization required')
+                }
+
+                const fetchAuthorizedJson = async (url, init = {}) => {
+                    const response = await requireAuthorizedResponse(await fetch(url, init))
+                    if (!response.ok) {
+                        throw new Error(`Request failed: ${response.status}`)
+                    }
+                    return response.json()
+                }
+
+                const submitAuthToken = async (providedToken = authToken.value) => {
+                    const token = (providedToken || '').trim()
+                    if (!token) {
+                        setAuthRequired(defaultAuthMessage)
+                        return false
+                    }
+
+                    authRequired.value = true
+                    authBusy.value = true
+                    authToken.value = token
+                    authStatus.value = 'Authorizing this dashboard...'
+
+                    try {
+                        const response = await fetch('/api/v1/auth/session', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            credentials: 'same-origin',
+                            body: JSON.stringify({ token })
+                        })
+
+                        if (!response.ok) {
+                            setAuthRequired(await parseAuthError(response))
+                            return false
+                        }
+
+                        authToken.value = ''
+                        window.location.replace(`${window.location.pathname}${window.location.search}`)
+                        return true
+                    } catch (err) {
+                        setAuthRequired(err?.message || 'Failed to authorize this dashboard')
+                        return false
+                    }
+                }
+
+                const bootstrapBrowserAuth = async () => {
+                    const bootstrapToken = consumeBootstrapToken()
+                    if (!bootstrapToken) {
+                        return true
+                    }
+
+                    authToken.value = bootstrapToken
+                    await submitAuthToken(bootstrapToken)
+                    return false
+                }
 
                 // Token usage data - matches API response from /api/v1/token-usage
                 const tokenUsage = ref({
@@ -566,37 +781,27 @@
                 const fetchInitialData = async () => {
                     try {
                         // Fetch token usage
-                        const tokenRes = await fetch('/api/v1/token-usage')
-                        if (tokenRes.ok) {
-                            const data = await tokenRes.json()
-                            if (data.usage) {
-                                updateTokenUsage(data.usage)
-                            }
+                        const tokenData = await fetchAuthorizedJson('/api/v1/token-usage')
+                        if (tokenData.usage) {
+                            updateTokenUsage(tokenData.usage)
                         }
 
                         // Fetch agents
-                        const agentsRes = await fetch('/api/v1/agents')
-                        if (agentsRes.ok) {
-                            const data = await agentsRes.json()
-                            agents.value = data.agents || data || []
-                        }
+                        const agentData = await fetchAuthorizedJson('/api/v1/agents')
+                        agents.value = agentData.agents || agentData || []
 
                         // Fetch current model
-                        const modelsRes = await fetch('/api/v1/models')
-                        if (modelsRes.ok) {
-                            const data = await modelsRes.json()
-                            const current = (data.models || []).find(m => m.current)
-                            currentModel.value = current?.name || current?.id || 'Unknown'
-                        }
+                        const modelData = await fetchAuthorizedJson('/api/v1/models')
+                        const current = (modelData.models || []).find(m => m.current)
+                        currentModel.value = current?.name || current?.id || 'Unknown'
 
                         // Fetch telemetry
-                        const telemetryRes = await fetch('/api/v1/telemetry')
-                        if (telemetryRes.ok) {
-                            const data = await telemetryRes.json()
-                            updateFromTelemetry(data)
-                        }
+                        const telemetryData = await fetchAuthorizedJson('/api/v1/telemetry')
+                        updateFromTelemetry(telemetryData)
                     } catch (err) {
-                        console.error('Error fetching initial data:', err)
+                        if (!authRequired.value) {
+                            console.error('Error fetching initial data:', err)
+                        }
                     }
                 }
 
@@ -691,6 +896,10 @@
 
                 // WebSocket connection
                 const connectWebSocket = () => {
+                    if (authRequired.value || authBusy.value) {
+                        return
+                    }
+
                     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
                     const wsUrl = `${protocol}//${window.location.host}/api/v1/ws/telemetry?interval=2`
 
@@ -710,8 +919,15 @@
                         }
                     }
 
-                    ws.value.onclose = () => {
+                    ws.value.onclose = (event) => {
+                        if (event.code === 1008) {
+                            setAuthRequired(event.reason || defaultAuthMessage)
+                            return
+                        }
                         connected.value = false
+                        if (authRequired.value || authBusy.value) {
+                            return
+                        }
                         console.log('Dashboard WebSocket closed, reconnecting...')
                         setTimeout(connectWebSocket, 3000)
                     }
@@ -723,12 +939,16 @@
 
                 // Also connect to events WebSocket for tool executions
                 const connectEventsWebSocket = () => {
+                    if (authRequired.value || authBusy.value) {
+                        return
+                    }
+
                     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
                     const eventsUrl = `${protocol}//${window.location.host}/api/v1/events/ws`
 
-                    const eventsWs = new WebSocket(eventsUrl)
+                    eventsWs.value = new WebSocket(eventsUrl)
 
-                    eventsWs.onmessage = (event) => {
+                    eventsWs.value.onmessage = (event) => {
                         try {
                             const data = JSON.parse(event.data)
                             if (data.event === 'tool') {
@@ -755,14 +975,27 @@
                         }
                     }
 
-                    eventsWs.onclose = () => {
+                    eventsWs.value.onclose = (event) => {
+                        if (event.code === 1008) {
+                            setAuthRequired(event.reason || defaultAuthMessage)
+                            return
+                        }
+                        if (authRequired.value || authBusy.value) {
+                            return
+                        }
                         setTimeout(connectEventsWebSocket, 3000)
                     }
                 }
 
                 // Lifecycle
-                onMounted(() => {
-                    fetchInitialData()
+                onMounted(async () => {
+                    if (!await bootstrapBrowserAuth()) {
+                        return
+                    }
+                    await fetchInitialData()
+                    if (authRequired.value) {
+                        return
+                    }
                     connectWebSocket()
                     connectEventsWebSocket()
 
@@ -802,9 +1035,7 @@
                 })
 
                 onUnmounted(() => {
-                    if (ws.value) {
-                        ws.value.close()
-                    }
+                    closeSockets()
                 })
 
                 return {
@@ -829,7 +1060,12 @@
                     getProgressColor,
                     getAgentStatusClass,
                     getEngineBadgeClass,
-                    getToolBadgeClass
+                    getToolBadgeClass,
+                    authRequired,
+                    authBusy,
+                    authToken,
+                    authStatus,
+                    submitAuthToken
                 }
             }
         }).mount('#app')

--- a/penguin/web/static/index.html
+++ b/penguin/web/static/index.html
@@ -215,10 +215,93 @@
             margin-top: 0.5rem;
             border-radius: var(--radius);
         }
+
+        .auth-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(2, 6, 23, 0.9);
+            backdrop-filter: blur(6px);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            z-index: 60;
+        }
+
+        .auth-card {
+            width: min(100%, 30rem);
+            background-color: hsl(var(--muted));
+            border: 1px solid hsl(var(--border));
+            border-radius: calc(var(--radius) * 1.5);
+            padding: 1.5rem;
+            box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+        }
+
+        .auth-input {
+            width: 100%;
+            background-color: hsl(var(--background));
+            border: 1px solid hsl(var(--border));
+            color: hsl(var(--foreground));
+            border-radius: var(--radius);
+            padding: 0.75rem 1rem;
+        }
+
+        .auth-input:focus {
+            outline: none;
+            border-color: hsl(var(--primary));
+            box-shadow: 0 0 0 1px hsl(var(--primary));
+        }
+
+        [v-cloak] {
+            display: none;
+        }
     </style>
 </head>
 <body>
     <div id="app" class="h-screen flex" v-cloak>
+        <div v-if="authRequired || authBusy" class="auth-overlay">
+            <div class="auth-card space-y-4">
+                <div class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Protected Local Penguin</div>
+                <div>
+                    <h2 class="text-2xl font-semibold">Authorize this browser</h2>
+                    <p class="mt-2 text-sm text-muted-foreground">
+                        {{ authStatus || 'Paste the startup token printed by penguin-web. Penguin will exchange it for a local session cookie and reload automatically.' }}
+                    </p>
+                </div>
+
+                <div v-if="!authBusy" class="space-y-3">
+                    <label class="block text-sm font-medium text-muted-foreground" for="auth-token-input">Startup token</label>
+                    <input
+                        id="auth-token-input"
+                        v-model="authToken"
+                        @keydown.enter.prevent="submitAuthToken()"
+                        type="password"
+                        autocomplete="off"
+                        spellcheck="false"
+                        placeholder="Paste local startup token"
+                        class="auth-input"
+                    />
+                    <button
+                        @click="submitAuthToken()"
+                        :disabled="!authToken.trim()"
+                        class="button w-full"
+                    >
+                        Authorize browser
+                    </button>
+                    <p class="text-xs text-muted-foreground">
+                        This protects the local dashboard only. No Penguin account is required.
+                    </p>
+                </div>
+
+                <div v-else class="space-y-2">
+                    <div class="text-sm text-foreground">Authorizing local browser session...</div>
+                    <div class="progress-bar-bg">
+                        <div class="progress-bar w-2/3"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Sidebar -->
         <div class="w-80 sidebar flex flex-col">
             <div class="p-4 border-b border-border">
@@ -344,6 +427,113 @@
                 const uploadedImage = ref(null)
                 const imagePath = ref(null)
                 const supportsImages = ref(false)
+                const authRequired = ref(false)
+                const authBusy = ref(false)
+                const authToken = ref('')
+                const authStatus = ref('')
+
+                const defaultAuthMessage = 'This local Penguin instance is protected. Paste the startup token printed by penguin-web to authorize this browser.'
+
+                const setAuthRequired = (message) => {
+                    authRequired.value = true
+                    authBusy.value = false
+                    authStatus.value = message || defaultAuthMessage
+                    isTyping.value = false
+                    streamProgress.value = null
+                    if (ws.value && ws.value.readyState !== WebSocket.CLOSED && ws.value.readyState !== WebSocket.CLOSING) {
+                        ws.value.close()
+                    }
+                }
+
+                const parseAuthError = async (response) => {
+                    try {
+                        const data = await response.clone().json()
+                        return data?.detail?.error?.message || data?.detail || response.statusText
+                    } catch {
+                        try {
+                            const text = await response.clone().text()
+                            return text || response.statusText
+                        } catch {
+                            return response.statusText
+                        }
+                    }
+                }
+
+                const consumeBootstrapToken = () => {
+                    const hash = window.location.hash.startsWith('#')
+                        ? window.location.hash.slice(1)
+                        : window.location.hash
+                    if (!hash) return ''
+                    const params = new URLSearchParams(hash)
+                    const token = params.get('local_token') || ''
+                    if (!token) return ''
+                    history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+                    return token
+                }
+
+                const requireAuthorizedResponse = async (response) => {
+                    if (response.status !== 401) {
+                        return response
+                    }
+
+                    setAuthRequired(await parseAuthError(response))
+                    throw new Error('Penguin browser authorization required')
+                }
+
+                const fetchAuthorizedJson = async (url, init = {}) => {
+                    const response = await requireAuthorizedResponse(await fetch(url, init))
+                    if (!response.ok) {
+                        throw new Error(`Request failed: ${response.status}`)
+                    }
+                    return response.json()
+                }
+
+                const submitAuthToken = async (providedToken = authToken.value) => {
+                    const token = (providedToken || '').trim()
+                    if (!token) {
+                        setAuthRequired(defaultAuthMessage)
+                        return false
+                    }
+
+                    authRequired.value = true
+                    authBusy.value = true
+                    authToken.value = token
+                    authStatus.value = 'Authorizing this browser...'
+
+                    try {
+                        const response = await fetch('/api/v1/auth/session', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            credentials: 'same-origin',
+                            body: JSON.stringify({ token })
+                        })
+
+                        if (!response.ok) {
+                            setAuthRequired(await parseAuthError(response))
+                            return false
+                        }
+
+                        authToken.value = ''
+                        window.location.replace(`${window.location.pathname}${window.location.search}`)
+                        return true
+                    } catch (err) {
+                        setAuthRequired(err?.message || 'Failed to authorize this browser')
+                        return false
+                    }
+                }
+
+                const bootstrapBrowserAuth = async () => {
+                    const bootstrapToken = consumeBootstrapToken()
+                    if (!bootstrapToken) {
+                        return true
+                    }
+
+                    authToken.value = bootstrapToken
+                    await submitAuthToken(bootstrapToken)
+                    return false
+                }
 
                 const scrollToBottom = async () => {
                     await nextTick()
@@ -354,19 +544,19 @@
 
                 const refreshConversations = async () => {
                     try {
-                        const response = await fetch('/api/v1/conversations')
-                        const data = await response.json()
+                        const data = await fetchAuthorizedJson('/api/v1/conversations')
                         conversations.value = data.conversations
                     } catch (error) {
-                        console.error('Error fetching conversations:', error)
+                        if (!authRequired.value) {
+                            console.error('Error fetching conversations:', error)
+                        }
                     }
                 }
 
                 const selectConversation = async (id) => {
                     selectedConversationId.value = id
                     try {
-                        const response = await fetch(`/api/v1/conversations/${id}`)
-                        const data = await response.json()
+                        const data = await fetchAuthorizedJson(`/api/v1/conversations/${id}`)
                         
                         // Check if data has messages directly or nested under 'messages'
                         const messageList = data.messages || (data.messages && Array.isArray(data.messages)) 
@@ -384,19 +574,20 @@
                         
                         await scrollToBottom()
                     } catch (error) {
-                        console.error('Error loading conversation:', error)
+                        if (!authRequired.value) {
+                            console.error('Error loading conversation:', error)
+                        }
                     }
                 }
 
                 const startNewConversation = async () => {
                     try {
-                        const response = await fetch('/api/v1/conversations/create', {
+                        const data = await fetchAuthorizedJson('/api/v1/conversations/create', {
                             method: 'POST',
                             headers: {
                                 'Content-Type': 'application/json'
                             }
                         });
-                        const data = await response.json();
                         selectedConversationId.value = data.conversation_id;
                         
                         // Clear existing messages
@@ -442,6 +633,10 @@
                 }
 
                 const connectWebSocket = () => {
+                    if (authRequired.value || authBusy.value) {
+                        return;
+                    }
+
                     if (ws.value && ws.value.readyState === WebSocket.OPEN) {
                         ws.value.close();
                     }
@@ -518,7 +713,11 @@
                         isTyping.value = false;
                     };
                     
-                    ws.value.onclose = () => {
+                    ws.value.onclose = (event) => {
+                        if (event.code === 1008) {
+                            setAuthRequired(event.reason || defaultAuthMessage);
+                            return;
+                        }
                         console.log('WebSocket closed');
                     };
                 };
@@ -628,10 +827,10 @@
                         const formData = new FormData();
                         formData.append('file', file);
                         
-                        const response = await fetch('/api/v1/upload', {
+                        const response = await requireAuthorizedResponse(await fetch('/api/v1/upload', {
                             method: 'POST',
                             body: formData
-                        });
+                        }));
                         
                         if (response.ok) {
                             const data = await response.json();
@@ -653,24 +852,28 @@
                 // Check if model supports images
                 const checkImageSupport = async () => {
                     try {
-                        const response = await fetch('/api/v1/capabilities');
-                        if (response.ok) {
-                            const data = await response.json();
-                            supportsImages.value = data.vision_enabled || false;
-                        }
+                        const data = await fetchAuthorizedJson('/api/v1/capabilities');
+                        supportsImages.value = data.vision_enabled || false;
                     } catch (error) {
-                        console.error('Error checking image support:', error);
-                        // Assume no support on error
-                        supportsImages.value = false;
+                        if (!authRequired.value) {
+                            console.error('Error checking image support:', error);
+                            supportsImages.value = false;
+                        }
                     }
                 };
 
                 // Initialize
                 onMounted(async () => {
+                    if (!await bootstrapBrowserAuth()) {
+                        return;
+                    }
                     await checkImageSupport();
-                    connectWebSocket();
+                    if (authRequired.value) return;
                     await refreshConversations();
+                    if (authRequired.value) return;
                     await startNewConversation();
+                    if (authRequired.value) return;
+                    connectWebSocket();
                     autoResize();
                 });
 
@@ -694,7 +897,12 @@
                     streamProgress,
                     uploadedImage,
                     handleFileUpload,
-                    supportsImages
+                    supportsImages,
+                    authRequired,
+                    authBusy,
+                    authToken,
+                    authStatus,
+                    submitAuthToken
                 }
             }
         }).mount('#app')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,9 @@ Documentation = "https://penguin-rho.vercel.app"
 "Bug Tracker" = "https://github.com/Maximooch/penguin/issues"
 
 [project.scripts]
+# `penguin`, `ptui`, and `penguin-tui` all route through the TUI launcher,
+# which prefers a local Penguin web server at http://127.0.0.1:9000 unless
+# overridden via `--url` or `PENGUIN_WEB_URL`.
 penguin = "penguin.cli.entrypoint:main"
 penguin-cli = "penguin.cli.entrypoint:main_cli"
 ptui = "penguin.cli.entrypoint:main_tui"

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -13,12 +13,14 @@ import pytest
 from PIL import Image
 from fastapi import FastAPI, WebSocketException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 from starlette.websockets import WebSocketDisconnect
 
 from penguin.web.middleware.auth import (
     AuthConfig,
     AuthenticationError,
     authenticate_connection,
+    build_session_cookie_settings,
     get_startup_auth_token,
     require_websocket_auth,
 )
@@ -50,6 +52,10 @@ def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_OAUTH_EXPIRES_AT_MS", raising=False)
     monkeypatch.delenv("OPENAI_ACCOUNT_ID", raising=False)
     provider_credentials_service._WARNED_LEGACY_PATHS.clear()
+
+
+def _loopback_client(app: FastAPI, base_url: str = "http://127.0.0.1:9000") -> TestClient:
+    return TestClient(app, base_url=base_url, client=("127.0.0.1", 50000))
 
 
 @pytest.fixture
@@ -91,6 +97,7 @@ def test_authenticate_connection_accepts_startup_token_header(
     monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
     monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
     connection = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
         headers={"X-API-Key": "startup-token-123"},
         query_params={},
     )
@@ -99,6 +106,44 @@ def test_authenticate_connection_accepts_startup_token_header(
 
     assert result["method"] == "startup_token"
     assert result["subject"] == "local_bootstrap"
+
+
+def test_authenticate_connection_rejects_startup_token_from_non_loopback_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.25"),
+        headers={"X-API-Key": "startup-token-123"},
+        query_params={},
+    )
+
+    with pytest.raises(AuthenticationError, match="No valid authentication"):
+        authenticate_connection(connection, AuthConfig())
+
+
+def test_build_session_cookie_settings_rejects_non_loopback_http_client() -> None:
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/api/v1/auth/session",
+            "raw_path": b"/api/v1/auth/session",
+            "query_string": b"",
+            "headers": [],
+            "client": ("203.0.113.25", 9000),
+            "server": ("127.0.0.1", 9000),
+        }
+    )
+
+    with pytest.raises(
+        AuthenticationError,
+        match="Browser session cookies are only issued for loopback hosts or HTTPS origins",
+    ):
+        build_session_cookie_settings(request, AuthConfig())
 
 
 def test_startup_auth_token_generated_only_without_configured_api_keys(
@@ -363,6 +408,21 @@ def test_http_auth_logs_warning_once_per_path(
     assert "POST /api/v1/auth/session" in warning_records[0].message
 
 
+def test_auth_failure_cache_is_bounded_and_normalized() -> None:
+    from penguin.web.middleware.auth import (
+        _AUTH_FAILURE_CACHE_LIMIT,
+        _SEEN_AUTH_FAILURES,
+        log_auth_failure_once,
+    )
+
+    _SEEN_AUTH_FAILURES.clear()
+    for idx in range(_AUTH_FAILURE_CACHE_LIMIT * 2):
+        log_auth_failure_once("http", f"/session/session_{idx}")
+
+    assert len(_SEEN_AUTH_FAILURES) == 1
+    assert ("http", "/session/:id") in _SEEN_AUTH_FAILURES
+
+
 def test_openapi_schema_remains_public_when_auth_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -592,7 +652,7 @@ def test_auth_session_endpoint_accepts_startup_token_and_sets_cookie(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     response = client.post(
         "/api/v1/auth/session",
@@ -610,7 +670,7 @@ def test_auth_session_endpoint_accepts_startup_token_and_sets_cookie(
 def test_auth_session_get_returns_bootstrap_instructions(
     local_auth_app: FastAPI,
 ) -> None:
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     response = client.get("/api/v1/auth/session")
 
@@ -629,7 +689,7 @@ def test_auth_session_endpoint_accepts_configured_api_key(
     app = FastAPI()
     app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
     app.include_router(router)
-    client = TestClient(app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(app)
 
     response = client.post(
         "/api/v1/auth/session",
@@ -644,7 +704,7 @@ def test_auth_session_endpoint_accepts_configured_api_key(
 def test_auth_session_endpoint_is_public_but_rejects_invalid_token(
     local_auth_app: FastAPI,
 ) -> None:
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     response = client.post("/api/v1/auth/session", json={"token": "bad-token"})
 
@@ -653,7 +713,7 @@ def test_auth_session_endpoint_is_public_but_rejects_invalid_token(
 
 
 def test_auth_logout_clears_cookie(local_auth_app: FastAPI) -> None:
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     response = client.post("/api/v1/auth/logout")
 
@@ -668,7 +728,7 @@ def test_http_protected_endpoint_accepts_session_cookie(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     auth_response = client.post(
         "/api/v1/auth/session",
@@ -688,7 +748,7 @@ async def test_sse_endpoint_accepts_session_cookie(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
-    client = TestClient(local_auth_sse_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_sse_app)
 
     auth_response = client.post(
         "/api/v1/auth/session",
@@ -748,7 +808,7 @@ def test_websocket_accepts_session_cookie(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
-    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+    client = _loopback_client(local_auth_app)
 
     auth_response = client.post(
         "/api/v1/auth/session",

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -54,7 +54,9 @@ def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     provider_credentials_service._WARNED_LEGACY_PATHS.clear()
 
 
-def _loopback_client(app: FastAPI, base_url: str = "http://127.0.0.1:9000") -> TestClient:
+def _loopback_client(
+    app: FastAPI, base_url: str = "http://127.0.0.1:9000"
+) -> TestClient:
     return TestClient(app, base_url=base_url, client=("127.0.0.1", 50000))
 
 
@@ -534,6 +536,21 @@ def test_authorize_ui_includes_fragment_bootstrap_and_navigation_links() -> None
     assert "/api/v1/auth/session" in content
     assert "/chat" in content
     assert "/dashboard" in content
+
+
+def test_authorize_ui_clears_fragment_before_auth_request() -> None:
+    authorize_path = (
+        Path(__file__).resolve().parents[2]
+        / "penguin"
+        / "web"
+        / "static"
+        / "authorize.html"
+    )
+    content = authorize_path.read_text()
+
+    clear_idx = content.index("clearBootstrapFragment()")
+    fetch_idx = content.index("await fetch('/api/v1/auth/session'")
+    assert clear_idx < fetch_idx
 
 
 def test_upload_rejects_spoofed_image_bytes(

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from penguin.web.middleware.auth import (
     AuthConfig,
     AuthenticationError,
     authenticate_connection,
+    get_startup_auth_token,
     require_websocket_auth,
 )
 from penguin.web.routes import ALLOWED_UPLOAD_CONTENT_TYPES, router
@@ -30,6 +32,8 @@ def clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
     monkeypatch.delenv("PENGUIN_CORS_ORIGINS", raising=False)
     monkeypatch.delenv("PENGUIN_MAX_UPLOAD_BYTES", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
+    monkeypatch.delenv("PENGUIN_SESSION_SECRET", raising=False)
     monkeypatch.delenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", raising=False)
     monkeypatch.delenv("PENGUIN_PROVIDER_AUTH_STORE", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -70,6 +74,20 @@ def test_authenticate_connection_rejects_query_param_api_keys(
 
     with pytest.raises(AuthenticationError, match="No valid authentication"):
         authenticate_connection(connection, auth_config)
+
+
+def test_startup_auth_token_generated_only_without_configured_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+
+    token = get_startup_auth_token(AuthConfig())
+
+    assert token
+    assert os.environ["PENGUIN_AUTH_STARTUP_TOKEN"] == token
+
+    monkeypatch.setenv("PENGUIN_API_KEYS", "configured-key")
+    assert get_startup_auth_token(AuthConfig()) is None
 
 
 @pytest.mark.asyncio
@@ -160,7 +178,9 @@ def test_chat_stream_websocket_rejects_query_param_api_key(
     assert exc_info.value.code == 1008
 
 
-def test_default_cors_origins_do_not_use_wildcard(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_cors_origins_do_not_use_wildcard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from penguin.web.app import DEFAULT_DEV_CORS_ORIGINS, create_app
 
     app = create_app()
@@ -237,7 +257,9 @@ def test_provider_credentials_prefer_environment_over_legacy_file(
 ) -> None:
     store_path = tmp_path / "providers.json"
     store_path.write_text(
-        json.dumps({"version": 1, "providers": {"openai": {"type": "api", "key": "file-key"}}}),
+        json.dumps(
+            {"version": 1, "providers": {"openai": {"type": "api", "key": "file-key"}}}
+        ),
         encoding="utf-8",
     )
     monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
@@ -255,7 +277,12 @@ def test_provider_credentials_warn_on_legacy_store_usage(
 ) -> None:
     store_path = tmp_path / "provider_auth.json"
     store_path.write_text(
-        json.dumps({"version": 1, "providers": {"anthropic": {"type": "api", "key": "file-key"}}}),
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {"anthropic": {"type": "api", "key": "file-key"}},
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.setenv("PENGUIN_PROVIDER_AUTH_STORE", str(store_path))
@@ -307,7 +334,12 @@ def test_provider_credentials_custom_store_path_does_not_warn(
 ) -> None:
     store_path = tmp_path / "providers.json"
     store_path.write_text(
-        json.dumps({"version": 1, "providers": {"anthropic": {"type": "api", "key": "file-key"}}}),
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {"anthropic": {"type": "api", "key": "file-key"}},
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.setenv("PENGUIN_PROVIDER_CREDENTIALS_STORE", str(store_path))
@@ -349,3 +381,78 @@ def test_http_auth_does_not_mask_downstream_exceptions(
 
     assert response.status_code == 500
     assert "AUTHENTICATION_ERROR" not in response.text
+
+
+@pytest.fixture
+def local_auth_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from penguin.web.middleware.auth import AuthenticationMiddleware
+
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    app = FastAPI()
+    app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
+    app.include_router(router)
+    return app
+
+
+def test_auth_session_endpoint_accepts_startup_token_and_sets_cookie(
+    local_auth_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    response = client.post(
+        "/api/v1/auth/session",
+        json={"token": "startup-token-123"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is True
+    assert response.json()["method"] == "startup_token"
+    assert "penguin_session=" in response.headers["set-cookie"]
+    assert "HttpOnly" in response.headers["set-cookie"]
+    assert "SameSite=lax" in response.headers["set-cookie"]
+
+
+def test_auth_session_endpoint_accepts_configured_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from penguin.web.middleware.auth import AuthenticationMiddleware
+
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "configured-key")
+    app = FastAPI()
+    app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
+    app.include_router(router)
+    client = TestClient(app, base_url="http://127.0.0.1:9000")
+
+    response = client.post(
+        "/api/v1/auth/session",
+        json={"token": "configured-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["method"] == "api_key"
+    assert "penguin_session=" in response.headers["set-cookie"]
+
+
+def test_auth_session_endpoint_is_public_but_rejects_invalid_token(
+    local_auth_app: FastAPI,
+) -> None:
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    response = client.post("/api/v1/auth/session", json={"token": "bad-token"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid local authorization token"
+
+
+def test_auth_logout_clears_cookie(local_auth_app: FastAPI) -> None:
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    response = client.post("/api/v1/auth/logout")
+
+    assert response.status_code == 200
+    assert response.json() == {"authenticated": False}
+    assert "penguin_session=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import os
@@ -21,6 +22,7 @@ from penguin.web.middleware.auth import (
     require_websocket_auth,
 )
 from penguin.web.routes import ALLOWED_UPLOAD_CONTENT_TYPES, router
+from penguin.web.sse_events import router as sse_router, set_core_instance
 from penguin.web.services import provider_credentials as provider_credentials_service
 
 
@@ -388,9 +390,34 @@ def local_auth_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     from penguin.web.middleware.auth import AuthenticationMiddleware
 
     monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    router.core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(current_agent_id=None)
+    )
+    app = FastAPI()
+
+    @app.get("/protected")
+    async def protected() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def local_auth_sse_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    from penguin.web.middleware.auth import AuthenticationMiddleware
+
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    event_bus = SimpleNamespace(
+        subscribe=lambda *args, **kwargs: None,
+        unsubscribe=lambda *args, **kwargs: None,
+    )
+    set_core_instance(SimpleNamespace(event_bus=event_bus))
     app = FastAPI()
     app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
     app.include_router(router)
+    app.include_router(sse_router)
     return app
 
 
@@ -456,3 +483,104 @@ def test_auth_logout_clears_cookie(local_auth_app: FastAPI) -> None:
     assert response.json() == {"authenticated": False}
     assert "penguin_session=" in response.headers["set-cookie"]
     assert "Max-Age=0" in response.headers["set-cookie"]
+
+
+def test_http_protected_endpoint_accepts_session_cookie(
+    local_auth_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    auth_response = client.post(
+        "/api/v1/auth/session",
+        json={"token": "startup-token-123"},
+    )
+    assert auth_response.status_code == 200
+
+    response = client.get("/protected")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_sse_endpoint_accepts_session_cookie(
+    local_auth_sse_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    client = TestClient(local_auth_sse_app, base_url="http://127.0.0.1:9000")
+
+    auth_response = client.post(
+        "/api/v1/auth/session",
+        json={"token": "startup-token-123"},
+    )
+    assert auth_response.status_code == 200
+
+    cookie_header = (
+        auth_response.headers["set-cookie"].split(";", 1)[0].encode("latin-1")
+    )
+    messages: list[dict[str, object]] = []
+    request_sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await asyncio.sleep(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        messages.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/api/v1/events/sse",
+        "raw_path": b"/api/v1/events/sse",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"cookie", cookie_header)],
+        "client": ("127.0.0.1", 9000),
+        "server": ("127.0.0.1", 9000),
+        "state": {},
+    }
+
+    await local_auth_sse_app(scope, receive, send)
+
+    assert any(
+        message.get("type") == "http.response.start" and message.get("status") == 200
+        for message in messages
+    )
+    body = b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message.get("type") == "http.response.body"
+    )
+    assert b"server.connected" in body
+
+
+def test_websocket_accepts_session_cookie(
+    local_auth_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    auth_response = client.post(
+        "/api/v1/auth/session",
+        json={"token": "startup-token-123"},
+    )
+    assert auth_response.status_code == 200
+    cookie_header = auth_response.headers["set-cookie"].split(";", 1)[0]
+
+    with client.websocket_connect(
+        "/api/v1/events/ws",
+        headers={"Cookie": cookie_header},
+    ) as websocket:
+        assert websocket is not None

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import os
 import warnings
 from pathlib import Path
@@ -60,7 +61,13 @@ def auth_config(monkeypatch: pytest.MonkeyPatch) -> AuthConfig:
 
 def test_public_endpoint_root_is_exact_match_only(auth_config: AuthConfig) -> None:
     assert auth_config.is_public_endpoint("/") is True
+    assert auth_config.is_public_endpoint("/authorize") is True
+    assert auth_config.is_public_endpoint("/chat") is True
+    assert auth_config.is_public_endpoint("/dashboard") is True
+    assert auth_config.is_public_endpoint("/openapi.json") is True
     assert auth_config.is_public_endpoint("/api/v1/health") is True
+    assert auth_config.is_public_endpoint("/favicon.ico") is True
+    assert auth_config.is_public_endpoint("/apple-touch-icon.png") is True
     assert auth_config.is_public_endpoint("/api/v1/capabilities") is False
     assert auth_config.is_public_endpoint("/static/index.html") is True
     assert auth_config.is_public_endpoint("/static-assets") is False
@@ -76,6 +83,22 @@ def test_authenticate_connection_rejects_query_param_api_keys(
 
     with pytest.raises(AuthenticationError, match="No valid authentication"):
         authenticate_connection(connection, auth_config)
+
+
+def test_authenticate_connection_accepts_startup_token_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    connection = SimpleNamespace(
+        headers={"X-API-Key": "startup-token-123"},
+        query_params={},
+    )
+
+    result = authenticate_connection(connection, AuthConfig())
+
+    assert result["method"] == "startup_token"
+    assert result["subject"] == "local_bootstrap"
 
 
 def test_startup_auth_token_generated_only_without_configured_api_keys(
@@ -127,6 +150,7 @@ async def test_require_websocket_auth_rejects_missing_credentials(
         await require_websocket_auth(websocket)
 
     assert exc_info.value.code == 1008
+    assert "This Penguin instance is protected." in exc_info.value.reason
 
 
 @pytest.fixture
@@ -307,7 +331,149 @@ def test_http_auth_returns_401_without_credentials(
     response = client.get("/api/v1/capabilities")
 
     assert response.status_code == 401
-    assert response.json()["detail"]["error"]["code"] == "AUTHENTICATION_FAILED"
+    error = response.json()["detail"]["error"]
+    assert error["code"] == "AUTHENTICATION_FAILED"
+    assert "This Penguin instance is protected." in error["message"]
+    assert "POST /api/v1/auth/session" in error["suggested_action"]
+
+
+def test_http_auth_logs_warning_once_per_path(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "http-test-key")
+
+    from penguin.web.app import create_app
+    from penguin.web.middleware.auth import _SEEN_AUTH_FAILURES
+
+    _SEEN_AUTH_FAILURES.clear()
+    client = TestClient(create_app())
+
+    with caplog.at_level(logging.DEBUG, logger="penguin.web.middleware.auth"):
+        first = client.get("/api/v1/capabilities")
+        second = client.get("/api/v1/capabilities")
+
+    assert first.status_code == 401
+    assert second.status_code == 401
+    warning_records = [
+        record for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert len(warning_records) == 1
+    assert "POST /api/v1/auth/session" in warning_records[0].message
+
+
+def test_openapi_schema_remains_public_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "http-test-key")
+
+    from penguin.web.app import create_app
+
+    client = TestClient(create_app())
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert response.json()["openapi"].startswith("3.")
+
+
+def test_browser_icon_requests_are_not_authenticated_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "http-test-key")
+
+    from penguin.web.app import create_app
+
+    client = TestClient(create_app())
+    response = client.get("/favicon.ico")
+
+    assert response.status_code == 404
+
+
+def test_root_chat_dashboard_and_authorize_html_disable_caching() -> None:
+    from penguin.web.app import create_app
+
+    client = TestClient(create_app())
+
+    root = client.get("/")
+    chat = client.get("/chat")
+    dashboard = client.get("/dashboard")
+    authorize = client.get("/authorize")
+
+    assert root.status_code == 200
+    assert root.headers["cache-control"] == "no-store, max-age=0"
+    assert root.headers["pragma"] == "no-cache"
+    assert chat.status_code == 200
+    assert chat.headers["cache-control"] == "no-store, max-age=0"
+    assert chat.headers["pragma"] == "no-cache"
+    assert dashboard.status_code == 200
+    assert dashboard.headers["cache-control"] == "no-store, max-age=0"
+    assert dashboard.headers["pragma"] == "no-cache"
+    assert authorize.status_code == 200
+    assert authorize.headers["cache-control"] == "no-store, max-age=0"
+    assert authorize.headers["pragma"] == "no-cache"
+
+
+def test_authorize_page_loads_when_auth_is_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+
+    from penguin.web.app import create_app
+
+    client = TestClient(create_app())
+    response = client.get("/authorize")
+
+    assert response.status_code == 200
+    assert "Authorize this browser" in response.text
+
+
+def test_chat_ui_includes_fragment_bootstrap_and_local_auth_gate() -> None:
+    index_path = (
+        Path(__file__).resolve().parents[2]
+        / "penguin"
+        / "web"
+        / "static"
+        / "index.html"
+    )
+    content = index_path.read_text()
+
+    assert "local_token" in content
+    assert "/api/v1/auth/session" in content
+    assert "Authorize this browser" in content
+
+
+def test_dashboard_ui_includes_fragment_bootstrap_and_local_auth_gate() -> None:
+    dashboard_path = (
+        Path(__file__).resolve().parents[2]
+        / "penguin"
+        / "web"
+        / "static"
+        / "dashboard.html"
+    )
+    content = dashboard_path.read_text()
+
+    assert "local_token" in content
+    assert "/api/v1/auth/session" in content
+    assert "Authorize this browser" in content
+
+
+def test_authorize_ui_includes_fragment_bootstrap_and_navigation_links() -> None:
+    authorize_path = (
+        Path(__file__).resolve().parents[2]
+        / "penguin"
+        / "web"
+        / "static"
+        / "authorize.html"
+    )
+    content = authorize_path.read_text()
+
+    assert "local_token" in content
+    assert "/api/v1/auth/session" in content
+    assert "/chat" in content
+    assert "/dashboard" in content
 
 
 def test_upload_rejects_spoofed_image_bytes(
@@ -439,6 +605,18 @@ def test_auth_session_endpoint_accepts_startup_token_and_sets_cookie(
     assert "penguin_session=" in response.headers["set-cookie"]
     assert "HttpOnly" in response.headers["set-cookie"]
     assert "SameSite=lax" in response.headers["set-cookie"]
+
+
+def test_auth_session_get_returns_bootstrap_instructions(
+    local_auth_app: FastAPI,
+) -> None:
+    client = TestClient(local_auth_app, base_url="http://127.0.0.1:9000")
+
+    response = client.get("/api/v1/auth/session")
+
+    assert response.status_code == 200
+    assert "Use POST /api/v1/auth/session" in response.text
+    assert "startup token printed by penguin-web" in response.text
 
 
 def test_auth_session_endpoint_accepts_configured_api_key(

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -80,7 +80,10 @@ def test_installed_penguin_version_falls_back_to_package_version(
 
     monkeypatch.setattr(opencode_launcher.importlib.metadata, "version", _missing)
 
-    assert opencode_launcher._installed_penguin_version() == "0.6.2.2"
+    assert (
+        opencode_launcher._installed_penguin_version()
+        == opencode_launcher.PENGUIN_VERSION
+    )
 
 
 def test_binary_supports_url_mode_from_help_output(
@@ -124,7 +127,7 @@ def test_build_command_uses_sidecar_when_local_source_missing(
 
     cmd, cwd = opencode_launcher._build_opencode_command(
         project_dir,
-        "http://localhost:8000",
+        "http://127.0.0.1:9000",
         ["--foo", "bar"],
         use_global_opencode=False,
     )
@@ -156,7 +159,7 @@ def test_build_command_rejects_incompatible_sidecar_without_url_option(
     with pytest.raises(RuntimeError) as exc:
         opencode_launcher._build_opencode_command(
             project_dir,
-            "http://localhost:8000",
+            "http://127.0.0.1:9000",
             [],
             use_global_opencode=False,
         )
@@ -189,7 +192,7 @@ def test_build_command_uses_global_attach_mode_when_requested(
 
     cmd, cwd = opencode_launcher._build_opencode_command(
         project_dir,
-        "http://localhost:8000",
+        "http://127.0.0.1:9000",
         ["--session", "abc123"],
         use_global_opencode=True,
     )
@@ -198,7 +201,7 @@ def test_build_command_uses_global_attach_mode_when_requested(
     assert cmd == [
         global_bin,
         "attach",
-        "http://localhost:8000",
+        "http://127.0.0.1:9000",
         "--dir",
         str(project_dir),
         "--session",
@@ -224,7 +227,7 @@ def test_build_command_error_surfaces_sidecar_bootstrap_detail(
     with pytest.raises(RuntimeError) as exc:
         opencode_launcher._build_opencode_command(
             project_dir,
-            "http://localhost:8000",
+            "http://127.0.0.1:9000",
             [],
             use_global_opencode=False,
         )
@@ -535,8 +538,191 @@ def test_main_autostarts_web_and_preserves_project_directory_env(
         assert env_map["PENGUIN_PROJECT_ROOT"] == str(project_dir)
         assert env_map["PENGUIN_WRITE_ROOT"] == "project"
         assert env_map["PWD"] == str(project_dir)
-        assert env_map["PENGUIN_WEB_URL"] == "http://localhost:8000"
+        assert env_map["PENGUIN_WEB_URL"] == "http://127.0.0.1:9000"
     assert stop_calls == [fake_proc]
+
+
+def test_parse_args_defaults_to_local_web_port_9000(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PENGUIN_WEB_URL", raising=False)
+
+    args, extra = opencode_launcher._parse_args([])
+
+    assert args.url == "http://127.0.0.1:9000"
+    assert extra == []
+
+
+def test_prepare_local_auth_env_seeds_shared_startup_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(tmp_path))
+
+    opencode_launcher._prepare_local_auth_env(
+        "http://127.0.0.1:9000", env, server_running=False
+    )
+
+    assert env["PENGUIN_AUTH_STARTUP_TOKEN"]
+    assert env["PENGUIN_LOCAL_AUTH_TOKEN"] == env["PENGUIN_AUTH_STARTUP_TOKEN"]
+
+
+def test_prepare_local_auth_env_preserves_existing_api_keys() -> None:
+    env = {
+        "PENGUIN_AUTH_ENABLED": "true",
+        "PENGUIN_API_KEYS": "configured-key",
+    }
+
+    opencode_launcher._prepare_local_auth_env(
+        "http://127.0.0.1:9000", env, server_running=False
+    )
+
+    assert "PENGUIN_AUTH_STARTUP_TOKEN" not in env
+    assert "PENGUIN_LOCAL_AUTH_TOKEN" not in env
+
+
+def test_prepare_local_auth_env_respects_explicit_auth_disable() -> None:
+    env = {"PENGUIN_AUTH_ENABLED": "false"}
+
+    opencode_launcher._prepare_local_auth_env(
+        "http://127.0.0.1:9000", env, server_running=False
+    )
+
+    assert "PENGUIN_AUTH_STARTUP_TOKEN" not in env
+    assert "PENGUIN_LOCAL_AUTH_TOKEN" not in env
+
+
+def test_prepare_local_auth_env_reads_existing_local_token_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env: dict[str, str] = {}
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(tmp_path))
+    token_file = tmp_path / "127.0.0.1-9000.token"
+    token_file.write_text("existing-token", encoding="utf-8")
+
+    opencode_launcher._prepare_local_auth_env(
+        "http://127.0.0.1:9000", env, server_running=True
+    )
+
+    assert env["PENGUIN_LOCAL_AUTH_TOKEN"] == "existing-token"
+    assert "PENGUIN_AUTH_STARTUP_TOKEN" not in env
+
+
+def test_main_reuses_cached_local_auth_token_for_running_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "sandbox"
+    project_dir.mkdir()
+    cache_dir = tmp_path / "auth-cache"
+    cache_dir.mkdir()
+    (cache_dir / "127.0.0.1-9000.token").write_text("cached-token", encoding="utf-8")
+    captured_run_env: dict[str, str] = {}
+
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(cache_dir))
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
+    monkeypatch.delenv("PENGUIN_LOCAL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        opencode_launcher, "_is_server_running", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(opencode_launcher, "_is_local_url", lambda base_url: True)
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_build_opencode_command",
+        lambda *args, **kwargs: (["opencode", str(project_dir)], None),
+    )
+
+    def _run(cmd: list[str], cwd: Path | None, env: dict[str, str]):
+        del cmd, cwd
+        captured_run_env.update(env)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", _run)
+
+    exit_code = opencode_launcher.main([str(project_dir)])
+
+    assert exit_code == 0
+    assert captured_run_env["PENGUIN_LOCAL_AUTH_TOKEN"] == "cached-token"
+
+
+def test_prepare_local_auth_env_does_not_invent_token_for_running_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    env: dict[str, str] = {"PENGUIN_AUTH_ENABLED": "true"}
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(tmp_path))
+
+    opencode_launcher._prepare_local_auth_env(
+        "http://127.0.0.1:9000", env, server_running=True
+    )
+
+    assert "PENGUIN_LOCAL_AUTH_TOKEN" not in env
+    assert "PENGUIN_AUTH_STARTUP_TOKEN" not in env
+
+
+def test_main_shares_startup_token_with_autostarted_local_auth_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "sandbox"
+    project_dir.mkdir()
+
+    fake_proc = _FakeProcess(running=True)
+    captured_start_env: dict[str, str] = {}
+    captured_run_env: dict[str, str] = {}
+
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(tmp_path / "auth-cache"))
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
+    monkeypatch.delenv("PENGUIN_LOCAL_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        opencode_launcher.atexit, "register", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        opencode_launcher, "_is_server_running", lambda *args, **kwargs: False
+    )
+    monkeypatch.setattr(opencode_launcher, "_is_local_url", lambda base_url: True)
+    monkeypatch.setattr(
+        opencode_launcher, "_ensure_web_runtime_available", lambda: None
+    )
+
+    def _start(base_url: str, env: dict[str, str]) -> _FakeProcess:
+        del base_url
+        captured_start_env.update(env)
+        return fake_proc
+
+    monkeypatch.setattr(opencode_launcher, "_start_web_server", _start)
+    monkeypatch.setattr(
+        opencode_launcher, "_wait_for_server", lambda *args, **kwargs: True
+    )
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_build_opencode_command",
+        lambda *args, **kwargs: (["opencode", str(project_dir)], None),
+    )
+
+    def _run(cmd: list[str], cwd: Path | None, env: dict[str, str]):
+        del cmd, cwd
+        captured_run_env.update(env)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(opencode_launcher.subprocess, "run", _run)
+    monkeypatch.setattr(opencode_launcher, "_stop_process", lambda proc: None)
+
+    exit_code = opencode_launcher.main([str(project_dir)])
+
+    assert exit_code == 0
+    assert captured_start_env["PENGUIN_AUTH_STARTUP_TOKEN"]
+    assert (
+        captured_start_env["PENGUIN_LOCAL_AUTH_TOKEN"]
+        == captured_start_env["PENGUIN_AUTH_STARTUP_TOKEN"]
+    )
+    assert (
+        captured_run_env["PENGUIN_LOCAL_AUTH_TOKEN"]
+        == captured_start_env["PENGUIN_AUTH_STARTUP_TOKEN"]
+    )
 
 
 def test_main_returns_error_when_autostart_health_never_recovers(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -37,17 +37,55 @@ def test_main_defaults_to_localhost_without_auth(monkeypatch, capsys):
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
     monkeypatch.setattr(server, "create_app_factory", lambda: app)
     monkeypatch.delenv("HOST", raising=False)
-    monkeypatch.setenv("PORT", "8000")
+    monkeypatch.delenv("PORT", raising=False)
     monkeypatch.setenv("DEBUG", "false")
     monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
+
+    assert server.main() == 0
+
+    output = capsys.readouterr().out
+    assert "http://127.0.0.1:9000" in output
+    assert "Penguin local web auth is enabled." in output
+    assert (
+        "Browser/dashboard only: open this local authorization URL once for this browser."
+        in output
+    )
+    assert "TUI/CLI: local Penguin sessions authenticate automatically." in output
+    assert "CI/headless: use PENGUIN_API_KEYS with X-API-Key header auth." in output
+    assert "PENGUIN_AUTH_ENABLED=false uv run penguin-web" in output
+    assert calls[0][0][0] is app
+    assert calls[0][1]["host"] == "127.0.0.1"
+    assert calls[0][1]["port"] == 9000
+
+
+def test_main_explicit_false_prints_unsecured_warning(monkeypatch, capsys):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "false")
     monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
 
     assert server.main() == 0
 
     output = capsys.readouterr().out
-    assert "http://127.0.0.1:8000" in output
+    assert (
+        "Warning: Penguin local web auth is explicitly disabled for this session."
+        in output
+    )
+    assert "Protected local startup is the default: uv run penguin-web" in output
+    assert "PENGUIN_AUTH_ENABLED=false uv run penguin-web" in output
     assert calls[0][0][0] is app
-    assert calls[0][1]["host"] == "127.0.0.1"
 
 
 def test_main_prints_startup_token_when_auth_bootstrap_enabled(monkeypatch, capsys):
@@ -69,9 +107,40 @@ def test_main_prints_startup_token_when_auth_bootstrap_enabled(monkeypatch, caps
     assert server.main() == 0
 
     output = capsys.readouterr().out
-    assert "Local Penguin authorization is enabled." in output
-    assert "http://127.0.0.1:9000/api/v1/auth/session" in output
-    assert "Startup token:" in output
+    assert "Penguin local web auth is enabled." in output
+    assert (
+        "Browser/dashboard only: open this local authorization URL once for this browser."
+        in output
+    )
+    assert "http://127.0.0.1:9000/authorize#local_token=" in output
+    assert "Startup token (debug fallback):" in output
+    assert "TUI/CLI: local Penguin sessions authenticate automatically." in output
+    assert calls[0][0][0] is app
+
+
+def test_main_writes_local_auth_token_cache_when_bootstrap_enabled(
+    monkeypatch, capsys, tmp_path
+):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+    monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(tmp_path))
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setenv("PORT", "9000")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "cached-startup-token")
+
+    assert server.main() == 0
+
+    capsys.readouterr()
+    assert (tmp_path / "127.0.0.1-9000.token").read_text() == "cached-startup-token"
     assert calls[0][0][0] is app
 
 
@@ -118,19 +187,20 @@ def test_validate_startup_security_allows_local_without_auth(monkeypatch):
 
 
 def test_validate_startup_security_blocks_non_local_without_auth(monkeypatch):
-    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "false")
     monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
 
     try:
         server.validate_startup_security("0.0.0.0")
     except RuntimeError as exc:
-        assert "PENGUIN_AUTH_ENABLED=true" in str(exc)
+        assert "PENGUIN_AUTH_ENABLED=false" in str(exc)
+        assert "HOST=127.0.0.1" in str(exc)
     else:
         raise AssertionError("Expected insecure startup to be blocked")
 
 
 def test_validate_startup_security_allows_non_local_with_auth(monkeypatch):
-    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
     monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
 
     server.validate_startup_security("0.0.0.0")

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -50,6 +50,31 @@ def test_main_defaults_to_localhost_without_auth(monkeypatch, capsys):
     assert calls[0][1]["host"] == "127.0.0.1"
 
 
+def test_main_prints_startup_token_when_auth_bootstrap_enabled(monkeypatch, capsys):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setenv("PORT", "9000")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
+
+    assert server.main() == 0
+
+    output = capsys.readouterr().out
+    assert "Local Penguin authorization is enabled." in output
+    assert "http://127.0.0.1:9000/api/v1/auth/session" in output
+    assert "Startup token:" in output
+    assert calls[0][0][0] is app
+
+
 def test_start_server_non_debug_uses_app_instance(monkeypatch):
     calls = []
     app = object()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import logging
 
 from penguin.web import server
 
@@ -142,6 +143,51 @@ def test_main_writes_local_auth_token_cache_when_bootstrap_enabled(
     capsys.readouterr()
     assert (tmp_path / "127.0.0.1-9000.token").read_text() == "cached-startup-token"
     assert calls[0][0][0] is app
+
+
+def test_main_continues_when_local_auth_token_cache_write_fails(
+    monkeypatch, capsys, caplog
+):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+    monkeypatch.setattr(
+        server,
+        "write_local_auth_token",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setenv("PORT", "9000")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "cached-startup-token")
+
+    with caplog.at_level(logging.WARNING, logger="penguin.web.server"):
+        assert server.main() == 0
+
+    output = capsys.readouterr().out
+    assert "http://127.0.0.1:9000/authorize#local_token=" in output
+    assert any(
+        "Failed to write local auth token cache" in x.message for x in caplog.records
+    )
+    assert calls[0][0][0] is app
+
+
+def test_main_returns_error_for_invalid_port(monkeypatch, capsys):
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setenv("PORT", "not-a-port")
+    monkeypatch.setenv("DEBUG", "false")
+
+    assert server.main() == 1
+
+    output = capsys.readouterr().out
+    assert "Invalid PORT value 'not-a-port'" in output
 
 
 def test_start_server_non_debug_uses_app_instance(monkeypatch):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -27,6 +27,29 @@ def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     assert calls[0][1]["port"] == 8080
 
 
+def test_main_defaults_to_localhost_without_auth(monkeypatch, capsys):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setenv("PORT", "8000")
+    monkeypatch.setenv("DEBUG", "false")
+    monkeypatch.delenv("PENGUIN_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PENGUIN_ALLOW_INSECURE_NO_AUTH", raising=False)
+
+    assert server.main() == 0
+
+    output = capsys.readouterr().out
+    assert "http://127.0.0.1:8000" in output
+    assert calls[0][0][0] is app
+    assert calls[0][1]["host"] == "127.0.0.1"
+
+
 def test_start_server_non_debug_uses_app_instance(monkeypatch):
     calls = []
     app = object()
@@ -43,6 +66,23 @@ def test_start_server_non_debug_uses_app_instance(monkeypatch):
     assert calls[0][1]["host"] == "127.0.0.1"
     assert calls[0][1]["port"] == 9000
     assert calls[0][1]["reload"] is False
+
+
+def test_start_server_defaults_to_localhost(monkeypatch):
+    calls = []
+    app = object()
+
+    fake_uvicorn = types.SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(server, "create_app_factory", lambda: app)
+
+    server.start_server(port=9000, debug=False)
+
+    assert calls[0][0][0] is app
+    assert calls[0][1]["host"] == "127.0.0.1"
+    assert calls[0][1]["port"] == 9000
 
 
 def test_validate_startup_security_allows_local_without_auth(monkeypatch):


### PR DESCRIPTION
## Summary
- Enable `penguin-web` auth by default for local startup, while keeping `PENGUIN_AUTH_ENABLED=false` as the explicit opt-out.
- Add a browser-friendly local authorization flow with a fragment-based bootstrap URL, session-cookie auth, and a dedicated `/authorize` page.
- Align `penguin-tui` and the launcher with the protected local server so TUI bootstrap, session creation, chat sends, and session refreshes all reuse authenticated local requests.
## Why
Running a local Penguin web server should be safe by default. The previous flow left the default posture ambiguous and created mismatches between browser clients, TUI clients, and separately started local servers.
This change makes the local web surface protected-by-default, keeps browser auth ergonomic, and removes the auth gaps that were causing anonymous TUI requests and repeated `401` loops.

## What Changed
- Added a shared protected-by-default auth helper for the web server and local launcher flows.
- Switched local web startup defaults to:
  - `HOST=127.0.0.1`
  - `PORT=9000`
  - auth enabled unless explicitly disabled
- Added startup-token bootstrap for local browser authorization with:
  - `POST /api/v1/auth/session`
  - `POST /api/v1/auth/logout`
  - signed `HttpOnly` session cookies
  - `/authorize#local_token=...` browser bootstrap flow
- Updated the static browser UI to:
  - stop anonymous retry storms
  - auto-bootstrap from the fragment token
  - show an in-product local authorization gate
- Updated `penguin-tui` / launcher integration to:
  - reuse cached local startup tokens for already-running local servers
  - send authenticated requests for bootstrap, session creation, chat sends, and session refreshes
- Updated startup messaging to explain:
  - browser/dashboard flow
  - automatic TUI/CLI behavior
  - CI/headless `PENGUIN_API_KEYS` usage
  - explicit local no-auth opt-out
- Updated architecture and packaging notes to reflect the `127.0.0.1:9000` default and launcher behavior.
- Updated the web security hardening plan to clarify the intended browser bootstrap UX and non-browser auth expectations.

## Verification
```bash
uv run pytest -q tests/test_web_server.py tests/test_opencode_launcher.py tests/api/test_web_auth_hardening.py
bun run typecheck
```
Result:

- 71 passed
- TUI typecheck passed
Notes

- Browser/dashboard auth is now one-click and local-only.
- TUI/CLI local sessions authenticate automatically.
- CI/headless flows should use configured PENGUIN_API_KEYS.
- Manual token redemption remains a fallback/debug path, not the intended primary UX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local browser authorization UI, token bootstrap via URL fragment, session-based login with HttpOnly cookies, logout, and UI flows that block until authorized.

* **Configuration Changes**
  * Default web endpoint now http://127.0.0.1:9000; launcher auto-starts a local loopback server by default with CLI/env override; local startup tokens are created/reused for bootstrap.

* **Security Improvements**
  * Loopback-only startup-token path, stricter session cookie policies, constant-time API key checks, standardized auth failure messages, and no-cache headers for UI assets.

* **Documentation & Tests**
  * Expanded security hardening plan, follow-up checklist, and extensive test coverage for startup-token, session issuance, SSE/WebSocket, launcher, and server behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->