### PR TITLE
feat: add project bootstrap workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,18 @@ Commands
 - Full repo tests (legacy/misc): python run_all_tests.py ; python misc/run_all_memory_tests.py
 - Build wheel/sdist: python -m build
 - Publish (manual): twine upload dist/*
-- Dev web server: PORT=8080 uv run penguin-web
-- Dev web server with reload: PORT=8080 DEBUG=true uv run penguin-web
+- Dev web server: HOST=127.0.0.1 PORT=8080 uv run penguin-web
+- Dev web server with reload: HOST=127.0.0.1 PORT=8080 DEBUG=true uv run penguin-web
 - TUI against dev web server: uv run penguin --url http://127.0.0.1:8080 --no-web-autostart
+- If port `9000` is already occupied by a running Penguin backend/TUI session, use a different non-reserved local port for testing or verification, e.g. `8080` or `9010`.
+- Per `docs/docs/usage/web_interface.md`, port `9000` is the documented/default Penguin web server port, so treat it as the primary runtime port and avoid stealing it for ad hoc verification when a real backend is already running.
+- Current runtime truth: `penguin-web` host/port selection is reliably controlled by env vars (`HOST` / `PORT`). Do not assume `penguin-web --host ... --port ...` works until that path is explicitly fixed and verified.
 
 Style and Conventions
 - Follow .cursorrules at repo root. Key points: PEP 8, explicit > implicit, single responsibility, comprehensive type annotations, Google-style docstrings, robust exception handling, logging.
 - Imports: ruff/isort with profile=black; order stdlib, third-party, first-party (penguin). Combine "as" imports; known-first-party = ["penguin"].
 - Formatting: Black 88 col; Ruff line-length 88; quotes = double (ruff fmt). Target Python 3.9+ (ruff target 3.8, black target py39).
-- Types: annotate all public functions and dataclasses; prefer precise types (dict[str, Any] over Dict). Use Pydantic models where appropriate.
+- Types: annotate all public functions and dataclasses; prefer precise types (dict[str, Any] over Dict). Use Pydantic types where appropriate.
 - Naming Penguin: Just call it "Penguin", not "Penguin AI", or "Penguin AI Assistant". In some cases "Penguin Agent" are reasonable though.
 - Naming: snake_case for functions/vars; PascalCase for classes; UPPER_SNAKE for constants; clear, descriptive names.
 - Errors: raise specific exceptions, no bare except; add context; never swallow; log via logging with appropriate level.

--- a/context/TASK_SCRATCHPAD.md
+++ b/context/TASK_SCRATCHPAD.md
@@ -1,0 +1,6 @@
+# TUI Project Command Bugfix Scratchpad
+
+- Update `context/tasks/project-bootstrap-workflow.md` with file-level checklist.
+- Extract a small Penguin local/project command parser helper.
+- Move command detection ahead of session creation in TUI prompt submit flow.
+- Add regression tests for no session bootstrap / no navigation / alias parsing.

--- a/context/tasks/codex-integration-parity.md
+++ b/context/tasks/codex-integration-parity.md
@@ -1,0 +1,225 @@
+# Codex Integration Parity
+
+## Purpose
+
+This document tracks the remaining parity gaps between Penguin's
+ChatGPT-backed OpenAI/Codex integration and the upstream Codex client.
+
+The goal is not to clone Codex wholesale. The goal is to identify the request
+parameters, catalog metadata, and runtime behaviors that materially improve
+model access, latency, reliability, and tool-call behavior in Penguin.
+
+## Current State
+
+Penguin can authenticate against ChatGPT-backed Codex OAuth and route requests
+to the Codex responses endpoint.
+
+Recent fixes made the integration usable with the authenticated Codex model
+catalog, including latest model discovery and lowercase model IDs such as
+`gpt-5.5`.
+
+The remaining gaps are mostly request shaping and runtime/tool behavior.
+
+## Reference Points
+
+- Upstream Codex request construction:
+  `reference/codex/codex-rs/core/src/client.rs`
+- Upstream Codex model metadata:
+  `reference/codex/codex-rs/protocol/src/openai_models.rs`
+- Penguin Codex OAuth request construction:
+  `penguin/llm/adapters/openai.py`
+- Penguin model catalog merge path:
+  `penguin/web/services/provider_catalog.py`
+  `penguin/web/services/opencode_provider.py`
+
+## Parity Gaps
+
+### 1. Service Tier / Fast Mode
+
+Codex supports Fast mode for supported ChatGPT-backed models. In the upstream
+client, the local `ServiceTier::Fast` setting is sent to the Responses payload
+as:
+
+```json
+{"service_tier": "priority"}
+```
+
+Penguin currently does not pass `service_tier` in the Codex OAuth request
+payload.
+
+Expected Penguin behavior:
+
+- expose a safe config/UI setting for standard vs fast
+- only offer fast when the selected model advertises a fast speed tier
+- send `service_tier: "priority"` for fast mode
+- omit `service_tier` for standard mode
+- make the higher credit consumption clear in UI copy
+
+### 2. Prompt Cache Key
+
+Codex sends a stable `prompt_cache_key` based on the conversation id.
+
+Penguin currently does not send `prompt_cache_key` for ChatGPT-backed Codex
+requests.
+
+Expected Penguin behavior:
+
+- use a stable session/conversation id as `prompt_cache_key`
+- preserve the same key across a conversation
+- avoid leaking filesystem paths or sensitive local details into the key
+
+This is likely a low-risk latency/cache efficiency improvement.
+
+### 3. Model Capability Gating
+
+Codex model metadata includes capabilities such as:
+
+- supported reasoning efforts
+- support for reasoning summaries
+- support for verbosity
+- default verbosity
+- support for parallel tool calls
+- additional speed tiers
+
+Penguin currently consumes enough catalog data to show and select models, but
+does not fully use these model capabilities to shape every request.
+
+Expected Penguin behavior:
+
+- preserve capability metadata from the authenticated Codex catalog
+- gate request parameters by model capability
+- avoid sending unsupported parameters
+- surface unavailable controls as disabled rather than silently ignoring them
+
+### 4. Verbosity / Text Options
+
+Codex can build a Responses `text` parameter from model verbosity and output
+schema settings when the selected model supports it.
+
+Penguin supports response-format style options in some paths, but does not
+currently expose Codex-style model verbosity for ChatGPT-backed Codex requests.
+
+Expected Penguin behavior:
+
+- add optional `verbosity` support only for models that advertise it
+- avoid applying verbosity globally to providers that do not support it
+- keep structured output behavior separate from verbosity controls
+
+### 5. Parallel Tool Calls
+
+Codex passes `parallel_tool_calls` when the model and tool runtime can support
+it.
+
+Penguin currently does not request parallel tool calls for Codex OAuth traffic.
+This should not be enabled blindly. It depends on Penguin's tool runtime being
+able to execute, stream, order, persist, and recover from concurrent tool calls.
+
+Expected Penguin behavior:
+
+- first harden tool execution and result persistence
+- then enable `parallel_tool_calls` only for safe tool subsets
+- gate by model capability and Penguin runtime capability
+- keep a conservative default until the tool loop is proven stable
+
+### 6. Client Metadata / Installation Identity
+
+Codex sends client metadata such as `x-codex-installation-id`.
+
+Penguin sends its own lightweight headers, including `originator: penguin`, but
+does not mirror the upstream client metadata.
+
+Expected Penguin behavior:
+
+- decide whether Penguin needs a stable local installation id
+- avoid adding identifiers unless they provide diagnostics or upstream behavior
+  benefits
+- keep any identifier non-sensitive and resettable
+
+This is lower priority than service tier, caching, and tool-loop correctness.
+
+### 7. WebSocket / Incremental Request Path
+
+Codex has a WebSocket path with incremental request reuse. Penguin currently
+uses HTTP SSE for ChatGPT-backed Codex responses.
+
+Expected Penguin behavior:
+
+- keep SSE as the correctness baseline
+- consider WebSocket/incremental transport only after request parity and tool
+  runtime stability are addressed
+- treat this as a performance optimization, not a first-order feature gap
+
+### 8. Tool Runtime Parity
+
+Codex's model integration is tightly coupled to its tool contracts, tool output
+shaping, truncation behavior, diff tracking, approval flow, and loop control.
+
+Penguin currently has a separate tool/runtime stack. Recent observed behavior
+shows a useful but over-aggressive guard:
+
+- the model made repeated empty tool-only turns
+- the tool output began with the same content
+- Penguin classified the sequence as a repeated stale loop
+- the task stopped after the empty tool-only threshold
+
+This appears to be a Penguin runtime/tool-loop issue rather than an OpenAI
+Codex model issue.
+
+Expected Penguin behavior:
+
+- fix any read-tool bugs first
+- include tool name, arguments, path, range, and output identity in repeated
+  tool-only loop signatures
+- distinguish legitimate exploration from stale repeated output
+- tune thresholds by mode when needed
+- surface continuation affordances when the guard stops a run
+
+## Suggested Implementation Order
+
+### Phase 1: Low-Risk Request Parity
+
+1. Add `service_tier` config plumbing for ChatGPT-backed Codex.
+2. Gate fast mode by authenticated model metadata.
+3. Add stable `prompt_cache_key` based on session/conversation id.
+4. Add focused tests for payload construction.
+
+### Phase 2: Catalog Capability Propagation
+
+1. Preserve Codex model capability fields in Penguin's provider catalog.
+2. Expose speed-tier and verbosity metadata to the UI/TUI provider surface.
+3. Gate unavailable controls from the catalog rather than hardcoded model names.
+
+### Phase 3: Tool Loop Hardening
+
+1. Audit the read tool for repeated/range/limit behavior.
+2. Fix repeated empty tool-only detection to account for arguments and file
+   ranges.
+3. Add regression tests for repeated file reads with different limits/ranges.
+4. Improve user-facing continuation behavior after guarded stops.
+
+### Phase 4: Advanced Runtime Parity
+
+1. Add verbosity support for models that advertise it.
+2. Evaluate `parallel_tool_calls` with a restricted safe tool set.
+3. Consider WebSocket/incremental transport only if SSE latency remains a real
+   bottleneck.
+
+## Non-Goals
+
+- Do not make Penguin depend on Codex internals directly.
+- Do not enable parallel tool calls before the tool runtime can safely support
+  them.
+- Do not mirror upstream client metadata unless it has a clear benefit.
+- Do not hardcode latest model names where authenticated catalog metadata can
+  answer the question.
+
+## Open Questions
+
+- Should fast mode be a global provider setting, a per-session setting, or a
+  per-request variant?
+- Should standard mode explicitly send a null/standard value, or simply omit
+  `service_tier`?
+- Should Penguin expose Codex-Spark as a separate model choice only, or also
+  provide speed-oriented UI grouping?
+- Which Penguin tools are safe candidates for eventual parallel tool calls?
+- Should the repeated empty tool-only guard be configurable per mode?

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -119,6 +119,112 @@ Recommended rule:
 
 That keeps the nice UX without turning project selection into roulette.
 
+
+## Canonical Contract Summary
+
+This section is the current recommended mental model for how Blueprint, project bootstrap, project execution, and ITUV ownership should fit together.
+
+### Blueprint Ownership
+
+The Blueprint is a **declarative work specification**.
+It should define:
+- project/task metadata
+- dependencies / DAG shape
+- acceptance criteria
+- recipes for the USE gate
+- ITUV defaults and timeboxes
+- routing hints / skills / required tools where relevant
+
+The Blueprint should **not** be treated as the live execution engine.
+Its job is to describe the work graph, not to execute it.
+
+### PM-System Ownership
+
+Once a Blueprint is imported, the source of truth should become the **project/task management system**.
+That runtime/project state should own:
+- projects
+- tasks / subtasks
+- dependencies
+- readiness / frontier selection
+- task status
+- task phase
+- clarification state
+- artifacts / evidence / validation outputs
+
+In other words:
+- Blueprint declares the intended work graph
+- the PM system holds the live operational truth
+
+### `project init` Contract
+
+`project init` should:
+- create the project shell
+- parse/import Blueprint or spec input
+- sync tasks and dependencies into the PM system
+- validate import honesty
+- fail/rollback on malformed, empty, or invalid imports
+
+`project init` should **not** start execution.
+
+Mental model:
+> Prepare the work graph.
+
+### `project start` Contract
+
+`project start` should:
+- resolve an **existing project**
+- inspect the ready frontier from PM-system state
+- execute against the real project/runtime truth path
+- preserve clarification / waiting / time-limit / no-ready-work truth
+- use the stored project/task graph rather than reparsing the Blueprint
+
+`project start` should be the **primary user-facing execution command** in the TUI.
+
+Mental model:
+> Run this existing project.
+
+### `project run` Status
+
+Current understanding after the audit:
+- `project run` is historically broader and more ambiguous than `project start`
+- the old CLI path appears to combine spec parsing, project creation, and a heavier orchestration/validation workflow
+- that path is currently drifted enough that it should not be treated as the clean parity target for this PR
+
+For this PR, `project run` should be treated as **legacy / deferred** unless and until it is repaired and redefined around a crisp cross-surface contract.
+
+The current preferred product flow is:
+1. `project init`
+2. `project start`
+
+### ITUV Ownership
+
+ITUV should be understood as split across declaration and execution:
+- Blueprint declares ITUV intent, defaults, recipes, and acceptance expectations
+- the PM/runtime system enforces and records ITUV transitions in live execution
+
+That means ITUV does **not** live only in the Blueprint.
+It becomes meaningful when the project/task lifecycle is instantiated in the PM system and advanced through runtime execution.
+
+### Recommended Product Flow
+
+The cleanest user-facing story is:
+
+1. author or choose a Blueprint/spec
+2. run `project init`
+3. inspect the created project/tasks if needed
+4. run `project start`
+5. observe clarification / waiting / review / completion truth from the runtime
+
+This keeps import/bootstrap concerns separate from execution concerns and reduces command overlap.
+
+### Implication for This PR
+
+For the current PR, the highest-leverage target is:
+- make `project init` excellent
+- make `project start` excellent
+- make web/API/TUI parity excellent around those two commands
+- defer treating `project run` as a first-class user-facing command until its contract is repaired and made consistent
+
 ## Why This Workflow Matters
 
 This workflow is compelling because it compresses a lot of power into a tiny command surface:
@@ -445,15 +551,33 @@ The order matters. Backend parity comes before TUI parity, because the TUI canno
 
 #### Step 2 — Audit and Define `project run` vs `project start`
 
+**Clarified framing:**
+- The goal is **not** to make web/API or TUI intentionally weaker than the CLI.
+- The goal is to achieve **true parity** across CLI, web/API, TUI, and Link where practical.
+- `project start` is already a relatively clear contract: run an **existing project** through the current RunMode/project execution truth path.
+- `project run` is the confusing one. The open question is **not** whether web/API should get it; web/API should. The question is whether `project run` should mean the **same thing everywhere**, and if so, what that thing exactly is.
+- The current risk is semantic drift:
+  - CLI `project run` still looks like a heavier orchestration/workflow macro involving spec parsing, task-by-task orchestration, validation, and PR creation.
+  - The new web route currently behaves more like **spec/bootstrap + start**.
+- That mismatch is not acceptable long-term if parity is the goal.
+
 ##### `penguin/cli/cli.py`
 - [ ] Audit the exact current behavior of `project run` versus `project start`.
-- [ ] Document whether `run` is a bootstrap/workflow macro and `start` is the RunMode execution path.
-- [ ] Identify any stale assumptions or overlapping semantics that would make the web/TUI surface confusing.
+- [ ] Confirm whether `run` is currently a broader project/workflow macro while `start` is the RunMode execution path.
+- [ ] Identify stale assumptions or overlapping semantics that would make the web/TUI/Link surface confusing.
 
 ##### `penguin/project/` runtime/orchestration files
-- [ ] Trace which subsystems each command actually hits (`RunMode`, workflow orchestrator, spec parser, validation, task executor).
-- [ ] Decide whether `project run` deserves a first-class web/TUI surface or should remain a more advanced/API-facing operation.
-- [ ] Record the distinction in this doc once confirmed.
+- [ ] Trace which subsystems each command actually hits (`RunMode`, workflow orchestrator, spec parser, validation, task executor, git/PR path).
+- [ ] Decide what the authoritative cross-surface contract should be for `project run`.
+- [ ] If parity is the goal, either:
+  - [ ] lift the web/API `project run` surface up to the real CLI/kernel behavior, or
+  - [ ] intentionally simplify/redefine CLI `project run` so all surfaces converge on the same truth.
+- [ ] Record the distinction and decision in this doc once confirmed.
+
+##### Product / Surface Constraint
+- [ ] Keep `project start` as the primary user-facing execution UX in the TUI.
+- [ ] Still give web/API full access to `project run` if the kernel supports it.
+- [ ] Do **not** ship two verbs with fuzzy overlap across surfaces. If both verbs exist, users and APIs must be able to rely on a crisp distinction.
 
 #### Step 3 — Expand the TUI Surface to Match the Real Backend
 

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -575,24 +575,25 @@ The order matters. Backend parity comes before TUI parity, because the TUI canno
 - [ ] Record the distinction and decision in this doc once confirmed.
 
 ##### Product / Surface Constraint
-- [ ] Keep `project start` as the primary user-facing execution UX in the TUI.
-- [ ] Still give web/API full access to `project run` if the kernel supports it.
+- [x] Keep `project start` as the primary user-facing execution UX in the TUI.
+- [x] Keep `project run` out of the TUI for this PR while its cross-surface contract remains legacy/deferred.
+- [x] Add provisional comments around the web/API `project run` route so it is not mistaken for the preferred TUI/product path.
 - [ ] Do **not** ship two verbs with fuzzy overlap across surfaces. If both verbs exist, users and APIs must be able to rely on a crisp distinction.
 
 #### Step 3 — Expand the TUI Surface to Match the Real Backend
 
 ##### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
-- [ ] Add discoverable project commands for the full backend-supported project surface.
-- [ ] Keep `project start` as the primary user-facing execution UX.
-- [ ] Add discoverable task commands once task web/API parity exists.
-- [ ] Keep prefill-vs-direct-execution behavior intentional and consistent with upstream OpenCode patterns.
-- [ ] Ensure success/failure feedback is explicit enough to be believable for users.
+- [x] Add discoverable project commands for the backend-supported project surface, excluding deferred `project run`.
+- [x] Keep `project start` as the primary user-facing execution UX.
+- [x] Add discoverable task commands once task web/API parity exists.
+- [x] Keep prefill-vs-direct-execution behavior intentional and consistent with upstream OpenCode patterns.
+- [x] Ensure success/failure feedback is explicit enough to be believable for users.
 
 ##### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts`
-- [ ] Extend the parser to cover all backend-supported project commands.
-- [ ] Extend the parser to cover all backend-supported task commands.
-- [ ] Keep this file the single source of truth for slash command parsing and aliases.
-- [ ] Avoid drift between command palette entries and submit-path parsing.
+- [x] Extend the parser to cover all backend-supported project commands, excluding deferred `project run`.
+- [x] Extend the parser to cover all backend-supported task commands.
+- [x] Keep this file the single source of truth for slash command parsing and aliases.
+- [x] Avoid drift between command palette entries and submit-path parsing.
 
 #### Step 4 — Strong Backend + TUI Tests
 

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -604,10 +604,10 @@ The order matters. Backend parity comes before TUI parity, because the TUI canno
 - [ ] Keep error/precondition coverage honest, especially for ambiguous identifiers and missing resources.
 
 ##### `penguin-tui/packages/opencode/test/cli/tui/`
-- [ ] Add submit-path tests proving each exposed project command hits the correct backend endpoint.
-- [ ] Add submit-path tests proving each exposed task command hits the correct backend endpoint.
+- [x] Add submit-path/runtime-helper tests proving each exposed project command hits the correct backend endpoint.
+- [x] Add submit-path/runtime-helper tests proving each exposed task command hits the correct backend endpoint.
 - [ ] Keep no-session-bootstrap and no-navigation guarantees for local/project/task commands from home.
-- [ ] Assert visible success/failure feedback for command execution.
+- [x] Assert visible success/failure feedback for command execution through command-result coverage.
 - [ ] Keep both dashed and spaced aliases covered where supported.
 
 #### Step 5 — Final Docs / Branch Verification / PR Readiness

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -316,18 +316,29 @@ A first version of this workflow is good enough when:
 
 ## File-Level Implementation Checklist
 
-### Current TUI Bugfix Scope
+### Completed Bootstrap / Runtime Hardening
 
-This checklist covers the current `penguin-tui` bug where local/project commands can
-accidentally create and navigate into a new session when submitted from home.
+#### `penguin/web/server.py`
+- [x] Make `penguin-web --host <HOST> --port <PORT>` actually work
+- [x] Keep env-based `HOST` / `PORT` overrides working
+- [x] Ensure startup path resolves a truthful bound host/port configuration
 
-This is intentionally narrower than the broader bootstrap workflow UX.
-The immediate fix is:
-- parse command intent before session creation
-- execute local/project commands without chat/session bootstrap
-- preserve current chat behavior for real prompts
+#### `penguin/web/services/projects.py`
+- [x] Treat malformed / effectively empty Blueprint imports as honest bootstrap failures with rollback
+- [x] Preserve rollback behavior for lint-error cases like duplicate task IDs and dependency cycles
+- [x] Keep response payloads explicit about why initialization failed
+- [x] Preserve current real RunMode wiring for actual `project start` execution
 
-### Files
+#### `penguin/project/blueprint_parser.py`
+- [x] Tighten malformed frontmatter / underspecified Blueprint shape handling
+- [x] Reject clearly broken Blueprint roots, task collections, and task entries instead of degrading into empty successful imports
+
+#### `tests/` bootstrap/runtime coverage
+- [x] Add regression tests for malformed Blueprint rollback
+- [x] Add regression tests for empty/no-task Blueprint rollback
+- [x] Add deterministic tests for successful `project start` request/response shape with mocked or controlled runtime execution
+
+### Completed TUI Bugfix Slice
 
 #### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
 - [x] Move Penguin local/project command detection ahead of session creation in `submit()`
@@ -351,18 +362,144 @@ The immediate fix is:
 - [x] Add parser/submit regression tests for Penguin local/project commands
 - [x] Assert home-screen local/project commands do **not** require session bootstrap
 - [x] Assert home-screen local/project commands do **not** trigger session navigation
-- [ ] Assert project commands route to the correct backend endpoints
 - [x] Assert both dashed and spaced forms parse equivalently
 
-### Explicit Non-Goals For This Patch
-- [x] Do **not** require command-palette discoverability in the same bugfix commit
-- [x] Do **not** redesign project feedback/UI beyond current minimal success/error reporting
-- [x] Do **not** broaden this into a general TUI command-architecture rewrite
+### Remaining Work For A Full Bootstrap/TUI PR
 
-### Acceptance Criteria For This TUI Slice
-- [x] From home, `/project init ...` does not create a session
-- [x] From home, `/project start ...` does not create a session
-- [x] From home, `/settings`, `/config`, `/thinking`, and `/tool_details` do not create a session
+This branch is no longer just a kernel/runtime hardening slice. If the PR is going to claim that project bootstrap works for users, the TUI surface has to expose and prove the feature honestly.
+
+#### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
+- [ ] Add first-class command palette/discoverability entries for project bootstrap actions instead of relying on hidden slash-command knowledge alone
+- [ ] Ensure project command execution emits user-visible success/failure feedback that is explicit enough to be believable in normal use
+- [ ] Decide whether project-command success should also refresh relevant project/session state in-place, not just show a toast
+
+#### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts`
+- [ ] Keep project command parsing as the single source of truth for both slash submission and any command-palette/project-action entrypoint
+- [ ] Avoid introducing duplicated syntax rules between prompt submit flow and palette actions
+- [ ] If palette actions prefill prompts instead of directly executing, document that as an intentional UX choice
+
+#### `penguin-tui/packages/opencode/test/cli/tui/`
+- [ ] Assert project commands route to the correct backend endpoints from the real submit path
+- [ ] Assert both dashed and spaced forms route equivalently through the submit path
+- [ ] Assert success/failure feedback is surfaced for project init/start command execution
+- [ ] Keep no-session-bootstrap and no-navigation guarantees intact while adding discoverability coverage
+
+#### `docs/docs/usage/web_interface.md`
+- [ ] Reconcile docs with the now-fixed `penguin-web --host/--port` CLI behavior
+- [ ] Keep the `9000` default/runtime-port guidance explicit while making alternate-port testing guidance honest
+
+#### `AGENTS.md`
+- [ ] Reconcile the temporary “prefer env vars because CLI flags are inaccurate” note with the now-fixed server behavior
+- [ ] Keep the warning that `9000` is Penguin's primary/default runtime port and should not be casually hijacked for ad hoc verification
+
+#### Merged-Branch Verification
+- [ ] Re-run the relevant TUI tests on the merged `project-bootstrap-workflow` branch
+- [ ] Re-run `bun run typecheck` for `penguin-tui`
+- [ ] Re-run targeted Python/web/bootstrap tests on the merged branch:
+  - [ ] `pytest tests/test_web_server.py -q`
+  - [ ] `pytest tests/test_blueprint_linter.py -q`
+  - [ ] `pytest tests/api/test_web_routes_task_shapes.py -q`
+
+### Next Phase: Full Web/API + TUI Parity Checklist
+
+This is the remaining implementation map for a **full feature/system overhaul PR**.
+The order matters. Backend parity comes before TUI parity, because the TUI cannot honestly expose commands that the web/API does not support.
+
+#### Step 1A — Project Web/API Parity
+
+##### `penguin/web/routes.py`
+- [ ] Add a real web route for project create.
+- [ ] Add a real web route for project delete.
+- [ ] Add a real web route for project run.
+- [ ] Keep existing project routes (`list`, `get`, `init`, `start`) aligned with the same request/response conventions.
+- [ ] Ensure route naming and HTTP verbs are honest and resource-shaped where practical.
+
+##### `penguin/web/services/projects.py`
+- [ ] Extract or add service functions for project create/delete/run so route handlers stay thin.
+- [ ] Keep project start on the real RunMode truth path.
+- [ ] Make delete semantics explicit and safe.
+- [ ] Make run semantics explicit instead of letting them remain fuzzy CLI-only behavior.
+- [ ] Normalize success/error payload shape across create/init/start/run/delete.
+
+##### project request/response schema location(s)
+- [ ] Add or update request models for project create/delete/run.
+- [ ] Keep response payloads explicit enough for TUI feedback.
+- [ ] Avoid creating route-only ad hoc payloads that drift from service truth.
+
+#### Step 1B — Task Web/API Parity
+
+##### `penguin/web/routes.py`
+- [ ] Add honest task routes for create/list/start/complete/delete if they are missing or incomplete.
+- [ ] Keep task routes aligned with current task lifecycle truth (`status`, `phase`, review state, clarification where relevant).
+- [ ] Prefer resource-shaped route conventions over scattered RPC-style naming where practical.
+
+##### `penguin/web/services/tasks.py` or `penguin/web/services/projects.py`
+- [ ] Put task business logic in services, not route bodies.
+- [ ] Keep task start/complete semantics aligned with current project/task lifecycle rules.
+- [ ] Ensure delete behavior is explicit and tested.
+- [ ] Keep payload shapes consistent with the project/task APIs already exposed elsewhere.
+
+##### task request/response schema location(s)
+- [ ] Add or update request models for task create/start/complete/delete.
+- [ ] Ensure list responses expose enough task truth for the TUI to render believable feedback.
+
+#### Step 2 — Audit and Define `project run` vs `project start`
+
+##### `penguin/cli/cli.py`
+- [ ] Audit the exact current behavior of `project run` versus `project start`.
+- [ ] Document whether `run` is a bootstrap/workflow macro and `start` is the RunMode execution path.
+- [ ] Identify any stale assumptions or overlapping semantics that would make the web/TUI surface confusing.
+
+##### `penguin/project/` runtime/orchestration files
+- [ ] Trace which subsystems each command actually hits (`RunMode`, workflow orchestrator, spec parser, validation, task executor).
+- [ ] Decide whether `project run` deserves a first-class web/TUI surface or should remain a more advanced/API-facing operation.
+- [ ] Record the distinction in this doc once confirmed.
+
+#### Step 3 — Expand the TUI Surface to Match the Real Backend
+
+##### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
+- [ ] Add discoverable project commands for the full backend-supported project surface.
+- [ ] Keep `project start` as the primary user-facing execution UX.
+- [ ] Add discoverable task commands once task web/API parity exists.
+- [ ] Keep prefill-vs-direct-execution behavior intentional and consistent with upstream OpenCode patterns.
+- [ ] Ensure success/failure feedback is explicit enough to be believable for users.
+
+##### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts`
+- [ ] Extend the parser to cover all backend-supported project commands.
+- [ ] Extend the parser to cover all backend-supported task commands.
+- [ ] Keep this file the single source of truth for slash command parsing and aliases.
+- [ ] Avoid drift between command palette entries and submit-path parsing.
+
+#### Step 4 — Strong Backend + TUI Tests
+
+##### `tests/api/`
+- [ ] Add route/service coverage for project create/delete/run.
+- [ ] Add route/service coverage for task create/list/start/complete/delete.
+- [ ] Add deterministic tests for any non-trivial RunMode-backed project/task operation.
+- [ ] Keep error/precondition coverage honest, especially for ambiguous identifiers and missing resources.
+
+##### `penguin-tui/packages/opencode/test/cli/tui/`
+- [ ] Add submit-path tests proving each exposed project command hits the correct backend endpoint.
+- [ ] Add submit-path tests proving each exposed task command hits the correct backend endpoint.
+- [ ] Keep no-session-bootstrap and no-navigation guarantees for local/project/task commands from home.
+- [ ] Assert visible success/failure feedback for command execution.
+- [ ] Keep both dashed and spaced aliases covered where supported.
+
+#### Step 5 — Final Docs / Branch Verification / PR Readiness
+
+##### `docs/docs/usage/web_interface.md`
+- [ ] Reconcile the docs with the final web/API project/task command surface.
+- [ ] Keep the `9000` default/runtime-port guidance explicit.
+
+##### `AGENTS.md`
+- [ ] Reconcile temporary notes with the now-fixed server CLI behavior.
+- [ ] Keep the warning about not casually hijacking `9000` for ad hoc testing.
+
+##### merged branch verification
+- [ ] Re-run the relevant TUI tests on the merged `project-bootstrap-workflow` branch.
+- [ ] Re-run `bun run typecheck` for `penguin-tui`.
+- [ ] Re-run targeted Python/web/bootstrap/project/task tests on the merged branch.
+- [ ] Open the PR only after the exposed TUI commands correspond to real backend support.
 
 - `context/tasks/cli-surface-audit.md`
   - CLI surface drift and immediate correctness fixes

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -311,7 +311,7 @@ A first version of this workflow is good enough when:
 - [ ] Consider a controlled verification seam for tests so success-path web checks do not depend on a live provider call.
 
 #### `tests/` web/project-start coverage
-- [ ] Add deterministic tests for successful `project start` request/response shape with mocked or controlled runtime execution.
+- [x] Add deterministic tests for successful `project start` request/response shape with mocked or controlled runtime execution.
 - [ ] Keep precondition coverage for missing project and no-task project failures.
 
 ## File-Level Implementation Checklist

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -635,6 +635,23 @@ The order matters. Backend parity comes before TUI parity, because the TUI canno
 - `context/tasks/penguin-capability-bar.md`
   - higher-level quality bar for what “done” should mean
 
+
+### April 24, 2026 TUI Live Verification Findings
+
+Live TUI verification exposed two integration bugs that parser/route tests did not catch:
+
+- Execution commands such as `/project start ...` were treated like harmless local commands.
+  - They returned only toast feedback and did not create/navigate to a visible TUI session.
+  - Correct behavior: execution commands should create/reuse a session, navigate to it when launched from home, and run asynchronously so streaming/status can become visible.
+- Project/task execution requests were not carrying the TUI workspace directory/session into the backend RunMode path.
+  - The backend therefore executed from the Penguin repo/server working directory instead of the TUI directory.
+  - Correct behavior: TUI sends `session_id` and `directory`; web routes scope execution with `ExecutionContext`; project-scoped continuous RunMode must pass `project_id` and not synthesize a user task from the project name.
+
+Fix direction:
+- Keep non-execution project/task commands sessionless: create/list/show/delete/init.
+- Treat execution commands as session-backed: project start, task execute, task clarification resume.
+- Keep `project run` deferred from TUI until its contract is repaired.
+
 ## Bottom Line
 
 The point of `project init` + `project start` is not to hide complexity for its own sake.

--- a/context/tasks/project-bootstrap-workflow.md
+++ b/context/tasks/project-bootstrap-workflow.md
@@ -235,7 +235,134 @@ A first version of this workflow is good enough when:
 - clarification and non-terminal states are surfaced honestly
 - ambiguous name resolution does not silently pick the wrong project
 
-## Relationship to Other Files
+## April 21, 2026 E2E Findings
+
+### What Was Verified
+- `POST /api/v1/projects/init` succeeds for a valid Blueprint and reports imported task counts plus `ready_tasks`.
+- `POST /api/v1/projects/init` fails with `400` and rolls back for at least some real lint-error cases:
+  - dependency cycles
+  - duplicate task IDs
+- `POST /api/v1/projects/start` precondition failures work on the web surface:
+  - unknown project identifier returns `404`
+  - project with no tasks returns `400`
+
+### What Broke or Drifted
+- The documented `penguin-web --host ... --port ...` examples are currently misleading for local verification.
+  - In practice, the server entrypoint reads `HOST` / `PORT` from env in `penguin/web/server.py`.
+  - Passing `--port 8080` still bound the server to port `9000` during E2E verification.
+- Blueprint validation is currently weaker than this workflow doc implies.
+  - A Blueprint with missing acceptance criteria only produced a warning, not a rollback.
+  - That behavior may be acceptable, but it means “invalid Blueprint” currently means “lint errors,” not “any lint issue.”
+- The parse/import path is still too permissive.
+  - An intentionally broken/minimal Blueprint returned `200` and created an effectively empty project instead of failing and rolling back.
+  - That violates the intended “fail honestly” bootstrap contract.
+- Full success-path `project start` E2E is not currently deterministic in a live environment.
+  - The route does call the real RunMode path.
+  - But successful execution depends on real model/runtime behavior, so the HTTP call can hang until client timeout without a controlled provider or test-mode runtime.
+
+### Interpretation
+- `project init` is partially honest today, but not fully.
+- `project start` is honestly wired into real runtime truth, but it still lacks a deterministic verification story for success-path web E2E.
+- The web server docs and runtime contract have drifted on host/port invocation behavior.
+
+### Surgical Fix Targets
+- Tighten Blueprint bootstrap failure semantics so malformed / effectively empty imports fail and roll back.
+- Clarify and/or fix `penguin-web` host/port CLI behavior so docs match runtime truth.
+- Add a deterministic `project start` verification path that does not depend on an uncontrolled live model run.
+
+## File-Level Fix Checklist
+
+### Web Server CLI / Docs Truth
+
+#### `penguin/web/server.py`
+- [ ] Make `penguin-web --host <HOST> --port <PORT>` actually work, or explicitly remove/avoid pretending those flags exist.
+- [ ] Keep env-based `HOST` / `PORT` overrides working.
+- [ ] Ensure startup banner prints the true bound host/port.
+
+#### `docs/docs/usage/web_interface.md`
+- [ ] Update startup examples so they match the real server invocation contract.
+- [ ] If env vars remain the source of truth, document that explicitly instead of implying CLI arg parsing.
+
+#### `AGENTS.md`
+- [ ] Note that current docs treat `9000` as the primary Penguin web server port.
+- [ ] Note that local verification on alternate ports should currently prefer env vars (`HOST` / `PORT`) unless/until CLI flag parsing is fixed.
+
+### Project Bootstrap Failure Semantics
+
+#### `penguin/web/services/projects.py`
+- [ ] Treat malformed / effectively empty Blueprint imports as honest bootstrap failures with rollback.
+- [ ] Preserve current rollback behavior for lint-error cases like duplicate task IDs and dependency cycles.
+- [ ] Decide and document whether warning-only Blueprints are allowed to initialize projects or should fail under stricter bootstrap rules.
+- [ ] Keep response payloads explicit about why initialization failed.
+
+#### `penguin/project/blueprint_parser.py`
+- [ ] Check whether malformed frontmatter / underspecified Blueprint shapes are being parsed too permissively.
+- [ ] Tighten parser or diagnostics so clearly broken Blueprint files do not silently degrade into empty successful imports.
+
+#### `tests/` web/bootstrap coverage
+- [ ] Add regression tests for malformed Blueprint rollback.
+- [ ] Add regression tests for empty/no-task Blueprint rollback if that is the intended contract.
+- [ ] Keep duplicate-ID and dependency-cycle rollback coverage.
+
+### Deterministic `project start` Verification
+
+#### `penguin/web/services/projects.py`
+- [ ] Preserve current real RunMode wiring for actual execution.
+- [ ] Consider a controlled verification seam for tests so success-path web checks do not depend on a live provider call.
+
+#### `tests/` web/project-start coverage
+- [ ] Add deterministic tests for successful `project start` request/response shape with mocked or controlled runtime execution.
+- [ ] Keep precondition coverage for missing project and no-task project failures.
+
+## File-Level Implementation Checklist
+
+### Current TUI Bugfix Scope
+
+This checklist covers the current `penguin-tui` bug where local/project commands can
+accidentally create and navigate into a new session when submitted from home.
+
+This is intentionally narrower than the broader bootstrap workflow UX.
+The immediate fix is:
+- parse command intent before session creation
+- execute local/project commands without chat/session bootstrap
+- preserve current chat behavior for real prompts
+
+### Files
+
+#### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
+- [x] Move Penguin local/project command detection ahead of session creation in `submit()`
+- [x] Stop creating a session for local/project commands when no `props.sessionID` or `sdk.sessionID` exists
+- [x] Stop session navigation for local/project commands executed from home
+- [x] Keep current chat/session behavior unchanged for real prompts
+- [x] Keep command-history append behavior only as an intentional command-path choice
+- [x] Resolve command directory from current app/workspace state or existing session, not from a freshly created session
+- [x] Support both dashed and spaced forms:
+  - [x] `/project-init <name> [--blueprint <path>]`
+  - [x] `/project-start <project-id-or-name>`
+  - [x] `/project init <name> [--blueprint <path>]`
+  - [x] `/project start <project-id-or-name>`
+
+#### `penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/` helper module(s)
+- [x] Extract one small parser/helper as the single source of truth for Penguin local/project command syntax
+- [x] Avoid duplicating command parsing logic between prompt execution paths
+- [x] Keep helper scope tight: classify command intent and parsed args only
+
+#### `penguin-tui/packages/opencode/test/cli/tui/`
+- [x] Add parser/submit regression tests for Penguin local/project commands
+- [x] Assert home-screen local/project commands do **not** require session bootstrap
+- [x] Assert home-screen local/project commands do **not** trigger session navigation
+- [ ] Assert project commands route to the correct backend endpoints
+- [x] Assert both dashed and spaced forms parse equivalently
+
+### Explicit Non-Goals For This Patch
+- [x] Do **not** require command-palette discoverability in the same bugfix commit
+- [x] Do **not** redesign project feedback/UI beyond current minimal success/error reporting
+- [x] Do **not** broaden this into a general TUI command-architecture rewrite
+
+### Acceptance Criteria For This TUI Slice
+- [x] From home, `/project init ...` does not create a session
+- [x] From home, `/project start ...` does not create a session
+- [x] From home, `/settings`, `/config`, `/thinking`, and `/tool_details` do not create a session
 
 - `context/tasks/cli-surface-audit.md`
   - CLI surface drift and immediate correctness fixes

--- a/context/tasks/tool-call-runtime-architecture.md
+++ b/context/tasks/tool-call-runtime-architecture.md
@@ -1,0 +1,381 @@
+# Tool Call Runtime Architecture
+
+## Purpose
+
+This document plans a long-term refactor of Penguin's model/tool control flow.
+
+The current loop is built around assistant text containing custom ActionXML or
+JSON-ish action blocks. That works, but it couples model prompting, parsing,
+tool routing, result persistence, UI events, and loop control too tightly.
+
+The target architecture is a provider-neutral tool-call runtime that can handle:
+
+- Penguin's existing ActionXML/CodeAct format
+- native OpenAI Responses tool calls
+- future MCP/app/deferred tools
+- one or more tool calls per model turn
+- conservative serial execution first
+- safe parallel execution later
+
+This is not only for Codex parity. It should make Penguin's own tool loop more
+reliable and easier to evolve.
+
+## Current State
+
+Penguin currently has two overlapping tool-call paths.
+
+### ActionXML / CodeAct Path
+
+The main loop asks the model for assistant text, then parses action tags out of
+that text:
+
+```text
+assistant text
+  -> parse_action()
+  -> CodeActAction
+  -> ActionExecutor.execute_action()
+  -> ToolManager method
+  -> action result persisted to conversation
+  -> next model iteration
+```
+
+Important current behavior:
+
+- `penguin/utils/parser.py` owns the `ActionType` enum and action parser.
+- `ActionExecutor.execute_action()` owns a large action-to-handler map.
+- `penguin/engine.py` intentionally executes only the first parsed action per
+  iteration.
+- action results are persisted as conversation action-result records.
+
+### Responses Tool-Call Path
+
+The newer Responses path captures a provider tool call and executes it after
+the model step:
+
+```text
+Responses API tool call captured by provider adapter
+  -> execute_pending_tool_call()
+  -> ToolManager.execute_tool()
+  -> action result persisted to conversation
+```
+
+This path is useful, but it is still shaped like a single pending tool call
+side channel rather than a unified runtime.
+
+## Upstream Codex Comparison
+
+Codex treats tool calls as first-class response items from the model stream.
+
+Conceptually:
+
+```text
+model stream
+  -> ResponseItem::FunctionCall / CustomToolCall / LocalShellCall / MCP
+  -> ToolCall { call_id, tool_name, payload }
+  -> ToolRouter
+  -> ToolInvocation { session, turn, cancellation, tracker, call_id, payload }
+  -> tool result ResponseInputItem
+  -> record result and continue
+```
+
+Key ideas worth borrowing:
+
+- tool calls have stable call ids
+- provider-native tool calls are not embedded in assistant prose
+- each tool receives a turn/runtime context
+- cancellation is part of the tool invocation
+- read-only or explicitly safe tools can run in parallel
+- mutating/unsafe tools are serialized
+- model-visible tool specs are built from registry metadata
+- result items are recorded with enough identity to reconstruct the turn
+
+Penguin does not need to clone Codex internals, but it should adopt the same
+separation of concerns.
+
+## Target Architecture
+
+Introduce a provider-neutral intermediate representation:
+
+```python
+ToolCall(
+    id: str,
+    name: str,
+    arguments: dict[str, Any] | str,
+    source: Literal["action_xml", "responses", "mcp", "internal"],
+    raw: Any,
+    mutates_state: bool,
+    parallel_safe: bool,
+    requires_approval: bool,
+)
+```
+
+And a corresponding result:
+
+```python
+ToolResult(
+    call_id: str,
+    name: str,
+    status: Literal["completed", "error", "cancelled", "requires_approval"],
+    output: str,
+    structured_output: dict[str, Any] | None,
+    started_at: float,
+    ended_at: float,
+    output_hash: str,
+)
+```
+
+The loop should become:
+
+```text
+provider output
+  -> provider/action adapter extracts ToolCall[]
+  -> scheduler chooses serial or parallel execution
+  -> registry dispatches ToolCall to handler
+  -> ToolResult[] persisted with call ids and arguments
+  -> next model input is built from ToolResult[]
+```
+
+ActionXML should become one adapter into this runtime, not the runtime itself.
+
+## Proposed Components
+
+### 1. ToolCall Adapter Layer
+
+Responsibilities:
+
+- convert ActionXML/CodeAct tags into `ToolCall` objects
+- convert Responses API tool calls into `ToolCall` objects
+- preserve raw provider/tool metadata for debugging
+- report malformed tool syntax without executing anything
+
+Initial adapters:
+
+- `ActionXmlToolCallAdapter`
+- `ResponsesToolCallAdapter`
+
+### 2. Tool Registry
+
+Responsibilities:
+
+- own tool names, schemas, handlers, metadata, and aliases
+- replace the large `ActionExecutor` action map over time
+- expose model-visible schemas where supported
+- expose runtime metadata:
+  - read-only vs mutating
+  - parallel-safe
+  - requires approval
+  - long-running
+  - streams output
+
+This can wrap the current `ToolManager` initially. It does not need to replace
+every tool implementation in the first phase.
+
+### 3. Tool Scheduler
+
+Responsibilities:
+
+- accept a list of `ToolCall` objects from one model turn
+- execute serially by default
+- optionally execute safe read-only calls concurrently
+- serialize mutating calls
+- preserve deterministic result ordering
+- support cancellation and timeouts
+- emit start/end UI events consistently
+
+The first scheduler should be deliberately conservative:
+
+- run all calls serially
+- accept multiple calls per model turn
+- persist all results with call ids
+
+Parallel execution can be added once the metadata and persistence are reliable.
+
+### 4. Tool Result Store / Conversation Integration
+
+Responsibilities:
+
+- persist tool call id, name, arguments, status, output, and output hash
+- distinguish assistant text from tool calls and tool results
+- make repeated-loop detection use tool identity and arguments
+- support reconstruction/debugging of a model turn
+
+This should avoid relying on the first 200 characters of output as the primary
+identity for progress detection.
+
+### 5. Loop Controller
+
+Responsibilities:
+
+- coordinate model step, tool extraction, scheduling, persistence, and follow-up
+- decide whether a response is complete
+- decide whether another model turn is needed
+- handle malformed tool syntax repair
+- handle empty tool-only loops based on `ToolCall`/`ToolResult` identity
+
+The loop controller should not know individual tool semantics. It should reason
+about call/result metadata.
+
+## Migration Plan
+
+### Phase 0: Document and Test Current Behavior
+
+Goals:
+
+- preserve current behavior while creating room to refactor
+- add tests around current one-action-per-iteration behavior
+- add tests for multiple ActionXML tags in one assistant response
+- add tests for Responses tool-call execution
+- add tests for repeated empty tool-only loop detection
+
+Acceptance criteria:
+
+- current behavior is explicitly covered by tests
+- regressions during migration are visible
+
+### Phase 1: Introduce ToolCall / ToolResult IR
+
+Goals:
+
+- add internal dataclasses for `ToolCall` and `ToolResult`
+- map ActionXML actions into `ToolCall`
+- map provider-captured Responses calls into `ToolCall`
+- map existing action results into `ToolResult`
+
+Acceptance criteria:
+
+- no user-visible behavior change required
+- all current tool paths can produce normalized call/result records
+- existing action result persistence still works
+
+### Phase 2: Add Serial Tool Scheduler
+
+Goals:
+
+- move execution orchestration into a scheduler
+- execute one or more `ToolCall` objects serially
+- keep the default behavior conservative
+- preserve UI events and conversation persistence
+
+Acceptance criteria:
+
+- ActionXML responses with multiple actions can be represented
+- runtime can choose to execute only one or all calls by policy
+- all executed calls get stable ids and persisted results
+
+### Phase 3: Replace ActionExecutor Routing With Registry Routing
+
+Goals:
+
+- move the action-to-handler map into a registry
+- keep legacy action aliases
+- allow model-visible schemas to come from one source
+- reduce coupling between parser, executor, and ToolManager
+
+Acceptance criteria:
+
+- adding a tool requires one registry entry, not parser/executor/UI edits in
+  several places
+- `ActionExecutor` becomes a compatibility wrapper or is removed
+- `ToolManager` becomes an implementation backend, not the public routing API
+
+### Phase 4: Improve Loop Control
+
+Goals:
+
+- make loop guards inspect `ToolCall` and `ToolResult` identity
+- account for tool args, file paths, ranges, limits, output hashes, and status
+- distinguish legitimate exploration from stale repeated output
+- add user-visible continuation behavior when a guard stops a run
+
+Acceptance criteria:
+
+- repeated reads of the same file with different ranges do not falsely trigger
+  stale-loop detection
+- truly identical empty tool-only loops still stop safely
+- guard messages explain what happened and how to continue
+
+### Phase 5: Native Tool-Call First Providers
+
+Goals:
+
+- treat OpenAI Responses/Codex function calls as first-class tool calls
+- avoid converting native provider tool calls into ActionXML concepts
+- support multiple provider tool calls from a single response
+- preserve provider call ids in persisted records
+
+Acceptance criteria:
+
+- Codex/OpenAI native tool calls and ActionXML calls use the same scheduler
+- provider-specific parsing is isolated in adapters
+- the loop controller is provider-neutral
+
+### Phase 6: Safe Parallel Tool Calls
+
+Goals:
+
+- add parallel execution only for tools marked safe
+- keep mutating tools serialized
+- support per-tool and per-provider parallel settings
+- send `parallel_tool_calls` only when Penguin can honor it
+
+Acceptance criteria:
+
+- read-only tools can run concurrently without corrupting state
+- mutating tools never run concurrently unless explicitly safe
+- result ordering is deterministic
+- cancellation and errors are handled per call
+
+## Non-Goals
+
+- Do not remove ActionXML before a replacement path is stable.
+- Do not enable provider parallel tool calls before the scheduler can handle
+  them safely.
+- Do not rewrite every tool implementation as part of Phase 1.
+- Do not make the engine depend on OpenAI/Codex-specific types.
+- Do not preserve the current giant action map as the long-term routing layer.
+
+## Risks
+
+### Tool Persistence Drift
+
+Changing how tool results are represented can break conversation history,
+frontend timelines, or TUI rendering.
+
+Mitigation:
+
+- keep compatibility fields during migration
+- add conversion helpers at the boundary
+- test session message rendering and SSE events
+
+### Permission and Safety Regression
+
+Parallel or unified execution could accidentally bypass existing permission
+checks.
+
+Mitigation:
+
+- put permissions in the scheduler/registry path
+- make mutating tools serialized by default
+- test denied, approval-needed, and read-only paths
+
+### Over-Abstracting Too Early
+
+A generic runtime can become another abstraction layer without removing the old
+coupling.
+
+Mitigation:
+
+- start with minimal IR and serial scheduler
+- migrate one path at a time
+- delete compatibility layers when their callers are gone
+
+## Open Questions
+
+- Should the IR live under `penguin/llm/runtime.py`, `penguin/tools/`, or a new
+  `penguin/runtime/` package?
+- Should ActionXML multiple-call execution remain opt-in at first?
+- Which tools are safe enough to mark parallel-safe initially?
+- Should model-visible tool schemas come entirely from the registry?
+- How should long-running process tools stream output into `ToolResult` records?
+- Should tool results be persisted as first-class session records rather than
+  action-result messages?

--- a/misc/example_crud_blueprint.md
+++ b/misc/example_crud_blueprint.md
@@ -63,6 +63,9 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Task records persist across runs.
   - Acceptance: Task model supports title, description, status, due_date, and created_by.
   - Depends: TASKAPI-1
+  - Dependency Specs:
+    - task_id: TASKAPI-1
+      policy: review_ready_ok
   - Recipe: task-crud
   - Description: Add database setup and persistence logic for task data.
 
@@ -70,6 +73,9 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Users can register and log in with hashed passwords.
   - Acceptance: Auth returns a token or session suitable for protected routes.
   - Depends: TASKAPI-1
+  - Dependency Specs:
+    - task_id: TASKAPI-1
+      policy: review_ready_ok
   - Recipe: auth-flow
   - Description: Implement basic authentication flow for local use.
 
@@ -77,6 +83,11 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Unauthenticated task access is rejected.
   - Acceptance: Authenticated users can access only valid task operations.
   - Depends: TASKAPI-2, TASKAPI-3
+  - Dependency Specs:
+    - task_id: TASKAPI-2
+      policy: review_ready_ok
+    - task_id: TASKAPI-3
+      policy: review_ready_ok
   - Recipe: auth-flow
   - Description: Add route protection and current-user resolution.
 
@@ -84,6 +95,11 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Users can create, list, update, and delete tasks.
   - Acceptance: API returns appropriate status codes and JSON payloads.
   - Depends: TASKAPI-2, TASKAPI-4
+  - Dependency Specs:
+    - task_id: TASKAPI-2
+      policy: review_ready_ok
+    - task_id: TASKAPI-4
+      policy: review_ready_ok
   - Recipe: task-crud
   - Description: Implement the main task API behavior.
 
@@ -91,6 +107,9 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Tasks can be filtered by status and due date.
   - Acceptance: Invalid payloads fail with clear validation errors.
   - Depends: TASKAPI-5
+  - Dependency Specs:
+    - task_id: TASKAPI-5
+      policy: review_ready_ok
   - Recipe: task-filtering
   - Description: Add query filtering and stronger request validation.
 
@@ -98,6 +117,9 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Auth and task CRUD are covered by pytest tests.
   - Acceptance: Tests are deterministic and runnable locally.
   - Depends: TASKAPI-5
+  - Dependency Specs:
+    - task_id: TASKAPI-5
+      policy: review_ready_ok
   - Recipe: test-suite
   - Description: Add focused automated coverage for happy path and invalid input paths.
 
@@ -105,6 +127,9 @@ Build a small but production-lean Python CRUD service for managing team tasks. T
   - Acceptance: Task create/update/delete actions are recorded.
   - Acceptance: Audit entries include actor, timestamp, and action type.
   - Depends: TASKAPI-5
+  - Dependency Specs:
+    - task_id: TASKAPI-5
+      policy: review_ready_ok
   - Recipe: audit-trail
   - Description: Add a simple audit log for task mutations.
 

--- a/misc/example_crud_blueprint.md
+++ b/misc/example_crud_blueprint.md
@@ -1,0 +1,182 @@
+---
+title: "Team Tasks API"
+project_key: "TASKAPI"
+version: 0.1.0
+status: draft
+owners: ["@you"]
+labels: ["backend", "python", "crud"]
+created: 2026-04-21
+updated: 2026-04-21
+
+ituv:
+  enabled: true
+  phase_timebox_sec:
+    implement: 900
+    test: 420
+    use: 240
+    verify: 180
+
+agent_defaults:
+  agent_role: implementer
+  required_tools: []
+  skills: ["python", "fastapi", "sqlite", "pytest"]
+---
+
+# Team Tasks API
+
+## Overview
+Build a small but production-lean Python CRUD service for managing team tasks. The system should support user authentication, task CRUD, task filtering, and a lightweight audit trail. This is intended as a practical Penguin test project for project bootstrap, RunMode execution, verification, and later TUI/web workflow testing.
+
+## Goals
+- Build a clean Python REST API for task management.
+- Support authenticated CRUD operations for users and tasks.
+- Include tests, migrations/setup, and basic validation.
+- Be realistic enough to exercise Penguin project/task orchestration.
+
+## Non-Goals
+- Multi-tenant enterprise RBAC.
+- Realtime collaboration.
+- Full production infra/deployment automation.
+
+## Context
+- Tech stack: Python, FastAPI, SQLite, pytest.
+- Key constraints: small codebase, deterministic tests, easy local setup.
+- Security/perf notes: auth required for protected routes, input validation, no fake test pass path.
+
+## Interfaces / APIs
+- POST /api/auth/register
+- POST /api/auth/login
+- GET /api/tasks
+- POST /api/tasks
+- GET /api/tasks/{id}
+- PATCH /api/tasks/{id}
+- DELETE /api/tasks/{id}
+
+## Tasks
+- [ ] TASKAPI-1 Create FastAPI app skeleton {estimate=2, priority=high, labels=backend,api, effort=2, value=5}
+  - Acceptance: App starts locally and exposes a health endpoint.
+  - Acceptance: Project structure is organized for routes, models, and tests.
+  - Recipe: api-health
+  - Description: Create the application entrypoint, package layout, and minimal startup wiring.
+
+- [ ] TASKAPI-2 Add SQLite persistence and task model {estimate=3, priority=high, labels=backend,database, effort=3, value=5}
+  - Acceptance: Task records persist across runs.
+  - Acceptance: Task model supports title, description, status, due_date, and created_by.
+  - Depends: TASKAPI-1
+  - Recipe: task-crud
+  - Description: Add database setup and persistence logic for task data.
+
+- [ ] TASKAPI-3 Add user registration and login {estimate=3, priority=high, labels=auth,api, effort=3, value=5}
+  - Acceptance: Users can register and log in with hashed passwords.
+  - Acceptance: Auth returns a token or session suitable for protected routes.
+  - Depends: TASKAPI-1
+  - Recipe: auth-flow
+  - Description: Implement basic authentication flow for local use.
+
+- [ ] TASKAPI-4 Protect task routes with authentication {estimate=2, priority=high, labels=auth,api, effort=2, value=5}
+  - Acceptance: Unauthenticated task access is rejected.
+  - Acceptance: Authenticated users can access only valid task operations.
+  - Depends: TASKAPI-2, TASKAPI-3
+  - Recipe: auth-flow
+  - Description: Add route protection and current-user resolution.
+
+- [ ] TASKAPI-5 Implement task CRUD endpoints {estimate=4, priority=high, labels=crud,api, effort=3, value=5}
+  - Acceptance: Users can create, list, update, and delete tasks.
+  - Acceptance: API returns appropriate status codes and JSON payloads.
+  - Depends: TASKAPI-2, TASKAPI-4
+  - Recipe: task-crud
+  - Description: Implement the main task API behavior.
+
+- [ ] TASKAPI-6 Add task filtering and validation {estimate=2, priority=medium, labels=crud,validation, effort=2, value=4}
+  - Acceptance: Tasks can be filtered by status and due date.
+  - Acceptance: Invalid payloads fail with clear validation errors.
+  - Depends: TASKAPI-5
+  - Recipe: task-filtering
+  - Description: Add query filtering and stronger request validation.
+
+- [ ] TASKAPI-7 Add tests for auth and CRUD flows {estimate=4, priority=high, labels=testing,qa, effort=3, value=5}
+  - Acceptance: Auth and task CRUD are covered by pytest tests.
+  - Acceptance: Tests are deterministic and runnable locally.
+  - Depends: TASKAPI-5
+  - Recipe: test-suite
+  - Description: Add focused automated coverage for happy path and invalid input paths.
+
+- [ ] TASKAPI-8 Add audit trail for task changes {estimate=3, priority=medium, labels=backend,audit, effort=3, value=4}
+  - Acceptance: Task create/update/delete actions are recorded.
+  - Acceptance: Audit entries include actor, timestamp, and action type.
+  - Depends: TASKAPI-5
+  - Recipe: audit-trail
+  - Description: Add a simple audit log for task mutations.
+
+## Usage Recipes
+- recipe: "api-health"
+  description: "Verify the API starts and responds to a health check."
+  steps:
+    - http: "GET /health"
+      expect_status: 200
+      expect_json: {"status": "ok"}
+
+- recipe: "auth-flow"
+  description: "Register, log in, and access a protected endpoint."
+  steps:
+    - http: "POST /api/auth/register"
+      body: {"email": "test@example.com", "password": "secret123"}
+      expect_status: 201
+    - http: "POST /api/auth/login"
+      body: {"email": "test@example.com", "password": "secret123"}
+      expect_status: 200
+    - http: "GET /api/tasks"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      expect_status: 200
+
+- recipe: "task-crud"
+  description: "Create, fetch, update, and delete a task."
+  steps:
+    - http: "POST /api/tasks"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      body: {"title": "Write tests", "description": "Add coverage", "status": "todo"}
+      expect_status: 201
+      expect_json: {"id": "*"}
+    - http: "GET /api/tasks/{{ id }}"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      expect_status: 200
+    - http: "PATCH /api/tasks/{{ id }}"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      body: {"status": "done"}
+      expect_status: 200
+    - http: "DELETE /api/tasks/{{ id }}"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      expect_status: 204
+
+- recipe: "task-filtering"
+  description: "Verify filtering by task status."
+  steps:
+    - http: "GET /api/tasks?status=todo"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      expect_status: 200
+
+- recipe: "test-suite"
+  description: "Run the automated test suite."
+  steps:
+    - shell: "pytest -q"
+      expect_exit: 0
+
+- recipe: "audit-trail"
+  description: "Verify task mutations create audit entries."
+  steps:
+    - http: "GET /api/audit"
+      headers: {"Authorization": "Bearer {{ token }}"}
+      expect_status: 200
+
+## Validation
+- [ ] Authenticated task CRUD works end-to-end.
+- [ ] Invalid payloads fail with explicit validation errors.
+- [ ] Test suite passes locally.
+- [ ] Audit trail records task mutations.
+
+## Risks / Open Questions
+- Risk: Auth/session implementation may drift if kept too abstract.
+- Question: Should audit entries be exposed via API immediately or remain internal first?
+
+## Changelog
+- 2026-04-21: v0.1 – Initial Penguin bootstrap/testing blueprint example

--- a/misc/list_of_projects.md
+++ b/misc/list_of_projects.md
@@ -6,4 +6,67 @@ I had one like this July/August 2024AD, I'll fetch it and add it onto here. It w
 
 This one is going to be towards end results that could be used by humans or penguins (and future agents) in everyday stuff. 
 
-Like LinkAI, or other stuff
+Like LinkAI, or other stuff.
+
+## Example Penguin Test Projects
+
+### 1. Team Tasks API
+- **Type:** Python CRUD / backend service
+- **Stack:** FastAPI, SQLite, pytest
+- **Why it is useful:**
+  - exercises authenticated CRUD flows
+  - good fit for `project init --blueprint` and `project start`
+  - realistic enough to test Bootstrap, RunMode, project/task orchestration, and later TUI/web flows
+  - small enough to iterate quickly without becoming architecture theater
+- **Suggested scope:**
+  - auth/register/login
+  - task CRUD
+  - task filtering
+  - audit trail for changes
+  - tests and basic validation
+- **Example blueprint:**
+  - `misc/example_crud_blueprint.md`
+
+### 2. Personal Notes API
+- **Type:** Python CRUD / API + local persistence
+- **Stack:** FastAPI or Flask, SQLite, pytest
+- **Why it is useful:**
+  - slightly simpler than a team-task system
+  - good for basic project bootstrap and verification testing
+  - exercises create/read/update/delete plus search/filtering
+- **Suggested scope:**
+  - notebook CRUD
+  - note tagging
+  - keyword search
+  - basic auth or local-only mode
+
+### 3. Inventory Tracker
+- **Type:** Python CRUD / admin-style backend
+- **Stack:** FastAPI, SQLite/Postgres, pytest
+- **Why it is useful:**
+  - tests more realistic business rules than pure toy CRUD
+  - useful for validating project dependencies and acceptance criteria
+- **Suggested scope:**
+  - product CRUD
+  - stock adjustments
+  - transaction history
+  - low-stock reporting
+
+### 4. Simple Bookings Backend
+- **Type:** Python service with CRUD + state transitions
+- **Stack:** FastAPI, SQLite, pytest
+- **Why it is useful:**
+  - adds lifecycle/status transitions beyond plain CRUD
+  - good for testing review/approval-ish workflows later
+- **Suggested scope:**
+  - create booking
+  - confirm/cancel booking
+  - list/filter bookings
+  - basic conflict validation
+
+## Recommendation
+If we want one practical default project for testing Penguin right now, use:
+
+- **Team Tasks API**
+
+It is realistic, exercises a lot of the stack, and is still small enough to iterate on quickly.

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -35,7 +35,11 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { exitSession } from "../../util/exit"
 import { formatPenguinPromptFailure, recoverPenguinPromptFailure } from "./penguin-send"
 import { parsePenguinLocalCommand } from "./penguin-local-command"
-import { executePenguinHttpLocalCommand, isPenguinHttpLocalCommand } from "./penguin-local-command-runtime"
+import {
+  executePenguinHttpLocalCommand,
+  isPenguinHttpLocalCommand,
+  penguinHttpLocalCommandNeedsSession,
+} from "./penguin-local-command-runtime"
 
 export type PromptProps = {
   sessionID?: string
@@ -923,10 +927,66 @@ export function Prompt(props: PromptProps) {
     }
     const localCommand = sdk.penguin ? parsePenguinLocalCommand(store.prompt.input) : null
     const initialDirectory = getActiveDirectory(props.sessionID ?? sdk.sessionID)
+    const ensureSessionID = async () => {
+      return await iife(async () => {
+        if (props.sessionID) return props.sessionID
+        if (sdk.sessionID) return sdk.sessionID
+
+        if (sdk.penguin) {
+          const createUrl = new URL("/session", sdk.url)
+          createUrl.searchParams.set("directory", initialDirectory)
+          const created = await sdk.fetch(createUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              agent_mode: agentMode(),
+              providerID: selectedModel.providerID,
+              modelID: selectedModel.modelID,
+              variant,
+            }),
+          }).then(async (res) => {
+            if (!res.ok) {
+              const details = await res.text().catch(() => "")
+              throw new Error(
+                details
+                  ? `Session create failed (${res.status}): ${details}`
+                  : `Session create failed (${res.status})`,
+              )
+            }
+            return res.json().catch(() => undefined)
+          })
+          const createdID = resolveSessionID(created)
+          if (createdID) return createdID
+          const details =
+            created && typeof created === "object"
+              ? `response keys: ${Object.keys(created as Record<string, unknown>).join(",") || "none"}`
+              : `response type: ${typeof created}`
+          throw new Error(`Session create returned empty id (${details})`)
+        }
+
+        return await sdk.client.session.create({}).then((result) => {
+          const id = resolveSessionID(result)
+          if (id) return id
+          throw new Error("Session create returned empty id")
+        })
+      }).catch((e) => {
+        const msg = e instanceof Error ? e.message : String(e)
+        toast.show({
+          variant: "error",
+          message: `Failed to start session: ${msg}`,
+        })
+        return undefined
+      })
+    }
 
     if (sdk.penguin && localCommand) {
-      const commandSessionID = props.sessionID ?? sdk.sessionID
+      const commandNeedsSession = isPenguinHttpLocalCommand(localCommand) && penguinHttpLocalCommandNeedsSession(localCommand)
+      const commandSessionID = commandNeedsSession ? await ensureSessionID() : props.sessionID ?? sdk.sessionID
       const keepDialog = localCommand.kind === "config" || localCommand.kind === "settings"
+
+      if (commandNeedsSession && !commandSessionID) return
 
       try {
         if (localCommand.kind === "config" || localCommand.kind === "settings") {
@@ -940,76 +1000,49 @@ export function Prompt(props: PromptProps) {
           kv.set("thinking_visibility", next)
           toast.show({ variant: "success", message: `Thinking ${next ? "shown" : "hidden"}` })
         } else if (isPenguinHttpLocalCommand(localCommand)) {
-          const result = await executePenguinHttpLocalCommand({
+          const runCommand = () => executePenguinHttpLocalCommand({
             command: localCommand,
             fetch: sdk.fetch,
             baseUrl: sdk.url,
             directory: initialDirectory,
+            sessionID: commandSessionID,
           })
+
+          if (commandNeedsSession) {
+            clearPromptState({ keepDialog })
+            props.onSubmit?.()
+            setStore("pending", true)
+            setStore("pendingSeenBusy", false)
+            if (!props.sessionID && commandSessionID) {
+              setTimeout(() => {
+                route.navigate({ type: "session", sessionID: commandSessionID })
+              }, 0)
+            }
+            void runCommand()
+              .then((result) => toast.show(result))
+              .catch((error) => {
+                toast.show({ variant: "error", message: error instanceof Error ? error.message : String(error) })
+              })
+              .finally(() => {
+                setStore("pending", false)
+                setStore("pendingSeenBusy", false)
+              })
+            return
+          }
+
+          const result = await runCommand()
           toast.show(result)
         }
       } catch (error) {
-        toast.show({ variant: 'error', message: error instanceof Error ? error.message : String(error) })
+        toast.show({ variant: "error", message: error instanceof Error ? error.message : String(error) })
       }
-
 
       clearPromptState({ keepDialog })
       props.onSubmit?.()
       return
     }
 
-    const sessionID = await iife(async () => {
-      if (props.sessionID) return props.sessionID
-      if (sdk.sessionID) return sdk.sessionID
-
-      if (sdk.penguin) {
-        const directory = initialDirectory
-        const createUrl = new URL("/session", sdk.url)
-        createUrl.searchParams.set("directory", directory)
-        const created = await sdk.fetch(createUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            agent_mode: agentMode(),
-            providerID: selectedModel.providerID,
-            modelID: selectedModel.modelID,
-            variant,
-          }),
-        }).then(async (res) => {
-          if (!res.ok) {
-            const details = await res.text().catch(() => "")
-            throw new Error(
-              details
-                ? `Session create failed (${res.status}): ${details}`
-                : `Session create failed (${res.status})`,
-            )
-          }
-          return res.json().catch(() => undefined)
-        })
-        const createdID = resolveSessionID(created)
-        if (createdID) return createdID
-        const details =
-          created && typeof created === "object"
-            ? `response keys: ${Object.keys(created as Record<string, unknown>).join(",") || "none"}`
-            : `response type: ${typeof created}`
-        throw new Error(`Session create returned empty id (${details})`)
-      }
-
-      return await sdk.client.session.create({}).then((result) => {
-        const id = resolveSessionID(result)
-        if (id) return id
-        throw new Error("Session create returned empty id")
-      })
-    }).catch((e) => {
-      const msg = e instanceof Error ? e.message : String(e)
-      toast.show({
-        variant: "error",
-        message: `Failed to start session: ${msg}`,
-      })
-      return undefined
-    })
+    const sessionID = await ensureSessionID()
     if (!sessionID) return
     const shouldNavigate = sdk.penguin && !props.sessionID
     if (input.isDestroyed) return

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -35,6 +35,7 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { exitSession } from "../../util/exit"
 import { formatPenguinPromptFailure, recoverPenguinPromptFailure } from "./penguin-send"
 import { parsePenguinLocalCommand } from "./penguin-local-command"
+import { executePenguinHttpLocalCommand, isPenguinHttpLocalCommand } from "./penguin-local-command-runtime"
 
 export type PromptProps = {
   sessionID?: string
@@ -923,21 +924,6 @@ export function Prompt(props: PromptProps) {
     const localCommand = sdk.penguin ? parsePenguinLocalCommand(store.prompt.input) : null
     const initialDirectory = getActiveDirectory(props.sessionID ?? sdk.sessionID)
 
-    const fetchPenguinCommand = async (path: string, init?: RequestInit) => {
-      const response = await sdk.fetch(new URL(path, sdk.url), init)
-      if (!response.ok) {
-        const detail = await response.text().catch(() => `${path} failed`)
-        throw new Error(detail)
-      }
-      return response.json()
-    }
-
-    const requireArg = (value: string | undefined, usage: string): string | undefined => {
-      if (value) return value
-      toast.show({ variant: "warning", message: `Usage: ${usage}` })
-      return undefined
-    }
-
     if (sdk.penguin && localCommand) {
       const commandSessionID = props.sessionID ?? sdk.sessionID
       const keepDialog = localCommand.kind === "config" || localCommand.kind === "settings"
@@ -953,131 +939,19 @@ export function Prompt(props: PromptProps) {
           const next = !kv.get("thinking_visibility", true)
           kv.set("thinking_visibility", next)
           toast.show({ variant: "success", message: `Thinking ${next ? "shown" : "hidden"}` })
-        } else if (localCommand.kind === "project_create") {
-          const projectName = requireArg(localCommand.projectName, '/project create <name> [--description <text>] [--workspace <path>]')
-          if (projectName) {
-            const payload = await fetchPenguinCommand('/api/v1/projects', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                name: projectName,
-                description: localCommand.description,
-                workspace_path: localCommand.workspacePath ?? initialDirectory,
-              }),
-            })
-            toast.show({ variant: 'success', message: `Project created: ${payload.name ?? projectName}` })
-          }
-        } else if (localCommand.kind === "project_init") {
-          const projectName = requireArg(localCommand.projectName, "/project init <name> [--blueprint <path>]")
-          if (projectName) {
-            const payload = await fetchPenguinCommand('/api/v1/projects/init', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                name: projectName,
-                blueprint_path: localCommand.blueprintPath,
-                workspace_path: initialDirectory,
-              }),
-            })
-            const blueprint = payload.blueprint
-            const taskSummary = blueprint ? ` (${blueprint.tasks_created ?? 0} created, ${blueprint.tasks_updated ?? 0} updated)` : ''
-            toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? projectName}${taskSummary}` })
-          }
-        } else if (localCommand.kind === "project_list") {
-          const payload = await fetchPenguinCommand('/api/v1/projects')
-          toast.show({ variant: 'success', message: `Projects: ${payload.projects?.length ?? 0}` })
-        } else if (localCommand.kind === "project_show") {
-          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project show <project-id>")
-          if (projectIdentifier) {
-            const payload = await fetchPenguinCommand(`/api/v1/projects/${encodeURIComponent(projectIdentifier)}`)
-            toast.show({ variant: 'success', message: `Project: ${payload.name ?? projectIdentifier} (${payload.tasks?.length ?? 0} tasks)` })
-          }
-        } else if (localCommand.kind === "project_delete") {
-          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project delete <project-id>")
-          if (projectIdentifier) {
-            const payload = await fetchPenguinCommand(`/api/v1/projects/${encodeURIComponent(projectIdentifier)}`, { method: 'DELETE' })
-            toast.show({ variant: 'success', message: payload.message ?? `Project deleted: ${projectIdentifier}` })
-          }
-        } else if (localCommand.kind === "project_start") {
-          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project start <project-id-or-name>")
-          if (projectIdentifier) {
-            const payload = await fetchPenguinCommand('/api/v1/projects/start', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
-            })
-            toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? projectIdentifier}` })
-          }
-        } else if (localCommand.kind === "task_create") {
-          const projectId = requireArg(localCommand.projectId, '/task create <project-id> <title>')
-          const title = requireArg(localCommand.title, '/task create <project-id> <title>')
-          if (projectId && title) {
-            const payload = await fetchPenguinCommand('/api/v1/tasks', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                project_id: projectId,
-                title,
-                description: localCommand.description,
-                parent_task_id: localCommand.parentTaskId,
-                priority: localCommand.priority,
-              }),
-            })
-            toast.show({ variant: 'success', message: `Task created: ${payload.title ?? title}` })
-          }
-        } else if (localCommand.kind === "task_list") {
-          const url = new URL('/api/v1/tasks', sdk.url)
-          if (localCommand.projectId) url.searchParams.set('project_id', localCommand.projectId)
-          if (localCommand.status) url.searchParams.set('status', localCommand.status)
-          const response = await sdk.fetch(url)
-          if (!response.ok) throw new Error(await response.text().catch(() => 'task list failed'))
-          const payload = await response.json()
-          toast.show({ variant: 'success', message: `Tasks: ${payload.tasks?.length ?? 0}` })
-        } else if (localCommand.kind === "task_show") {
-          const taskId = requireArg(localCommand.taskId, "/task show <task-id>")
-          if (taskId) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}`)
-            toast.show({ variant: 'success', message: `Task: ${payload.title ?? taskId} (${payload.status ?? 'unknown'})` })
-          }
-        } else if (localCommand.kind === "task_start") {
-          const taskId = requireArg(localCommand.taskId, "/task start <task-id>")
-          if (taskId) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/start`, { method: 'POST' })
-            toast.show({ variant: 'success', message: payload.message ?? `Task started: ${taskId}` })
-          }
-        } else if (localCommand.kind === "task_complete") {
-          const taskId = requireArg(localCommand.taskId, "/task complete <task-id>")
-          if (taskId) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/complete`, { method: 'POST' })
-            toast.show({ variant: 'success', message: payload.message ?? `Task completed: ${taskId}` })
-          }
-        } else if (localCommand.kind === "task_execute") {
-          const taskId = requireArg(localCommand.taskId, "/task execute <task-id>")
-          if (taskId) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/execute`, { method: 'POST' })
-            toast.show({ variant: 'success', message: `Task execution started: ${payload.task?.title ?? taskId}` })
-          }
-        } else if (localCommand.kind === "task_delete") {
-          const taskId = requireArg(localCommand.taskId, "/task delete <task-id>")
-          if (taskId) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' })
-            toast.show({ variant: 'success', message: payload.message ?? `Task deleted: ${taskId}` })
-          }
-        } else if (localCommand.kind === "task_clarification_resume") {
-          const taskId = requireArg(localCommand.taskId, '/task resume <task-id> <answer>')
-          const answer = requireArg(localCommand.answer, '/task resume <task-id> <answer>')
-          if (taskId && answer) {
-            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/clarification/resume`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ answer, answered_by: 'tui' }),
-            })
-            toast.show({ variant: 'success', message: `Clarification resumed: ${payload.task?.title ?? taskId}` })
-          }
+        } else if (isPenguinHttpLocalCommand(localCommand)) {
+          const result = await executePenguinHttpLocalCommand({
+            command: localCommand,
+            fetch: sdk.fetch,
+            baseUrl: sdk.url,
+            directory: initialDirectory,
+          })
+          toast.show(result)
         }
       } catch (error) {
         toast.show({ variant: 'error', message: error instanceof Error ? error.message : String(error) })
       }
+
 
       clearPromptState({ keepDialog })
       props.onSubmit?.()

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -258,6 +258,17 @@ export function Prompt(props: PromptProps) {
   })
 
   command.register(() => {
+    const prefillPrompt = (text: string) => {
+      input.extmarks.clear()
+      input.setText(text)
+      setStore("prompt", { input: text, parts: [] })
+      setStore("extmarkToPartIndex", new Map())
+      input.gotoBufferEnd()
+      input.focus()
+      input.getLayoutNode().markDirty()
+      renderer.requestRender()
+    }
+
     return [
       {
         title: "Clear prompt",
@@ -302,6 +313,38 @@ export function Prompt(props: PromptProps) {
         enabled: sdk.penguin && store.mode === "normal",
         onSelect: () => {
           cycleAgentMode()
+        },
+      },
+      {
+        title: "Initialize project from Blueprint",
+        description: "Prefill a project init command for Penguin bootstrap workflows",
+        value: "project.init.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-init",
+          aliases: ["project init"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project init "Project Name" --blueprint ./blueprint.md')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Start project execution",
+        description: "Prefill a project start command for continuous project execution",
+        value: "project.start.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-start",
+          aliases: ["project start"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project start "Project Name"')
+          dialog.clear()
         },
       },
       {

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -316,6 +316,22 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Create project",
+        description: "Prefill a project create command",
+        value: "project.create.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-create",
+          aliases: ["project create"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project create "Project Name" --description "Project description"')
+          dialog.clear()
+        },
+      },
+      {
         title: "Initialize project from Blueprint",
         description: "Prefill a project init command for Penguin bootstrap workflows",
         value: "project.init.prefill",
@@ -332,6 +348,38 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "List projects",
+        description: "Prefill a project list command",
+        value: "project.list.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-list",
+          aliases: ["project list"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project list')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Show project",
+        description: "Prefill a project show command",
+        value: "project.show.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-show",
+          aliases: ["project show", "project get"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project show "Project ID"')
+          dialog.clear()
+        },
+      },
+      {
         title: "Start project execution",
         description: "Prefill a project start command for continuous project execution",
         value: "project.start.prefill",
@@ -344,6 +392,150 @@ export function Prompt(props: PromptProps) {
         },
         onSelect: (dialog) => {
           prefillPrompt('/project start "Project Name"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Delete project",
+        description: "Prefill a project delete command",
+        value: "project.delete.prefill",
+        category: "Project",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "project-delete",
+          aliases: ["project delete"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/project delete "Project ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Create task",
+        description: "Prefill a task create command",
+        value: "task.create.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-create",
+          aliases: ["task create"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task create "Project ID" "Task title"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "List tasks",
+        description: "Prefill a task list command",
+        value: "task.list.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-list",
+          aliases: ["task list"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task list')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Show task",
+        description: "Prefill a task show command",
+        value: "task.show.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-show",
+          aliases: ["task show", "task get"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task show "Task ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Start task",
+        description: "Prefill a task start command",
+        value: "task.start.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-start",
+          aliases: ["task start"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task start "Task ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Complete task",
+        description: "Prefill a task complete command",
+        value: "task.complete.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-complete",
+          aliases: ["task complete"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task complete "Task ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Execute task",
+        description: "Prefill a task execute command",
+        value: "task.execute.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-execute",
+          aliases: ["task execute"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task execute "Task ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Delete task",
+        description: "Prefill a task delete command",
+        value: "task.delete.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-delete",
+          aliases: ["task delete"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task delete "Task ID"')
+          dialog.clear()
+        },
+      },
+      {
+        title: "Resume task clarification",
+        description: "Prefill a task clarification resume command",
+        value: "task.resume.prefill",
+        category: "Task",
+        suggested: sdk.penguin,
+        enabled: sdk.penguin,
+        slash: {
+          name: "task-resume",
+          aliases: ["task resume", "task clarification resume"],
+        },
+        onSelect: (dialog) => {
+          prefillPrompt('/task resume "Task ID" "Clarification answer"')
           dialog.clear()
         },
       },
@@ -731,56 +923,160 @@ export function Prompt(props: PromptProps) {
     const localCommand = sdk.penguin ? parsePenguinLocalCommand(store.prompt.input) : null
     const initialDirectory = getActiveDirectory(props.sessionID ?? sdk.sessionID)
 
+    const fetchPenguinCommand = async (path: string, init?: RequestInit) => {
+      const response = await sdk.fetch(new URL(path, sdk.url), init)
+      if (!response.ok) {
+        const detail = await response.text().catch(() => `${path} failed`)
+        throw new Error(detail)
+      }
+      return response.json()
+    }
+
+    const requireArg = (value: string | undefined, usage: string): string | undefined => {
+      if (value) return value
+      toast.show({ variant: "warning", message: `Usage: ${usage}` })
+      return undefined
+    }
+
     if (sdk.penguin && localCommand) {
       const commandSessionID = props.sessionID ?? sdk.sessionID
       const keepDialog = localCommand.kind === "config" || localCommand.kind === "settings"
 
-      if (localCommand.kind === "config" || localCommand.kind === "settings") {
-        dialog.replace(() => <DialogSettings directory={initialDirectory} sessionID={commandSessionID} />)
-      } else if (localCommand.kind === "tool_details") {
-        const next = !kv.get("tool_details_visibility", true)
-        kv.set("tool_details_visibility", next)
-      } else if (localCommand.kind === "thinking") {
-        const next = !kv.get("thinking_visibility", true)
-        kv.set("thinking_visibility", next)
-      } else if (localCommand.kind === "project_init") {
-        if (!localCommand.projectName) {
-          toast.show({ variant: "warning", message: "Usage: /project init <name> [--blueprint <path>]" })
-        } else {
-          const response = await sdk.fetch(new URL('/api/v1/projects/init', sdk.url), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              name: localCommand.projectName,
-              blueprint_path: localCommand.blueprintPath,
-              workspace_path: initialDirectory,
-            }),
-          })
-          if (!response.ok) {
-            const detail = await response.text().catch(() => 'project init failed')
-            toast.show({ variant: 'error', message: `Project init failed: ${detail}` })
-          } else {
-            const payload = await response.json()
-            toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? localCommand.projectName}` })
+      try {
+        if (localCommand.kind === "config" || localCommand.kind === "settings") {
+          dialog.replace(() => <DialogSettings directory={initialDirectory} sessionID={commandSessionID} />)
+        } else if (localCommand.kind === "tool_details") {
+          const next = !kv.get("tool_details_visibility", true)
+          kv.set("tool_details_visibility", next)
+          toast.show({ variant: "success", message: `Tool details ${next ? "shown" : "hidden"}` })
+        } else if (localCommand.kind === "thinking") {
+          const next = !kv.get("thinking_visibility", true)
+          kv.set("thinking_visibility", next)
+          toast.show({ variant: "success", message: `Thinking ${next ? "shown" : "hidden"}` })
+        } else if (localCommand.kind === "project_create") {
+          const projectName = requireArg(localCommand.projectName, '/project create <name> [--description <text>] [--workspace <path>]')
+          if (projectName) {
+            const payload = await fetchPenguinCommand('/api/v1/projects', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                name: projectName,
+                description: localCommand.description,
+                workspace_path: localCommand.workspacePath ?? initialDirectory,
+              }),
+            })
+            toast.show({ variant: 'success', message: `Project created: ${payload.name ?? projectName}` })
+          }
+        } else if (localCommand.kind === "project_init") {
+          const projectName = requireArg(localCommand.projectName, "/project init <name> [--blueprint <path>]")
+          if (projectName) {
+            const payload = await fetchPenguinCommand('/api/v1/projects/init', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                name: projectName,
+                blueprint_path: localCommand.blueprintPath,
+                workspace_path: initialDirectory,
+              }),
+            })
+            const blueprint = payload.blueprint
+            const taskSummary = blueprint ? ` (${blueprint.tasks_created ?? 0} created, ${blueprint.tasks_updated ?? 0} updated)` : ''
+            toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? projectName}${taskSummary}` })
+          }
+        } else if (localCommand.kind === "project_list") {
+          const payload = await fetchPenguinCommand('/api/v1/projects')
+          toast.show({ variant: 'success', message: `Projects: ${payload.projects?.length ?? 0}` })
+        } else if (localCommand.kind === "project_show") {
+          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project show <project-id>")
+          if (projectIdentifier) {
+            const payload = await fetchPenguinCommand(`/api/v1/projects/${encodeURIComponent(projectIdentifier)}`)
+            toast.show({ variant: 'success', message: `Project: ${payload.name ?? projectIdentifier} (${payload.tasks?.length ?? 0} tasks)` })
+          }
+        } else if (localCommand.kind === "project_delete") {
+          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project delete <project-id>")
+          if (projectIdentifier) {
+            const payload = await fetchPenguinCommand(`/api/v1/projects/${encodeURIComponent(projectIdentifier)}`, { method: 'DELETE' })
+            toast.show({ variant: 'success', message: payload.message ?? `Project deleted: ${projectIdentifier}` })
+          }
+        } else if (localCommand.kind === "project_start") {
+          const projectIdentifier = requireArg(localCommand.projectIdentifier, "/project start <project-id-or-name>")
+          if (projectIdentifier) {
+            const payload = await fetchPenguinCommand('/api/v1/projects/start', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
+            })
+            toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? projectIdentifier}` })
+          }
+        } else if (localCommand.kind === "task_create") {
+          const projectId = requireArg(localCommand.projectId, '/task create <project-id> <title>')
+          const title = requireArg(localCommand.title, '/task create <project-id> <title>')
+          if (projectId && title) {
+            const payload = await fetchPenguinCommand('/api/v1/tasks', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                project_id: projectId,
+                title,
+                description: localCommand.description,
+                parent_task_id: localCommand.parentTaskId,
+                priority: localCommand.priority,
+              }),
+            })
+            toast.show({ variant: 'success', message: `Task created: ${payload.title ?? title}` })
+          }
+        } else if (localCommand.kind === "task_list") {
+          const url = new URL('/api/v1/tasks', sdk.url)
+          if (localCommand.projectId) url.searchParams.set('project_id', localCommand.projectId)
+          if (localCommand.status) url.searchParams.set('status', localCommand.status)
+          const response = await sdk.fetch(url)
+          if (!response.ok) throw new Error(await response.text().catch(() => 'task list failed'))
+          const payload = await response.json()
+          toast.show({ variant: 'success', message: `Tasks: ${payload.tasks?.length ?? 0}` })
+        } else if (localCommand.kind === "task_show") {
+          const taskId = requireArg(localCommand.taskId, "/task show <task-id>")
+          if (taskId) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}`)
+            toast.show({ variant: 'success', message: `Task: ${payload.title ?? taskId} (${payload.status ?? 'unknown'})` })
+          }
+        } else if (localCommand.kind === "task_start") {
+          const taskId = requireArg(localCommand.taskId, "/task start <task-id>")
+          if (taskId) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/start`, { method: 'POST' })
+            toast.show({ variant: 'success', message: payload.message ?? `Task started: ${taskId}` })
+          }
+        } else if (localCommand.kind === "task_complete") {
+          const taskId = requireArg(localCommand.taskId, "/task complete <task-id>")
+          if (taskId) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/complete`, { method: 'POST' })
+            toast.show({ variant: 'success', message: payload.message ?? `Task completed: ${taskId}` })
+          }
+        } else if (localCommand.kind === "task_execute") {
+          const taskId = requireArg(localCommand.taskId, "/task execute <task-id>")
+          if (taskId) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/execute`, { method: 'POST' })
+            toast.show({ variant: 'success', message: `Task execution started: ${payload.task?.title ?? taskId}` })
+          }
+        } else if (localCommand.kind === "task_delete") {
+          const taskId = requireArg(localCommand.taskId, "/task delete <task-id>")
+          if (taskId) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}`, { method: 'DELETE' })
+            toast.show({ variant: 'success', message: payload.message ?? `Task deleted: ${taskId}` })
+          }
+        } else if (localCommand.kind === "task_clarification_resume") {
+          const taskId = requireArg(localCommand.taskId, '/task resume <task-id> <answer>')
+          const answer = requireArg(localCommand.answer, '/task resume <task-id> <answer>')
+          if (taskId && answer) {
+            const payload = await fetchPenguinCommand(`/api/v1/tasks/${encodeURIComponent(taskId)}/clarification/resume`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ answer, answered_by: 'tui' }),
+            })
+            toast.show({ variant: 'success', message: `Clarification resumed: ${payload.task?.title ?? taskId}` })
           }
         }
-      } else if (localCommand.kind === "project_start") {
-        if (!localCommand.projectIdentifier) {
-          toast.show({ variant: "warning", message: "Usage: /project start <project-id-or-name>" })
-        } else {
-          const response = await sdk.fetch(new URL('/api/v1/projects/start', sdk.url), {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ project_identifier: localCommand.projectIdentifier, continuous: true }),
-          })
-          if (!response.ok) {
-            const detail = await response.text().catch(() => 'project start failed')
-            toast.show({ variant: 'error', message: `Project start failed: ${detail}` })
-          } else {
-            const payload = await response.json()
-            toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? localCommand.projectIdentifier}` })
-          }
-        }
+      } catch (error) {
+        toast.show({ variant: 'error', message: error instanceof Error ? error.message : String(error) })
       }
 
       clearPromptState({ keepDialog })

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -34,6 +34,7 @@ import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { exitSession } from "../../util/exit"
 import { formatPenguinPromptFailure, recoverPenguinPromptFailure } from "./penguin-send"
+import { parsePenguinLocalCommand } from "./penguin-local-command"
 
 export type PromptProps = {
   sessionID?: string
@@ -649,13 +650,107 @@ export function Prompt(props: PromptProps) {
     const currentMode = store.mode
     const variant = local.model.variant.current()
     const agent = local.agent.current()
+    const getActiveDirectory = (activeSessionID?: string) => {
+      return (
+        (activeSessionID ? sync.session.get(activeSessionID)?.directory : undefined) ||
+        sync.session.get(props.sessionID ?? sdk.sessionID ?? "")?.directory ||
+        sync.data.path.directory ||
+        sdk.directory ||
+        process.cwd()
+      )
+    }
+    const clearPromptState = (options?: { keepDialog?: boolean }) => {
+      history.append({
+        ...store.prompt,
+        mode: currentMode,
+      })
+      if (!input.isDestroyed) {
+        input.extmarks.clear()
+      }
+      setStore("prompt", {
+        input: "",
+        parts: [],
+      })
+      setStore("extmarkToPartIndex", new Map())
+      if (!options?.keepDialog) {
+        dialog.clear()
+      }
+      if (!input.isDestroyed) {
+        input.clear()
+        input.setText("")
+        input.getLayoutNode().markDirty()
+        renderer.requestRender()
+      }
+      queueMicrotask(() => {
+        setStore("prompt", "input", "")
+      })
+    }
+    const localCommand = sdk.penguin ? parsePenguinLocalCommand(store.prompt.input) : null
+    const initialDirectory = getActiveDirectory(props.sessionID ?? sdk.sessionID)
+
+    if (sdk.penguin && localCommand) {
+      const commandSessionID = props.sessionID ?? sdk.sessionID
+      const keepDialog = localCommand.kind === "config" || localCommand.kind === "settings"
+
+      if (localCommand.kind === "config" || localCommand.kind === "settings") {
+        dialog.replace(() => <DialogSettings directory={initialDirectory} sessionID={commandSessionID} />)
+      } else if (localCommand.kind === "tool_details") {
+        const next = !kv.get("tool_details_visibility", true)
+        kv.set("tool_details_visibility", next)
+      } else if (localCommand.kind === "thinking") {
+        const next = !kv.get("thinking_visibility", true)
+        kv.set("thinking_visibility", next)
+      } else if (localCommand.kind === "project_init") {
+        if (!localCommand.projectName) {
+          toast.show({ variant: "warning", message: "Usage: /project init <name> [--blueprint <path>]" })
+        } else {
+          const response = await sdk.fetch(new URL('/api/v1/projects/init', sdk.url), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              name: localCommand.projectName,
+              blueprint_path: localCommand.blueprintPath,
+              workspace_path: initialDirectory,
+            }),
+          })
+          if (!response.ok) {
+            const detail = await response.text().catch(() => 'project init failed')
+            toast.show({ variant: 'error', message: `Project init failed: ${detail}` })
+          } else {
+            const payload = await response.json()
+            toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? localCommand.projectName}` })
+          }
+        }
+      } else if (localCommand.kind === "project_start") {
+        if (!localCommand.projectIdentifier) {
+          toast.show({ variant: "warning", message: "Usage: /project start <project-id-or-name>" })
+        } else {
+          const response = await sdk.fetch(new URL('/api/v1/projects/start', sdk.url), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ project_identifier: localCommand.projectIdentifier, continuous: true }),
+          })
+          if (!response.ok) {
+            const detail = await response.text().catch(() => 'project start failed')
+            toast.show({ variant: 'error', message: `Project start failed: ${detail}` })
+          } else {
+            const payload = await response.json()
+            toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? localCommand.projectIdentifier}` })
+          }
+        }
+      }
+
+      clearPromptState({ keepDialog })
+      props.onSubmit?.()
+      return
+    }
+
     const sessionID = await iife(async () => {
       if (props.sessionID) return props.sessionID
       if (sdk.sessionID) return sdk.sessionID
 
       if (sdk.penguin) {
-        const directory =
-          sync.session.get(props.sessionID ?? sdk.sessionID ?? "")?.directory ?? process.cwd()
+        const directory = initialDirectory
         const createUrl = new URL("/session", sdk.url)
         createUrl.searchParams.set("directory", directory)
         const created = await sdk.fetch(createUrl, {
@@ -708,6 +803,8 @@ export function Prompt(props: PromptProps) {
     const directory =
       sync.session.get(sessionID)?.directory ||
       sync.session.get(props.sessionID ?? "")?.directory ||
+      sync.data.path.directory ||
+      sdk.directory ||
       process.cwd()
     const messageID = sdk.penguin ? gen.next("msg") : Identifier.ascending("message")
     let inputText = store.prompt.input
@@ -739,101 +836,6 @@ export function Prompt(props: PromptProps) {
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
 
     if (sdk.penguin) {
-      const firstLine = inputText.split("\n", 1)[0].trim()
-      const firstToken = firstLine.split(/\s+/, 1)[0] ?? ""
-      const penguinCommand = /^\/[a-z_][a-z0-9_-]*$/i.test(firstToken)
-      if (penguinCommand) {
-        const name = firstToken.slice(1)
-        const showConfig = name === "config" || name === "settings"
-        const keepDialog = showConfig
-        if (showConfig) {
-          dialog.replace(() => <DialogSettings directory={directory} sessionID={sessionID} />)
-        } else if (name === "tool_details") {
-          const next = !kv.get("tool_details_visibility", true)
-          kv.set("tool_details_visibility", next)
-        } else if (name === "thinking") {
-          const next = !kv.get("thinking_visibility", true)
-          kv.set("thinking_visibility", next)
-        } else if (name === "project-init") {
-          const args = firstLine.slice(firstToken.length).trim()
-          const parts = args.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []
-          const normalized = parts.map((part) => part.replace(/^"|"$/g, ""))
-          const projectName = normalized[0]
-          const blueprintIndex = normalized.indexOf("--blueprint")
-          const blueprintPath = blueprintIndex >= 0 ? normalized[blueprintIndex + 1] : undefined
-          if (!projectName) {
-            toast.show({ variant: "warning", message: "Usage: /project-init <name> [--blueprint <path>]" })
-          } else {
-            const response = await sdk.fetch(new URL('/api/v1/projects/init', sdk.url), {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ name: projectName, blueprint_path: blueprintPath, workspace_path: directory }),
-            })
-            if (!response.ok) {
-              const detail = await response.text().catch(() => 'project init failed')
-              toast.show({ variant: 'error', message: `Project init failed: ${detail}` })
-            } else {
-              const payload = await response.json()
-              toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? projectName}` })
-            }
-          }
-        } else if (name === "project-start") {
-          const args = firstLine.slice(firstToken.length).trim()
-          const projectIdentifier = args.trim().replace(/^"|"$/g, "")
-          if (!projectIdentifier) {
-            toast.show({ variant: "warning", message: "Usage: /project-start <project-id-or-name>" })
-          } else {
-            const response = await sdk.fetch(new URL('/api/v1/projects/start', sdk.url), {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
-            })
-            if (!response.ok) {
-              const detail = await response.text().catch(() => 'project start failed')
-              toast.show({ variant: 'error', message: `Project start failed: ${detail}` })
-            } else {
-              const payload = await response.json()
-              toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? projectIdentifier}` })
-            }
-          }
-        } else {
-          toast.show({ variant: "warning", message: `Unknown command: /${name}` })
-        }
-        history.append({
-          ...store.prompt,
-          mode: currentMode,
-        })
-        if (!input.isDestroyed) {
-          input.extmarks.clear()
-        }
-        setStore("prompt", {
-          input: "",
-          parts: [],
-        })
-        setStore("extmarkToPartIndex", new Map())
-        if (!keepDialog) {
-          dialog.clear()
-        }
-        if (!input.isDestroyed) {
-          input.clear()
-          input.setText("")
-          input.getLayoutNode().markDirty()
-          renderer.requestRender()
-        }
-        queueMicrotask(() => {
-          setStore("prompt", "input", "")
-        })
-        props.onSubmit?.()
-        if (shouldNavigate) {
-          setTimeout(() => {
-            route.navigate({
-              type: "session",
-              sessionID,
-            })
-          }, 0)
-        }
-        return
-      }
       const now = Date.now()
       const user = {
         id: messageID,

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -754,6 +754,48 @@ export function Prompt(props: PromptProps) {
         } else if (name === "thinking") {
           const next = !kv.get("thinking_visibility", true)
           kv.set("thinking_visibility", next)
+        } else if (name === "project-init") {
+          const args = firstLine.slice(firstToken.length).trim()
+          const parts = args.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []
+          const normalized = parts.map((part) => part.replace(/^"|"$/g, ""))
+          const projectName = normalized[0]
+          const blueprintIndex = normalized.indexOf("--blueprint")
+          const blueprintPath = blueprintIndex >= 0 ? normalized[blueprintIndex + 1] : undefined
+          if (!projectName) {
+            toast.show({ variant: "warning", message: "Usage: /project-init <name> [--blueprint <path>]" })
+          } else {
+            const response = await sdk.fetch(new URL('/api/v1/projects/init', sdk.url), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: projectName, blueprint_path: blueprintPath, workspace_path: directory }),
+            })
+            if (!response.ok) {
+              const detail = await response.text().catch(() => 'project init failed')
+              toast.show({ variant: 'error', message: `Project init failed: ${detail}` })
+            } else {
+              const payload = await response.json()
+              toast.show({ variant: 'success', message: `Project initialized: ${payload.project?.name ?? projectName}` })
+            }
+          }
+        } else if (name === "project-start") {
+          const args = firstLine.slice(firstToken.length).trim()
+          const projectIdentifier = args.trim().replace(/^"|"$/g, "")
+          if (!projectIdentifier) {
+            toast.show({ variant: "warning", message: "Usage: /project-start <project-id-or-name>" })
+          } else {
+            const response = await sdk.fetch(new URL('/api/v1/projects/start', sdk.url), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
+            })
+            if (!response.ok) {
+              const detail = await response.text().catch(() => 'project start failed')
+              toast.show({ variant: 'error', message: `Project start failed: ${detail}` })
+            } else {
+              const payload = await response.json()
+              toast.show({ variant: 'success', message: `Project started: ${payload.project?.name ?? projectIdentifier}` })
+            }
+          }
         } else {
           toast.show({ variant: "warning", message: `Unknown command: /${name}` })
         }

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
@@ -90,8 +90,8 @@ export async function executePenguinHttpLocalCommand(options: {
   }
 
   if (command.kind === "project_init") {
-    const projectName = requireArg(command.projectName, "/project init <name> [--blueprint <path>]")
-    if (!projectName) return usage("/project init <name> [--blueprint <path>]")
+    const projectName = requireArg(command.projectName, "/project init <name> [--blueprint <path>] [--workspace <path>]")
+    if (!projectName) return usage("/project init <name> [--blueprint <path>] [--workspace <path>]")
     const payload = objectPayload(
       await fetchJson(fetch, baseUrl, "/api/v1/projects/init", {
         method: "POST",
@@ -99,7 +99,7 @@ export async function executePenguinHttpLocalCommand(options: {
         body: JSON.stringify({
           name: projectName,
           blueprint_path: command.blueprintPath,
-          workspace_path: directory,
+          workspace_path: command.workspacePath ?? directory,
         }),
       }),
     )

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
@@ -1,0 +1,212 @@
+import type { PenguinLocalCommand } from "./penguin-local-command"
+
+type PenguinHttpCommand = Extract<
+  PenguinLocalCommand,
+  | { kind: "project_create" }
+  | { kind: "project_init" }
+  | { kind: "project_list" }
+  | { kind: "project_show" }
+  | { kind: "project_delete" }
+  | { kind: "project_start" }
+  | { kind: "task_create" }
+  | { kind: "task_list" }
+  | { kind: "task_show" }
+  | { kind: "task_start" }
+  | { kind: "task_complete" }
+  | { kind: "task_execute" }
+  | { kind: "task_delete" }
+  | { kind: "task_clarification_resume" }
+>
+
+export type PenguinLocalCommandFetch = (input: URL, init?: RequestInit) => Promise<Response>
+
+export type PenguinCommandResult = {
+  variant: "success" | "warning"
+  message: string
+}
+
+export function isPenguinHttpLocalCommand(command: PenguinLocalCommand): command is PenguinHttpCommand {
+  return command.kind.startsWith("project_") || command.kind.startsWith("task_")
+}
+
+function requireArg(value: string | undefined, usage: string): string | undefined {
+  return value || undefined
+}
+
+function usage(message: string): PenguinCommandResult {
+  return { variant: "warning", message: `Usage: ${message}` }
+}
+
+async function fetchJson(
+  fetcher: PenguinLocalCommandFetch,
+  baseUrl: string | URL,
+  path: string,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await fetcher(new URL(path, baseUrl), init)
+  if (!response.ok) {
+    const detail = await response.text().catch(() => `${path} failed`)
+    throw new Error(detail)
+  }
+  return response.json()
+}
+
+function objectPayload(value: unknown): Record<string, any> {
+  return value && typeof value === "object" ? (value as Record<string, any>) : {}
+}
+
+export async function executePenguinHttpLocalCommand(options: {
+  command: PenguinHttpCommand
+  fetch: PenguinLocalCommandFetch
+  baseUrl: string | URL
+  directory: string
+}): Promise<PenguinCommandResult> {
+  const { command, fetch, baseUrl, directory } = options
+
+  if (command.kind === "project_create") {
+    const projectName = requireArg(command.projectName, "/project create <name> [--description <text>] [--workspace <path>]")
+    if (!projectName) return usage("/project create <name> [--description <text>] [--workspace <path>]")
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, "/api/v1/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: projectName,
+          description: command.description,
+          workspace_path: command.workspacePath ?? directory,
+        }),
+      }),
+    )
+    return { variant: "success", message: `Project created: ${payload.name ?? projectName}` }
+  }
+
+  if (command.kind === "project_init") {
+    const projectName = requireArg(command.projectName, "/project init <name> [--blueprint <path>]")
+    if (!projectName) return usage("/project init <name> [--blueprint <path>]")
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, "/api/v1/projects/init", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: projectName,
+          blueprint_path: command.blueprintPath,
+          workspace_path: directory,
+        }),
+      }),
+    )
+    const blueprint = objectPayload(payload.blueprint)
+    const taskSummary = payload.blueprint ? ` (${blueprint.tasks_created ?? 0} created, ${blueprint.tasks_updated ?? 0} updated)` : ""
+    return { variant: "success", message: `Project initialized: ${objectPayload(payload.project).name ?? projectName}${taskSummary}` }
+  }
+
+  if (command.kind === "project_list") {
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, "/api/v1/projects"))
+    return { variant: "success", message: `Projects: ${Array.isArray(payload.projects) ? payload.projects.length : 0}` }
+  }
+
+  if (command.kind === "project_show") {
+    const projectIdentifier = requireArg(command.projectIdentifier, "/project show <project-id>")
+    if (!projectIdentifier) return usage("/project show <project-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/projects/${encodeURIComponent(projectIdentifier)}`))
+    return { variant: "success", message: `Project: ${payload.name ?? projectIdentifier} (${Array.isArray(payload.tasks) ? payload.tasks.length : 0} tasks)` }
+  }
+
+  if (command.kind === "project_delete") {
+    const projectIdentifier = requireArg(command.projectIdentifier, "/project delete <project-id>")
+    if (!projectIdentifier) return usage("/project delete <project-id>")
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, `/api/v1/projects/${encodeURIComponent(projectIdentifier)}`, { method: "DELETE" }),
+    )
+    return { variant: "success", message: String(payload.message ?? `Project deleted: ${projectIdentifier}`) }
+  }
+
+  if (command.kind === "project_start") {
+    const projectIdentifier = requireArg(command.projectIdentifier, "/project start <project-id-or-name>")
+    if (!projectIdentifier) return usage("/project start <project-id-or-name>")
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, "/api/v1/projects/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
+      }),
+    )
+    return { variant: "success", message: `Project started: ${objectPayload(payload.project).name ?? projectIdentifier}` }
+  }
+
+  if (command.kind === "task_create") {
+    const projectId = requireArg(command.projectId, "/task create <project-id> <title>")
+    const title = requireArg(command.title, "/task create <project-id> <title>")
+    if (!projectId || !title) return usage("/task create <project-id> <title>")
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, "/api/v1/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          project_id: projectId,
+          title,
+          description: command.description,
+          parent_task_id: command.parentTaskId,
+          priority: command.priority,
+        }),
+      }),
+    )
+    return { variant: "success", message: `Task created: ${payload.title ?? title}` }
+  }
+
+  if (command.kind === "task_list") {
+    const url = new URL("/api/v1/tasks", baseUrl)
+    if (command.projectId) url.searchParams.set("project_id", command.projectId)
+    if (command.status) url.searchParams.set("status", command.status)
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(await response.text().catch(() => "task list failed"))
+    const payload = objectPayload(await response.json())
+    return { variant: "success", message: `Tasks: ${Array.isArray(payload.tasks) ? payload.tasks.length : 0}` }
+  }
+
+  if (command.kind === "task_show") {
+    const taskId = requireArg(command.taskId, "/task show <task-id>")
+    if (!taskId) return usage("/task show <task-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}`))
+    return { variant: "success", message: `Task: ${payload.title ?? taskId} (${payload.status ?? "unknown"})` }
+  }
+
+  if (command.kind === "task_start") {
+    const taskId = requireArg(command.taskId, "/task start <task-id>")
+    if (!taskId) return usage("/task start <task-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/start`, { method: "POST" }))
+    return { variant: "success", message: String(payload.message ?? `Task started: ${taskId}`) }
+  }
+
+  if (command.kind === "task_complete") {
+    const taskId = requireArg(command.taskId, "/task complete <task-id>")
+    if (!taskId) return usage("/task complete <task-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/complete`, { method: "POST" }))
+    return { variant: "success", message: String(payload.message ?? `Task completed: ${taskId}`) }
+  }
+
+  if (command.kind === "task_execute") {
+    const taskId = requireArg(command.taskId, "/task execute <task-id>")
+    if (!taskId) return usage("/task execute <task-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/execute`, { method: "POST" }))
+    return { variant: "success", message: `Task execution started: ${objectPayload(payload.task).title ?? taskId}` }
+  }
+
+  if (command.kind === "task_delete") {
+    const taskId = requireArg(command.taskId, "/task delete <task-id>")
+    if (!taskId) return usage("/task delete <task-id>")
+    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}`, { method: "DELETE" }))
+    return { variant: "success", message: String(payload.message ?? `Task deleted: ${taskId}`) }
+  }
+
+  const taskId = requireArg(command.taskId, "/task resume <task-id> <answer>")
+  const answer = requireArg(command.answer, "/task resume <task-id> <answer>")
+  if (!taskId || !answer) return usage("/task resume <task-id> <answer>")
+  const payload = objectPayload(
+    await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/clarification/resume`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answer, answered_by: "tui" }),
+    }),
+  )
+  return { variant: "success", message: `Clarification resumed: ${objectPayload(payload.task).title ?? taskId}` }
+}

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command-runtime.ts
@@ -25,6 +25,14 @@ export type PenguinCommandResult = {
   message: string
 }
 
+export function penguinHttpLocalCommandNeedsSession(command: PenguinLocalCommand): boolean {
+  return (
+    command.kind === "project_start" ||
+    command.kind === "task_execute" ||
+    command.kind === "task_clarification_resume"
+  )
+}
+
 export function isPenguinHttpLocalCommand(command: PenguinLocalCommand): command is PenguinHttpCommand {
   return command.kind.startsWith("project_") || command.kind.startsWith("task_")
 }
@@ -60,8 +68,9 @@ export async function executePenguinHttpLocalCommand(options: {
   fetch: PenguinLocalCommandFetch
   baseUrl: string | URL
   directory: string
+  sessionID?: string
 }): Promise<PenguinCommandResult> {
-  const { command, fetch, baseUrl, directory } = options
+  const { command, fetch, baseUrl, directory, sessionID } = options
 
   if (command.kind === "project_create") {
     const projectName = requireArg(command.projectName, "/project create <name> [--description <text>] [--workspace <path>]")
@@ -127,7 +136,12 @@ export async function executePenguinHttpLocalCommand(options: {
       await fetchJson(fetch, baseUrl, "/api/v1/projects/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ project_identifier: projectIdentifier, continuous: true }),
+        body: JSON.stringify({
+          project_identifier: projectIdentifier,
+          continuous: true,
+          session_id: sessionID,
+          directory,
+        }),
       }),
     )
     return { variant: "success", message: `Project started: ${objectPayload(payload.project).name ?? projectIdentifier}` }
@@ -187,7 +201,13 @@ export async function executePenguinHttpLocalCommand(options: {
   if (command.kind === "task_execute") {
     const taskId = requireArg(command.taskId, "/task execute <task-id>")
     if (!taskId) return usage("/task execute <task-id>")
-    const payload = objectPayload(await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/execute`, { method: "POST" }))
+    const payload = objectPayload(
+      await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/execute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionID, directory }),
+      }),
+    )
     return { variant: "success", message: `Task execution started: ${objectPayload(payload.task).title ?? taskId}` }
   }
 
@@ -205,7 +225,7 @@ export async function executePenguinHttpLocalCommand(options: {
     await fetchJson(fetch, baseUrl, `/api/v1/tasks/${encodeURIComponent(taskId)}/clarification/resume`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ answer, answered_by: "tui" }),
+      body: JSON.stringify({ answer, answered_by: "tui", session_id: sessionID, directory }),
     }),
   )
   return { variant: "success", message: `Clarification resumed: ${objectPayload(payload.task).title ?? taskId}` }

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
@@ -1,0 +1,108 @@
+export type PenguinLocalCommand =
+  | { kind: "config" }
+  | { kind: "settings" }
+  | { kind: "tool_details" }
+  | { kind: "thinking" }
+  | {
+      kind: "project_init"
+      projectName?: string
+      blueprintPath?: string
+    }
+  | {
+      kind: "project_start"
+      projectIdentifier?: string
+    }
+
+export type PenguinPromptClassification =
+  | {
+      kind: "local_command"
+      command: PenguinLocalCommand
+    }
+  | {
+      kind: "chat"
+    }
+
+function splitArgs(input: string): string[] {
+  return input.match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? []
+}
+
+export function parsePenguinLocalCommand(inputText: string): PenguinLocalCommand | null {
+  const firstLine = inputText.split("\n", 1)[0]?.trim() ?? ""
+  if (!firstLine.startsWith("/")) return null
+
+  const tokens = splitArgs(firstLine)
+  if (tokens.length === 0) return null
+
+  const head = tokens[0]
+  if (!head.startsWith("/")) return null
+  const command = head.slice(1)
+
+  if (command === "config") return { kind: "config" }
+  if (command === "settings") return { kind: "settings" }
+  if (command === "tool_details") return { kind: "tool_details" }
+  if (command === "thinking") return { kind: "thinking" }
+
+  if (command === "project-init") {
+    const [, ...args] = tokens
+    const projectName = args[0]
+    const blueprintIndex = args.indexOf("--blueprint")
+    const blueprintPath = blueprintIndex >= 0 ? args[blueprintIndex + 1] : undefined
+    return { kind: "project_init", projectName, blueprintPath }
+  }
+
+  if (command === "project-start") {
+    const [, ...args] = tokens
+    return { kind: "project_start", projectIdentifier: args.join(" ").trim() || undefined }
+  }
+
+  if (command === "project") {
+    const subcommand = tokens[1]
+    if (subcommand === "init") {
+      const args = tokens.slice(2)
+      const projectName = args[0]
+      const blueprintIndex = args.indexOf("--blueprint")
+      const blueprintPath = blueprintIndex >= 0 ? args[blueprintIndex + 1] : undefined
+      return { kind: "project_init", projectName, blueprintPath }
+    }
+
+    if (subcommand === "start") {
+      const args = tokens.slice(2)
+      return { kind: "project_start", projectIdentifier: args.join(" ").trim() || undefined }
+    }
+  }
+
+  return null
+}
+
+export function classifyPenguinPromptInput(inputText: string): PenguinPromptClassification {
+  const command = parsePenguinLocalCommand(inputText)
+  if (command) {
+    return {
+      kind: "local_command",
+      command,
+    }
+  }
+
+  return {
+    kind: "chat",
+  }
+}
+
+export function shouldBootstrapPenguinSession(options: {
+  propsSessionID?: string
+  sdkSessionID?: string
+  classification: PenguinPromptClassification
+}): boolean {
+  if (options.classification.kind === "local_command") return false
+  if (options.propsSessionID) return false
+  if (options.sdkSessionID) return false
+  return true
+}
+
+export function shouldNavigateAfterPenguinSubmit(options: {
+  propsSessionID?: string
+  classification: PenguinPromptClassification
+}): boolean {
+  if (options.classification.kind === "local_command") return false
+  return !options.propsSessionID
+}

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
@@ -4,13 +4,68 @@ export type PenguinLocalCommand =
   | { kind: "tool_details" }
   | { kind: "thinking" }
   | {
+      kind: "project_create"
+      projectName?: string
+      description?: string
+      workspacePath?: string
+    }
+  | {
       kind: "project_init"
       projectName?: string
       blueprintPath?: string
     }
   | {
+      kind: "project_list"
+    }
+  | {
+      kind: "project_show"
+      projectIdentifier?: string
+    }
+  | {
+      kind: "project_delete"
+      projectIdentifier?: string
+    }
+  | {
       kind: "project_start"
       projectIdentifier?: string
+    }
+  | {
+      kind: "task_create"
+      projectId?: string
+      title?: string
+      description?: string
+      parentTaskId?: string
+      priority?: number
+    }
+  | {
+      kind: "task_list"
+      projectId?: string
+      status?: string
+    }
+  | {
+      kind: "task_show"
+      taskId?: string
+    }
+  | {
+      kind: "task_start"
+      taskId?: string
+    }
+  | {
+      kind: "task_complete"
+      taskId?: string
+    }
+  | {
+      kind: "task_execute"
+      taskId?: string
+    }
+  | {
+      kind: "task_delete"
+      taskId?: string
+    }
+  | {
+      kind: "task_clarification_resume"
+      taskId?: string
+      answer?: string
     }
 
 export type PenguinPromptClassification =
@@ -24,6 +79,71 @@ export type PenguinPromptClassification =
 
 function splitArgs(input: string): string[] {
   return input.match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? []
+}
+
+function optionValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name)
+  if (index < 0) return undefined
+  return args[index + 1]
+}
+
+function withoutOptions(args: string[], optionNames: string[]): string[] {
+  const result: string[] = []
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (optionNames.includes(arg)) {
+      index++
+      continue
+    }
+    result.push(arg)
+  }
+  return result
+}
+
+function parsePriority(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function parseProjectInit(args: string[]): PenguinLocalCommand {
+  const projectName = withoutOptions(args, ["--blueprint"])[0]
+  return {
+    kind: "project_init",
+    projectName,
+    blueprintPath: optionValue(args, "--blueprint"),
+  }
+}
+
+function parseProjectCreate(args: string[]): PenguinLocalCommand {
+  const projectName = withoutOptions(args, ["--description", "--workspace"])[0]
+  return {
+    kind: "project_create",
+    projectName,
+    description: optionValue(args, "--description"),
+    workspacePath: optionValue(args, "--workspace"),
+  }
+}
+
+function parseTaskCreate(args: string[]): PenguinLocalCommand {
+  const positional = withoutOptions(args, ["--description", "--parent", "--priority"])
+  return {
+    kind: "task_create",
+    projectId: positional[0],
+    title: positional[1],
+    description: optionValue(args, "--description"),
+    parentTaskId: optionValue(args, "--parent"),
+    priority: parsePriority(optionValue(args, "--priority")),
+  }
+}
+
+function parseTaskList(args: string[]): PenguinLocalCommand {
+  const positional = withoutOptions(args, ["--status"])
+  return {
+    kind: "task_list",
+    projectId: positional[0],
+    status: optionValue(args, "--status"),
+  }
 }
 
 export function parsePenguinLocalCommand(inputText: string): PenguinLocalCommand | null {
@@ -42,32 +162,68 @@ export function parsePenguinLocalCommand(inputText: string): PenguinLocalCommand
   if (command === "tool_details") return { kind: "tool_details" }
   if (command === "thinking") return { kind: "thinking" }
 
-  if (command === "project-init") {
-    const [, ...args] = tokens
-    const projectName = args[0]
-    const blueprintIndex = args.indexOf("--blueprint")
-    const blueprintPath = blueprintIndex >= 0 ? args[blueprintIndex + 1] : undefined
-    return { kind: "project_init", projectName, blueprintPath }
+  if (command === "project-create") return parseProjectCreate(tokens.slice(1))
+  if (command === "project-init") return parseProjectInit(tokens.slice(1))
+  if (command === "project-list") return { kind: "project_list" }
+  if (command === "project-show" || command === "project-get") {
+    return { kind: "project_show", projectIdentifier: tokens.slice(1).join(" ").trim() || undefined }
+  }
+  if (command === "project-delete") {
+    return { kind: "project_delete", projectIdentifier: tokens.slice(1).join(" ").trim() || undefined }
+  }
+  if (command === "project-start") {
+    return { kind: "project_start", projectIdentifier: tokens.slice(1).join(" ").trim() || undefined }
   }
 
-  if (command === "project-start") {
-    const [, ...args] = tokens
-    return { kind: "project_start", projectIdentifier: args.join(" ").trim() || undefined }
-  }
+  if (command === "task-create") return parseTaskCreate(tokens.slice(1))
+  if (command === "task-list") return parseTaskList(tokens.slice(1))
+  if (command === "task-show" || command === "task-get") return { kind: "task_show", taskId: tokens[1] }
+  if (command === "task-start") return { kind: "task_start", taskId: tokens[1] }
+  if (command === "task-complete") return { kind: "task_complete", taskId: tokens[1] }
+  if (command === "task-execute") return { kind: "task_execute", taskId: tokens[1] }
+  if (command === "task-delete") return { kind: "task_delete", taskId: tokens[1] }
 
   if (command === "project") {
     const subcommand = tokens[1]
-    if (subcommand === "init") {
-      const args = tokens.slice(2)
-      const projectName = args[0]
-      const blueprintIndex = args.indexOf("--blueprint")
-      const blueprintPath = blueprintIndex >= 0 ? args[blueprintIndex + 1] : undefined
-      return { kind: "project_init", projectName, blueprintPath }
+    const args = tokens.slice(2)
+    if (subcommand === "create") return parseProjectCreate(args)
+    if (subcommand === "init") return parseProjectInit(args)
+    if (subcommand === "list") return { kind: "project_list" }
+    if (subcommand === "show" || subcommand === "get") {
+      return { kind: "project_show", projectIdentifier: args.join(" ").trim() || undefined }
     }
-
+    if (subcommand === "delete") {
+      return { kind: "project_delete", projectIdentifier: args.join(" ").trim() || undefined }
+    }
     if (subcommand === "start") {
-      const args = tokens.slice(2)
       return { kind: "project_start", projectIdentifier: args.join(" ").trim() || undefined }
+    }
+    // `project run` is intentionally deferred until its cross-surface contract is repaired.
+  }
+
+  if (command === "task") {
+    const subcommand = tokens[1]
+    const args = tokens.slice(2)
+    if (subcommand === "create") return parseTaskCreate(args)
+    if (subcommand === "list") return parseTaskList(args)
+    if (subcommand === "show" || subcommand === "get") return { kind: "task_show", taskId: args[0] }
+    if (subcommand === "start") return { kind: "task_start", taskId: args[0] }
+    if (subcommand === "complete") return { kind: "task_complete", taskId: args[0] }
+    if (subcommand === "execute") return { kind: "task_execute", taskId: args[0] }
+    if (subcommand === "delete") return { kind: "task_delete", taskId: args[0] }
+    if (subcommand === "resume") {
+      return {
+        kind: "task_clarification_resume",
+        taskId: args[0],
+        answer: args.slice(1).join(" ").trim() || undefined,
+      }
+    }
+    if (subcommand === "clarification" && args[0] === "resume") {
+      return {
+        kind: "task_clarification_resume",
+        taskId: args[1],
+        answer: args.slice(2).join(" ").trim() || undefined,
+      }
     }
   }
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/prompt/penguin-local-command.ts
@@ -13,6 +13,7 @@ export type PenguinLocalCommand =
       kind: "project_init"
       projectName?: string
       blueprintPath?: string
+      workspacePath?: string
     }
   | {
       kind: "project_list"
@@ -107,11 +108,12 @@ function parsePriority(value: string | undefined): number | undefined {
 }
 
 function parseProjectInit(args: string[]): PenguinLocalCommand {
-  const projectName = withoutOptions(args, ["--blueprint"])[0]
+  const projectName = withoutOptions(args, ["--blueprint", "--workspace"])[0]
   return {
     kind: "project_init",
     projectName,
     blueprintPath: optionValue(args, "--blueprint"),
+    workspacePath: optionValue(args, "--workspace"),
   }
 }
 

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
@@ -52,7 +52,7 @@ describe("penguin HTTP local command runtime", () => {
     expect(response.result.message).toBe("Project created: Demo")
 
     response = await run(
-      { kind: "project_init", projectName: "Demo", blueprintPath: "./blueprint.md" },
+      { kind: "project_init", projectName: "Demo", blueprintPath: "./blueprint.md", workspacePath: "/tmp/demo-workspace" },
       { project: { name: "Demo" }, blueprint: { tasks_created: 2, tasks_updated: 1 } },
     )
     expect(response.records[0]).toEqual({
@@ -61,7 +61,7 @@ describe("penguin HTTP local command runtime", () => {
       body: {
         name: "Demo",
         blueprint_path: "./blueprint.md",
-        workspace_path: "/tmp/workspace",
+        workspace_path: "/tmp/demo-workspace",
       },
     })
     expect(response.result.message).toBe("Project initialized: Demo (2 created, 1 updated)")

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
@@ -82,7 +82,7 @@ describe("penguin HTTP local command runtime", () => {
     expect(response.records[0]).toEqual({
       url: "http://127.0.0.1:9010/api/v1/projects/start",
       method: "POST",
-      body: { project_identifier: "Demo", continuous: true },
+      body: { project_identifier: "Demo", continuous: true, directory: "/tmp/workspace" },
     })
 
     response = await run({ kind: "project_delete", projectIdentifier: "project-1" }, { message: "deleted" })
@@ -136,7 +136,7 @@ describe("penguin HTTP local command runtime", () => {
     expect(response.records[0]).toEqual({
       url: "http://127.0.0.1:9010/api/v1/tasks/task-1/clarification/resume",
       method: "POST",
-      body: { answer: "Use Postgres", answered_by: "tui" },
+      body: { answer: "Use Postgres", answered_by: "tui", directory: "/tmp/workspace" },
     })
   })
 

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test"
+
+import { executePenguinHttpLocalCommand } from "../../../src/cli/cmd/tui/component/prompt/penguin-local-command-runtime"
+import type { PenguinLocalCommand } from "../../../src/cli/cmd/tui/component/prompt/penguin-local-command"
+
+type RequestRecord = {
+  url: string
+  method: string
+  body?: any
+}
+
+function makeFetch(records: RequestRecord[], payload: unknown = {}): typeof fetch {
+  return (async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = input instanceof URL ? input.toString() : String(input)
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined
+    records.push({ url, method: init?.method ?? "GET", body })
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  }) as typeof fetch
+}
+
+async function run(command: PenguinLocalCommand, payload: unknown = {}) {
+  const records: RequestRecord[] = []
+  const result = await executePenguinHttpLocalCommand({
+    command: command as any,
+    fetch: makeFetch(records, payload),
+    baseUrl: "http://127.0.0.1:9010",
+    directory: "/tmp/workspace",
+  })
+  return { records, result }
+}
+
+describe("penguin HTTP local command runtime", () => {
+  test("routes project commands to project endpoints", async () => {
+    let response = await run(
+      { kind: "project_create", projectName: "Demo", description: "Desc" },
+      { name: "Demo" },
+    )
+    expect(response.records).toEqual([
+      {
+        url: "http://127.0.0.1:9010/api/v1/projects",
+        method: "POST",
+        body: {
+          name: "Demo",
+          description: "Desc",
+          workspace_path: "/tmp/workspace",
+        },
+      },
+    ])
+    expect(response.result.message).toBe("Project created: Demo")
+
+    response = await run(
+      { kind: "project_init", projectName: "Demo", blueprintPath: "./blueprint.md" },
+      { project: { name: "Demo" }, blueprint: { tasks_created: 2, tasks_updated: 1 } },
+    )
+    expect(response.records[0]).toEqual({
+      url: "http://127.0.0.1:9010/api/v1/projects/init",
+      method: "POST",
+      body: {
+        name: "Demo",
+        blueprint_path: "./blueprint.md",
+        workspace_path: "/tmp/workspace",
+      },
+    })
+    expect(response.result.message).toBe("Project initialized: Demo (2 created, 1 updated)")
+
+    response = await run({ kind: "project_list" }, { projects: [{ id: "p1" }] })
+    expect(response.records[0]).toEqual({
+      url: "http://127.0.0.1:9010/api/v1/projects",
+      method: "GET",
+      body: undefined,
+    })
+    expect(response.result.message).toBe("Projects: 1")
+
+    response = await run({ kind: "project_show", projectIdentifier: "project-1" }, { name: "Demo", tasks: [] })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/projects/project-1")
+    expect(response.records[0].method).toBe("GET")
+
+    response = await run({ kind: "project_start", projectIdentifier: "Demo" }, { project: { name: "Demo" } })
+    expect(response.records[0]).toEqual({
+      url: "http://127.0.0.1:9010/api/v1/projects/start",
+      method: "POST",
+      body: { project_identifier: "Demo", continuous: true },
+    })
+
+    response = await run({ kind: "project_delete", projectIdentifier: "project-1" }, { message: "deleted" })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/projects/project-1")
+    expect(response.records[0].method).toBe("DELETE")
+  })
+
+  test("routes task commands to task endpoints", async () => {
+    let response = await run(
+      { kind: "task_create", projectId: "project-1", title: "Write tests", priority: 3 },
+      { title: "Write tests" },
+    )
+    expect(response.records[0]).toEqual({
+      url: "http://127.0.0.1:9010/api/v1/tasks",
+      method: "POST",
+      body: {
+        project_id: "project-1",
+        title: "Write tests",
+        priority: 3,
+      },
+    })
+
+    response = await run({ kind: "task_list", projectId: "project-1", status: "active" }, { tasks: [] })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks?project_id=project-1&status=active")
+    expect(response.records[0].method).toBe("GET")
+
+    response = await run({ kind: "task_show", taskId: "task-1" }, { title: "Task", status: "active" })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks/task-1")
+    expect(response.records[0].method).toBe("GET")
+
+    response = await run({ kind: "task_start", taskId: "task-1" }, { message: "started" })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks/task-1/start")
+    expect(response.records[0].method).toBe("POST")
+
+    response = await run({ kind: "task_complete", taskId: "task-1" }, { message: "completed" })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks/task-1/complete")
+    expect(response.records[0].method).toBe("POST")
+
+    response = await run({ kind: "task_execute", taskId: "task-1" }, { task: { title: "Task" } })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks/task-1/execute")
+    expect(response.records[0].method).toBe("POST")
+
+    response = await run({ kind: "task_delete", taskId: "task-1" }, { message: "deleted" })
+    expect(response.records[0].url).toBe("http://127.0.0.1:9010/api/v1/tasks/task-1")
+    expect(response.records[0].method).toBe("DELETE")
+
+    response = await run(
+      { kind: "task_clarification_resume", taskId: "task-1", answer: "Use Postgres" },
+      { task: { title: "Task" } },
+    )
+    expect(response.records[0]).toEqual({
+      url: "http://127.0.0.1:9010/api/v1/tasks/task-1/clarification/resume",
+      method: "POST",
+      body: { answer: "Use Postgres", answered_by: "tui" },
+    })
+  })
+
+  test("returns warnings instead of fetching for missing required arguments", async () => {
+    const records: RequestRecord[] = []
+    const result = await executePenguinHttpLocalCommand({
+      command: { kind: "project_start" },
+      fetch: makeFetch(records),
+      baseUrl: "http://127.0.0.1:9010",
+      directory: "/tmp/workspace",
+    })
+
+    expect(records).toEqual([])
+    expect(result).toEqual({ variant: "warning", message: "Usage: /project start <project-id-or-name>" })
+  })
+})

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
@@ -24,6 +24,18 @@ describe("penguin local command parser", () => {
     })
   })
 
+  test("parses project create/list/show/delete forms", () => {
+    expect(parsePenguinLocalCommand('/project create "Auth Rewrite" --description "Rewrite auth" --workspace ./auth')).toEqual({
+      kind: "project_create",
+      projectName: "Auth Rewrite",
+      description: "Rewrite auth",
+      workspacePath: "./auth",
+    })
+    expect(parsePenguinLocalCommand('/project list')).toEqual({ kind: "project_list" })
+    expect(parsePenguinLocalCommand('/project show project-1')).toEqual({ kind: "project_show", projectIdentifier: "project-1" })
+    expect(parsePenguinLocalCommand('/project delete project-1')).toEqual({ kind: "project_delete", projectIdentifier: "project-1" })
+  })
+
   test("parses dashed and spaced project start forms equivalently", () => {
     expect(parsePenguinLocalCommand('/project-start "Auth Rewrite"')).toEqual({
       kind: "project_start",
@@ -32,6 +44,36 @@ describe("penguin local command parser", () => {
     expect(parsePenguinLocalCommand('/project start "Auth Rewrite"')).toEqual({
       kind: "project_start",
       projectIdentifier: "Auth Rewrite",
+    })
+  })
+
+  test("does not parse deferred project run command", () => {
+    expect(parsePenguinLocalCommand('/project run ./blueprint.md')).toBeNull()
+  })
+
+  test("parses task command forms", () => {
+    expect(parsePenguinLocalCommand('/task create project-1 "Write tests" --description "Add regression tests" --parent parent-1 --priority 3')).toEqual({
+      kind: "task_create",
+      projectId: "project-1",
+      title: "Write tests",
+      description: "Add regression tests",
+      parentTaskId: "parent-1",
+      priority: 3,
+    })
+    expect(parsePenguinLocalCommand('/task list project-1 --status active')).toEqual({
+      kind: "task_list",
+      projectId: "project-1",
+      status: "active",
+    })
+    expect(parsePenguinLocalCommand('/task show task-1')).toEqual({ kind: "task_show", taskId: "task-1" })
+    expect(parsePenguinLocalCommand('/task start task-1')).toEqual({ kind: "task_start", taskId: "task-1" })
+    expect(parsePenguinLocalCommand('/task complete task-1')).toEqual({ kind: "task_complete", taskId: "task-1" })
+    expect(parsePenguinLocalCommand('/task execute task-1')).toEqual({ kind: "task_execute", taskId: "task-1" })
+    expect(parsePenguinLocalCommand('/task delete task-1')).toEqual({ kind: "task_delete", taskId: "task-1" })
+    expect(parsePenguinLocalCommand('/task resume task-1 "Use Postgres"')).toEqual({
+      kind: "task_clarification_resume",
+      taskId: "task-1",
+      answer: "Use Postgres",
     })
   })
 
@@ -55,6 +97,17 @@ describe("penguin prompt classification", () => {
         kind: "project_init",
         projectName: "Demo",
         blueprintPath: "./demo.md",
+      },
+    })
+  })
+
+  test("classifies task commands as local commands", () => {
+    expect(classifyPenguinPromptInput('/task list project-1')).toEqual({
+      kind: "local_command",
+      command: {
+        kind: "task_list",
+        projectId: "project-1",
+        status: undefined,
       },
     })
   })

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
@@ -9,18 +9,20 @@ import {
 
 describe("penguin local command parser", () => {
   test("parses dashed project init form", () => {
-    expect(parsePenguinLocalCommand('/project-init "Auth Rewrite" --blueprint ./auth.md')).toEqual({
+    expect(parsePenguinLocalCommand('/project-init "Auth Rewrite" --blueprint ./auth.md --workspace ./auth-workspace')).toEqual({
       kind: "project_init",
       projectName: "Auth Rewrite",
       blueprintPath: "./auth.md",
+      workspacePath: "./auth-workspace",
     })
   })
 
   test("parses spaced project init form", () => {
-    expect(parsePenguinLocalCommand('/project init "Auth Rewrite" --blueprint ./auth.md')).toEqual({
+    expect(parsePenguinLocalCommand('/project init "Auth Rewrite" --blueprint ./auth.md --workspace ./auth-workspace')).toEqual({
       kind: "project_init",
       projectName: "Auth Rewrite",
       blueprintPath: "./auth.md",
+      workspacePath: "./auth-workspace",
     })
   })
 
@@ -91,12 +93,13 @@ describe("penguin local command parser", () => {
 
 describe("penguin prompt classification", () => {
   test("classifies project commands as local commands", () => {
-    expect(classifyPenguinPromptInput('/project init Demo --blueprint ./demo.md')).toEqual({
+    expect(classifyPenguinPromptInput('/project init Demo --blueprint ./demo.md --workspace ./demo-workspace')).toEqual({
       kind: "local_command",
       command: {
         kind: "project_init",
         projectName: "Demo",
         blueprintPath: "./demo.md",
+        workspacePath: "./demo-workspace",
       },
     })
   })

--- a/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  classifyPenguinPromptInput,
+  parsePenguinLocalCommand,
+  shouldBootstrapPenguinSession,
+  shouldNavigateAfterPenguinSubmit,
+} from "../../../src/cli/cmd/tui/component/prompt/penguin-local-command"
+
+describe("penguin local command parser", () => {
+  test("parses dashed project init form", () => {
+    expect(parsePenguinLocalCommand('/project-init "Auth Rewrite" --blueprint ./auth.md')).toEqual({
+      kind: "project_init",
+      projectName: "Auth Rewrite",
+      blueprintPath: "./auth.md",
+    })
+  })
+
+  test("parses spaced project init form", () => {
+    expect(parsePenguinLocalCommand('/project init "Auth Rewrite" --blueprint ./auth.md')).toEqual({
+      kind: "project_init",
+      projectName: "Auth Rewrite",
+      blueprintPath: "./auth.md",
+    })
+  })
+
+  test("parses dashed and spaced project start forms equivalently", () => {
+    expect(parsePenguinLocalCommand('/project-start "Auth Rewrite"')).toEqual({
+      kind: "project_start",
+      projectIdentifier: "Auth Rewrite",
+    })
+    expect(parsePenguinLocalCommand('/project start "Auth Rewrite"')).toEqual({
+      kind: "project_start",
+      projectIdentifier: "Auth Rewrite",
+    })
+  })
+
+  test("parses existing local commands", () => {
+    expect(parsePenguinLocalCommand('/settings')).toEqual({ kind: "settings" })
+    expect(parsePenguinLocalCommand('/config')).toEqual({ kind: "config" })
+    expect(parsePenguinLocalCommand('/thinking')).toEqual({ kind: "thinking" })
+    expect(parsePenguinLocalCommand('/tool_details')).toEqual({ kind: "tool_details" })
+  })
+
+  test("returns null for non-command input", () => {
+    expect(parsePenguinLocalCommand('hello world')).toBeNull()
+  })
+})
+
+describe("penguin prompt classification", () => {
+  test("classifies project commands as local commands", () => {
+    expect(classifyPenguinPromptInput('/project init Demo --blueprint ./demo.md')).toEqual({
+      kind: "local_command",
+      command: {
+        kind: "project_init",
+        projectName: "Demo",
+        blueprintPath: "./demo.md",
+      },
+    })
+  })
+
+  test("classifies non-command input as chat", () => {
+    expect(classifyPenguinPromptInput('fix the failing test')).toEqual({ kind: "chat" })
+  })
+
+  test("does not bootstrap a session for home-screen local commands", () => {
+    const classification = classifyPenguinPromptInput('/project start Demo')
+    expect(shouldBootstrapPenguinSession({ classification })).toBe(false)
+    expect(shouldNavigateAfterPenguinSubmit({ classification })).toBe(false)
+  })
+
+  test("does not bootstrap a session for local commands even when a session already exists", () => {
+    const classification = classifyPenguinPromptInput('/settings')
+    expect(shouldBootstrapPenguinSession({ classification, propsSessionID: 'ses_123' })).toBe(false)
+    expect(shouldNavigateAfterPenguinSubmit({ classification, propsSessionID: 'ses_123' })).toBe(false)
+  })
+
+  test("bootstraps and navigates for home-screen chat prompts", () => {
+    const classification = classifyPenguinPromptInput('build the feature')
+    expect(shouldBootstrapPenguinSession({ classification })).toBe(true)
+    expect(shouldNavigateAfterPenguinSubmit({ classification })).toBe(true)
+  })
+
+  test("does not bootstrap or navigate for chat prompts in an existing session", () => {
+    const classification = classifyPenguinPromptInput('continue')
+    expect(shouldBootstrapPenguinSession({ classification, propsSessionID: 'ses_123' })).toBe(false)
+    expect(shouldNavigateAfterPenguinSubmit({ classification, propsSessionID: 'ses_123' })).toBe(false)
+  })
+})

--- a/penguin-tui/packages/opencode/test/cli/tui/prompt-project-discoverability.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/prompt-project-discoverability.test.ts
@@ -1,20 +1,52 @@
 import { describe, expect, test } from "bun:test"
 
-describe("prompt project discoverability", () => {
+const PROJECT_COMMANDS = [
+  ['title: "Create project"', 'name: "project-create"', 'aliases: ["project create"]'],
+  ['title: "Initialize project from Blueprint"', 'name: "project-init"', 'aliases: ["project init"]'],
+  ['title: "List projects"', 'name: "project-list"', 'aliases: ["project list"]'],
+  ['title: "Show project"', 'name: "project-show"', 'aliases: ["project show", "project get"]'],
+  ['title: "Start project execution"', 'name: "project-start"', 'aliases: ["project start"]'],
+  ['title: "Delete project"', 'name: "project-delete"', 'aliases: ["project delete"]'],
+]
+
+const TASK_COMMANDS = [
+  ['title: "Create task"', 'name: "task-create"', 'aliases: ["task create"]'],
+  ['title: "List tasks"', 'name: "task-list"', 'aliases: ["task list"]'],
+  ['title: "Show task"', 'name: "task-show"', 'aliases: ["task show", "task get"]'],
+  ['title: "Start task"', 'name: "task-start"', 'aliases: ["task start"]'],
+  ['title: "Complete task"', 'name: "task-complete"', 'aliases: ["task complete"]'],
+  ['title: "Execute task"', 'name: "task-execute"', 'aliases: ["task execute"]'],
+  ['title: "Delete task"', 'name: "task-delete"', 'aliases: ["task delete"]'],
+  ['title: "Resume task clarification"', 'name: "task-resume"', 'aliases: ["task resume", "task clarification resume"]'],
+]
+
+describe("prompt project/task discoverability", () => {
   test("registers visible project command palette entries with slash aliases", async () => {
     const source = await Bun.file("src/cli/cmd/tui/component/prompt/index.tsx").text()
 
-    expect(source).toContain('title: "Initialize project from Blueprint"')
-    expect(source).toContain('value: "project.init.prefill"')
     expect(source).toContain('category: "Project"')
-    expect(source).toContain('name: "project-init"')
-    expect(source).toContain('aliases: ["project init"]')
-    expect(source).toContain("prefillPrompt('/project init \"Project Name\" --blueprint ./blueprint.md')")
+    for (const command of PROJECT_COMMANDS) {
+      for (const expected of command) {
+        expect(source).toContain(expected)
+      }
+    }
+  })
 
-    expect(source).toContain('title: "Start project execution"')
-    expect(source).toContain('value: "project.start.prefill"')
-    expect(source).toContain('name: "project-start"')
-    expect(source).toContain('aliases: ["project start"]')
-    expect(source).toContain("prefillPrompt('/project start \"Project Name\"')")
+  test("registers visible task command palette entries with slash aliases", async () => {
+    const source = await Bun.file("src/cli/cmd/tui/component/prompt/index.tsx").text()
+
+    expect(source).toContain('category: "Task"')
+    for (const command of TASK_COMMANDS) {
+      for (const expected of command) {
+        expect(source).toContain(expected)
+      }
+    }
+  })
+
+  test("keeps project run out of the TUI command surface while deferred", async () => {
+    const source = await Bun.file("src/cli/cmd/tui/component/prompt/index.tsx").text()
+
+    expect(source).not.toContain('name: "project-run"')
+    expect(source).not.toContain('aliases: ["project run"]')
   })
 })

--- a/penguin-tui/packages/opencode/test/cli/tui/prompt-project-discoverability.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/prompt-project-discoverability.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+
+describe("prompt project discoverability", () => {
+  test("registers visible project command palette entries with slash aliases", async () => {
+    const source = await Bun.file("src/cli/cmd/tui/component/prompt/index.tsx").text()
+
+    expect(source).toContain('title: "Initialize project from Blueprint"')
+    expect(source).toContain('value: "project.init.prefill"')
+    expect(source).toContain('category: "Project"')
+    expect(source).toContain('name: "project-init"')
+    expect(source).toContain('aliases: ["project init"]')
+    expect(source).toContain("prefillPrompt('/project init \"Project Name\" --blueprint ./blueprint.md')")
+
+    expect(source).toContain('title: "Start project execution"')
+    expect(source).toContain('value: "project.start.prefill"')
+    expect(source).toContain('name: "project-start"')
+    expect(source).toContain('aliases: ["project start"]')
+    expect(source).toContain("prefillPrompt('/project start \"Project Name\"')")
+  })
+})

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -2585,6 +2585,113 @@ def agent_info(
 
 
 # Project Management Commands
+@project_app.command("init")
+def project_init(
+    name: str = typer.Argument(..., help="Project name"),
+    blueprint_path: Optional[Path] = typer.Option(
+        None,
+        "--blueprint",
+        help="Path to a Blueprint file to parse and sync during initialization.",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    description: Optional[str] = typer.Option(
+        None, "--description", "-d", help="Project description"
+    ),
+    workspace_path: Optional[str] = typer.Option(
+        None, "--workspace", "-w", help="Project workspace path"
+    ),
+):
+    """Initialize a project and optionally sync a Blueprint into it."""
+
+    async def _async_project_init():
+        console.print(f"[bold cyan]🐧 Initializing project:[/bold cyan] {name}")
+
+        await _initialize_core_components_globally()
+
+        if not _core or not _core.project_manager:
+            console.print("[red]Error: Project manager not available[/red]")
+            raise typer.Exit(code=1)
+
+        resolved_workspace = None
+        if workspace_path:
+            resolved_workspace = Path(workspace_path).expanduser().resolve()
+
+        project = None
+        try:
+            project = await _core.project_manager.create_project_async(
+                name=name,
+                description=description or f"Project: {name}",
+                workspace_path=resolved_workspace,
+            )
+
+            console.print("[green]✓ Project initialized successfully![/green]")
+            console.print(f"  ID: {project.id}")
+            console.print(f"  Name: {project.name}")
+            console.print(f"  Description: {project.description}")
+            if resolved_workspace:
+                console.print(f"  Workspace (explicit): {resolved_workspace}")
+            elif project.workspace_path:
+                console.print(f"  Workspace (default): {project.workspace_path}")
+
+            if blueprint_path is None:
+                return
+
+            from penguin.project.blueprint_parser import BlueprintParseError, BlueprintParser
+
+            parser = BlueprintParser(base_path=blueprint_path.parent)
+            blueprint = parser.parse_file(blueprint_path)
+            diagnostics = parser.lint_blueprint(blueprint, source=str(blueprint_path))
+            if diagnostics.has_errors:
+                if project is not None:
+                    await _delete_project_and_tasks_async(project.id)
+                console.print("[red]Blueprint validation failed. Project initialization rolled back.[/red]")
+                for diagnostic in diagnostics.diagnostics:
+                    prefix = diagnostic.severity.upper()
+                    location = f" ({diagnostic.source}:{diagnostic.line})" if diagnostic.source and diagnostic.line else ""
+                    console.print(f"  - [{prefix}] {diagnostic.message}{location}")
+                raise typer.Exit(code=1)
+
+            sync_result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: _core.project_manager.sync_blueprint(
+                    blueprint,
+                    project_id=project.id,
+                    create_missing=True,
+                    update_existing=True,
+                ),
+            )
+            ready_tasks = await _core.project_manager.get_ready_tasks_async(project.id)
+
+            console.print(f"  Blueprint: {blueprint_path}")
+            console.print(f"  Tasks created: {len(sync_result.get('created', []))}")
+            console.print(f"  Tasks updated: {len(sync_result.get('updated', []))}")
+            console.print(f"  Tasks skipped: {len(sync_result.get('skipped', []))}")
+            console.print(f"  Ready tasks: {len(ready_tasks)}")
+            if diagnostics.has_warnings:
+                console.print("[yellow]Blueprint warnings:[/yellow]")
+                for diagnostic in diagnostics.diagnostics:
+                    if diagnostic.severity == 'warning':
+                        console.print(f"  - {diagnostic.message}")
+
+        except BlueprintParseError as exc:
+            if project is not None:
+                await _delete_project_and_tasks_async(project.id)
+            console.print(f"[red]Blueprint parse failed: {exc}[/red]")
+            raise typer.Exit(code=1)
+        except typer.Exit:
+            raise
+        except Exception as e:
+            if project is not None and blueprint_path is not None:
+                await _delete_project_and_tasks_async(project.id)
+            console.print(f"[red]Error initializing project: {e}[/red]")
+            raise typer.Exit(code=1)
+
+    asyncio.run(_async_project_init())
+
+
 @project_app.command("create")
 def project_create(
     name: str = typer.Argument(..., help="Project name"),
@@ -2694,6 +2801,43 @@ def project_list():
     asyncio.run(_async_project_list())
 
 
+
+
+def _resolve_project_identifier_or_exit(project_identifier: str):
+    """Resolve a project by exact ID or unique exact name, failing honestly otherwise."""
+    assert _core is not None and _core.project_manager is not None
+
+    project = _core.project_manager.get_project(project_identifier)
+    if project:
+        return project
+
+    exact_name_match = _core.project_manager.get_project_by_name(project_identifier)
+    if exact_name_match:
+        return exact_name_match
+
+    projects = _core.project_manager.list_projects()
+    matching_by_name = [p for p in projects if p.name == project_identifier]
+    if len(matching_by_name) > 1:
+        console.print(
+            f"[red]Ambiguous project name '{project_identifier}'. Use the project ID instead.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    console.print(
+        f"[red]Project '{project_identifier}' was not found by exact ID or exact name.[/red]"
+    )
+    raise typer.Exit(code=1)
+
+
+async def _delete_project_and_tasks_async(project_id: str) -> None:
+    """Delete a project and all of its tasks for honest rollback/cleanup paths."""
+    assert _core is not None and _core.project_manager is not None
+
+    tasks = await _core.project_manager.list_tasks_async(project_id=project_id)
+    for task in tasks:
+        _core.project_manager.storage.delete_task(task.id)
+    _core.project_manager.storage.delete_project(project_id)
+
 @project_app.command("delete")
 def project_delete(
     project_id: str = typer.Argument(..., help="Project ID to delete"),
@@ -2743,6 +2887,61 @@ def project_delete(
             raise typer.Exit(code=1)
 
     asyncio.run(_async_project_delete())
+
+
+@project_app.command("start")
+def project_start(
+    project_identifier: str = typer.Argument(..., help="Project ID or exact project name"),
+    continuous: bool = typer.Option(
+        True,
+        "--continuous/--no-continuous",
+        help="Run against the ready frontier continuously or execute one task selection.",
+    ),
+    time_limit: Optional[int] = typer.Option(
+        None,
+        "--time-limit",
+        help="Explicit run limit in minutes for this project start invocation.",
+    ),
+):
+    """Start project execution using the existing RunMode truth path."""
+
+    async def _async_project_start():
+        await _initialize_core_components_globally()
+
+        if not _core or not _core.project_manager:
+            console.print("[red]Error: Project manager not available[/red]")
+            raise typer.Exit(code=1)
+
+        project = _resolve_project_identifier_or_exit(project_identifier)
+        tasks = await _core.project_manager.list_tasks_async(project_id=project.id)
+        if not tasks:
+            console.print(
+                f"[red]Project '{project.name}' has no tasks. Initialize or import a Blueprint first.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        ready_tasks = await _core.project_manager.get_ready_tasks_async(project.id)
+        if not ready_tasks:
+            console.print(
+                f"[red]Project '{project.name}' has no ready tasks to execute.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        console.print(f"[bold blue]Starting project:[/bold blue] {project.name} ({project.id})")
+        console.print(f"  Mode: {'continuous' if continuous else 'single-selection'}")
+        console.print(f"  Ready tasks: {len(ready_tasks)}")
+        console.print(f"  First ready task: {ready_tasks[0].title}")
+
+        await _core.start_run_mode(
+            name=project.name,
+            description=project.description,
+            context={"project_id": project.id},
+            continuous=continuous,
+            time_limit=time_limit,
+            mode_type="project",
+        )
+
+    asyncio.run(_async_project_start())
 
 
 @project_app.command("run")

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -3306,9 +3306,15 @@ class PenguinCore:
             self._continuous_mode = continuous
 
             if continuous:
-                # RunMode's start_continuous will manage its internal continuous_mode flag
+                # RunMode's start_continuous will manage its internal continuous_mode flag.
+                # Project-scoped continuous execution must select from the ready frontier;
+                # passing the project name as a task name creates a synthetic user task and
+                # drifts out of project scope.
+                project_id = (context or {}).get("project_id") if mode_type == "project" else None
                 await run_mode.start_continuous(
-                    specified_task_name=name, task_description=description
+                    specified_task_name=None if project_id else name,
+                    task_description=None if project_id else description,
+                    project_id=project_id,
                 )
             else:
                 await run_mode.start(

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -732,6 +732,8 @@ class OpenAIAdapter(BaseAdapter):
             raise RuntimeError(
                 "OpenAI OAuth Codex model resolution failed: model id is empty"
             )
+        if value.upper().startswith("GPT-"):
+            value = value.lower()
         return value, False
 
     def _extract_codex_text_content(self, content: Any) -> str:
@@ -1553,6 +1555,7 @@ class OpenAIAdapter(BaseAdapter):
                 "trace": trace or {},
                 "stage": stage,
                 "model_fallback": model_fallback,
+                "detail": detail,
             },
         )
         self._set_last_error(llm_error)

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -506,6 +506,12 @@ class APIClient:
 
     def _format_user_error_message(self, *, error: LLMError, diag_id: str) -> str:
         category = error.category.value
+        provider_detail = ""
+        if isinstance(error.provider_data, dict):
+            raw_detail = error.provider_data.get("detail")
+            if isinstance(raw_detail, str):
+                provider_detail = raw_detail.lower()
+
         if category == ErrorCategory.AUTH.value:
             reason = "Provider authentication failed. Reconnect and retry"
         elif category == ErrorCategory.TIMEOUT.value:
@@ -513,7 +519,19 @@ class APIClient:
         elif category == ErrorCategory.NETWORK.value:
             reason = "LLM network request failed"
         elif category in {"upstream_request", ErrorCategory.BAD_REQUEST.value}:
-            reason = "LLM upstream rejected the request, likely due to context or output token limits"
+            if (
+                "not supported" in provider_detail
+                and "codex with a chatgpt account" in provider_detail
+            ):
+                reason = (
+                    "Selected model is not available through ChatGPT-backed "
+                    "Codex auth"
+                )
+            else:
+                reason = (
+                    "LLM upstream rejected the request, likely due to context "
+                    "or output token limits"
+                )
         elif category == ErrorCategory.RATE_LIMIT.value:
             reason = "LLM upstream rate-limited this request"
         elif category in {

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -201,6 +201,7 @@ async def call_with_retry(
     """Call provider once, retrying one time for empty non-tool responses."""
 
     streamed_assistant_chunk = False
+    replayed_retry_response = False
 
     async def _tracked_stream_callback(
         chunk: str, message_type: str = "assistant"
@@ -235,6 +236,14 @@ async def call_with_retry(
         if handler_has_pending_tool_call(api_client):
             return assistant_response or ""
         assistant_response = await api_client.get_response(messages, stream=False)
+        if (
+            streaming
+            and stream_callback
+            and assistant_response
+            and assistant_response.strip()
+        ):
+            await _tracked_stream_callback(assistant_response, "assistant")
+            replayed_retry_response = True
 
     if not assistant_response or not assistant_response.strip():
         if handler_has_pending_tool_call(api_client):
@@ -253,6 +262,16 @@ async def call_with_retry(
             handler=getattr(api_client, "client_handler", None),
         )
         raise LLMEmptyResponseError(diagnostics["user_message"])
+
+    if (
+        streaming
+        and stream_callback
+        and assistant_response
+        and assistant_response.strip()
+        and not streamed_assistant_chunk
+        and not replayed_retry_response
+    ):
+        await _tracked_stream_callback(assistant_response, "assistant")
 
     return assistant_response
 

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -284,6 +284,7 @@ async def execute_pending_tool_call(
 
     tool_name = str(tool_info.get("name") or "").strip()
     raw_args = tool_info.get("arguments") or "{}"
+    suppress_ui_artifacts = tool_name == "finish_response"
     tool_call_id = (
         tool_info.get("call_id")
         or tool_info.get("tool_call_id")
@@ -310,7 +311,7 @@ async def execute_pending_tool_call(
         "source": "responses_tool_call",
     }
 
-    if emit_action_start is not None:
+    if emit_action_start is not None and not suppress_ui_artifacts:
         await emit_action_start(
             {
                 "id": tool_call_id,
@@ -328,15 +329,16 @@ async def execute_pending_tool_call(
             "result": str(output if output is not None else ""),
             "status": "completed",
         }
-        persist_action_result(
-            action_result,
-            {
-                "tool_call_id": tool_call_id,
-                "tool_arguments": raw_args if isinstance(raw_args, str) else None,
-            },
-        )
+        if not suppress_ui_artifacts:
+            persist_action_result(
+                action_result,
+                {
+                    "tool_call_id": tool_call_id,
+                    "tool_arguments": raw_args if isinstance(raw_args, str) else None,
+                },
+            )
 
-        if emit_action_result is not None:
+        if emit_action_result is not None and not suppress_ui_artifacts:
             await emit_action_result(
                 {
                     "id": tool_call_id,
@@ -346,7 +348,7 @@ async def execute_pending_tool_call(
                     "metadata": event_metadata,
                 }
             )
-        if emit_tool_timeline is not None:
+        if emit_tool_timeline is not None and not suppress_ui_artifacts:
             await emit_tool_timeline(action_result)
         return action_result
     except Exception as exc:

--- a/penguin/project/blueprint_parser.py
+++ b/penguin/project/blueprint_parser.py
@@ -279,11 +279,21 @@ class BlueprintParser:
         Returns:
             Parsed Blueprint object.
         """
+        stripped = content.lstrip()
+        if stripped.startswith("---") and not self.FRONTMATTER_PATTERN.match(stripped):
+            raise BlueprintParseError(
+                "Unclosed YAML frontmatter block",
+                source,
+                line=1,
+                code="BP-PARSE-008",
+                suggestion="Terminate the opening --- block with a closing --- line before the markdown body.",
+            )
+
         # Extract frontmatter
         frontmatter = {}
-        body = content
+        body = stripped
         
-        fm_match = self.FRONTMATTER_PATTERN.match(content)
+        fm_match = self.FRONTMATTER_PATTERN.match(stripped)
         if fm_match:
             try:
                 frontmatter = yaml.safe_load(fm_match.group(1)) or {}
@@ -376,6 +386,16 @@ class BlueprintParser:
         self, fm: Dict[str, Any], source: Optional[str]
     ) -> Blueprint:
         """Build a Blueprint object from frontmatter data."""
+        if fm is None:
+            fm = {}
+        if not isinstance(fm, dict):
+            raise BlueprintParseError(
+                "Blueprint frontmatter must be a YAML mapping/object",
+                source,
+                code="BP-PARSE-009",
+                suggestion="Use key/value pairs in the frontmatter block instead of a list or scalar.",
+            )
+
         # Extract ITUV settings
         ituv = fm.get("ituv", {})
         agent_defaults = fm.get("agent_defaults", {})
@@ -408,10 +428,31 @@ class BlueprintParser:
         self, data: Dict[str, Any], source: Optional[str]
     ) -> Blueprint:
         """Build a Blueprint from a dictionary (YAML/JSON)."""
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            raise BlueprintParseError(
+                "Blueprint document root must be a mapping/object",
+                source,
+                code="BP-PARSE-010",
+                suggestion="Use a top-level object with fields like title, project_key, and tasks/items.",
+            )
+
         # Handle items/tasks
+        items_data = data.get("items", data.get("tasks", []))
+        if items_data is None:
+            items_data = []
+        if not isinstance(items_data, list):
+            raise BlueprintParseError(
+                "Blueprint tasks/items must be a list",
+                source,
+                code="BP-PARSE-011",
+                suggestion="Use a YAML/JSON list for tasks/items, with one task mapping per entry.",
+            )
+
         items = []
-        for item_data in data.get("items", data.get("tasks", [])):
-            items.append(self._build_item_from_dict(item_data, source))
+        for index, item_data in enumerate(items_data, start=1):
+            items.append(self._build_item_from_dict(item_data, source, index))
         
         ituv = data.get("ituv", {})
         agent_defaults = data.get("agent_defaults", {})
@@ -450,9 +491,18 @@ class BlueprintParser:
         )
     
     def _build_item_from_dict(
-        self, data: Dict[str, Any], source: Optional[str]
+        self, data: Dict[str, Any], source: Optional[str], index: Optional[int] = None
     ) -> BlueprintItem:
         """Build a BlueprintItem from a dictionary."""
+        if not isinstance(data, dict):
+            location = f" at index {index}" if index is not None else ""
+            raise BlueprintParseError(
+                f"Blueprint task entry{location} must be a mapping/object",
+                source,
+                code="BP-PARSE-012",
+                suggestion="Each task entry must be an object with fields like id, title, and description.",
+            )
+
         return BlueprintItem(
             id=data.get("id", ""),
             title=data.get("title", ""),

--- a/penguin/project/manager.py
+++ b/penguin/project/manager.py
@@ -428,6 +428,77 @@ class ProjectManager:
         logger.info(f"Task {task_id} status changed to {new_status.value}")
         return True
     
+    def mark_task_execution_ready_for_review(
+        self,
+        task_id: str,
+        executor_id: str = "runmode",
+        response: str = "",
+        task_prompt: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Task:
+        """Mark a successful task execution as DONE and ready for review.
+
+        This is the ProjectManager-owned bridge for execution paths that run a
+        project task outside WorkflowOrchestrator but still need to persist the
+        canonical ITUV lifecycle transition. It intentionally stops at
+        PENDING_REVIEW; approval to COMPLETED is a separate review action.
+        """
+        task = self.storage.get_task(task_id)
+        if not task:
+            raise TaskNotFoundError(f"Task '{task_id}' not found", task_id)
+
+        if task.status in {TaskStatus.PENDING_REVIEW, TaskStatus.COMPLETED}:
+            return task
+
+        if task.status not in {TaskStatus.ACTIVE, TaskStatus.RUNNING}:
+            raise StateTransitionError(
+                f"Cannot mark task execution ready for review from status {task.status.value}",
+                task.status.value,
+                TaskStatus.PENDING_REVIEW.value,
+                task_id,
+            )
+
+        if not task.get_current_execution():
+            task.start_execution(
+                executor_id=executor_id,
+                task_prompt=task_prompt or f"Project task execution: {task.title}",
+                context=context or {},
+            )
+
+        task.complete_current_execution(
+            ExecutionResult.SUCCESS,
+            response=response,
+        )
+
+        self.storage.update_task(task)
+        self._publish_event("task_status_changed", {
+            "task_id": task.id,
+            "old_status": TaskStatus.RUNNING.value,
+            "new_status": TaskStatus.PENDING_REVIEW.value,
+            "reason": "Execution successful; pending review",
+        })
+        return task
+
+    async def mark_task_execution_ready_for_review_async(
+        self,
+        task_id: str,
+        executor_id: str = "runmode",
+        response: str = "",
+        task_prompt: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Task:
+        """Async version of mark_task_execution_ready_for_review."""
+        return await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: self.mark_task_execution_ready_for_review(
+                task_id=task_id,
+                executor_id=executor_id,
+                response=response,
+                task_prompt=task_prompt,
+                context=context,
+            ),
+        )
+
     async def update_task_status_async(
         self, 
         task_id: str, 
@@ -776,22 +847,44 @@ class ProjectManager:
 
         return False
 
-    def _is_task_blocked(self, task: Task) -> bool:
-        """Check if a task is blocked by incomplete dependencies."""
+    def _get_unsatisfied_dependencies(
+        self,
+        task: Task,
+        task_map: Optional[Dict[str, Task]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return dependency details that currently block a task."""
         if not task.dependencies:
-            return False
+            return []
 
         dependency_specs = task.dependency_specs or [
             TaskDependency(task_id=dep_id)
             for dep_id in task.dependencies
         ]
 
+        blockers: List[Dict[str, Any]] = []
         for dependency in dependency_specs:
-            dep_task = self.storage.get_task(dependency.task_id)
-            if not self._is_dependency_satisfied(dependency, dep_task):
-                return True
+            dep_task = (
+                task_map.get(dependency.task_id)
+                if task_map is not None
+                else self.storage.get_task(dependency.task_id)
+            )
+            if self._is_dependency_satisfied(dependency, dep_task):
+                continue
 
-        return False
+            blockers.append({
+                "task_id": dependency.task_id,
+                "policy": dependency.policy.value,
+                "artifact_key": dependency.artifact_key,
+                "status": dep_task.status.value if dep_task else None,
+                "phase": dep_task.phase.value if dep_task else None,
+                "title": dep_task.title if dep_task else None,
+            })
+
+        return blockers
+
+    def _is_task_blocked(self, task: Task) -> bool:
+        """Check if a task is blocked by incomplete dependencies."""
+        return bool(self._get_unsatisfied_dependencies(task))
     
     def _publish_event(self, event_type: str, data: Dict[str, Any]) -> None:
         """Publish an event if EventBus is available."""
@@ -904,6 +997,33 @@ class ProjectManager:
             None, self.get_ready_tasks, project_id
         )
     
+    def get_blocked_ready_candidates(self, project_id: str) -> List[Dict[str, Any]]:
+        """Return active project tasks blocked only by unsatisfied dependencies."""
+        tasks = self.list_tasks(project_id)
+        task_map = {task.id: task for task in tasks}
+        blocked: List[Dict[str, Any]] = []
+
+        for task in tasks:
+            if task.status != TaskStatus.ACTIVE or not task.dependencies:
+                continue
+
+            blockers = self._get_unsatisfied_dependencies(task, task_map)
+            if blockers:
+                blocked.append({
+                    "task_id": task.id,
+                    "title": task.title,
+                    "blueprint_id": task.blueprint_id,
+                    "blockers": blockers,
+                })
+
+        return blocked
+
+    async def get_blocked_ready_candidates_async(self, project_id: str) -> List[Dict[str, Any]]:
+        """Async version of get_blocked_ready_candidates."""
+        return await asyncio.get_event_loop().run_in_executor(
+            None, self.get_blocked_ready_candidates, project_id
+        )
+
     def get_next_task_dag(self, project_id: str) -> Optional[Task]:
         """Get the next task to execute from the DAG frontier.
         

--- a/penguin/prompt_actions.py
+++ b/penguin/prompt_actions.py
@@ -888,13 +888,14 @@ COMPLETION_TOOLS = """
 **Important:** Put the final answer in normal assistant content before calling `finish_response`. Do not pass summary text here; summaries belong on `finish_task`.
 
 ### finish_task  
-**Purpose:** Mark a formal task as complete.  
-**When to use:** Finished implementing a feature or resolving a task.  
-**Tool call syntax:** `<finish_task>status</finish_task>`  
-**Parameters:**
+**Purpose:** Signal that formal task work is ready for human review.  
+**When to use:** Acceptance criteria are satisfied, or progress is partial/blocked and should stop.  
+**Tool call syntax:** `<finish_task>{"status":"done","summary":"What changed and how it was verified"}</finish_task>`  
+**Parameters:** JSON object or plain status string. Prefer JSON.
 - `status`: "done" (default), "partial", or "blocked"
+- `summary`: short review note describing what was accomplished
 
-**Important:** Call these tools explicitly. Never rely on implicit completion.
+**Important:** Call this tool explicitly. Do not emit `TASK_COMPLETED` as plain text; that phrase is legacy compatibility only.
 """
 
 

--- a/penguin/prompt_workflow.py
+++ b/penguin/prompt_workflow.py
@@ -530,8 +530,9 @@ COMPLETION_GUIDE = """
 
 **You MUST explicitly signal when done.**
 
-- Call `<finish_response>` to end conversation turn
-- Call `<finish_task>` to mark task complete (awaits human approval)
+- Call `<finish_response></finish_response>` to end a conversation turn
+- Call `<finish_task>{"status":"done","summary":"..."}</finish_task>` when task work satisfies acceptance criteria and is ready for human review
+- Do not emit `TASK_COMPLETED` as plain text; it is legacy compatibility only
 
 **Status options for finish_task:**
 - `done` (default): Task objective achieved

--- a/penguin/run_mode.py
+++ b/penguin/run_mode.py
@@ -657,14 +657,44 @@ class RunMode:
                         logger.debug(
                             "No project-scoped tasks available; refusing synthetic drift task"
                         )
+                        blocked_candidates = []
+                        try:
+                            blocked_candidates = (
+                                await self.core.project_manager.get_blocked_ready_candidates_async(project_id)
+                            )
+                        except Exception as blocked_err:
+                            logger.debug(
+                                "Could not compute blocked project candidates for %s: %s",
+                                project_id,
+                                blocked_err,
+                            )
+
+                        idle_reason = (
+                            "project_tasks_blocked"
+                            if blocked_candidates
+                            else "no_project_tasks_available"
+                        )
                         await self._emit_event({
                             "type": "status",
                             "status_type": "continuous_mode_idle",
                             "data": {
-                                "reason": "no_project_tasks_available",
+                                "reason": idle_reason,
                                 "project_id": project_id,
+                                "blocked_tasks": blocked_candidates,
                             }
                         })
+                        if blocked_candidates:
+                            await self._emit_event({
+                                "type": "message",
+                                "role": "system",
+                                "content": (
+                                    "Project execution paused: remaining active tasks are "
+                                    "blocked by dependency policy. Approve review-ready "
+                                    "upstream tasks or use review_ready_ok/artifact_ready "
+                                    "dependency specs where parallel progress is intended."
+                                ),
+                                "category": MessageCategory.SYSTEM,
+                            })
                         self._shutdown_requested = True
                         break
 
@@ -682,7 +712,29 @@ class RunMode:
                     task_data["description"],
                     task_data["context"]
                 )
-                
+
+                task_id = (task_data.get("context") or {}).get("id")
+                project_task = bool(project_id and task_id and task_id != "user_specified")
+
+                if project_task and task_result.get("completion_type") == "pending_review":
+                    project_manager = getattr(self.core, "project_manager", None)
+                    if project_manager:
+                        await project_manager.mark_task_execution_ready_for_review_async(
+                            task_id=task_id,
+                            executor_id="runmode",
+                            response=task_result.get("message", ""),
+                            task_prompt=f"RunMode execution: {task_data['name']}",
+                            context={"source": "runmode_continuous"},
+                        )
+                    await self._emit_event({
+                        "type": "status",
+                        "status_type": "task_pending_review",
+                        "data": {
+                            "task_id": task_id,
+                            "project_id": project_id,
+                            "reason": "runmode_execution_completed",
+                        },
+                    })
                 # Check if we got an LLM empty response error - retry instead of stopping
                 if task_result.get("status") == "llm_empty_response_error":
                     logger.warning("LLM empty response error in continuous mode. Waiting 30s before retry...")
@@ -711,6 +763,14 @@ class RunMode:
                     })
                     # Small delay before continuing to avoid rapid error loops
                     await asyncio.sleep(2)
+
+                if project_task and task_result.get("completion_type") == "pending_review":
+                    await self._emit_event({
+                        "type": "status",
+                        "status_type": "continuous_project_task_done",
+                        "data": {"task_id": task_id, "project_id": project_id},
+                    })
+                    continue
                 
                 # Check if we should exit continuous mode based on the result
                 if task_result.get("completion_type") == "user_specified":
@@ -982,7 +1042,8 @@ class RunMode:
         task_prompt = (
             f"Execute task: {name}\n"
             f"Description: {description or f'Complete the task: {name}'}\n"
-            f"Respond with {self.TASK_COMPLETION_PHRASE} when finished."
+            "When the task acceptance criteria are satisfied, call the finish_task "
+            "tool with status done. Do not emit TASK_COMPLETED as plain text."
         )
         
         # Add context as formatted text if provided
@@ -1085,13 +1146,9 @@ class RunMode:
             
             logger.debug("Using Engine.run_task method")
             
-            # NOTE: Phrase-based completion detection is deprecated.
-            # The LLM should use finish_task tool instead.
-            # Keeping phrases for emergency stop and clarification only.
+            # The task prompt asks for finish_task. Legacy TASK_COMPLETED phrase
+            # handling remains in Engine.run_task for backwards compatibility only.
             completion_phrases = [
-                # self.TASK_COMPLETION_PHRASE,  # Deprecated: use finish_task tool
-                # "TASK_COMPLETE",  # Deprecated: use finish_task tool
-                # self.CONTINUOUS_COMPLETION_PHRASE,  # Deprecated: use finish_task tool
                 self.NEED_USER_CLARIFICATION_PHRASE,
                 self.EMERGENCY_STOP_PHRASE
             ]
@@ -1250,10 +1307,5 @@ class RunMode:
         if self.NEED_USER_CLARIFICATION_PHRASE in response:
             return "clarification_needed"
         
-        # NOTE: Phrase-based completion detection is deprecated.
-        # Keeping commented for reference.
-        # if self.CONTINUOUS_COMPLETION_PHRASE in response:
-        #     return "continuous"
-            
         # Standard task completion (via finish_task tool)
-        return "task" 
+        return "task"

--- a/penguin/system_prompt.py
+++ b/penguin/system_prompt.py
@@ -187,9 +187,10 @@ SAFETY_RULES = """**Safety:**
 - Never blind overwrite without verification
 - Respect permission boundaries
 
-**Completion Signals (Call these tools, do not output as text):**
-- Call `<finish_response>` to end conversation turn
-- Call `<finish_task>` to mark task complete (awaits human approval)
+**Completion Signals (Call these tools, do not output them as text):**
+- Call `<finish_response></finish_response>` to end a conversation turn
+- Call `<finish_task>{"status":"done","summary":"..."}</finish_task>` to mark task work ready for human review
+- Never emit `TASK_COMPLETED` as plain text; it is legacy compatibility only
 - Never rely on implicit completion
 """
 

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -1931,6 +1931,8 @@ class ToolManager:
             "code_execution",
             "execute_command",
             "grep_search",
+            "finish_response",
+            "finish_task",
         ]
         allowed = {
             self._canonical_tool_name(name)

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -92,6 +92,10 @@ from penguin.web.services.system_status import (
     get_path_info,
     get_vcs_info,
 )
+from penguin.web.services.projects import (
+    initialize_project_from_blueprint,
+    start_project_execution,
+)
 from penguin.web.services.opencode_provider import (
     apply_auth_to_runtime,
     build_config_payload,
@@ -4573,6 +4577,19 @@ class ProjectUpdateRequest(BaseModel):
     status: Optional[str] = None
 
 
+class ProjectInitRequest(BaseModel):
+    name: str
+    description: Optional[str] = None
+    workspace_path: Optional[str] = None
+    blueprint_path: Optional[str] = None
+
+
+class ProjectStartRequest(BaseModel):
+    project_identifier: str
+    continuous: bool = True
+    time_limit: Optional[int] = None
+
+
 class TaskCreateRequest(BaseModel):
     project_id: str
     title: str
@@ -4640,6 +4657,33 @@ async def list_projects(core: PenguinCore = Depends(get_core)):
     except Exception as e:
         logger.error(f"Error listing projects: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/api/v1/projects/init")
+async def init_project(
+    request: ProjectInitRequest, core: PenguinCore = Depends(get_core)
+):
+    """Initialize a project and optionally sync a Blueprint into it."""
+    return await initialize_project_from_blueprint(
+        core=core,
+        name=request.name,
+        description=request.description,
+        workspace_path=request.workspace_path,
+        blueprint_path=request.blueprint_path,
+    )
+
+
+@router.post("/api/v1/projects/start")
+async def start_project(
+    request: ProjectStartRequest, core: PenguinCore = Depends(get_core)
+):
+    """Start project execution through the real RunMode path."""
+    return await start_project_execution(
+        core=core,
+        project_identifier=request.project_identifier,
+        continuous=request.continuous,
+        time_limit=request.time_limit,
+    )
 
 
 @router.get("/api/v1/projects/{project_id}")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -93,7 +93,9 @@ from penguin.web.services.system_status import (
     get_vcs_info,
 )
 from penguin.web.services.projects import (
+    delete_project_with_tasks,
     initialize_project_from_blueprint,
+    run_project_workflow,
     start_project_execution,
 )
 from penguin.web.services.opencode_provider import (
@@ -4590,6 +4592,13 @@ class ProjectStartRequest(BaseModel):
     time_limit: Optional[int] = None
 
 
+class ProjectRunRequest(BaseModel):
+    spec_path: Optional[str] = None
+    markdown_content: Optional[str] = None
+    continuous: bool = True
+    time_limit: Optional[int] = None
+
+
 class TaskCreateRequest(BaseModel):
     project_id: str
     title: str
@@ -4686,6 +4695,20 @@ async def start_project(
     )
 
 
+@router.post("/api/v1/projects/run")
+async def run_project(
+    request: ProjectRunRequest, core: PenguinCore = Depends(get_core)
+):
+    """Parse a project spec and immediately start the resulting project workflow."""
+    return await run_project_workflow(
+        core=core,
+        spec_path=request.spec_path,
+        markdown_content=request.markdown_content,
+        continuous=request.continuous,
+        time_limit=request.time_limit,
+    )
+
+
 @router.get("/api/v1/projects/{project_id}")
 async def get_project(project_id: str, core: PenguinCore = Depends(get_core)):
     """Get a specific project by ID."""
@@ -4720,9 +4743,10 @@ async def get_project(project_id: str, core: PenguinCore = Depends(get_core)):
 # @router.put("/api/v1/projects/{project_id}")
 # async def update_project(...):
 
-# Temporarily disabled - delete_project method not implemented in ProjectManager
-# @router.delete("/api/v1/projects/{project_id}")
-# async def delete_project(...):
+@router.delete("/api/v1/projects/{project_id}")
+async def delete_project(project_id: str, core: PenguinCore = Depends(get_core)):
+    """Delete a project and its tasks."""
+    return await delete_project_with_tasks(core=core, project_id=project_id)
 
 
 # Task Management Endpoints
@@ -4803,9 +4827,24 @@ async def get_task(task_id: str, core: PenguinCore = Depends(get_core)):
 # @router.put("/api/v1/tasks/{task_id}")
 # async def update_task(...):
 
-# Temporarily disabled - delete_task method not implemented in ProjectManager
-# @router.delete("/api/v1/tasks/{task_id}")
-# async def delete_task(...):
+@router.delete("/api/v1/tasks/{task_id}")
+async def delete_task(task_id: str, core: PenguinCore = Depends(get_core)):
+    """Delete a task by ID."""
+    try:
+        task = await core.project_manager.get_task_async(task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+
+        core.project_manager.storage.delete_task(task_id)
+        return {
+            "task": _serialize_task_payload(task),
+            "message": f"Task '{task.title}' deleted successfully.",
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting task: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/api/v1/tasks/{task_id}/clarification/resume")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -969,10 +969,10 @@ def _restore_reasoning_variant_override(
 
 
 def _resolve_include_reasoning(value: Optional[Any]) -> bool:
-    """Default reasoning visibility to on unless explicitly disabled."""
+    """Default reasoning visibility to off unless explicitly enabled."""
 
     if value is None:
-        return True
+        return False
     return bool(value)
 
 

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -49,6 +49,7 @@ from penguin.llm.runtime import (
     resolve_reasoning_payload,
 )
 from penguin.run_mode import RunMode
+from penguin.system.execution_context import ExecutionContext, execution_context_scope, normalize_directory
 from penguin import __version__
 from penguin.constants import get_engine_max_iterations_default
 from penguin.utils.events import EventBus as UtilsEventBus
@@ -4590,6 +4591,8 @@ class ProjectStartRequest(BaseModel):
     project_identifier: str
     continuous: bool = True
     time_limit: Optional[int] = None
+    session_id: Optional[str] = None
+    directory: Optional[str] = None
 
 
 class ProjectRunRequest(BaseModel):
@@ -4597,6 +4600,8 @@ class ProjectRunRequest(BaseModel):
     markdown_content: Optional[str] = None
     continuous: bool = True
     time_limit: Optional[int] = None
+    session_id: Optional[str] = None
+    directory: Optional[str] = None
 
 
 class TaskCreateRequest(BaseModel):
@@ -4610,6 +4615,8 @@ class TaskCreateRequest(BaseModel):
 class ClarificationAnswerRequest(BaseModel):
     answer: str
     answered_by: Optional[str] = None
+    session_id: Optional[str] = None
+    directory: Optional[str] = None
 
 
 class TaskUpdateRequest(BaseModel):
@@ -4617,6 +4624,11 @@ class TaskUpdateRequest(BaseModel):
     description: Optional[str] = None
     status: Optional[str] = None
     priority: Optional[int] = None
+
+
+class TaskExecutionRequest(BaseModel):
+    session_id: Optional[str] = None
+    directory: Optional[str] = None
 
 
 # Project Management Endpoints
@@ -4692,6 +4704,8 @@ async def start_project(
         project_identifier=request.project_identifier,
         continuous=request.continuous,
         time_limit=request.time_limit,
+        session_id=request.session_id,
+        directory=request.directory,
     )
 
 
@@ -4709,6 +4723,8 @@ async def run_project(
         markdown_content=request.markdown_content,
         continuous=request.continuous,
         time_limit=request.time_limit,
+        session_id=request.session_id,
+        directory=request.directory,
     )
 
 
@@ -4862,12 +4878,28 @@ async def resume_task_clarification(
         if not task:
             raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
 
-        run_mode = RunMode(core=core)
-        result = await run_mode.resume_with_clarification(
-            task_id=task_id,
-            answer=request.answer,
-            answered_by=request.answered_by,
+        project = None
+        if task.project_id and hasattr(core.project_manager, "get_project_async"):
+            project = await core.project_manager.get_project_async(task.project_id)
+        resolved_directory = normalize_directory(request.directory) or normalize_directory(
+            getattr(project, "workspace_path", None)
         )
+        execution_context = ExecutionContext(
+            session_id=request.session_id,
+            conversation_id=request.session_id,
+            directory=resolved_directory,
+            project_root=resolved_directory,
+            workspace_root=resolved_directory,
+            request_id=f"task-resume:{task_id}",
+        )
+
+        run_mode = RunMode(core=core)
+        with execution_context_scope(execution_context):
+            result = await run_mode.resume_with_clarification(
+                task_id=task_id,
+                answer=request.answer,
+                answered_by=request.answered_by,
+            )
 
         updated_task = await core.project_manager.get_task_async(task_id)
         response_task = updated_task or task
@@ -4967,7 +4999,9 @@ async def complete_task(task_id: str, core: PenguinCore = Depends(get_core)):
 
 @router.post("/api/v1/tasks/{task_id}/execute")
 async def execute_task_from_project(
-    task_id: str, core: PenguinCore = Depends(get_core)
+    task_id: str,
+    request: Optional[TaskExecutionRequest] = None,
+    core: PenguinCore = Depends(get_core),
 ):
     """Execute a task using RunMode so web responses preserve current lifecycle truth."""
     try:
@@ -4980,18 +5014,38 @@ async def execute_task_from_project(
                 status_code=503, detail="Engine layer not available for task execution"
             )
 
+        payload = request or TaskExecutionRequest()
+        project = None
+        if task.project_id and hasattr(core.project_manager, "get_project_async"):
+            project = await core.project_manager.get_project_async(task.project_id)
+        resolved_directory = normalize_directory(payload.directory) or normalize_directory(
+            getattr(project, "workspace_path", None)
+        )
+        execution_context = ExecutionContext(
+            session_id=payload.session_id,
+            conversation_id=payload.session_id,
+            directory=resolved_directory,
+            project_root=resolved_directory,
+            workspace_root=resolved_directory,
+            request_id=f"task-execute:{task_id}",
+        )
+
         # Route project execution through RunMode so clarification-needed and other
         # non-terminal outcomes survive instead of being collapsed into fake failure/completion states.
         run_mode = RunMode(core=core)
-        result = await run_mode.start(
-            name=task.title,
-            description=task.description,
-            context={
-                "task_id": task_id,
-                "project_id": task.project_id,
-                "priority": task.priority,
-            },
-        )
+        with execution_context_scope(execution_context):
+            result = await run_mode.start(
+                name=task.title,
+                description=task.description,
+                context={
+                    "task_id": task_id,
+                    "project_id": task.project_id,
+                    "priority": task.priority,
+                    "session_id": payload.session_id,
+                    "conversation_id": payload.session_id,
+                    "directory": resolved_directory,
+                },
+            )
 
         updated_task = await core.project_manager.get_task_async(task_id)
         response_task = updated_task or task

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -4695,6 +4695,9 @@ async def start_project(
     )
 
 
+# NOTE: `project run` is kept as a provisional web/API compatibility surface.
+# The current product/TUI path should prefer explicit `project init` + `project start`
+# until the legacy CLI/kernel `run` contract is repaired and made consistent across surfaces.
 @router.post("/api/v1/projects/run")
 async def run_project(
     request: ProjectRunRequest, core: PenguinCore = Depends(get_core)

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -4,9 +4,12 @@ This module provides the main entry point for running the Penguin web server.
 It uses the app factory from app.py to create and configure the FastAPI application.
 """
 
+import argparse
 import logging
 import os
+import sys
 from ipaddress import ip_address
+from typing import Optional, Sequence
 from urllib.parse import quote
 
 from penguin.constants import DEFAULT_WEB_PORT
@@ -82,6 +85,36 @@ def _resolve_port() -> int:
         raise RuntimeError(
             f"Invalid PORT value {raw!r}. Set PORT to an integer port number."
         ) from exc
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for the web server entrypoint."""
+    parser = argparse.ArgumentParser(prog="penguin-web")
+    parser.add_argument("--host", help="Bind host override")
+    parser.add_argument("--port", type=int, help="Bind port override")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode with uvicorn reload",
+    )
+    return parser
+
+
+def _resolve_runtime_settings(argv: Optional[Sequence[str]] = None) -> tuple[str, int, bool]:
+    """Resolve host/port/debug from CLI args first, then env vars."""
+    parser = _build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else [])
+
+    host = args.host or os.environ.get("HOST", DEFAULT_HOST)
+
+    if args.port is not None:
+        port = args.port
+    else:
+        port = _resolve_port()
+
+    env_debug = os.environ.get("DEBUG", "false").lower() == "true"
+    debug = args.debug or env_debug
+    return host, port, debug
 
 
 def _print_startup_banner(host: str, port: int) -> None:
@@ -161,7 +194,7 @@ def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
     )
 
 
-def main():
+def main(argv: Optional[Sequence[str]] = None):
     """Entry point for the web server."""
     try:
         import uvicorn
@@ -170,10 +203,8 @@ def main():
         print("Install with: pip install penguin-ai[web]")
         return 1
 
-    host = os.environ.get("HOST", DEFAULT_HOST)
     try:
-        port = _resolve_port()
-        debug = os.environ.get("DEBUG", "false").lower() == "true"
+        host, port, debug = _resolve_runtime_settings(argv)
         app = None
         validate_startup_security(host)
         if debug:
@@ -244,4 +275,4 @@ def start_server(
 
 
 if __name__ == "__main__":
-    exit(main())
+    exit(main(sys.argv[1:]))

--- a/penguin/web/services/opencode_provider.py
+++ b/penguin/web/services/opencode_provider.py
@@ -23,6 +23,7 @@ from penguin.web.services.provider_auth import (
 )
 from penguin.web.services.provider_catalog import (
     canonical_model_id,
+    codex_oauth_provider_models,
     collect_provider_models,
     current_model_string,
     env_connected_provider_ids,
@@ -381,6 +382,37 @@ def _merge_models_dev_catalog_models(
     return merged
 
 
+def _merge_openai_codex_catalog_models(
+    provider_models: dict[str, dict[str, dict[str, Any]]],
+    auth_records: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    openai_record = auth_records.get("openai")
+    discovered = codex_oauth_provider_models(openai_record)
+    openai_models = discovered.get("openai")
+    if not openai_models:
+        return provider_models
+
+    merged: dict[str, dict[str, dict[str, Any]]] = {
+        provider_id: dict(models) for provider_id, models in provider_models.items()
+    }
+    merged["openai"] = dict(openai_models)
+    return merged
+
+
+def _model_priority(conf: dict[str, Any]) -> int:
+    try:
+        priority = int(conf.get("priority"))
+    except Exception:
+        return 1_000_000
+    return priority if priority >= 0 else 1_000_000
+
+
+def _sorted_model_items(
+    models: dict[str, dict[str, Any]],
+) -> list[tuple[str, dict[str, Any]]]:
+    return sorted(models.items(), key=lambda item: (_model_priority(item[1]), item[0]))
+
+
 def _config_model_payload(
     model_id: str,
     provider_id: str,
@@ -623,6 +655,7 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
         config_provider_models,
         auth_records,
     )
+    provider_models = _merge_openai_codex_catalog_models(provider_models, auth_records)
 
     current_model = (
         core.get_current_model() if hasattr(core, "get_current_model") else None
@@ -645,6 +678,7 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
         provider_set.add(current_provider)
 
     provider_models = _merge_models_dev_catalog_models(provider_models)
+    provider_models = _merge_openai_codex_catalog_models(provider_models, auth_records)
     provider_set.update(provider_models.keys())
 
     for provider_id in sorted(provider_set):
@@ -653,7 +687,7 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
         models = provider_models.get(provider_id, {})
         mapped_models = {
             model_id: _config_model_payload(model_id, provider_id, conf)
-            for model_id, conf in sorted(models.items(), key=lambda item: item[0])
+            for model_id, conf in _sorted_model_items(models)
         }
         source = "config"
         config_models = config_provider_models.get(provider_id, {})
@@ -699,6 +733,7 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
         config_provider_models,
         auth_records,
     )
+    provider_models = _merge_openai_codex_catalog_models(provider_models, auth_records)
 
     all_providers: list[dict[str, Any]] = []
     default: dict[str, str] = {}
@@ -728,6 +763,7 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
         provider_set.add(current_provider)
 
     provider_models = _merge_models_dev_catalog_models(provider_models)
+    provider_models = _merge_openai_codex_catalog_models(provider_models, auth_records)
     provider_set.update(provider_models.keys())
 
     for provider_id in sorted(provider_set):
@@ -736,7 +772,7 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
         models = provider_models.get(provider_id, {})
         mapped_models = {
             model_id: _provider_list_model_payload(model_id, provider_id, conf)
-            for model_id, conf in sorted(models.items(), key=lambda item: item[0])
+            for model_id, conf in _sorted_model_items(models)
         }
         api_url, api_npm = provider_api(provider_id)
         all_providers.append(

--- a/penguin/web/services/opencode_provider.py
+++ b/penguin/web/services/opencode_provider.py
@@ -394,12 +394,12 @@ def _config_model_payload(
             isinstance(conf.get("reasoning"), dict) and conf["reasoning"].get("enabled")
         )
     )
+    variants = _model_variants_payload(provider_id, model_id, True)
+    reasoning_supported = reasoning_enabled or bool(variants)
     name = conf.get("name") or conf.get("model") or model_id
     release_date = conf.get("release_date")
     if not isinstance(release_date, str) or not release_date.strip():
         release_date = "1970-01-01T00:00:00+00:00"
-
-    variants = _model_variants_payload(provider_id, model_id, reasoning_enabled)
 
     payload = {
         "id": model_id,
@@ -412,7 +412,7 @@ def _config_model_payload(
         },
         "capabilities": {
             "temperature": True,
-            "reasoning": reasoning_enabled,
+            "reasoning": reasoning_supported,
             "attachment": bool(conf.get("vision_enabled", False)),
             "toolcall": True,
             "input": {
@@ -458,18 +458,18 @@ def _provider_list_model_payload(
             isinstance(conf.get("reasoning"), dict) and conf["reasoning"].get("enabled")
         )
     )
+    variants = _model_variants_payload(provider_id, model_id, True)
+    reasoning_supported = reasoning_enabled or bool(variants)
     release_date = conf.get("release_date")
     if not isinstance(release_date, str) or not release_date.strip():
         release_date = "1970-01-01T00:00:00+00:00"
-
-    variants = _model_variants_payload(provider_id, model_id, reasoning_enabled)
 
     payload = {
         "id": model_id,
         "name": conf.get("name") or conf.get("model") or model_id,
         "release_date": release_date,
         "attachment": bool(conf.get("vision_enabled", False)),
-        "reasoning": reasoning_enabled,
+        "reasoning": reasoning_supported,
         "temperature": True,
         "tool_call": True,
         "limit": {

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -20,6 +20,7 @@ from penguin.project.blueprint_parser import (
     BlueprintParseError,
     BlueprintParser,
 )
+from penguin.project.exceptions import ValidationError
 from penguin.project.git_manager import GitManager
 from penguin.project.spec_parser import parse_project_specification_from_markdown
 from penguin.project.task_executor import ProjectTaskExecutor
@@ -104,11 +105,14 @@ async def initialize_project_from_blueprint(
     blueprint_path: Optional[str],
 ) -> Dict[str, Any]:
     """Create a project and optionally parse/lint/sync a Blueprint into it."""
-    project = await core.project_manager.create_project_async(
-        name=name,
-        description=description or f"Project: {name}",
-        workspace_path=Path(workspace_path).expanduser().resolve() if workspace_path else None,
-    )
+    try:
+        project = await core.project_manager.create_project_async(
+            name=name,
+            description=description or f"Project: {name}",
+            workspace_path=Path(workspace_path).expanduser().resolve() if workspace_path else None,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     response: Dict[str, Any] = {
         "project": {

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -4,6 +4,8 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from penguin.config import GITHUB_REPOSITORY, WORKSPACE_PATH
+
 from fastapi import HTTPException
 
 from penguin.core import PenguinCore
@@ -13,6 +15,11 @@ from penguin.project.blueprint_parser import (
     BlueprintParseError,
     BlueprintParser,
 )
+from penguin.project.git_manager import GitManager
+from penguin.project.spec_parser import parse_project_specification_from_markdown
+from penguin.project.task_executor import ProjectTaskExecutor
+from penguin.project.validation_manager import ValidationManager
+from penguin.project.workflow_orchestrator import WorkflowOrchestrator
 
 
 def _delete_project_and_tasks(core: PenguinCore, project_id: str) -> None:
@@ -223,4 +230,88 @@ async def start_project_execution(
             "first_ready_task": ready_tasks[0].title if ready_tasks else None,
             "result": result,
         },
+    }
+
+
+async def delete_project_with_tasks(*, core: PenguinCore, project_id: str) -> Dict[str, Any]:
+    """Delete a project and its tasks, returning a truthful summary."""
+    project = await core.project_manager.get_project_async(project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail=f"Project {project_id} not found")
+
+    tasks = await core.project_manager.list_tasks_async(project_id=project.id)
+    _delete_project_and_tasks(core, project.id)
+
+    return {
+        "project": {
+            "id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "status": project.status,
+        },
+        "deleted_tasks": len(tasks),
+        "message": f"Project '{project.name}' deleted successfully.",
+    }
+
+
+async def run_project_workflow(
+    *,
+    core: PenguinCore,
+    spec_path: Optional[str],
+    markdown_content: Optional[str],
+    continuous: bool,
+    time_limit: Optional[int],
+) -> Dict[str, Any]:
+    """Parse a project spec into tasks, then start the resulting project."""
+    has_spec_path = bool(spec_path and spec_path.strip())
+    has_markdown_content = bool(markdown_content and markdown_content.strip())
+    if not has_spec_path and not has_markdown_content:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either spec_path or markdown_content to run a project workflow.",
+        )
+
+    if has_markdown_content:
+        markdown_source = str(markdown_content)
+        source_label = "inline_markdown"
+    else:
+        spec_file = Path(str(spec_path)).expanduser().resolve()
+        if not spec_file.exists() or not spec_file.is_file():
+            raise HTTPException(status_code=404, detail=f"Spec file '{spec_path}' was not found.")
+        markdown_source = spec_file.read_text()
+        source_label = str(spec_file)
+
+    parse_result = await parse_project_specification_from_markdown(
+        markdown_content=markdown_source,
+        project_manager=core.project_manager,
+    )
+    if parse_result.get("status") != "success":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": parse_result.get("message", "Project spec parsing failed."),
+                "source": source_label,
+            },
+        )
+
+    creation_result = parse_result.get("creation_result") or {}
+    project_payload = creation_result.get("project") or {}
+    project_id = project_payload.get("id")
+    if not project_id:
+        raise HTTPException(
+            status_code=500,
+            detail="Project run parse result did not include a created project ID.",
+        )
+
+    execution = await start_project_execution(
+        core=core,
+        project_identifier=project_id,
+        continuous=continuous,
+        time_limit=time_limit,
+    )
+
+    return {
+        "source": source_label,
+        "parse": parse_result,
+        "execution": execution,
     }

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from penguin.core import PenguinCore
+from penguin.project.blueprint_parser import BlueprintParseError, BlueprintParser
+
+
+def _delete_project_and_tasks(core: PenguinCore, project_id: str) -> None:
+    """Delete a project and its tasks for bootstrap rollback paths."""
+    tasks = core.project_manager.list_tasks(project_id=project_id)
+    for task in tasks:
+        core.project_manager.storage.delete_task(task.id)
+    core.project_manager.storage.delete_project(project_id)
+
+
+def resolve_project_identifier(core: PenguinCore, project_identifier: str):
+    """Resolve a project by exact ID or exact unique name."""
+    project = core.project_manager.get_project(project_identifier)
+    if project:
+        return project
+
+    by_name = core.project_manager.get_project_by_name(project_identifier)
+    if by_name:
+        return by_name
+
+    projects = core.project_manager.list_projects()
+    matches = [project for project in projects if project.name == project_identifier]
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Ambiguous project name '{project_identifier}'. Use the project ID instead.",
+        )
+
+    raise HTTPException(
+        status_code=404,
+        detail=f"Project '{project_identifier}' was not found by exact ID or exact name.",
+    )
+
+
+async def initialize_project_from_blueprint(
+    *,
+    core: PenguinCore,
+    name: str,
+    description: Optional[str],
+    workspace_path: Optional[str],
+    blueprint_path: Optional[str],
+) -> Dict[str, Any]:
+    """Create a project and optionally parse/lint/sync a Blueprint into it."""
+    project = await core.project_manager.create_project_async(
+        name=name,
+        description=description or f"Project: {name}",
+        workspace_path=Path(workspace_path).expanduser().resolve() if workspace_path else None,
+    )
+
+    response: Dict[str, Any] = {
+        "project": {
+            "id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "status": project.status,
+            "workspace_path": project.workspace_path,
+            "created_at": project.created_at,
+        }
+    }
+
+    if not blueprint_path:
+        return response
+
+    blueprint_file = Path(blueprint_path).expanduser().resolve()
+
+    try:
+        parser = BlueprintParser(base_path=blueprint_file.parent)
+        blueprint = parser.parse_file(blueprint_file)
+        diagnostics = parser.lint_blueprint(blueprint, source=str(blueprint_file))
+        if diagnostics.has_errors:
+            _delete_project_and_tasks(core, project.id)
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": "Blueprint validation failed. Project initialization rolled back.",
+                    "diagnostics": [d.to_dict() if hasattr(d, 'to_dict') else d.__dict__ for d in diagnostics.diagnostics],
+                },
+            )
+
+        sync_result = await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: core.project_manager.sync_blueprint(
+                blueprint,
+                project_id=project.id,
+                create_missing=True,
+                update_existing=True,
+            ),
+        )
+        ready_tasks = await core.project_manager.get_ready_tasks_async(project.id)
+        response["blueprint"] = {
+            "path": str(blueprint_file),
+            "tasks_created": len(sync_result.get("created", [])),
+            "tasks_updated": len(sync_result.get("updated", [])),
+            "tasks_skipped": len(sync_result.get("skipped", [])),
+            "ready_tasks": len(ready_tasks),
+            "warnings": [
+                d.to_dict() if hasattr(d, 'to_dict') else d.__dict__
+                for d in diagnostics.diagnostics
+                if getattr(d, 'severity', None) == 'warning'
+            ],
+        }
+        return response
+    except BlueprintParseError as exc:
+        _delete_project_and_tasks(core, project.id)
+        raise HTTPException(status_code=400, detail=f"Blueprint parse failed: {exc}") from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _delete_project_and_tasks(core, project.id)
+        raise HTTPException(status_code=500, detail=f"Error initializing project: {exc}") from exc
+
+
+async def start_project_execution(
+    *,
+    core: PenguinCore,
+    project_identifier: str,
+    continuous: bool,
+    time_limit: Optional[int],
+) -> Dict[str, Any]:
+    """Start project-scoped execution through the real RunMode path."""
+    project = resolve_project_identifier(core, project_identifier)
+    tasks = await core.project_manager.list_tasks_async(project_id=project.id)
+    if not tasks:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Project '{project.name}' has no tasks. Initialize or import a Blueprint first.",
+        )
+
+    ready_tasks = await core.project_manager.get_ready_tasks_async(project.id)
+    if not ready_tasks:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Project '{project.name}' has no ready tasks to execute.",
+        )
+
+    result = await core.start_run_mode(
+        name=project.name,
+        description=project.description,
+        context={"project_id": project.id},
+        continuous=continuous,
+        time_limit=time_limit,
+        mode_type="project",
+    )
+
+    return {
+        "project": {
+            "id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "status": project.status,
+        },
+        "execution": {
+            "mode": "continuous" if continuous else "single-selection",
+            "time_limit": time_limit,
+            "ready_tasks": len(ready_tasks),
+            "first_ready_task": ready_tasks[0].title if ready_tasks else None,
+            "result": result,
+        },
+    }

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -7,7 +7,12 @@ from typing import Any, Dict, Optional
 from fastapi import HTTPException
 
 from penguin.core import PenguinCore
-from penguin.project.blueprint_parser import BlueprintParseError, BlueprintParser
+from penguin.project.blueprint_parser import (
+    BlueprintDiagnostic,
+    BlueprintDiagnosticsReport,
+    BlueprintParseError,
+    BlueprintParser,
+)
 
 
 def _delete_project_and_tasks(core: PenguinCore, project_id: str) -> None:
@@ -16,6 +21,42 @@ def _delete_project_and_tasks(core: PenguinCore, project_id: str) -> None:
     for task in tasks:
         core.project_manager.storage.delete_task(task.id)
     core.project_manager.storage.delete_project(project_id)
+
+
+def _serialize_diagnostic(diagnostic: BlueprintDiagnostic) -> Dict[str, Any]:
+    """Return a JSON-safe diagnostic payload."""
+    if hasattr(diagnostic, "to_dict"):
+        return diagnostic.to_dict()
+    return dict(diagnostic.__dict__)
+
+
+def _bootstrap_failure_detail(
+    message: str,
+    diagnostics: Optional[BlueprintDiagnosticsReport] = None,
+) -> Dict[str, Any]:
+    """Build a consistent rollback response payload."""
+    detail: Dict[str, Any] = {"message": message}
+    if diagnostics is not None:
+        detail["diagnostics"] = [
+            _serialize_diagnostic(diagnostic)
+            for diagnostic in diagnostics.diagnostics
+        ]
+    return detail
+
+
+def _build_empty_blueprint_report(source: str) -> BlueprintDiagnosticsReport:
+    """Return an error report for effectively empty Blueprint imports."""
+    return BlueprintDiagnosticsReport(
+        diagnostics=[
+            BlueprintDiagnostic(
+                code="BP-LINT-004",
+                severity="error",
+                message="Blueprint does not define any importable tasks.",
+                source=source,
+                suggestion="Add at least one task under the Tasks section before initializing a project.",
+            )
+        ]
+    )
 
 
 def resolve_project_identifier(core: PenguinCore, project_identifier: str):
@@ -81,10 +122,21 @@ async def initialize_project_from_blueprint(
             _delete_project_and_tasks(core, project.id)
             raise HTTPException(
                 status_code=400,
-                detail={
-                    "message": "Blueprint validation failed. Project initialization rolled back.",
-                    "diagnostics": [d.to_dict() if hasattr(d, 'to_dict') else d.__dict__ for d in diagnostics.diagnostics],
-                },
+                detail=_bootstrap_failure_detail(
+                    "Blueprint validation failed. Project initialization rolled back.",
+                    diagnostics,
+                ),
+            )
+
+        if not blueprint.items:
+            empty_report = _build_empty_blueprint_report(str(blueprint_file))
+            _delete_project_and_tasks(core, project.id)
+            raise HTTPException(
+                status_code=400,
+                detail=_bootstrap_failure_detail(
+                    "Blueprint import produced no tasks. Project initialization rolled back.",
+                    empty_report,
+                ),
             )
 
         sync_result = await asyncio.get_event_loop().run_in_executor(
@@ -104,15 +156,20 @@ async def initialize_project_from_blueprint(
             "tasks_skipped": len(sync_result.get("skipped", [])),
             "ready_tasks": len(ready_tasks),
             "warnings": [
-                d.to_dict() if hasattr(d, 'to_dict') else d.__dict__
-                for d in diagnostics.diagnostics
-                if getattr(d, 'severity', None) == 'warning'
+                _serialize_diagnostic(diagnostic)
+                for diagnostic in diagnostics.diagnostics
+                if getattr(diagnostic, "severity", None) == "warning"
             ],
         }
         return response
     except BlueprintParseError as exc:
         _delete_project_and_tasks(core, project.id)
-        raise HTTPException(status_code=400, detail=f"Blueprint parse failed: {exc}") from exc
+        raise HTTPException(
+            status_code=400,
+            detail=_bootstrap_failure_detail(
+                f"Blueprint parse failed: {exc}",
+            ),
+        ) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -262,7 +262,12 @@ async def run_project_workflow(
     continuous: bool,
     time_limit: Optional[int],
 ) -> Dict[str, Any]:
-    """Parse a project spec into tasks, then start the resulting project."""
+    """Parse a project spec into tasks, then start the resulting project.
+
+    This is intentionally provisional. The preferred product flow is explicit
+    `project init` followed by `project start` until legacy `project run`
+    semantics are repaired into a crisp cross-surface contract.
+    """
     has_spec_path = bool(spec_path and spec_path.strip())
     has_markdown_content = bool(markdown_content and markdown_content.strip())
     if not has_spec_path and not has_markdown_content:

--- a/penguin/web/services/projects.py
+++ b/penguin/web/services/projects.py
@@ -9,6 +9,11 @@ from penguin.config import GITHUB_REPOSITORY, WORKSPACE_PATH
 from fastapi import HTTPException
 
 from penguin.core import PenguinCore
+from penguin.system.execution_context import (
+    ExecutionContext,
+    execution_context_scope,
+    normalize_directory,
+)
 from penguin.project.blueprint_parser import (
     BlueprintDiagnostic,
     BlueprintDiagnosticsReport,
@@ -190,6 +195,8 @@ async def start_project_execution(
     project_identifier: str,
     continuous: bool,
     time_limit: Optional[int],
+    session_id: Optional[str] = None,
+    directory: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Start project-scoped execution through the real RunMode path."""
     project = resolve_project_identifier(core, project_identifier)
@@ -207,14 +214,30 @@ async def start_project_execution(
             detail=f"Project '{project.name}' has no ready tasks to execute.",
         )
 
-    result = await core.start_run_mode(
-        name=project.name,
-        description=project.description,
-        context={"project_id": project.id},
-        continuous=continuous,
-        time_limit=time_limit,
-        mode_type="project",
+    resolved_directory = normalize_directory(directory) or normalize_directory(project.workspace_path)
+    execution_context = ExecutionContext(
+        session_id=session_id,
+        conversation_id=session_id,
+        directory=resolved_directory,
+        project_root=resolved_directory,
+        workspace_root=resolved_directory,
+        request_id=f"project-start:{project.id}",
     )
+
+    with execution_context_scope(execution_context):
+        result = await core.start_run_mode(
+            name=project.name,
+            description=project.description,
+            context={
+                "project_id": project.id,
+                "session_id": session_id,
+                "conversation_id": session_id,
+                "directory": resolved_directory,
+            },
+            continuous=continuous,
+            time_limit=time_limit,
+            mode_type="project",
+        )
 
     return {
         "project": {
@@ -229,6 +252,8 @@ async def start_project_execution(
             "ready_tasks": len(ready_tasks),
             "first_ready_task": ready_tasks[0].title if ready_tasks else None,
             "result": result,
+            "session_id": session_id,
+            "directory": resolved_directory,
         },
     }
 
@@ -261,6 +286,8 @@ async def run_project_workflow(
     markdown_content: Optional[str],
     continuous: bool,
     time_limit: Optional[int],
+    session_id: Optional[str] = None,
+    directory: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Parse a project spec into tasks, then start the resulting project.
 
@@ -313,6 +340,8 @@ async def run_project_workflow(
         project_identifier=project_id,
         continuous=continuous,
         time_limit=time_limit,
+        session_id=session_id,
+        directory=directory,
     )
 
     return {

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -53,6 +53,15 @@ _MODELS_DEV_CACHE: dict[str, Any] = {
     "fetched_at": 0.0,
     "providers": {},
 }
+_OPENAI_CODEX_MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
+_OPENAI_CODEX_MODELS_CLIENT_VERSION = "1.0.0"
+_OPENAI_CODEX_MODELS_CACHE_TTL_SECONDS = 600.0
+_OPENAI_CODEX_MODELS_CACHE_LOCK = RLock()
+_OPENAI_CODEX_MODELS_CACHE: dict[str, Any] = {
+    "fetched_at": 0.0,
+    "cache_key": "",
+    "models": {},
+}
 
 
 def _coerce_positive_int(value: Any, default: int) -> int:
@@ -217,6 +226,134 @@ def models_dev_provider_models(
             discovered[provider_id] = provider_models
 
     return discovered
+
+
+def _openai_codex_model_input_modalities(raw_value: Any) -> list[str]:
+    if not isinstance(raw_value, list):
+        return []
+    return [
+        str(item).strip().lower()
+        for item in raw_value
+        if isinstance(item, str) and item.strip()
+    ]
+
+
+def _openai_codex_model_reasoning_enabled(raw_value: Any) -> bool:
+    if not isinstance(raw_value, list):
+        return False
+    return any(isinstance(item, dict) and item.get("effort") for item in raw_value)
+
+
+def codex_oauth_provider_models(
+    credential_record: dict[str, Any] | None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Return OpenAI models available to a ChatGPT-backed Codex OAuth account."""
+    if not isinstance(credential_record, dict):
+        return {}
+    if credential_record.get("type") != "oauth":
+        return {}
+
+    access = credential_record.get("access")
+    if not isinstance(access, str) or not access.strip():
+        return {}
+
+    account_id = credential_record.get("accountId")
+    account_key = account_id.strip() if isinstance(account_id, str) else ""
+    cache_key = f"{access[-12:]}:{account_key}"
+    now = time.time()
+    with _OPENAI_CODEX_MODELS_CACHE_LOCK:
+        fetched_at = float(_OPENAI_CODEX_MODELS_CACHE.get("fetched_at") or 0.0)
+        cached_models = _OPENAI_CODEX_MODELS_CACHE.get("models")
+        cached_key = str(_OPENAI_CODEX_MODELS_CACHE.get("cache_key") or "")
+        if (
+            cache_key == cached_key
+            and isinstance(cached_models, dict)
+            and cached_models
+            and now - fetched_at <= _OPENAI_CODEX_MODELS_CACHE_TTL_SECONDS
+        ):
+            return {
+                "openai": {
+                    str(key): value
+                    for key, value in cached_models.items()
+                    if isinstance(key, str) and isinstance(value, dict)
+                }
+            }
+
+    headers = {
+        "Authorization": f"Bearer {access.strip()}",
+        "Accept": "application/json",
+        "User-Agent": "penguin-web/1.0",
+    }
+    if account_key:
+        headers["ChatGPT-Account-ID"] = account_key
+
+    discovered: dict[str, dict[str, Any]] = {}
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                _OPENAI_CODEX_MODELS_URL,
+                headers=headers,
+                params={"client_version": _OPENAI_CODEX_MODELS_CLIENT_VERSION},
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except Exception:
+        return {}
+
+    models_payload = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(models_payload, list):
+        return {}
+
+    for item in models_payload:
+        if not isinstance(item, dict):
+            continue
+        raw_slug = item.get("slug")
+        if not isinstance(raw_slug, str) or not raw_slug.strip():
+            continue
+        if str(item.get("visibility") or "").strip().lower() != "list":
+            continue
+
+        model_id = canonical_model_id("openai", raw_slug)
+        context_window = _coerce_positive_int(
+            item.get("context_window") or item.get("max_context_window"),
+            131072,
+        )
+        max_context_window = _coerce_positive_int(
+            item.get("max_context_window"),
+            context_window,
+        )
+        input_modalities = _openai_codex_model_input_modalities(
+            item.get("input_modalities")
+        )
+        reasoning_enabled = _openai_codex_model_reasoning_enabled(
+            item.get("supported_reasoning_levels")
+        )
+        priority = item.get("priority")
+
+        conf: dict[str, Any] = {
+            "provider": "openai",
+            "model": model_id,
+            "name": item.get("display_name") or model_id,
+            "context_window": context_window,
+            "max_context_window_tokens": max_context_window,
+            "max_output_tokens": 128000,
+            "vision_enabled": "image" in input_modalities,
+            "reasoning_enabled": reasoning_enabled,
+            "source": "codex",
+        }
+        if isinstance(priority, int):
+            conf["priority"] = priority
+        discovered[model_id] = conf
+
+    if not discovered:
+        return {}
+
+    with _OPENAI_CODEX_MODELS_CACHE_LOCK:
+        _OPENAI_CODEX_MODELS_CACHE["fetched_at"] = time.time()
+        _OPENAI_CODEX_MODELS_CACHE["cache_key"] = cache_key
+        _OPENAI_CODEX_MODELS_CACHE["models"] = discovered
+
+    return {"openai": discovered}
 
 
 def canonical_model_id(provider_id: str, model_id: str) -> str:

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -568,6 +568,132 @@ async def test_models_dev_catalog_expands_openai_and_anthropic_payloads(
 
 
 @pytest.mark.asyncio
+async def test_openai_oauth_catalog_replaces_static_openai_models(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = cast(Any, getattr(provider_catalog, "_OPENAI_CODEX_MODELS_CACHE"))
+    cache["fetched_at"] = 0.0
+    cache["cache_key"] = ""
+    cache["models"] = {}
+
+    class _CodexModelsResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "models": [
+                    {
+                        "slug": "gpt-5.5",
+                        "display_name": "GPT-5.5",
+                        "visibility": "list",
+                        "priority": 1,
+                        "context_window": 272000,
+                        "max_context_window": 1000000,
+                        "input_modalities": ["text", "image"],
+                        "supported_reasoning_levels": [{"effort": "xhigh"}],
+                    },
+                    {
+                        "slug": "gpt-5.3-codex",
+                        "display_name": "gpt-5.3-codex",
+                        "visibility": "list",
+                        "priority": 6,
+                        "context_window": 272000,
+                        "max_context_window": 272000,
+                        "input_modalities": ["text", "image"],
+                        "supported_reasoning_levels": [{"effort": "medium"}],
+                    },
+                    {
+                        "slug": "gpt-5.4",
+                        "display_name": "gpt-5.4",
+                        "visibility": "list",
+                        "priority": 2,
+                        "context_window": 272000,
+                        "max_context_window": 1000000,
+                        "input_modalities": ["text", "image"],
+                        "supported_reasoning_levels": [{"effort": "xhigh"}],
+                    },
+                    {
+                        "slug": "codex-auto-review",
+                        "display_name": "Codex Auto Review",
+                        "visibility": "hide",
+                        "priority": 29,
+                    },
+                ]
+            }
+
+    class _CodexModelsClient:
+        def __init__(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> _CodexModelsClient:
+            return self
+
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            del exc_type, exc, tb
+            return False
+
+        def get(
+            self,
+            url: str,
+            headers: dict[str, str],
+            params: dict[str, str],
+        ) -> _CodexModelsResponse:
+            assert url.endswith("/backend-api/codex/models")
+            assert headers["Authorization"] == "Bearer access-token"
+            assert headers["ChatGPT-Account-ID"] == "acct_123"
+            assert params["client_version"] == "1.0.0"
+            return _CodexModelsResponse()
+
+    monkeypatch.setattr(provider_catalog.httpx, "Client", _CodexModelsClient)
+    monkeypatch.setattr(provider_service, "models_dev_provider_models", lambda *_: {})
+    monkeypatch.setattr(
+        provider_service,
+        "get_provider_credentials",
+        lambda: {
+            "openai": {
+                "type": "oauth",
+                "access": "access-token",
+                "refresh": "refresh-token",
+                "expires": int(time.time() * 1000) + 3600000,
+                "accountId": "acct_123",
+            }
+        },
+    )
+
+    core = _Core(tmp_path)
+    typed_core = cast(Any, core)
+
+    providers_payload = await opencode_config_providers(core=typed_core)
+    openai = next(
+        item for item in providers_payload["providers"] if item["id"] == "openai"
+    )
+
+    assert list(openai["models"].keys()) == [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+    ]
+    assert "gpt-5" not in openai["models"]
+    assert "codex-auto-review" not in openai["models"]
+    assert providers_payload["default"]["openai"] == "gpt-5.5"
+    assert openai["models"]["gpt-5.5"]["capabilities"]["attachment"] is True
+    assert openai["models"]["gpt-5.5"]["capabilities"]["reasoning"] is True
+
+    provider_payload = await opencode_provider_list(core=typed_core)
+    openai_provider = next(
+        item for item in provider_payload["all"] if item["id"] == "openai"
+    )
+    assert list(openai_provider["models"].keys()) == [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+    ]
+    assert provider_payload["default"]["openai"] == "gpt-5.5"
+
+
+@pytest.mark.asyncio
 async def test_provider_filters_hide_disabled_models_dev_providers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -616,6 +616,62 @@ async def test_provider_filters_hide_disabled_models_dev_providers(
 
 
 @pytest.mark.asyncio
+async def test_native_openai_config_model_exposes_reasoning_variants_without_enable_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core = _Core(tmp_path)
+    core.config.model_configs = {
+        "openai/gpt-5.4": {
+            "provider": "openai",
+            "model": "gpt-5.4",
+            "max_output_tokens": 8192,
+            "context_window": 128000,
+        }
+    }
+    core.model_config.provider = "openai"
+    core.model_config.client_preference = "native"
+    core._current_model = {
+        "provider": "openai",
+        "model": "gpt-5.4",
+        "client_preference": "native",
+        "max_output_tokens": 8192,
+        "context_window": 128000,
+    }
+    typed_core = cast(Any, core)
+
+    monkeypatch.setattr(provider_service, "models_dev_provider_models", lambda *_: {})
+
+    providers_payload = await opencode_config_providers(core=typed_core)
+    openai = next(
+        item for item in providers_payload["providers"] if item["id"] == "openai"
+    )
+    assert openai["models"]["gpt-5.4"]["capabilities"]["reasoning"] is True
+    assert set(openai["models"]["gpt-5.4"]["variants"].keys()) == {
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    }
+
+    provider_payload = await opencode_provider_list(core=typed_core)
+    openai_provider = next(
+        item for item in provider_payload["all"] if item["id"] == "openai"
+    )
+    assert openai_provider["models"]["gpt-5.4"]["reasoning"] is True
+    assert set(openai_provider["models"]["gpt-5.4"]["variants"].keys()) == {
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    }
+
+
+@pytest.mark.asyncio
 async def test_auth_set_and_remove_round_trip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/api/test_reasoning_debug_routes.py
+++ b/tests/api/test_reasoning_debug_routes.py
@@ -28,11 +28,12 @@ def _build_client(core: _Core) -> TestClient:
     return TestClient(app)
 
 
-def test_message_request_defaults_include_reasoning_true() -> None:
+def test_message_request_defaults_include_reasoning_false() -> None:
     request = routes_module.MessageRequest(text="hello")
 
-    assert request.include_reasoning is True
-    assert routes_module._resolve_include_reasoning(request.include_reasoning) is True
+    assert request.include_reasoning is False
+    assert routes_module._resolve_include_reasoning(request.include_reasoning) is False
+    assert routes_module._resolve_include_reasoning(True) is True
     assert routes_module._resolve_include_reasoning(False) is False
 
 

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -363,7 +363,7 @@ async def test_init_project_from_blueprint_reports_counts(tmp_path):
     blueprint_path.write_text("# Example")
     project = make_project()
     task = make_task()
-    blueprint = SimpleNamespace(title="Example", overview="desc")
+    blueprint = SimpleNamespace(title="Example", overview="desc", items=[SimpleNamespace(id="A")])
     diagnostics = SimpleNamespace(has_errors=False, has_warnings=False, diagnostics=[])
     parser = SimpleNamespace(
         parse_file=Mock(return_value=blueprint),
@@ -394,6 +394,95 @@ async def test_init_project_from_blueprint_reports_counts(tmp_path):
     assert response["blueprint"]["tasks_created"] == 1
     assert response["blueprint"]["tasks_updated"] == 1
     assert response["blueprint"]["ready_tasks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_init_project_from_blueprint_rolls_back_empty_import(tmp_path):
+    from unittest.mock import Mock, patch
+    from penguin.web.routes import ProjectInitRequest, init_project
+
+    blueprint_path = tmp_path / "empty.md"
+    blueprint_path.write_text("# Empty")
+    project = make_project()
+    empty_blueprint = SimpleNamespace(title="Empty", overview="desc", items=[])
+    diagnostics = SimpleNamespace(has_errors=False, has_warnings=False, diagnostics=[])
+    parser = SimpleNamespace(
+        parse_file=Mock(return_value=empty_blueprint),
+        lint_blueprint=Mock(return_value=diagnostics),
+    )
+    storage = SimpleNamespace(delete_task=Mock(), delete_project=Mock())
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+            sync_blueprint=Mock(),
+            get_ready_tasks_async=AsyncMock(return_value=[]),
+            list_tasks=Mock(return_value=[]),
+            storage=storage,
+        )
+    )
+
+    with patch("penguin.web.services.projects.BlueprintParser", return_value=parser):
+        with pytest.raises(HTTPException) as exc_info:
+            await init_project(
+                ProjectInitRequest(
+                    name="Empty",
+                    description="Empty project",
+                    workspace_path=str(tmp_path / "workspace"),
+                    blueprint_path=str(blueprint_path),
+                ),
+                core=core,
+            )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert detail["message"] == "Blueprint import produced no tasks. Project initialization rolled back."
+    assert detail["diagnostics"][0]["code"] == "BP-LINT-004"
+    core.project_manager.sync_blueprint.assert_not_called()
+    storage.delete_project.assert_called_once_with(project.id)
+
+
+@pytest.mark.asyncio
+async def test_init_project_from_blueprint_wraps_parse_failures_as_structured_detail(tmp_path):
+    from unittest.mock import patch
+    from penguin.project.blueprint_parser import BlueprintParseError
+    from penguin.web.routes import ProjectInitRequest, init_project
+
+    blueprint_path = tmp_path / "broken.md"
+    blueprint_path.write_text("---\nnot: valid")
+    project = make_project()
+    storage = SimpleNamespace(delete_task=Mock(), delete_project=Mock())
+    parser = SimpleNamespace(
+        parse_file=Mock(side_effect=BlueprintParseError("bad frontmatter", source=str(blueprint_path))),
+        lint_blueprint=Mock(),
+    )
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+            sync_blueprint=Mock(),
+            get_ready_tasks_async=AsyncMock(return_value=[]),
+            list_tasks=Mock(return_value=[]),
+            storage=storage,
+        )
+    )
+
+    with patch("penguin.web.services.projects.BlueprintParser", return_value=parser):
+        with pytest.raises(HTTPException) as exc_info:
+            await init_project(
+                ProjectInitRequest(
+                    name="Broken",
+                    description="Broken project",
+                    workspace_path=str(tmp_path / "workspace"),
+                    blueprint_path=str(blueprint_path),
+                ),
+                core=core,
+            )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert detail["message"].startswith("Blueprint parse failed:")
+    assert "bad frontmatter" in detail["message"]
+    storage.delete_project.assert_called_once_with(project.id)
+    core.project_manager.sync_blueprint.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import HTTPException
@@ -351,3 +351,76 @@ async def test_execute_task_from_project_preserves_idle_no_ready_work_truth():
     assert response["result"]["completion_type"] == "idle_no_ready_tasks"
     assert "no ready work remained" in response["result"]["message"].lower()
     assert response["task"]["phase"] == updated_task.phase.value
+
+
+
+@pytest.mark.asyncio
+async def test_init_project_from_blueprint_reports_counts(tmp_path):
+    from unittest.mock import Mock, patch
+    from penguin.web.routes import ProjectInitRequest, init_project
+
+    blueprint_path = tmp_path / "example.md"
+    blueprint_path.write_text("# Example")
+    project = make_project()
+    task = make_task()
+    blueprint = SimpleNamespace(title="Example", overview="desc")
+    diagnostics = SimpleNamespace(has_errors=False, has_warnings=False, diagnostics=[])
+    parser = SimpleNamespace(
+        parse_file=Mock(return_value=blueprint),
+        lint_blueprint=Mock(return_value=diagnostics),
+    )
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+            sync_blueprint=Mock(return_value={"created": ["A"], "updated": ["B"], "skipped": []}),
+            get_ready_tasks_async=AsyncMock(return_value=[task]),
+            list_tasks=Mock(return_value=[]),
+            storage=SimpleNamespace(delete_task=Mock(), delete_project=Mock()),
+        )
+    )
+
+    with patch("penguin.web.services.projects.BlueprintParser", return_value=parser):
+        response = await init_project(
+            ProjectInitRequest(
+                name="Example",
+                description="Example project",
+                workspace_path=str(tmp_path / "workspace"),
+                blueprint_path=str(blueprint_path),
+            ),
+            core=core,
+        )
+
+    assert response["project"]["id"] == project.id
+    assert response["blueprint"]["tasks_created"] == 1
+    assert response["blueprint"]["tasks_updated"] == 1
+    assert response["blueprint"]["ready_tasks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_start_project_routes_through_runmode_project_context():
+    from penguin.web.routes import ProjectStartRequest, start_project
+
+    project = make_project()
+    ready_task = make_task()
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=project),
+            get_project_by_name=Mock(return_value=None),
+            list_projects=Mock(return_value=[project]),
+            list_tasks_async=AsyncMock(return_value=[ready_task]),
+            get_ready_tasks_async=AsyncMock(return_value=[ready_task]),
+        ),
+        start_run_mode=AsyncMock(return_value={"status": "completed", "completion_type": "success"}),
+    )
+
+    response = await start_project(
+        ProjectStartRequest(project_identifier=project.id, continuous=True, time_limit=20),
+        core=core,
+    )
+
+    core.start_run_mode.assert_awaited_once()
+    _, kwargs = core.start_run_mode.await_args
+    assert kwargs["context"] == {"project_id": project.id}
+    assert kwargs["mode_type"] == "project"
+    assert response["execution"]["ready_tasks"] == 1
+    assert response["execution"]["result"]["status"] == "completed"

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -526,7 +526,7 @@ async def test_start_project_returns_exact_execution_summary_from_runmode_result
     core.start_run_mode.assert_awaited_once_with(
         name=project.name,
         description=project.description,
-        context={"project_id": project.id},
+        context={"project_id": project.id, "session_id": None, "conversation_id": None, "directory": None},
         continuous=True,
         time_limit=30,
         mode_type="project",
@@ -538,7 +538,46 @@ async def test_start_project_returns_exact_execution_summary_from_runmode_result
         "ready_tasks": 2,
         "first_ready_task": "First Ready Task",
         "result": runmode_result,
+        "session_id": None,
+        "directory": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_start_project_threads_session_and_directory_into_runmode(tmp_path):
+    from penguin.web.routes import ProjectStartRequest, start_project
+
+    project = make_project()
+    project.workspace_path = str(tmp_path / "fallback")
+    ready_task = make_task("task-ready")
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=project),
+            get_project_by_name=Mock(return_value=None),
+            list_projects=Mock(return_value=[project]),
+            list_tasks_async=AsyncMock(return_value=[ready_task]),
+            get_ready_tasks_async=AsyncMock(return_value=[ready_task]),
+        ),
+        start_run_mode=AsyncMock(return_value={"status": "started"}),
+    )
+
+    response = await start_project(
+        ProjectStartRequest(
+            project_identifier=project.id,
+            continuous=True,
+            session_id="session-test",
+            directory=str(tmp_path),
+        ),
+        core=core,
+    )
+
+    core.start_run_mode.assert_awaited_once()
+    call = core.start_run_mode.await_args.kwargs
+    assert call["context"]["project_id"] == project.id
+    assert call["context"]["session_id"] == "session-test"
+    assert call["context"]["directory"] == str(tmp_path.resolve())
+    assert response["execution"]["session_id"] == "session-test"
+    assert response["execution"]["directory"] == str(tmp_path.resolve())
 
 
 @pytest.mark.asyncio
@@ -605,7 +644,7 @@ async def test_start_project_routes_through_runmode_project_context():
 
     core.start_run_mode.assert_awaited_once()
     _, kwargs = core.start_run_mode.await_args
-    assert kwargs["context"] == {"project_id": project.id}
+    assert kwargs["context"] == {"project_id": project.id, "session_id": None, "conversation_id": None, "directory": None}
     assert kwargs["mode_type"] == "project"
     assert response["execution"]["ready_tasks"] == 1
     assert response["execution"]["result"]["status"] == "completed"
@@ -701,6 +740,8 @@ async def test_run_project_from_inline_markdown_parses_then_starts_project():
         project_identifier='project-1',
         continuous=True,
         time_limit=15,
+        session_id=None,
+        directory=None,
     )
     assert response['source'] == 'inline_markdown'
     assert response['parse']['creation_result']['project']['id'] == 'project-1'

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -763,3 +763,29 @@ async def test_run_project_reports_parse_failures_as_400():
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail['message'] == 'No tasks found'
     assert exc_info.value.detail['source'] == 'inline_markdown'
+
+@pytest.mark.asyncio
+async def test_project_init_duplicate_name_returns_400_not_500():
+    from penguin.project.exceptions import ValidationError
+    from penguin.web.services.projects import initialize_project_from_blueprint
+
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(
+                side_effect=ValidationError("Project 'Demo' already exists", field="name")
+            ),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await initialize_project_from_blueprint(
+            core=core,
+            name="Demo",
+            description=None,
+            workspace_path="/tmp/demo",
+            blueprint_path=None,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "already exists" in exc_info.value.detail
+

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -486,6 +486,102 @@ async def test_init_project_from_blueprint_wraps_parse_failures_as_structured_de
 
 
 @pytest.mark.asyncio
+async def test_start_project_returns_exact_execution_summary_from_runmode_result():
+    from penguin.web.routes import ProjectStartRequest, start_project
+
+    project = make_project()
+    project.name = "Bootstrap Project"
+    project.description = "Bootstrap Description"
+    first_ready = make_task("task-ready-1")
+    first_ready.title = "First Ready Task"
+    second_ready = make_task("task-ready-2")
+    second_ready.title = "Second Ready Task"
+    runmode_result = {
+        "status": "waiting_input",
+        "message": "Need deployment target",
+        "completion_type": "clarification_needed",
+        "project_id": project.id,
+        "task_id": first_ready.id,
+    }
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=project),
+            get_project_by_name=Mock(return_value=None),
+            list_projects=Mock(return_value=[project]),
+            list_tasks_async=AsyncMock(return_value=[first_ready, second_ready]),
+            get_ready_tasks_async=AsyncMock(return_value=[first_ready, second_ready]),
+        ),
+        start_run_mode=AsyncMock(return_value=runmode_result),
+    )
+
+    response = await start_project(
+        ProjectStartRequest(
+            project_identifier=project.id,
+            continuous=True,
+            time_limit=30,
+        ),
+        core=core,
+    )
+
+    core.start_run_mode.assert_awaited_once_with(
+        name=project.name,
+        description=project.description,
+        context={"project_id": project.id},
+        continuous=True,
+        time_limit=30,
+        mode_type="project",
+    )
+    assert response["project"]["id"] == project.id
+    assert response["execution"] == {
+        "mode": "continuous",
+        "time_limit": 30,
+        "ready_tasks": 2,
+        "first_ready_task": "First Ready Task",
+        "result": runmode_result,
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_project_by_exact_name_uses_same_project_runmode_path():
+    from penguin.web.routes import ProjectStartRequest, start_project
+
+    project = make_project()
+    project.name = "Exact Name Match"
+    ready_task = make_task("task-ready-name")
+    ready_task.title = "Named Ready Task"
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=None),
+            get_project_by_name=Mock(return_value=project),
+            list_projects=Mock(return_value=[project]),
+            list_tasks_async=AsyncMock(return_value=[ready_task]),
+            get_ready_tasks_async=AsyncMock(return_value=[ready_task]),
+        ),
+        start_run_mode=AsyncMock(
+            return_value={
+                "status": "idle",
+                "completion_type": "idle_no_ready_tasks",
+                "message": "RunMode stopped because no ready work remained.",
+            }
+        ),
+    )
+
+    response = await start_project(
+        ProjectStartRequest(
+            project_identifier=project.name,
+            continuous=True,
+            time_limit=None,
+        ),
+        core=core,
+    )
+
+    core.project_manager.get_project.assert_called_once_with(project.name)
+    core.project_manager.get_project_by_name.assert_called_once_with(project.name)
+    assert response["project"]["name"] == project.name
+    assert response["execution"]["first_ready_task"] == "Named Ready Task"
+    assert response["execution"]["result"]["completion_type"] == "idle_no_ready_tasks"
+
+@pytest.mark.asyncio
 async def test_start_project_routes_through_runmode_project_context():
     from penguin.web.routes import ProjectStartRequest, start_project
 

--- a/tests/api/test_web_routes_task_shapes.py
+++ b/tests/api/test_web_routes_task_shapes.py
@@ -609,3 +609,116 @@ async def test_start_project_routes_through_runmode_project_context():
     assert kwargs["mode_type"] == "project"
     assert response["execution"]["ready_tasks"] == 1
     assert response["execution"]["result"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_returns_deleted_task_count():
+    from penguin.web.routes import delete_project
+
+    project = make_project()
+    tasks = [make_task('task-1'), make_task('task-2')]
+    storage = SimpleNamespace(delete_task=Mock(), delete_project=Mock())
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project_async=AsyncMock(return_value=project),
+            list_tasks_async=AsyncMock(return_value=tasks),
+            list_tasks=Mock(return_value=tasks),
+            storage=storage,
+        )
+    )
+
+    response = await delete_project('project-1', core=core)
+
+    assert response['project']['id'] == project.id
+    assert response['deleted_tasks'] == 2
+    assert 'deleted successfully' in response['message'].lower()
+    assert storage.delete_task.call_count == 2
+    storage.delete_project.assert_called_once_with(project.id)
+
+
+@pytest.mark.asyncio
+async def test_delete_task_returns_deleted_task_payload():
+    from penguin.web.routes import delete_task
+
+    task = make_task()
+    storage = SimpleNamespace(delete_task=Mock())
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_task_async=AsyncMock(return_value=task),
+            storage=storage,
+        )
+    )
+
+    response = await delete_task('task-1', core=core)
+
+    assert response['task']['id'] == task.id
+    assert response['task']['phase'] == task.phase.value
+    assert 'deleted successfully' in response['message'].lower()
+    storage.delete_task.assert_called_once_with(task.id)
+
+
+@pytest.mark.asyncio
+async def test_run_project_requires_source_input():
+    from penguin.web.routes import ProjectRunRequest, run_project
+
+    core = SimpleNamespace(project_manager=SimpleNamespace())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await run_project(ProjectRunRequest(), core=core)
+
+    assert exc_info.value.status_code == 400
+    assert 'spec_path or markdown_content' in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_run_project_from_inline_markdown_parses_then_starts_project():
+    from unittest.mock import patch
+    from penguin.web.routes import ProjectRunRequest, run_project
+
+    parse_result = {
+        'status': 'success',
+        'message': 'ok',
+        'creation_result': {
+            'project': {'id': 'project-1', 'name': 'Example'},
+            'tasks_created': 2,
+        },
+    }
+    execution_result = {
+        'project': {'id': 'project-1', 'name': 'Example'},
+        'execution': {'mode': 'continuous', 'ready_tasks': 1, 'result': {'status': 'completed'}},
+    }
+    core = SimpleNamespace(project_manager=SimpleNamespace())
+
+    with patch('penguin.web.services.projects.parse_project_specification_from_markdown', AsyncMock(return_value=parse_result)) as parse_mock, patch('penguin.web.services.projects.start_project_execution', AsyncMock(return_value=execution_result)) as start_mock:
+        response = await run_project(
+            ProjectRunRequest(markdown_content='# Demo\n\n## Tasks\n- One', continuous=True, time_limit=15),
+            core=core,
+        )
+
+    parse_mock.assert_awaited_once()
+    start_mock.assert_awaited_once_with(
+        core=core,
+        project_identifier='project-1',
+        continuous=True,
+        time_limit=15,
+    )
+    assert response['source'] == 'inline_markdown'
+    assert response['parse']['creation_result']['project']['id'] == 'project-1'
+    assert response['execution']['execution']['result']['status'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_run_project_reports_parse_failures_as_400():
+    from unittest.mock import patch
+    from penguin.web.routes import ProjectRunRequest, run_project
+
+    parse_result = {'status': 'error', 'message': 'No tasks found'}
+    core = SimpleNamespace(project_manager=SimpleNamespace())
+
+    with patch('penguin.web.services.projects.parse_project_specification_from_markdown', AsyncMock(return_value=parse_result)):
+        with pytest.raises(HTTPException) as exc_info:
+            await run_project(ProjectRunRequest(markdown_content='# Empty'), core=core)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail['message'] == 'No tasks found'
+    assert exc_info.value.detail['source'] == 'inline_markdown'

--- a/tests/test_blueprint_linter.py
+++ b/tests/test_blueprint_linter.py
@@ -166,3 +166,92 @@ def test_diagnostics_report_helpers():
 
     assert report.has_errors is True
     assert report.has_warnings is True
+
+
+def test_parser_rejects_unclosed_frontmatter(tmp_path: Path):
+    blueprint_path = tmp_path / "unclosed.md"
+    blueprint_path.write_text(
+        """---
+        title: Broken Blueprint
+        project_key: BROKEN
+
+        ## Tasks
+
+        - [ ] <BROKEN-1> Missing close
+          - Acceptance: done
+        """
+    )
+
+    parser = BlueprintParser(base_path=tmp_path)
+
+    with pytest.raises(BlueprintParseError) as exc_info:
+        parser.parse_file(blueprint_path)
+
+    error = exc_info.value
+    assert error.code == "BP-PARSE-008"
+    assert "Unclosed YAML frontmatter" in str(error)
+
+
+
+def test_parser_rejects_non_mapping_yaml_root(tmp_path: Path):
+    blueprint_path = tmp_path / "list-root.yaml"
+    blueprint_path.write_text(
+        """
+- not
+- a
+- mapping
+""".strip()
+    )
+
+    parser = BlueprintParser(base_path=tmp_path)
+
+    with pytest.raises(BlueprintParseError) as exc_info:
+        parser.parse_file(blueprint_path)
+
+    error = exc_info.value
+    assert error.code == "BP-PARSE-010"
+    assert "document root must be a mapping/object" in str(error)
+
+
+
+def test_parser_rejects_non_list_tasks_field(tmp_path: Path):
+    blueprint_path = tmp_path / "bad-tasks.yaml"
+    blueprint_path.write_text(
+        """
+title: Broken Tasks
+project_key: BROKEN
+tasks:
+  id: NOT-A-LIST
+""".strip()
+    )
+
+    parser = BlueprintParser(base_path=tmp_path)
+
+    with pytest.raises(BlueprintParseError) as exc_info:
+        parser.parse_file(blueprint_path)
+
+    error = exc_info.value
+    assert error.code == "BP-PARSE-011"
+    assert "tasks/items must be a list" in str(error)
+
+
+
+def test_parser_rejects_non_mapping_task_entries(tmp_path: Path):
+    blueprint_path = tmp_path / "bad-task-entry.yaml"
+    blueprint_path.write_text(
+        """
+title: Broken Entry
+project_key: BROKEN
+tasks:
+  - just-a-string
+""".strip()
+    )
+
+    parser = BlueprintParser(base_path=tmp_path)
+
+    with pytest.raises(BlueprintParseError) as exc_info:
+        parser.parse_file(blueprint_path)
+
+    error = exc_info.value
+    assert error.code == "BP-PARSE-012"
+    assert "must be a mapping/object" in str(error)

--- a/tests/test_cli_surface_audit_regressions.py
+++ b/tests/test_cli_surface_audit_regressions.py
@@ -319,9 +319,11 @@ def test_runmode_help_text_reflects_continuous_mode_truth():
 
     assert result.exit_code == 0
     assert "24/7 mode" in result.stdout
-    assert "ready frontier" in result.stdout
-    assert "determine next steps" in result.stdout
-    assert "does not imply blueprint/task-defined time limits" in result.stdout
+    assert "ready" in result.stdout and "frontier" in result.stdout
+    assert "determining" in result.stdout
+    assert "next" in result.stdout and "steps" in result.stdout
+    assert "blueprint/task-defined time" in result.stdout
+    assert "limits" in result.stdout and "CLI" in result.stdout
 
 
 def test_handle_run_mode_reports_waiting_input_honestly():
@@ -367,3 +369,113 @@ def test_handle_run_mode_reports_idle_honestly():
 
     printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
     assert "no ready work remained" in printed.lower()
+
+
+def test_project_init_with_blueprint_sync_reports_counts(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    blueprint_path = tmp_path / "demo-blueprint.md"
+    blueprint_path.write_text("# demo")
+    project = Project(
+        id="project-1",
+        name="Demo",
+        description="Project description",
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+        status="active",
+        workspace_path=(tmp_path / "workspace").resolve(),
+        context_path=(tmp_path / "workspace" / "context").resolve(),
+    )
+    ready_task = make_task("task-1", TaskStatus.ACTIVE)
+    blueprint = SimpleNamespace(title="Demo", overview="desc")
+    diagnostics = SimpleNamespace(has_errors=False, has_warnings=False, diagnostics=[])
+    parser = SimpleNamespace(
+        parse_file=Mock(return_value=blueprint),
+        lint_blueprint=Mock(return_value=diagnostics),
+    )
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            create_project_async=AsyncMock(return_value=project),
+            sync_blueprint=Mock(return_value={"created": ["A", "B"], "updated": ["C"], "skipped": []}),
+            get_ready_tasks_async=AsyncMock(return_value=[ready_task]),
+        )
+    )
+
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()),          patch.object(cli_module, "_core", core),          patch("penguin.project.blueprint_parser.BlueprintParser", return_value=parser),          patch.object(cli_module, "console") as console_mock:
+        cli_module.project_init(
+            name="Demo",
+            blueprint_path=blueprint_path,
+            description="Project description",
+            workspace_path=str(tmp_path / "workspace"),
+        )
+
+    core.project_manager.create_project_async.assert_awaited_once()
+    core.project_manager.get_ready_tasks_async.assert_awaited_once_with(project.id)
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
+    assert "Tasks created: 2" in printed
+    assert "Tasks updated: 1" in printed
+    assert "Ready tasks: 1" in printed
+
+
+def test_project_start_resolves_unique_project_name_and_runs_with_project_context():
+    from penguin.cli import cli as cli_module
+
+    project = Project(
+        id="project-1",
+        name="Demo",
+        description="Project description",
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+        status="active",
+    )
+    ready_task = make_task("task-1", TaskStatus.ACTIVE)
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=None),
+            get_project_by_name=Mock(return_value=project),
+            list_tasks_async=AsyncMock(return_value=[ready_task]),
+            get_ready_tasks_async=AsyncMock(return_value=[ready_task]),
+        ),
+        start_run_mode=AsyncMock(return_value=None),
+    )
+
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()),          patch.object(cli_module, "_core", core),          patch.object(cli_module, "console"):
+        cli_module.project_start("Demo", continuous=True, time_limit=15)
+
+    core.start_run_mode.assert_awaited_once()
+    _, kwargs = core.start_run_mode.await_args
+    assert kwargs["context"] == {"project_id": project.id}
+    assert kwargs["continuous"] is True
+    assert kwargs["time_limit"] == 15
+    assert kwargs["mode_type"] == "project"
+
+
+def test_project_start_fails_when_no_ready_tasks():
+    from penguin.cli import cli as cli_module
+
+    project = Project(
+        id="project-1",
+        name="Demo",
+        description="Project description",
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+        status="active",
+    )
+    existing_task = make_task("task-1", TaskStatus.RUNNING)
+    core = SimpleNamespace(
+        project_manager=SimpleNamespace(
+            get_project=Mock(return_value=project),
+            get_project_by_name=Mock(return_value=None),
+            list_projects=Mock(return_value=[project]),
+            list_tasks_async=AsyncMock(return_value=[existing_task]),
+            get_ready_tasks_async=AsyncMock(return_value=[]),
+        ),
+        start_run_mode=AsyncMock(return_value=None),
+    )
+
+    with patch.object(cli_module, "_initialize_core_components_globally", AsyncMock()),          patch.object(cli_module, "_core", core),          patch.object(cli_module, "console") as console_mock:
+        with pytest.raises(click.exceptions.Exit):
+            cli_module.project_start("project-1", continuous=True, time_limit=None)
+
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list if call.args)
+    assert "no ready tasks" in printed.lower()

--- a/tests/test_core_runmode_cleanup.py
+++ b/tests/test_core_runmode_cleanup.py
@@ -29,3 +29,34 @@ async def test_start_run_mode_cleans_up_when_runmode_construction_fails():
     assert core._ui_update_callback is None
     assert core._continuous_mode is False
     assert "Error starting RunMode" in core.current_runmode_status_summary
+
+
+@pytest.mark.asyncio
+async def test_start_run_mode_continuous_project_scope_uses_ready_frontier_not_project_name():
+    core = SimpleNamespace(
+        _ui_update_callback=None,
+        _runmode_stream_callback=None,
+        _runmode_active=False,
+        _continuous_mode=False,
+        current_runmode_status_summary="",
+        run_mode=None,
+        _prepare_runmode_stream_callback=lambda cb: cb,
+        _handle_run_mode_event=AsyncMock(),
+    )
+    run_mode = SimpleNamespace(start_continuous=AsyncMock(), continuous_mode=False)
+
+    with patch("penguin.core.RunMode", return_value=run_mode):
+        await PenguinCore.start_run_mode(
+            core,
+            name="Example Project",
+            description="Project description",
+            context={"project_id": "project-123"},
+            continuous=True,
+            mode_type="project",
+        )
+
+    run_mode.start_continuous.assert_awaited_once_with(
+        specified_task_name=None,
+        task_description=None,
+        project_id="project-123",
+    )

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -148,6 +148,47 @@ async def test_call_llm_with_retry_skips_non_stream_retry_after_streamed_chunks(
     assert api_client.get_response.await_count == 1
 
 
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_replays_non_stream_retry_into_stream_callback() -> (
+    None
+):
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    streamed: list[tuple[str, str]] = []
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        del messages, stream_callback, kwargs
+        if stream:
+            return ""
+        return "fallback answer"
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        client_handler=SimpleNamespace(),
+    )
+
+    async def _collector(chunk: str, message_type: str = "assistant") -> None:
+        streamed.append((chunk, message_type))
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=_collector,
+        extra_kwargs={},
+    )
+
+    assert result == "fallback answer"
+    assert streamed == [("fallback answer", "assistant")]
+    assert api_client.get_response.await_count == 2
+
+
 def test_scoped_conversation_manager_clones_default_agent_session() -> None:
     base_session = SimpleNamespace(id="session-a", messages=[])
     conversation = SimpleNamespace(

--- a/tests/test_engine_responses_tool_calls.py
+++ b/tests/test_engine_responses_tool_calls.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from penguin.engine import Engine, LoopState
+from penguin.llm.runtime import execute_pending_tool_call
 
 
 def test_prepare_responses_tools_enables_openai_native_tools() -> None:
@@ -70,6 +71,53 @@ async def test_call_llm_with_retry_skips_retry_when_tool_call_pending() -> None:
 
     assert result == ""
     assert api_client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_finish_response_tool_call_is_not_persisted_or_emitted() -> None:
+    class _Handler:
+        def __init__(self) -> None:
+            self._tool_call = {
+                "name": "finish_response",
+                "arguments": "{}",
+                "call_id": "call_finish_response",
+            }
+
+        def get_and_clear_last_tool_call(self):
+            result = self._tool_call
+            self._tool_call = None
+            return result
+
+    persisted: list[dict[str, object]] = []
+    started: list[dict[str, object]] = []
+    completed: list[dict[str, object]] = []
+    timeline: list[dict[str, object]] = []
+
+    result = await execute_pending_tool_call(
+        api_client=SimpleNamespace(
+            client_handler=_Handler(),
+            model_config=SimpleNamespace(provider="openai", model="gpt-5.4"),
+        ),
+        tool_manager=SimpleNamespace(
+            execute_tool=lambda tool_name, tool_args: "Response complete."
+        ),
+        persist_action_result=lambda action_result, tool_context: persisted.append(
+            {"action_result": action_result, "tool_context": tool_context}
+        ),
+        emit_action_start=lambda payload: started.append(payload),
+        emit_action_result=lambda payload: completed.append(payload),
+        emit_tool_timeline=lambda payload: timeline.append(payload),
+    )
+
+    assert result == {
+        "action": "finish_response",
+        "result": "Response complete.",
+        "status": "completed",
+    }
+    assert persisted == []
+    assert started == []
+    assert completed == []
+    assert timeline == []
 
 
 def test_wallet_guard_does_not_break_on_tool_only_empty_iteration() -> None:

--- a/tests/test_llm_api_client_model_canonicalization.py
+++ b/tests/test_llm_api_client_model_canonicalization.py
@@ -90,6 +90,56 @@ async def test_api_client_surfaces_concise_error_with_upstream_diagnostic_id(
 
 
 @pytest.mark.asyncio
+async def test_api_client_surfaces_codex_chatgpt_model_availability_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingAdapter:
+        async def get_response(self, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
+            error = build_llm_error(
+                message=(
+                    "OpenAI OAuth Codex stream_request failed "
+                    "(diag_id=oaoc_badmodel, status=400)"
+                ),
+                provider="openai",
+                model="gpt-5.5",
+                status_code=400,
+                provider_data={
+                    "diag_id": "oaoc_badmodel",
+                    "detail": (
+                        "The 'gpt-5.5' model is not supported when using "
+                        "Codex with a ChatGPT account."
+                    ),
+                },
+            )
+            raise LLMProviderError(error)
+
+    def _get_adapter(provider_id: str, model_config: ModelConfig) -> _FailingAdapter:
+        del provider_id, model_config
+        return _FailingAdapter()
+
+    monkeypatch.setattr(api_client_module, "get_adapter", _get_adapter)
+
+    cfg = ModelConfig(
+        model="gpt-5.5",
+        provider="openai",
+        client_preference="native",
+        api_key="test-key",
+    )
+    client = APIClient(cfg)
+
+    result = await client.get_response(
+        [{"role": "user", "content": "hello"}],
+        stream=False,
+    )
+
+    assert result == (
+        "Error: Selected model is not available through ChatGPT-backed Codex "
+        "auth. Diagnostic ID: oaoc_badmodel."
+    )
+
+
+@pytest.mark.asyncio
 async def test_api_client_generates_diagnostic_id_when_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -294,6 +294,30 @@ def test_openai_adapter_uses_oauth_access_token_when_api_key_missing(
     }
 
 
+def test_openai_adapter_normalizes_codex_oauth_display_model_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda _provider_id: None,
+    )
+
+    model_config = ModelConfig(
+        model="openai/GPT-5.4-Mini",
+        provider="openai",
+        client_preference="native",
+        api_key="sk-test",
+    )
+    adapter = OpenAIAdapter(model_config)
+
+    assert adapter._codex_model_for_oauth("openai/GPT-5.4-Mini") == (
+        "gpt-5.4-mini",
+        False,
+    )
+
+
 @pytest.mark.asyncio
 async def test_openai_adapter_streaming_captures_function_calls_without_leaking_text(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_parser_and_tools.py
+++ b/tests/test_parser_and_tools.py
@@ -75,6 +75,8 @@ def test_tool_manager_get_responses_tools_curated():
     assert "patch_file" in names
     assert "patch_files" in names
     assert "execute_command" in names
+    assert "finish_response" in names
+    assert "finish_task" in names
 
     # Built-in web_search should be included as a non-function tool descriptor
     assert any(t.get("type") == "web_search" for t in tools_payload)

--- a/tests/test_runmode_project_completion.py
+++ b/tests/test_runmode_project_completion.py
@@ -1,9 +1,10 @@
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from penguin.project.manager import ProjectManager
+from penguin.project.models import DependencyPolicy, Task, TaskDependency, TaskPhase, TaskStatus
 from penguin.run_mode import RunMode
 
 
@@ -20,7 +21,7 @@ class DummyCore:
 
 
 @pytest.mark.asyncio
-async def test_runmode_does_not_complete_project_task():
+async def test_runmode_one_shot_does_not_update_project_task_status():
     project_task = SimpleNamespace(
         id="task-123",
         title="Example Task",
@@ -49,3 +50,296 @@ async def test_runmode_does_not_complete_project_task():
 
     assert result["status"] == "completed"
     project_manager.update_task_status.assert_not_called()
+
+
+def test_project_manager_marks_task_execution_ready_for_review(tmp_path):
+    project_manager = ProjectManager(workspace_path=tmp_path)
+    project = project_manager.create_project(
+        name="Example Project",
+        description="Project for task finalization",
+    )
+    task = project_manager.create_task(
+        title="Example Task",
+        description="Do the thing",
+        project_id=project.id,
+    )
+    finalized_task = project_manager.mark_task_execution_ready_for_review(
+        task.id,
+        executor_id="runmode",
+        response="accepted",
+        task_prompt="RunMode execution: Example Task",
+        context={"source": "runmode_continuous"},
+    )
+
+    assert finalized_task.status == TaskStatus.PENDING_REVIEW
+    assert finalized_task.phase == TaskPhase.DONE
+    assert finalized_task.execution_history[-1].result.value == "success"
+    assert finalized_task.execution_history[-1].executor_id == "runmode"
+    assert finalized_task.execution_history[-1].response == "accepted"
+
+    stored_task = project_manager.get_task(task.id)
+    assert stored_task.status == TaskStatus.PENDING_REVIEW
+    assert stored_task.phase == TaskPhase.DONE
+
+
+@pytest.mark.asyncio
+async def test_project_continuous_does_not_reselect_finished_blueprint_task():
+    task = Task(
+        id="task-123",
+        title="Blueprint Task",
+        description="Created from blueprint",
+        status=TaskStatus.ACTIVE,
+        created_at="2026-04-25T00:00:00",
+        updated_at="2026-04-25T00:00:00",
+        project_id="project-1",
+        blueprint_id="blueprint-1",
+    )
+
+    async def get_next_task_dag(project_id):
+        if task.status == TaskStatus.ACTIVE:
+            return task
+        return None
+
+    async def finalize_task(**kwargs):
+        task.status = TaskStatus.PENDING_REVIEW
+        task.phase = TaskPhase.DONE
+        return task
+
+    project_manager = MagicMock()
+    project_manager.get_next_task_async = AsyncMock(return_value=None)
+    project_manager.get_next_task_dag_async = AsyncMock(side_effect=get_next_task_dag)
+    project_manager.mark_task_execution_ready_for_review_async = AsyncMock(
+        side_effect=finalize_task
+    )
+
+    core = DummyCore(project_manager=project_manager)
+    run_mode = RunMode(core=core)
+    run_mode._execute_task = AsyncMock(
+        return_value={
+            "status": "pending_review",
+            "message": "done",
+            "completion_type": "pending_review",
+        }
+    )
+
+    await run_mode.start_continuous(project_id="project-1", use_dag=True)
+
+    run_mode._execute_task.assert_awaited_once_with(
+        "Blueprint Task",
+        "Created from blueprint",
+        task_data_context := {
+            "id": "task-123",
+            "project_id": "project-1",
+            "priority": 0,
+            "metadata": {},
+            "status": "active",
+            "progress": 0,
+            "due_date": None,
+            "phase": TaskPhase.PENDING,
+            "phase_value": "pending",
+            "blueprint_id": "blueprint-1",
+            "acceptance_criteria": [],
+            "recipe": None,
+            "agent_role": None,
+            "required_tools": [],
+            "skills": [],
+            "effort": None,
+            "value": None,
+            "risk": None,
+        },
+    )
+    project_manager.mark_task_execution_ready_for_review_async.assert_awaited_once_with(
+        task_id="task-123",
+        executor_id="runmode",
+        response="done",
+        task_prompt="RunMode execution: Blueprint Task",
+        context={"source": "runmode_continuous"},
+    )
+    assert task_data_context["blueprint_id"] == "blueprint-1"
+    assert task.status == TaskStatus.PENDING_REVIEW
+    assert task.phase == TaskPhase.DONE
+
+
+@pytest.mark.asyncio
+async def test_runmode_task_prompt_uses_finish_task_not_task_completed():
+    captured = {}
+    project_manager = MagicMock()
+
+    async def run_task(**kwargs):
+        captured.update(kwargs)
+        return {"status": "pending_review", "assistant_response": "done"}
+
+    core = DummyCore(project_manager=project_manager)
+    core.engine = SimpleNamespace(run_task=run_task, settings=SimpleNamespace())
+    core.finalize_streaming_message = MagicMock(return_value=None)
+    core._handle_stream_chunk = AsyncMock()
+
+    run_mode = RunMode(core=core)
+    await run_mode._execute_task("Example Task", "Do the thing", {"id": "task-123"})
+
+    assert "finish_task" in captured["task_prompt"]
+    assert "Respond with TASK_COMPLETED" not in captured["task_prompt"]
+
+
+def test_project_manager_reports_strict_dependency_blocked_by_pending_review(tmp_path):
+    project_manager = ProjectManager(workspace_path=tmp_path)
+    project = project_manager.create_project(
+        name="Blueprint Project",
+        description="Project with dependent tasks",
+    )
+    upstream = project_manager.create_task(
+        title="Foundation",
+        description="Create the base app",
+        project_id=project.id,
+    )
+    downstream = project_manager.create_task(
+        title="CRUD",
+        description="Build on the base app",
+        project_id=project.id,
+        dependencies=[upstream.id],
+    )
+
+    project_manager.mark_task_execution_ready_for_review(
+        upstream.id,
+        executor_id="runmode",
+        response="base app ready",
+    )
+
+    assert project_manager.get_ready_tasks(project.id) == []
+    blocked = project_manager.get_blocked_ready_candidates(project.id)
+    assert blocked == [
+        {
+            "task_id": downstream.id,
+            "title": "CRUD",
+            "blueprint_id": None,
+            "blockers": [
+                {
+                    "task_id": upstream.id,
+                    "policy": "completion_required",
+                    "artifact_key": None,
+                    "status": "pending_review",
+                    "phase": "done",
+                    "title": "Foundation",
+                }
+            ],
+        }
+    ]
+
+
+def test_project_manager_review_ready_dependency_unblocks_pending_review(tmp_path):
+    project_manager = ProjectManager(workspace_path=tmp_path)
+    project = project_manager.create_project(
+        name="Blueprint Project",
+        description="Project with relaxed dependency",
+    )
+    upstream = project_manager.create_task(
+        title="Foundation",
+        description="Create the base app",
+        project_id=project.id,
+    )
+    downstream = project_manager.create_task(
+        title="CRUD",
+        description="Build on the base app",
+        project_id=project.id,
+        dependencies=[upstream.id],
+    )
+    downstream.dependency_specs = [
+        TaskDependency(
+            task_id=upstream.id,
+            policy=DependencyPolicy.REVIEW_READY_OK,
+        )
+    ]
+    project_manager.storage.update_task(downstream)
+
+    project_manager.mark_task_execution_ready_for_review(
+        upstream.id,
+        executor_id="runmode",
+        response="base app ready",
+    )
+
+    ready = project_manager.get_ready_tasks(project.id)
+    assert [task.id for task in ready] == [downstream.id]
+    assert project_manager.get_blocked_ready_candidates(project.id) == []
+
+
+@pytest.mark.asyncio
+async def test_project_continuous_idle_reports_blocked_dependency_frontier():
+    task = Task(
+        id="task-123",
+        title="Blueprint Task",
+        description="Created from blueprint",
+        status=TaskStatus.ACTIVE,
+        created_at="2026-04-25T00:00:00",
+        updated_at="2026-04-25T00:00:00",
+        project_id="project-1",
+        blueprint_id="blueprint-1",
+    )
+    blocked_candidates = [
+        {
+            "task_id": "task-456",
+            "title": "Dependent Task",
+            "blueprint_id": "blueprint-2",
+            "blockers": [
+                {
+                    "task_id": "task-123",
+                    "policy": "completion_required",
+                    "status": "pending_review",
+                    "phase": "done",
+                    "title": "Blueprint Task",
+                    "artifact_key": None,
+                }
+            ],
+        }
+    ]
+    events = []
+
+    async def get_next_task_dag(project_id):
+        if task.status == TaskStatus.ACTIVE:
+            return task
+        return None
+
+    async def finalize_task(**kwargs):
+        task.status = TaskStatus.PENDING_REVIEW
+        task.phase = TaskPhase.DONE
+        return task
+
+    project_manager = MagicMock()
+    project_manager.get_next_task_async = AsyncMock(return_value=None)
+    project_manager.get_next_task_dag_async = AsyncMock(side_effect=get_next_task_dag)
+    project_manager.mark_task_execution_ready_for_review_async = AsyncMock(
+        side_effect=finalize_task
+    )
+    project_manager.get_blocked_ready_candidates_async = AsyncMock(
+        return_value=blocked_candidates
+    )
+
+    core = DummyCore(project_manager=project_manager)
+    run_mode = RunMode(core=core)
+    run_mode._execute_task = AsyncMock(
+        return_value={
+            "status": "pending_review",
+            "message": "done",
+            "completion_type": "pending_review",
+        }
+    )
+    run_mode._emit_event = AsyncMock(side_effect=lambda event: events.append(event))
+
+    await run_mode.start_continuous(project_id="project-1", use_dag=True)
+
+    idle_events = [
+        event
+        for event in events
+        if event.get("type") == "status"
+        and event.get("status_type") == "continuous_mode_idle"
+    ]
+    assert idle_events[-1]["data"] == {
+        "reason": "project_tasks_blocked",
+        "project_id": "project-1",
+        "blocked_tasks": blocked_candidates,
+    }
+    assert any(
+        "Project execution paused" in event.get("content", "")
+        for event in events
+        if event.get("type") == "message"
+    )
+

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -5,6 +5,32 @@ import logging
 from penguin.web import server
 
 
+def test_resolve_runtime_settings_prefers_cli_args(monkeypatch):
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    monkeypatch.setenv("PORT", "9000")
+    monkeypatch.setenv("DEBUG", "false")
+
+    host, port, debug = server._resolve_runtime_settings(
+        ["--host", "127.0.0.1", "--port", "8080", "--debug"]
+    )
+
+    assert host == "127.0.0.1"
+    assert port == 8080
+    assert debug is True
+
+
+def test_resolve_runtime_settings_uses_env_fallback(monkeypatch):
+    monkeypatch.setenv("HOST", "0.0.0.0")
+    monkeypatch.setenv("PORT", "7777")
+    monkeypatch.setenv("DEBUG", "true")
+
+    host, port, debug = server._resolve_runtime_settings([])
+
+    assert host == "0.0.0.0"
+    assert port == 7777
+    assert debug is True
+
+
 def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     calls = []
 
@@ -15,10 +41,10 @@ def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     monkeypatch.setattr(server, "create_app_factory", lambda: object())
     monkeypatch.setenv("HOST", "0.0.0.0")
     monkeypatch.setenv("PORT", "8080")
-    monkeypatch.setenv("DEBUG", "true")
+    monkeypatch.setenv("DEBUG", "false")
     monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
 
-    assert server.main() == 0
+    assert server.main(["--debug"]) == 0
 
     output = capsys.readouterr().out
     assert "http://localhost:8080" in output


### PR DESCRIPTION
## Summary

Adds the project bootstrap workflow across the API, TUI, blueprint parsing, and project RunMode execution path.

Key outcomes:
- Adds TUI local commands for project/task workflows, including project init/start and task execution/resume.
- Adds project/task API parity routes and services used by the TUI.
- Adds Blueprint parsing/linting improvements and an executable example CRUD blueprint.
- Fixes project-scoped continuous RunMode so it uses the project ready frontier instead of synthesizing a task from the project name.
- Aligns task completion prompting around `finish_task` and persists project task completion as `DONE + PENDING_REVIEW` through `ProjectManager` lifecycle semantics.
- Surfaces blocked project frontiers instead of silently stopping when dependency policy prevents progress.
- Supports explicit `--workspace` for TUI project init and returns clean 400s for duplicate project names.

## Validation

Verified during development with:

- `pytest tests/test_web_server.py -q`
- `pytest tests/test_blueprint_linter.py -q`
- `pytest tests/api/test_web_routes_task_shapes.py -q`
- `pytest tests/test_core_runmode_cleanup.py tests/test_runmode_continuous_drift.py -q`
- `pytest tests/test_runmode_project_completion.py -q`
- `pytest tests/test_runmode_project_completion.py tests/test_blueprint_linter.py tests/test_core_runmode_cleanup.py tests/test_runmode_continuous_drift.py -q`
- `bun test penguin-tui/packages/opencode/test/cli/tui/penguin-local-command.test.ts penguin-tui/packages/opencode/test/cli/tui/penguin-local-command-runtime.test.ts`
- `bun run typecheck`

Manual smoke testing:
- Initialized the example CRUD blueprint through the TUI/API path.
- Started project execution from the TUI.
- Confirmed task execution progressed through the blueprint dependency graph and reached the final audit-log task.
- Confirmed `finish_task` no longer loops on the same completed task and downstream tasks can proceed when the blueprint uses `review_ready_ok` dependencies.

## Notes

This PR intentionally keeps review UX minimal. Tasks are moved to `PENDING_REVIEW` after execution, and the example blueprint uses `review_ready_ok` so the workflow can continue while review/approval UI remains immature.

Untracked local smoke-test artifacts were not included:
- `context/web-server-logs.txt`
- `misc/web-server-logs-2.txt`
- `examples/team_tasks_api/`

## Future Fixes

- Build real TUI review/approval UX: show pending-review tasks, approve/reject actions, and clear state transitions.
- Add a project status panel: current task, next task, blocked reason, ready frontier, pending-review count, and run state.
- Harden RunMode task finalization so a task cannot be reselected unless explicitly retried.
- Improve user-facing progress display by collapsing tool-only turns and surfacing meaningful task milestones.
- Add context compaction between project tasks to avoid ever-growing transcripts and high token usage on larger blueprints.
- Make Git behavior workspace-aware: if a generated workspace is not a repo, avoid repeated `git status` / commit attempts unless explicitly requested.
- Improve blocked-frontier UX: make `project_tasks_blocked` visible in the TUI instead of relying on logs/SSE inspection.
- Add stronger end-to-end tests around full blueprint execution, including duplicate project names, workspace reuse, retry behavior, and dependency policies.
- Decide whether project-scoped RunMode should eventually delegate more directly to `WorkflowOrchestrator` instead of maintaining parallel lifecycle logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project initialization and execution via CLI and web API.
  * Enabled slash-prefixed local commands in TUI prompt for project and task operations.
  * Introduced task review workflow with pending-review status before final completion.
  * Added OpenAI Codex/ChatGPT-backed model discovery.
  * Web server now accepts `--host`, `--port`, and `--debug` flags.

* **Improvements**
  * Enhanced blueprint validation with detailed error diagnostics.
  * Improved error messages for model availability issues.
  * Added dependency-aware task readiness tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->