### PR TITLE
Refactor Engine run_task into thin iteration-loop wrapper

### DIFF
--- a/context/tasks/runmode-pm-audit.md
+++ b/context/tasks/runmode-pm-audit.md
@@ -1,0 +1,109 @@
+# RunMode / PM Stack Audit
+
+## Purpose
+
+This note captures a skeptical execution-path review across the RunMode / Engine / Project stack after the `engine-run-task-thin-wrapper` refactor work. The goal is to identify where the current runtime is solid, where adapters still flatten truth, and where future cleanup should focus.
+
+## Entry Path Reviewed
+
+1. `penguin/cli/cli.py`
+   - `main_entry(...)`
+   - `_handle_run_mode(...)`
+2. `penguin/core.py`
+   - `start_run_mode(...)`
+   - `_handle_run_mode_event`
+   - `emit_ui_event(...)`
+3. `penguin/run_mode.py`
+   - `start(...)`
+   - `start_continuous(...)`
+   - clarification paths
+4. `penguin/engine.py`
+   - `run_task(...)`
+   - `_iteration_loop(...)`
+   - `_llm_step(...)`
+5. `penguin/project/`
+   - `task_executor.py`
+   - `workflow_orchestrator.py`
+   - `manager.py`
+   - `validation_manager.py`
+6. `penguin/web/routes.py`
+   - task execution / clarification resume / serialized task payloads
+
+## Verified Findings
+
+### What looks solid enough right now
+- `RunMode` is still the correct outer orchestration layer.
+  - task resolution
+  - continuous mode
+  - clarification persistence / resume
+  - idle / no-ready-work behavior
+  - time-limit handling
+- `Engine.run_task(...)` is now much closer to the right shape: setup + task-mode config + `_iteration_loop(...)` delegation.
+- Web/API route truth is materially better than before.
+  - task payloads preserve status/phase/dependencies/artifacts/clarification metadata
+  - execute/resume routes preserve clarification truth
+  - SSE/session-status truth now covers clarification, time-limit, and idle/no-ready-work
+
+### Highest-risk areas still in the stack
+- `penguin/core.py`
+  - status/event bridging still relies heavily on summary strings and centralized coordination state
+  - `start_run_mode(...)` cleanup/failure-path behavior deserves another pass
+- `penguin/project/task_executor.py`
+  - preserves `run_mode_result`, which is good
+  - but still reports a coarse top-level success shape that could flatten nuanced outcomes if consumers misuse it
+- `penguin/project/workflow_orchestrator.py`
+  - phase-aware and improved, but still an MVP orchestrator with narrow recipe/validation behavior
+- `penguin/project/validation_manager.py`
+  - fail-closed is better, but VERIFY is still pytest-centric and not a mature evidence system
+
+## Engine-Specific Review Notes
+
+### Thin-wrapper refactor conclusion
+The `run_task(...)` thin-wrapper refactor was the right move.
+
+It reduced real duplication between:
+- `run_task(...)`
+- `_iteration_loop(...)`
+
+That duplication was an Engine-vs-Engine problem, not a RunMode-vs-Engine boundary problem.
+
+### Additional verified issues fixed during review
+- task-mode stream callback contract now matches provider/runtime expectations
+- `_CURRENT_ENGINE_RUN_STATE` cleanup is now broader and safer
+- task completion phrases are now propagated into loop config and checked centrally
+- phrase-based task completion now emits the task completion event instead of silently breaking out
+- fallback task IDs are less collision-prone
+
+## Project / PM Review Notes
+
+### Main concern
+The next likely trust failures are more likely to come from `penguin/project` than from the newly-thinned `run_task(...)` path.
+
+### Why
+`penguin/project` still concentrates too much policy in a few places:
+- `manager.py`
+- `workflow_orchestrator.py`
+- `task_executor.py`
+- `validation_manager.py`
+
+That does not mean those files are broken. It means they remain the most likely place for contradictions, flattening adapters, or phase/status drift.
+
+## Suggested Follow-Up Priorities
+
+1. **Project Orchestration Hardening**
+   - especially `workflow_orchestrator.py` and `task_executor.py`
+2. **Validation / VERIFY Maturity Pass**
+3. **Core Runtime Decomposition Pass**
+   - especially the RunMode/event/status bridge in `core.py`
+4. **Engine Loop Cleanup Follow-On**
+   - remaining `run_response(...)` vs `_iteration_loop(...)` divergence
+
+## Bottom Line
+
+The `engine-run-task-thin-wrapper` branch still looks worth shipping.
+
+The refactor did not reveal a hidden fatal flaw in the current call chain.
+But it did reinforce that the next serious reliability work should focus on:
+- `penguin/project`
+- `core.py` event/status bridging
+- validation maturity

--- a/context/tasks/todo.md
+++ b/context/tasks/todo.md
@@ -154,6 +154,70 @@ Reference:
 - `context/tasks/web-and-tui-bugfix.md`
 - `context/tasks/tui-opencode-fork-alignment-plan.md`
 
+### PR: Core Runtime Decomposition Pass
+**Reason deferred:** high leverage for long-term reliability, but too invasive to mix with current command/bootstrap work
+
+- [ ] Extract RunMode/session-status bridging concerns out of `core.py`
+- [ ] Isolate streaming finalization / UI event normalization from general core orchestration
+- [ ] Reduce `current_runmode_status_summary` / `_handle_run_mode_event` coupling where tests protect behavior
+- [ ] Identify a stable services/helpers split for `core.py` before moving larger blocks
+- [ ] Add regression coverage around any extracted event/status bridge behavior
+
+Reference:
+- `penguin/core.py`
+- `context/tasks/runmode-command-loop-audit.md`
+
+### PR: Project Orchestration Hardening
+**Reason deferred:** high-value reliability work, especially in `penguin/project`, but should follow the current truth/UX passes
+
+- [ ] Audit `workflow_orchestrator.py` against current RunMode / ITUV truth and remove stale assumptions
+- [ ] Replace `print()`-based orchestrator debug paths with logging / structured diagnostics
+- [ ] Harden `ProjectTaskExecutor` so it does not collapse nuanced RunMode outcomes into generic executor success
+- [ ] Re-check status/phase transitions through `manager.py`, `workflow_orchestrator.py`, and `models.py` for contradictions
+- [ ] Add explicit regression tests for pending-review handoff, orchestration failure paths, and recipe/use gating
+
+Reference:
+- `penguin/project/workflow_orchestrator.py`
+- `penguin/project/task_executor.py`
+- `penguin/project/manager.py`
+- `penguin/project/models.py`
+
+### PR: Validation / VERIFY Maturity Pass
+**Reason deferred:** current validation is improved but still pytest-centric and too narrow for higher-trust project automation
+
+- [ ] Expand `ValidationManager` evidence beyond pytest exit codes and loose acceptance-criteria coverage
+- [ ] Distinguish test evidence, usage-recipe evidence, and explicit verification artifacts more cleanly
+- [ ] Tighten acceptance-criteria evaluation so "covered_by_test_evidence" is not the only meaningful success mode
+- [ ] Add tests for no-tests-found, timeout, missing-pytest, and mixed evidence scenarios at the orchestration layer
+- [ ] Decide which VERIFY semantics should stay MVP-simple vs move into a later TLA+/formal verification track
+
+Reference:
+- `penguin/project/validation_manager.py`
+- `context/tasks/penguin_tla.md`
+
+### PR: Legacy Workflow Surface Cleanup
+**Reason deferred:** stale or parallel execution surfaces can quietly undermine the newer runtime truth if left unaudited
+
+- [ ] Audit `dream_workflow.py` and any remaining alternate task/workflow entry points for stale constructor/runtime assumptions
+- [ ] Deprecate or remove dead workflow surfaces that are no longer the real execution path
+- [ ] Add a short architecture note documenting the authoritative runtime/orchestration paths
+
+Reference:
+- `penguin/project/dream_workflow.py`
+- `architecture.md`
+
+### PR: Engine Loop Cleanup Follow-On
+**Reason deferred:** `run_task()` thin-wrapper refactor reduces risk, but broader engine-loop cleanup still remains
+
+- [ ] Review remaining divergence between `run_response(...)` and `_iteration_loop(...)`
+- [ ] Identify whether any task-mode result shaping should move fully into `LoopConfig` or helper functions
+- [ ] Add coverage around message-callback/tool-output semantics and completion callbacks if further cleanup lands
+- [ ] Remove any now-dead task-loop code left behind by the thin-wrapper refactor
+
+Reference:
+- `penguin/engine.py`
+- `tests/test_engine_run_task_thin_wrapper.py`
+
 ---
 
 ## Strategic Read (April 17, 2026)

--- a/context/tasks/todo.md
+++ b/context/tasks/todo.md
@@ -38,6 +38,7 @@ parallel.
 ## In Progress
 
 ### PR: CLI Workspace Semantics and Ergonomics
+
 **Status:** materially underway / first implementation slice exists
 
 Completed in this thread:
@@ -57,6 +58,7 @@ Reference:
 - `context/tasks/cli-workspace-semantics-pr1-checklist.md`
 
 ### PR: RunMode Commands and Loop Ownership Audit / Command Truth
+
 **Status:** audit done, Phases 1/2/3/5/6 materially done, closeout decision pending
 
 Completed in this thread:
@@ -90,6 +92,7 @@ Reference:
 ## Next
 
 ### PR: Project Bootstrap Workflow MVP
+
 **Why next:** high leverage once workspace semantics and runmode command truth are stable enough
 
 - [ ] Add `penguin project init "name" --blueprint ./blueprint.md`
@@ -103,6 +106,7 @@ Reference:
 - `context/tasks/cli-refactor-and-bootstrap-audit.md`
 
 ### PR: RunMode Command Truth Cleanup Closeout
+
 **Why next:** if the current runmode truth branch/PR is left half-finished, the audit loses value
 
 - [ ] Finish remaining Phase 2 cleanup/tests
@@ -117,6 +121,7 @@ Reference:
 ## Deferred
 
 ### PR: PenguinAPI Surface Refresh
+
 **Reason deferred:** lower immediate leverage than CLI/web/runtime truth; still important, but not the bottleneck this week
 
 - [ ] Audit `PenguinAPI` method contracts against current runtime truth
@@ -129,6 +134,7 @@ Reference:
 - `context/tasks/penguinapi-surface-refresh-plan.md`
 
 ### PR: Reliability Pass 2
+
 **Reason deferred:** valuable hardening, but not the immediate unlock for product-facing flow
 
 - [ ] Extend Hypothesis/property-based coverage for dependency-policy semantics
@@ -142,6 +148,7 @@ Reference:
 - `context/tasks/penguin_tla.md`
 
 ### Later / Larger Runtime Cleanup
+
 **Reason deferred:** architecture cleanup should follow explicit contract truth, not race ahead of it
 
 - [ ] Broader `cli.py` decomposition/refactor
@@ -155,6 +162,7 @@ Reference:
 - `context/tasks/tui-opencode-fork-alignment-plan.md`
 
 ### PR: Core Runtime Decomposition Pass
+
 **Reason deferred:** high leverage for long-term reliability, but too invasive to mix with current command/bootstrap work
 
 - [ ] Extract RunMode/session-status bridging concerns out of `core.py`
@@ -168,6 +176,7 @@ Reference:
 - `context/tasks/runmode-command-loop-audit.md`
 
 ### PR: Project Orchestration Hardening
+
 **Reason deferred:** high-value reliability work, especially in `penguin/project`, but should follow the current truth/UX passes
 
 - [ ] Audit `workflow_orchestrator.py` against current RunMode / ITUV truth and remove stale assumptions
@@ -183,6 +192,7 @@ Reference:
 - `penguin/project/models.py`
 
 ### PR: Validation / VERIFY Maturity Pass
+
 **Reason deferred:** current validation is improved but still pytest-centric and too narrow for higher-trust project automation
 
 - [ ] Expand `ValidationManager` evidence beyond pytest exit codes and loose acceptance-criteria coverage
@@ -196,6 +206,7 @@ Reference:
 - `context/tasks/penguin_tla.md`
 
 ### PR: Legacy Workflow Surface Cleanup
+
 **Reason deferred:** stale or parallel execution surfaces can quietly undermine the newer runtime truth if left unaudited
 
 - [ ] Audit `dream_workflow.py` and any remaining alternate task/workflow entry points for stale constructor/runtime assumptions
@@ -207,6 +218,7 @@ Reference:
 - `architecture.md`
 
 ### PR: Engine Loop Cleanup Follow-On
+
 **Reason deferred:** `run_task()` thin-wrapper refactor reduces risk, but broader engine-loop cleanup still remains
 
 - [ ] Review remaining divergence between `run_response(...)` and `_iteration_loop(...)`

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -1861,27 +1861,11 @@ class Engine:
         """
         Multi-step reasoning loop with comprehensive task handling.
 
-        Args:
-            task_prompt: The prompt for the task
-            image_paths: Optional list of image paths for multi-modal inputs
-            max_iterations: Maximum number of iterations (overrides settings default)
-            task_context: Additional context for the task (metadata, environment, etc.)
-            task_id: Optional task ID for tracking and events
-            task_name: Optional task name for display and logging
-            completion_phrases: Additional completion phrases to check for
-            on_completion: Optional callback when task completes
-            enable_events: Whether to publish events (defaults to True)
-            message_callback: Optional callback to display messages during execution (message, type)
-
-        Returns:
-            Dictionary with task execution results including:
-            - assistant_response: The final response from the assistant
-            - iterations: Number of iterations performed
-            - status: Task status (completed, iterations_exceeded, stopped)
-            - action_results: Results of any actions executed
+        This is task-mode setup + delegation into the unified `_iteration_loop(...)`.
+        Task-specific behavior is carried through `LoopConfig` and task metadata,
+        while the shared iteration mechanics stay centralized in one place.
         """
         max_iters = max_iterations or self.settings.max_iterations_default
-        # Select agent and prepare its conversation
         selected, lite_output = await self._resolve_agent(
             agent_id=agent_id,
             agent_role=agent_role,
@@ -1911,261 +1895,46 @@ class Engine:
         if telemetry is not None:
             await telemetry.record_task(self.current_agent_id, task_name)
 
-        # Prepare task metadata
         task_metadata = {
             "id": task_id or f"task_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
             "name": task_name or "Unnamed Task",
             "context": task_context or {},
             "max_iterations": max_iters,
             "start_time": self.start_time.isoformat(),
+            "prompt": task_prompt,
         }
 
-        # Get standard and custom completion phrases
         standard_phrase = TASK_COMPLETION_PHRASE
         all_completion_phrases = [standard_phrase]
         if completion_phrases:
             all_completion_phrases.extend(completion_phrases)
 
-        # Store action results from all iterations
-        all_action_results = []
-
-        # Reset loop state for this run
-        self._get_loop_state().reset()
-
-        # Publish task start event if EventBus is available
-        if enable_events:
-            try:
-                from penguin.utils.events import EventBus, TaskEvent
-
-                event_bus = EventBus.get_instance()
-                await event_bus.publish(
-                    TaskEvent.STARTED.value,
-                    {
-                        "task_id": task_metadata["id"],
-                        "task_name": task_metadata["name"],
-                        "task_prompt": task_prompt,
-                        "max_iterations": max_iters,
-                        "context": task_context,
-                        "message_type": "status",
-                    },
-                )
-            except (ImportError, AttributeError):
-                # EventBus not available yet, continue with normal operation
-                logger.warning(
-                    "EventBus not available, continuing without event publishing"
-                )
-
-        last_response = ""
-        latest_usage: Dict[str, Any] = {}
-        completion_status = "iterations_exceeded"  # Default status
+        config = LoopConfig(
+            mode="task",
+            termination_action="finish_task",
+            streaming=self.settings.streaming_default,
+            stream_callback=message_callback if message_callback else None,
+            manage_streaming_state=False,
+            async_save=True,
+            enable_events=enable_events,
+            task_metadata=task_metadata,
+            message_callback=message_callback,
+            default_completion_status="iterations_exceeded",
+        )
 
         try:
-            # Main execution loop
-            while self.current_iteration < max_iters:
-                self.current_iteration += 1
-                logger.debug("Engine iteration %s (run_task)", self.current_iteration)
+            result = await self._iteration_loop(cm, config, max_iters)
+            result["task"] = task_metadata
 
-                # Check for external stop conditions
-                if await self._check_stop():
-                    completion_status = "stopped"
-                    break
-
-                # Execute LLM step with streaming support
-                response_data = await self._llm_step(
-                    tools_enabled=True,
-                    streaming=self.settings.streaming_default,
-                    stream_callback=message_callback if message_callback else None,
-                    agent_id=self.current_agent_id,
-                )
-
-                last_response = response_data.get("assistant_response", "")
-                iteration_results = response_data.get("action_results", [])
-                usage_data = response_data.get("usage")
-                if isinstance(usage_data, dict) and usage_data:
-                    latest_usage = usage_data
-
-                # Collect action results
-                if iteration_results:
-                    all_action_results.extend(iteration_results)
-
-                    # Display action results via callback
-                    if message_callback:
-                        for tool_result_info in iteration_results:
-                            if isinstance(tool_result_info, dict):
-                                action_name = tool_result_info.get(
-                                    "action", "UnknownAction"
-                                )
-                                result_str = tool_result_info.get("result", "")
-                                status = tool_result_info.get("status", "completed")
-
-                                callback_message_type = (
-                                    "tool_result"
-                                    if status == "completed"
-                                    else "tool_error"
-                                )
-                                await message_callback(
-                                    result_str,
-                                    callback_message_type,
-                                    action_name=action_name,
-                                )
-                            else:
-                                await message_callback(
-                                    str(tool_result_info), "system_output"
-                                )
-
-                # Publish progress event
-                if enable_events:
-                    try:
-                        from penguin.utils.events import EventBus, TaskEvent
-
-                        event_bus = EventBus.get_instance()
-                        await event_bus.publish(
-                            TaskEvent.PROGRESSED.value,
-                            {
-                                "task_id": task_metadata["id"],
-                                "task_name": task_metadata["name"],
-                                "iteration": self.current_iteration,
-                                "max_iterations": max_iters,
-                                "response": last_response,
-                                "progress": min(
-                                    100, int(100 * self.current_iteration / max_iters)
-                                ),
-                                "message_type": "status",
-                            },
-                        )
-                    except (ImportError, AttributeError):
-                        logger.debug("EventBus not available for progress event")
-
-                # CRITICAL FIX: Persist conversation after each iteration using async save
-                cm, _, _, _ = self._resolve_components(self.current_agent_id)
-                await self._save_conversation(cm, async_save=True)
-
-                # Check for task completion via finish_task tool call (primary)
-                finish_task_called = False
-                finish_status = "done"  # Default status
-                for tool_result in iteration_results:
-                    if isinstance(tool_result, dict):
-                        action_name = tool_result.get("action", "")
-                        if action_name in ("finish_task", "task_completed"):
-                            finish_task_called = True
-                            # Extract status from machine-readable marker [FINISH_STATUS:xxx]
-                            # This avoids false positives from user summaries containing words like "blocked"
-                            result_output = tool_result.get("result", "")
-                            status_match = re.search(
-                                r"\[FINISH_STATUS:(\w+)\]", result_output
-                            )
-                            if status_match:
-                                finish_status = status_match.group(1)
-                            break
-
-                if finish_task_called:
-                    # Task goes to PENDING_REVIEW, not COMPLETED
-                    # Human must approve to mark COMPLETED
-                    completion_status = "pending_review"
-                    logger.info(
-                        f"Task completion signal detected via 'finish_task' tool (status: {finish_status}). Marking for human review."
-                    )
-
-                    # Publish completion event (task is pending review, not fully completed)
-                    if enable_events:
-                        try:
-                            from penguin.utils.events import EventBus, TaskEvent
-
-                            event_bus = EventBus.get_instance()
-                            await event_bus.publish(
-                                TaskEvent.COMPLETED.value,
-                                {
-                                    "task_id": task_metadata["id"],
-                                    "task_name": task_metadata["name"],
-                                    "response": last_response,
-                                    "iteration": self.current_iteration,
-                                    "max_iterations": max_iters,
-                                    "context": task_context,
-                                    "finish_status": finish_status,
-                                    "requires_review": True,
-                                    "message_type": "status",
-                                },
-                            )
-                        except (ImportError, AttributeError):
-                            logger.debug("EventBus not available for completion event")
-                    break
-
-                if not iteration_results and self._queue_malformed_action_repair_note(
-                    cm,
-                    last_response,
-                    mode="task",
-                ):
-                    await self._save_conversation(cm, async_save=True)
-                    if message_callback:
-                        await message_callback(
-                            "Assistant returned malformed tool syntax; requesting a repair turn.",
-                            "system_output",
-                        )
-                    continue
-
-                # WALLET_GUARD: Consolidated termination checks
-                should_break, guard_status = self._check_wallet_guard_termination(
-                    last_response, iteration_results, mode="task"
-                )
-                if should_break:
-                    completion_status = guard_status or "implicit_completion"
-                    break
-
-        except LLMEmptyResponseError as e:
-            logger.warning(f"LLM returned empty response during task: {e}")
-            completion_status = "llm_empty_response_error"
-            if message_callback:
-                await message_callback(f"LLM Empty Response: {str(e)}", "error")
-
-        except Exception as e:
-            # Handle any execution errors
-            logger.error(f"Error executing task: {str(e)}")
-            completion_status = "error"
-
-            # Call message callback if provided
-            if message_callback:
-                await message_callback(f"Error executing task: {str(e)}", "error")
-
-            # Publish error event
-            if enable_events:
+            if on_completion:
                 try:
-                    from penguin.utils.events import EventBus, TaskEvent
+                    await on_completion(result)
+                except Exception as e:
+                    logger.error(f"Error in completion callback: {str(e)}")
 
-                    event_bus = EventBus.get_instance()
-                    await event_bus.publish(
-                        TaskEvent.FAILED.value,
-                        {
-                            "task_id": task_metadata["id"],
-                            "task_name": task_metadata["name"],
-                            "error": str(e),
-                            "iteration": self.current_iteration,
-                            "max_iterations": max_iters,
-                            "message_type": "status",
-                        },
-                    )
-                except (ImportError, AttributeError):
-                    logger.debug("EventBus not available for error event")
-
-        # Prepare result structure
-        result = {
-            "assistant_response": last_response,
-            "iterations": self.current_iteration,
-            "status": completion_status,
-            "action_results": all_action_results,
-            "usage": latest_usage,
-            "task": task_metadata,
-            "execution_time": (datetime.utcnow() - self.start_time).total_seconds(),
-        }
-
-        # Call completion callback if provided
-        if on_completion:
-            try:
-                await on_completion(result)
-            except Exception as e:
-                logger.error(f"Error in completion callback: {str(e)}")
-
-        _CURRENT_ENGINE_RUN_STATE.reset(token)
-        return result
+            return result
+        finally:
+            _CURRENT_ENGINE_RUN_STATE.reset(token)
 
     async def _execute_lite_agent(
         self,

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -107,9 +107,12 @@ class LoopConfig:
     # Termination signal - which action name triggers explicit completion
     termination_action: str  # "finish_response" or "finish_task"
 
+    # Termination phrases for non-action completion hints when applicable
+    completion_phrases: Optional[List[str]] = None
+
     # Streaming configuration
     streaming: bool = True
-    stream_callback: Optional[Callable[[str, str], Awaitable[None]]] = None
+    stream_callback: Optional[Callable[[str], None]] = None
 
     # Whether to reset/finalize streaming state between iterations
     manage_streaming_state: bool = False
@@ -122,11 +125,10 @@ class LoopConfig:
     task_metadata: Optional[Dict[str, Any]] = None
 
     # Message callback for tool results (run_task mode)
-    message_callback: Optional[Callable] = None
+    message_callback: Optional[Callable[..., Awaitable[None]]] = None
 
     # Default completion status when loop ends without explicit signal
     default_completion_status: str = "completed"
-
 
 @dataclass
 class LoopState:
@@ -1428,6 +1430,20 @@ class Engine:
                         f"Preview: {last_response[:100]}..."
                     )
 
+                if (
+                    last_response
+                    and config.completion_phrases
+                    and any(phrase in last_response for phrase in config.completion_phrases)
+                    and not termination_detected
+                ):
+                    logger.info(
+                        f"Completion phrase detected in {config.mode} loop output without explicit action."
+                    )
+                    completion_status = (
+                        "pending_review" if config.mode == "task" else config.default_completion_status
+                    )
+                    break
+
                 if not iteration_results and self._queue_malformed_action_repair_note(
                     cm,
                     last_response,
@@ -1888,41 +1904,45 @@ class Engine:
         self.current_iteration = 0
         self.start_time = datetime.utcnow()
 
-        cm, _api, _tm, _ae = self._resolve_components(self.current_agent_id)
-        cm.conversation.prepare_conversation(task_prompt, image_paths=image_paths)
-
-        telemetry = getattr(self, "telemetry", None)
-        if telemetry is not None:
-            await telemetry.record_task(self.current_agent_id, task_name)
-
-        task_metadata = {
-            "id": task_id or f"task_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
-            "name": task_name or "Unnamed Task",
-            "context": task_context or {},
-            "max_iterations": max_iters,
-            "start_time": self.start_time.isoformat(),
-            "prompt": task_prompt,
-        }
-
-        standard_phrase = TASK_COMPLETION_PHRASE
-        all_completion_phrases = [standard_phrase]
-        if completion_phrases:
-            all_completion_phrases.extend(completion_phrases)
-
-        config = LoopConfig(
-            mode="task",
-            termination_action="finish_task",
-            streaming=self.settings.streaming_default,
-            stream_callback=message_callback if message_callback else None,
-            manage_streaming_state=False,
-            async_save=True,
-            enable_events=enable_events,
-            task_metadata=task_metadata,
-            message_callback=message_callback,
-            default_completion_status="iterations_exceeded",
-        )
-
         try:
+            cm, _api, _tm, _ae = self._resolve_components(self.current_agent_id)
+            cm.conversation.prepare_conversation(task_prompt, image_paths=image_paths)
+
+            telemetry = getattr(self, "telemetry", None)
+            if telemetry is not None:
+                await telemetry.record_task(self.current_agent_id, task_name)
+
+            task_metadata = {
+                "id": task_id or f"task_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
+                "name": task_name or "Unnamed Task",
+                "context": task_context or {},
+                "max_iterations": max_iters,
+                "start_time": self.start_time.isoformat(),
+                "prompt": task_prompt,
+            }
+
+            all_completion_phrases = [TASK_COMPLETION_PHRASE]
+            if completion_phrases:
+                all_completion_phrases.extend(completion_phrases)
+
+            async def task_stream_adapter(chunk: str) -> None:
+                if message_callback:
+                    await message_callback(chunk, "assistant")
+
+            config = LoopConfig(
+                mode="task",
+                termination_action="finish_task",
+                completion_phrases=all_completion_phrases,
+                streaming=self.settings.streaming_default,
+                stream_callback=task_stream_adapter if message_callback else None,
+                manage_streaming_state=False,
+                async_save=True,
+                enable_events=enable_events,
+                task_metadata=task_metadata,
+                message_callback=message_callback,
+                default_completion_status="iterations_exceeded",
+            )
+
             result = await self._iteration_loop(cm, config, max_iters)
             result["task"] = task_metadata
 

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -11,6 +11,7 @@ remains test‑friendly and avoids hidden globals.
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+import uuid
 import asyncio
 import copy
 from contextlib import contextmanager
@@ -1442,6 +1443,19 @@ class Engine:
                     completion_status = (
                         "pending_review" if config.mode == "task" else config.default_completion_status
                     )
+                    if config.mode == "task" and config.enable_events and config.task_metadata:
+                        await self._publish_task_event(
+                            "COMPLETED",
+                            config.task_metadata,
+                            {
+                                "response": last_response,
+                                "iteration": self.current_iteration,
+                                "max_iterations": max_iterations,
+                                "completion_status": completion_status,
+                                "finish_status": "completion_phrase",
+                                "requires_review": True,
+                            },
+                        )
                     break
 
                 if not iteration_results and self._queue_malformed_action_repair_note(
@@ -1913,7 +1927,8 @@ class Engine:
                 await telemetry.record_task(self.current_agent_id, task_name)
 
             task_metadata = {
-                "id": task_id or f"task_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}",
+                "id": task_id
+                or f"task_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex}",
                 "name": task_name or "Unnamed Task",
                 "context": task_context or {},
                 "max_iterations": max_iters,
@@ -1925,9 +1940,11 @@ class Engine:
             if completion_phrases:
                 all_completion_phrases.extend(completion_phrases)
 
-            async def task_stream_adapter(chunk: str) -> None:
+            async def task_stream_adapter(
+                chunk: str, message_type: str = "assistant"
+            ) -> None:
                 if message_callback:
-                    await message_callback(chunk, "assistant")
+                    await message_callback(chunk, message_type)
 
             config = LoopConfig(
                 mode="task",

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -1888,14 +1888,65 @@ class Engine:
         api_client_override: Optional[Any] = None,
         model_config_override: Optional[Any] = None,
     ) -> Dict[str, Any]:
-        """
-        Multi-step reasoning loop with comprehensive task handling.
+        """Run a task-oriented reasoning loop using the shared iteration engine.
 
-        This is task-mode setup + delegation into the unified `_iteration_loop(...)`.
-        Task-specific behavior is carried through `LoopConfig` and task metadata,
-        while the shared iteration mechanics stay centralized in one place.
+        This method performs task-mode setup, prepares task_metadata, builds a
+        task-mode LoopConfig, and delegates the actual loop mechanics to
+        `_iteration_loop(...)`.
+
+        Args:
+            task_prompt: The prompt describing the task to execute.
+            image_paths: Optional image inputs for multimodal task execution.
+            max_iterations: Maximum iterations for the task loop. If ``None``,
+                ``self.settings.max_iterations_default`` is used.
+            task_context: Optional task-scoped metadata/context.
+            task_id: Optional explicit task identifier. If omitted, a generated
+                fallback identifier is used.
+            task_name: Optional human-readable task name.
+            completion_phrases: Optional additional completion phrases checked by
+                `_iteration_loop(...)` through ``LoopConfig.completion_phrases``.
+            on_completion: Optional async callback invoked with the final result.
+            enable_events: Whether task progress/completion events should be
+                published.
+            message_callback: Optional async callback for streamed assistant/tool
+                output. The public callback contract is ``(chunk, message_type)``.
+            agent_id: Optional explicit agent id override.
+            agent_role: Optional agent role for agent resolution.
+            api_client_override: Optional API client override for the resolved run.
+            model_config_override: Optional model config override for the resolved
+                run.
+
+        Returns:
+            A dictionary containing the final assistant response, iteration count,
+            action results, status, execution time, and attached ``task`` metadata.
+            Task-mode success typically resolves to ``pending_review`` after an
+            explicit task finish signal or equivalent completion phrase.
+
+        Raises:
+            Exception: Propagates agent resolution, component preparation,
+                `_iteration_loop(...)`, and ``on_completion`` callback failures.
+
+        Examples:
+            ```python
+            result = await engine.run_task(
+                task_prompt="Implement the feature",
+                task_name="Feature Work",
+            )
+
+            async def callback(chunk: str, message_type: str):
+                print(message_type, chunk)
+
+            result = await engine.run_task(
+                task_prompt="Investigate the bug",
+                message_callback=callback,
+            )
+            ```
         """
-        max_iters = max_iterations or self.settings.max_iterations_default
+        max_iters = (
+            max_iterations
+            if max_iterations is not None
+            else self.settings.max_iterations_default
+        )
         selected, lite_output = await self._resolve_agent(
             agent_id=agent_id,
             agent_role=agent_role,
@@ -1940,11 +1991,16 @@ class Engine:
             if completion_phrases:
                 all_completion_phrases.extend(completion_phrases)
 
-            async def task_stream_adapter(
-                chunk: str, message_type: str = "assistant"
+            async def task_message_callback_wrapper(
+                chunk: str, message_type: str, *args: Any, **kwargs: Any
             ) -> None:
                 if message_callback:
                     await message_callback(chunk, message_type)
+
+            async def task_stream_adapter(
+                chunk: str, message_type: str = "assistant"
+            ) -> None:
+                await task_message_callback_wrapper(chunk, message_type)
 
             config = LoopConfig(
                 mode="task",
@@ -1956,7 +2012,9 @@ class Engine:
                 async_save=True,
                 enable_events=enable_events,
                 task_metadata=task_metadata,
-                message_callback=message_callback,
+                message_callback=(
+                    task_message_callback_wrapper if message_callback else None
+                ),
                 default_completion_status="iterations_exceeded",
             )
 
@@ -1966,8 +2024,9 @@ class Engine:
             if on_completion:
                 try:
                     await on_completion(result)
-                except Exception as e:
-                    logger.error(f"Error in completion callback: {str(e)}")
+                except Exception:
+                    logger.exception("Error in completion callback")
+                    raise
 
             return result
         finally:

--- a/tests/test_engine_run_task_thin_wrapper.py
+++ b/tests/test_engine_run_task_thin_wrapper.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from penguin.engine import Engine, EngineSettings
+
+
+@pytest.mark.asyncio
+async def test_run_task_delegates_to_iteration_loop_and_preserves_task_metadata():
+    engine = Engine(
+        settings=EngineSettings(),
+        conversation_manager=SimpleNamespace(),
+        api_client=SimpleNamespace(),
+        tool_manager=SimpleNamespace(),
+        action_executor=SimpleNamespace(),
+    )
+    engine.default_agent_id = "default"
+    engine._resolve_agent = AsyncMock(return_value=("default", None))
+    cm = SimpleNamespace(conversation=SimpleNamespace(prepare_conversation=lambda *a, **k: None))
+    engine._resolve_components = MagicMock(return_value=(cm, None, None, None))
+    engine._iteration_loop = AsyncMock(
+        return_value={
+            "assistant_response": "done",
+            "iterations": 2,
+            "status": "pending_review",
+            "action_results": [{"action": "finish_task", "status": "completed"}],
+            "usage": {"total_tokens": 12},
+            "execution_time": 0.5,
+        }
+    )
+
+    result = await engine.run_task(
+        task_prompt="Do the thing",
+        task_context={"project_id": "p1"},
+        task_id="task-123",
+        task_name="Important Task",
+        enable_events=True,
+    )
+
+    engine._iteration_loop.assert_awaited_once()
+    _, args, kwargs = engine._iteration_loop.mock_calls[0]
+    config = args[1]
+    max_iters = args[2]
+
+    assert config.mode == "task"
+    assert config.termination_action == "finish_task"
+    assert config.enable_events is True
+    assert config.message_callback is None
+    assert config.default_completion_status == "iterations_exceeded"
+    assert config.task_metadata["id"] == "task-123"
+    assert config.task_metadata["name"] == "Important Task"
+    assert config.task_metadata["context"] == {"project_id": "p1"}
+    assert config.task_metadata["prompt"] == "Do the thing"
+    assert max_iters == engine.settings.max_iterations_default
+
+    assert result["status"] == "pending_review"
+    assert result["task"]["id"] == "task-123"
+    assert result["task"]["name"] == "Important Task"
+
+
+@pytest.mark.asyncio
+async def test_run_task_invokes_on_completion_with_result():
+    engine = Engine(
+        settings=EngineSettings(),
+        conversation_manager=SimpleNamespace(),
+        api_client=SimpleNamespace(),
+        tool_manager=SimpleNamespace(),
+        action_executor=SimpleNamespace(),
+    )
+    engine.default_agent_id = "default"
+    engine._resolve_agent = AsyncMock(return_value=("default", None))
+    cm = SimpleNamespace(conversation=SimpleNamespace(prepare_conversation=lambda *a, **k: None))
+    engine._resolve_components = MagicMock(return_value=(cm, None, None, None))
+    engine._iteration_loop = AsyncMock(
+        return_value={
+            "assistant_response": "done",
+            "iterations": 1,
+            "status": "pending_review",
+            "action_results": [],
+            "usage": {},
+            "execution_time": 0.1,
+        }
+    )
+    on_completion = AsyncMock()
+
+    result = await engine.run_task(
+        task_prompt="Do the thing",
+        task_name="Important Task",
+        on_completion=on_completion,
+    )
+
+    on_completion.assert_awaited_once()
+    callback_result = on_completion.await_args.args[0]
+    assert callback_result["status"] == "pending_review"
+    assert callback_result["task"]["name"] == "Important Task"
+    assert result["status"] == "pending_review"


### PR DESCRIPTION
## Summary

This PR reduces duplicated task-loop logic in `Engine.run_task(...)` by making it a thin task-mode wrapper around the shared `_iteration_loop(...)` machinery.

### What changed
- `Engine.run_task(...)` now focuses on:
  - agent resolution
  - conversation preparation
  - task metadata setup
  - task-mode `LoopConfig` construction
  - delegation into `_iteration_loop(...)`
  - result/task metadata post-processing
  - `on_completion` callback execution
- removed the duplicated inner task loop that previously recreated iteration/termination behavior already centralized in `_iteration_loop(...)`
- added focused regression coverage for the thin-wrapper behavior

### Why
Before this PR, `run_task(...)` had effectively become a shadow implementation of the engine iteration loop. That created real drift risk between:
- `run_task(...)`
- `run_response(...)`
- `_iteration_loop(...)`

This PR reduces that maintenance hazard while preserving task-mode semantics.

## Verification

Ran targeted runtime/task tests:

```bash
pytest -q \
  tests/test_engine_run_task_thin_wrapper.py \
  tests/test_runmode_clarification_handling.py \
  tests/test_runmode_streaming.py \
  tests/runmode/test_stream_mixed_types.py \
  tests/runmode/test_persistence_behavior.py \
  tests/test_task_state_machine_contract.py \
  tests/api/test_penguin_api_surface.py
```

Result:
- **12 passed**

## Notes

- This PR intentionally does **not** widen into broader `run_response(...)` cleanup.
- It also does **not** attempt to change RunMode/project orchestration behavior.
- One stale route-level expectation (`test_side_door_completion_semantics.py`) was intentionally not used as a gate here because it reflects older direct-engine assumptions rather than the current RunMode-based project execution path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified iteration handling for task runs, improving consistency, cleanup reliability, and lifecycle event behavior; task-run wrapper delegates iteration to a shared loop.
  * Added configurable completion-phrase detection to surface completions and mark outcomes as "pending_review" when appropriate.

* **Tests**
  * Added tests covering task-run wrapping, lifecycle callbacks, and returned task result payloads.

* **Documentation**
  * Added an execution-path audit and expanded the deferred backlog with five prioritized follow-up workstreams and clarified task-status notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->