### PR TITLE
Fix project reliability truth adapters and cleanup safety

### DIFF
--- a/context/tasks/runmode-pm-audit.md
+++ b/context/tasks/runmode-pm-audit.md
@@ -118,26 +118,26 @@ But it did reinforce that the next serious reliability work should focus on:
 ## Surgical Edit Checklist
 
 ### 1. `penguin/project/task_executor.py`
-- [ ] Stop flattening nuanced RunMode outcomes into a coarse top-level `status="success"`.
-- [ ] Derive or expose explicit runmode outcome fields (for example `run_mode_status` and `run_mode_completion_type`).
-- [ ] Preserve `run_mode_result` exactly as returned.
-- [ ] Add focused tests for `waiting_input`, `pending_review`, and executor error handling.
+- [x] Stop flattening nuanced RunMode outcomes into a coarse top-level `status="success"`.
+- [x] Derive or expose explicit runmode outcome fields (for example `run_mode_status` and `run_mode_completion_type`).
+- [x] Preserve `run_mode_result` exactly as returned.
+- [x] Add focused tests for `waiting_input`, `pending_review`, and executor error handling.
 
 ### 2. `penguin/core.py`
-- [ ] Harden `start_run_mode(...)` cleanup/failure-path behavior.
-- [ ] Avoid referencing partially-initialized `run_mode` state unsafely in `finally`.
-- [ ] Keep `_runmode_active`, `_runmode_stream_callback`, `_ui_update_callback`, and `_continuous_mode` cleanup honest on early failure.
-- [ ] Add failure-path tests if practical.
+- [x] Harden `start_run_mode(...)` cleanup/failure-path behavior.
+- [x] Avoid referencing partially-initialized `run_mode` state unsafely in `finally`.
+- [x] Keep `_runmode_active`, `_runmode_stream_callback`, `_ui_update_callback`, and `_continuous_mode` cleanup honest on early failure.
+- [x] Add failure-path tests if practical.
 
 ### 3. `penguin/project/workflow_orchestrator.py`
-- [ ] Remove `print()` debug usage and replace with logging.
-- [ ] Review phase/status transitions for flattening or misleading summaries.
-- [ ] Keep `PENDING_REVIEW` / verify semantics explicit.
+- [x] Remove `print()` debug usage and replace with logging.
+- [x] Review phase/status transitions for flattening or misleading summaries.
+- [x] Keep `PENDING_REVIEW` / verify semantics explicit.
 
 ### 4. `penguin/project/validation_manager.py`
-- [ ] Verify current fail-closed behavior still holds.
-- [ ] Identify where evidence/results are still too pytest-centric.
-- [ ] Defer broader VERIFY redesign unless a clearly surgical fix appears.
+- [x] Verify current fail-closed behavior still holds.
+- [x] Identify where evidence/results are still too pytest-centric.
+- [x] Defer broader VERIFY redesign unless a clearly surgical fix appears.
 
 ### 5. Follow-up discipline
 - [ ] Prefer adapter-truth fixes over broad refactors.

--- a/context/tasks/runmode-pm-audit.md
+++ b/context/tasks/runmode-pm-audit.md
@@ -113,3 +113,33 @@ But it did reinforce that the next serious reliability work should focus on:
 - `penguin/project`
 - `core.py` event/status bridging
 - validation maturity
+
+
+## Surgical Edit Checklist
+
+### 1. `penguin/project/task_executor.py`
+- [ ] Stop flattening nuanced RunMode outcomes into a coarse top-level `status="success"`.
+- [ ] Derive or expose explicit runmode outcome fields (for example `run_mode_status` and `run_mode_completion_type`).
+- [ ] Preserve `run_mode_result` exactly as returned.
+- [ ] Add focused tests for `waiting_input`, `pending_review`, and executor error handling.
+
+### 2. `penguin/core.py`
+- [ ] Harden `start_run_mode(...)` cleanup/failure-path behavior.
+- [ ] Avoid referencing partially-initialized `run_mode` state unsafely in `finally`.
+- [ ] Keep `_runmode_active`, `_runmode_stream_callback`, `_ui_update_callback`, and `_continuous_mode` cleanup honest on early failure.
+- [ ] Add failure-path tests if practical.
+
+### 3. `penguin/project/workflow_orchestrator.py`
+- [ ] Remove `print()` debug usage and replace with logging.
+- [ ] Review phase/status transitions for flattening or misleading summaries.
+- [ ] Keep `PENDING_REVIEW` / verify semantics explicit.
+
+### 4. `penguin/project/validation_manager.py`
+- [ ] Verify current fail-closed behavior still holds.
+- [ ] Identify where evidence/results are still too pytest-centric.
+- [ ] Defer broader VERIFY redesign unless a clearly surgical fix appears.
+
+### 5. Follow-up discipline
+- [ ] Prefer adapter-truth fixes over broad refactors.
+- [ ] Add tests before widening scope.
+- [ ] Treat `penguin/project` as the highest-risk area for future trust failures.

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -3295,6 +3295,7 @@ class PenguinCore:
         # Initialize status
         self.current_runmode_status_summary = "Starting RunMode..."
 
+        run_mode = None
         try:
             run_mode = RunMode(
                 self,  # core instance
@@ -3349,7 +3350,9 @@ class PenguinCore:
             self._ui_update_callback = None
 
             # Ensure state is cleaned up if run mode was not continuous or if continuous mode exited
-            if hasattr(run_mode, "continuous_mode") and not run_mode.continuous_mode:
+            if run_mode is None:
+                self._continuous_mode = False
+            elif hasattr(run_mode, "continuous_mode") and not run_mode.continuous_mode:
                 self._continuous_mode = False
 
             logger.info(

--- a/penguin/project/task_executor.py
+++ b/penguin/project/task_executor.py
@@ -68,9 +68,20 @@ class ProjectTaskExecutor:
             changed_by_task = list(set(final_changed_files) - set(initial_changed_files))
             logger.info(f"Task '{task.title}' modified {len(changed_by_task)} files.")
 
+            run_mode_status = run_result.get("status", "unknown") if isinstance(run_result, dict) else "unknown"
+            run_mode_completion_type = (
+                run_result.get("completion_type") if isinstance(run_result, dict) else None
+            )
+            message = (
+                f"Task execution returned RunMode status '{run_mode_status}'."
+                if run_mode_status != "unknown"
+                else "Task execution returned a non-dict RunMode result."
+            )
             return {
-                "status": "success",
-                "message": "Task execution completed by RunMode.",
+                "status": run_mode_status,
+                "message": message,
+                "run_mode_status": run_mode_status,
+                "run_mode_completion_type": run_mode_completion_type,
                 "run_mode_result": run_result,
                 "changed_files": changed_by_task,
             }

--- a/penguin/project/workflow_orchestrator.py
+++ b/penguin/project/workflow_orchestrator.py
@@ -145,6 +145,14 @@ class WorkflowOrchestrator:
             exec_result = await self.task_executor.execute_task(task)
             self._debug(f"Execution result: {exec_result}")
             executor_status = exec_result.get("status")
+            if (
+                executor_status is None
+                or not isinstance(executor_status, str)
+                or executor_status.strip() == ""
+            ):
+                raise ValueError(
+                    f"Malformed executor result for task {task.id} ({task.title}): {exec_result!r}"
+                )
             if executor_status == "error":
                 raise Exception(f"Task execution failed: {exec_result['message']}")
 

--- a/penguin/project/workflow_orchestrator.py
+++ b/penguin/project/workflow_orchestrator.py
@@ -42,16 +42,12 @@ class WorkflowOrchestrator:
         self.git_manager = git_manager
         logger.info("WorkflowOrchestrator initialized.")
 
-        # -----------------------------------------------------------------
-        # Simple debug helper – for now we just use print() so that the
-        # messages are always visible even if logging isn't configured.
-        # -----------------------------------------------------------------
         self._debug_enabled = True
 
     def _debug(self, message: str) -> None:
-        """Print a debug message if debugging is enabled."""
+        """Log a debug message if debugging is enabled."""
         if self._debug_enabled:
-            print(f"[WorkflowOrchestrator DEBUG] {message}")
+            logger.debug("[WorkflowOrchestrator DEBUG] %s", message)
 
     async def _execute_use_recipe(self, recipe: Dict[str, Any]) -> Dict[str, Any]:
         """Execute a minimal usage recipe, currently supporting shell steps only."""
@@ -148,9 +144,26 @@ class WorkflowOrchestrator:
             self._debug("Executing task via ProjectTaskExecutor")
             exec_result = await self.task_executor.execute_task(task)
             self._debug(f"Execution result: {exec_result}")
-            if exec_result["status"] == "error":
+            executor_status = exec_result.get("status")
+            if executor_status == "error":
                 raise Exception(f"Task execution failed: {exec_result['message']}")
-            
+
+            if executor_status not in {"completed", "pending_review", "success"}:
+                logger.info(
+                    "Task '%s' returned non-terminal executor status '%s'; leaving workflow in RUNNING.",
+                    task.title,
+                    executor_status,
+                )
+                return {
+                    "task_id": task.id,
+                    "task_title": task.title,
+                    "status": executor_status,
+                    "message": exec_result.get("message", "Task execution returned a non-terminal status."),
+                    "run_mode_completion_type": exec_result.get("run_mode_completion_type"),
+                    "run_mode_result": exec_result.get("run_mode_result"),
+                    "final_status": TaskStatus.RUNNING.value,
+                }
+
             changed_files = exec_result.get("changed_files", [])
 
             # 3. Reload task and validate the post-execution state.

--- a/tests/test_core_runmode_cleanup.py
+++ b/tests/test_core_runmode_cleanup.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from penguin.core import PenguinCore
+
+
+@pytest.mark.asyncio
+async def test_start_run_mode_cleans_up_when_runmode_construction_fails():
+    core = SimpleNamespace(
+        _ui_update_callback=None,
+        _runmode_stream_callback=None,
+        _runmode_active=False,
+        _continuous_mode=False,
+        current_runmode_status_summary="",
+        run_mode="stale",
+        _prepare_runmode_stream_callback=lambda cb: cb,
+        _handle_run_mode_event=AsyncMock(),
+    )
+
+    with patch("penguin.core.RunMode", side_effect=RuntimeError("init failed")):
+        with pytest.raises(RuntimeError, match="init failed"):
+            await PenguinCore.start_run_mode(core, name="Task")
+
+    assert core._runmode_active is False
+    assert core._runmode_stream_callback is None
+    assert core.run_mode is None
+    assert core._ui_update_callback is None
+    assert core._continuous_mode is False
+    assert "Error starting RunMode" in core.current_runmode_status_summary

--- a/tests/test_project_task_executor_truth.py
+++ b/tests/test_project_task_executor_truth.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from penguin.project.task_executor import ProjectTaskExecutor
+
+
+@pytest.mark.asyncio
+async def test_execute_task_preserves_runmode_status_and_completion_type():
+    task = SimpleNamespace(
+        id="task-1",
+        title="Task title",
+        description="Task description",
+        project_id="project-1",
+        acceptance_criteria=["one"],
+    )
+    git = SimpleNamespace(
+        get_changed_files=MagicMock(side_effect=[[], ["a.py", "b.py"]])
+    )
+    run_mode = SimpleNamespace(
+        start=AsyncMock(
+            return_value={
+                "status": "waiting_input",
+                "completion_type": "clarification_needed",
+                "message": "Need clarification",
+            }
+        )
+    )
+    executor = ProjectTaskExecutor(
+        run_mode=run_mode,
+        project_manager=SimpleNamespace(),
+        git_integration=git,
+    )
+
+    result = await executor.execute_task(task)
+
+    assert result["status"] == "waiting_input"
+    assert result["run_mode_status"] == "waiting_input"
+    assert result["run_mode_completion_type"] == "clarification_needed"
+    assert result["run_mode_result"]["message"] == "Need clarification"
+    assert sorted(result["changed_files"]) == ["a.py", "b.py"]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_returns_error_on_executor_failure():
+    task = SimpleNamespace(
+        id="task-1",
+        title="Task title",
+        description="Task description",
+        project_id="project-1",
+        acceptance_criteria=[],
+    )
+    git = SimpleNamespace(get_changed_files=MagicMock(return_value=[]))
+    run_mode = SimpleNamespace(start=AsyncMock(side_effect=RuntimeError("boom")))
+    executor = ProjectTaskExecutor(
+        run_mode=run_mode,
+        project_manager=SimpleNamespace(),
+        git_integration=git,
+    )
+
+    result = await executor.execute_task(task)
+
+    assert result["status"] == "error"
+    assert "boom" in result["message"]

--- a/tests/test_workflow_orchestrator_truth.py
+++ b/tests/test_workflow_orchestrator_truth.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from penguin.project.models import TaskPhase, TaskStatus
+from penguin.project.workflow_orchestrator import WorkflowOrchestrator
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_returns_waiting_input_without_validation():
+    task = SimpleNamespace(
+        id="task-1",
+        title="Task 1",
+        recipe=None,
+    )
+    project_manager = MagicMock()
+    project_manager.get_next_task_async = AsyncMock(return_value=task)
+    project_manager.update_task_status = MagicMock(return_value=True)
+    project_manager.update_task_phase_async = AsyncMock()
+    project_manager.get_task = MagicMock(return_value=SimpleNamespace(status=TaskStatus.RUNNING))
+
+    task_executor = SimpleNamespace(
+        execute_task=AsyncMock(
+            return_value={
+                "status": "waiting_input",
+                "message": "Need clarification",
+                "run_mode_completion_type": "clarification_needed",
+                "run_mode_result": {
+                    "status": "waiting_input",
+                    "completion_type": "clarification_needed",
+                },
+                "changed_files": [],
+            }
+        )
+    )
+    validation_manager = SimpleNamespace(validate_task_completion=AsyncMock())
+    git_manager = SimpleNamespace(create_pr_for_task=AsyncMock())
+    orchestrator = WorkflowOrchestrator(
+        project_manager=project_manager,
+        task_executor=task_executor,
+        validation_manager=validation_manager,
+        git_manager=git_manager,
+    )
+
+    result = await orchestrator.run_next_task(project_id="project-1")
+
+    assert result["status"] == "waiting_input"
+    assert result["final_status"] == TaskStatus.RUNNING.value
+    assert result["run_mode_completion_type"] == "clarification_needed"
+    validation_manager.validate_task_completion.assert_not_called()
+    git_manager.create_pr_for_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_returns_executor_error_without_revalidation():
+    task = SimpleNamespace(
+        id="task-1",
+        title="Task 1",
+        recipe=None,
+    )
+    project_manager = MagicMock()
+    project_manager.get_next_task_async = AsyncMock(return_value=task)
+    project_manager.update_task_status = MagicMock(return_value=True)
+    project_manager.update_task_phase_async = AsyncMock()
+    project_manager.get_task = MagicMock(return_value=SimpleNamespace(status=TaskStatus.RUNNING))
+
+    task_executor = SimpleNamespace(
+        execute_task=AsyncMock(
+            return_value={
+                "status": "error",
+                "message": "Critical executor error: boom",
+            }
+        )
+    )
+    validation_manager = SimpleNamespace(validate_task_completion=AsyncMock())
+    git_manager = SimpleNamespace(create_pr_for_task=AsyncMock())
+    orchestrator = WorkflowOrchestrator(
+        project_manager=project_manager,
+        task_executor=task_executor,
+        validation_manager=validation_manager,
+        git_manager=git_manager,
+    )
+
+    result = await orchestrator.run_next_task(project_id="project-1")
+
+    assert result["final_status"] == "FAILED"
+    validation_manager.validate_task_completion.assert_not_called()
+    git_manager.create_pr_for_task.assert_not_called()

--- a/tests/test_workflow_orchestrator_truth.py
+++ b/tests/test_workflow_orchestrator_truth.py
@@ -87,3 +87,36 @@ async def test_orchestrator_returns_executor_error_without_revalidation():
     assert result["final_status"] == "FAILED"
     validation_manager.validate_task_completion.assert_not_called()
     git_manager.create_pr_for_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_raises_on_malformed_executor_status():
+    task = SimpleNamespace(
+        id="task-1",
+        title="Task 1",
+        recipe=None,
+    )
+    project_manager = MagicMock()
+    project_manager.get_next_task_async = AsyncMock(return_value=task)
+    project_manager.update_task_status = MagicMock(return_value=True)
+    project_manager.update_task_phase_async = AsyncMock()
+    project_manager.get_task = MagicMock(return_value=SimpleNamespace(status=TaskStatus.RUNNING))
+
+    task_executor = SimpleNamespace(
+        execute_task=AsyncMock(return_value={"status": "", "message": "bad payload"})
+    )
+    validation_manager = SimpleNamespace(validate_task_completion=AsyncMock())
+    git_manager = SimpleNamespace(create_pr_for_task=AsyncMock())
+    orchestrator = WorkflowOrchestrator(
+        project_manager=project_manager,
+        task_executor=task_executor,
+        validation_manager=validation_manager,
+        git_manager=git_manager,
+    )
+
+    result = await orchestrator.run_next_task(project_id="project-1")
+
+    assert result["final_status"] == "FAILED"
+    assert "Malformed executor result" in result["error"]
+    validation_manager.validate_task_completion.assert_not_called()
+    git_manager.create_pr_for_task.assert_not_called()


### PR DESCRIPTION
## Summary\n- preserve nuanced RunMode outcomes in  instead of flattening everything to success\n- harden  cleanup on early failure\n- preserve non-terminal executor outcomes like  in \n- replace orchestrator print-debug with logging and add focused regression tests\n- record the deeper RunMode/PM stack audit and surgical checklist\n\n## Testing\n- pytest -q tests/test_project_task_executor_truth.py tests/test_core_runmode_cleanup.py tests/test_workflow_orchestrator_truth.py tests/test_runmode_project_completion.py tests/test_runmode_clarification_handling.py tests/api/test_penguin_api_surface.py\n\n## Notes\n-  was reviewed but intentionally deferred; it needs a broader VERIFY/formal-verification pass rather than a fake surgical redesign here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust cleanup on failed run initialization and safer handling of partial failures.
  * Defensive handling of malformed executor results to avoid silent failures.

* **New Features**
  * More granular execution reporting including explicit run-mode status and completion type.
  * Improved handling of intermediate task states (waiting for input, pending review).

* **Tests**
  * Added tests for run-mode failure cleanup, executor error paths, and orchestrator status handling.

* **Documentation**
  * Added a surgical checklist to the runmode audit document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->