### PR TITLE
Add Penguin Skills runtime and interfaces

### DIFF
--- a/.penguin/.gitignore
+++ b/.penguin/.gitignore
@@ -1,0 +1,2 @@
+settings.local.yml
+permission_audit.log

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -132,6 +132,55 @@ Minimum useful flow:
 
 Do not start with marketplaces, auto-install, or fancy package-manager support. Those are distribution questions layered on top of a local runtime contract.
 
+## Penguin vs Codex Skills Comparison
+
+Codex's local Skills support provides a useful reference implementation, but Penguin should not copy it blindly because Penguin has a different runtime shape: explicit tool orchestration, persistent conversations, context categories, and multi-agent execution.
+
+### Codex Reference Behavior
+
+Observed local reference files:
+
+- `reference/codex/codex-rs/core/src/context/available_skills_instructions.rs`
+- `reference/codex/codex-rs/core/src/context/skill_instructions.rs`
+
+Codex does two important things:
+
+1. It injects an available-skills developer-context block that lists skill name, description, and file path, plus trigger rules and progressive-disclosure instructions.
+2. It wraps activated skill content as a separate user-context fragment under `<skill>` with `<name>`, `<path>`, and the skill body.
+
+Codex's trigger model is explicit: use a skill when the user names it with `$SkillName`/plain text or when the task clearly matches a listed description. It also instructs the agent not to bulk-load `references/`, to resolve relative paths from the skill directory, and to use scripts/assets when relevant.
+
+### Penguin Current Approach
+
+Penguin's implementation is similar in intent but more runtime-oriented:
+
+- Skill discovery and validation live under `penguin/skills/`, not only in prompt text.
+- The compact skill catalog is injected into startup/session context.
+- Activation goes through dedicated native tools: `list_skills` and `activate_skill`.
+- Activated skill content is loaded as `MessageCategory.CONTEXT`, not `SYSTEM`.
+- Activation is deduped per session by `SkillManager`.
+- Activation output uses structured `<skill_content>` and `<skill_resources>` wrappers.
+- Skill scripts still go through normal Penguin command/file/network permission gates.
+
+This is the right divergence. Codex can rely heavily on file-read instructions because its reference implementation exposes file paths directly in contextual instructions. Penguin benefits from dedicated tools because it can attach metadata, dedupe activations, feed context-window accounting, and later emit web/TUI events.
+
+### Practical Differences
+
+| Area | Codex Reference | Penguin MVP |
+|---|---|---|
+| Catalog disclosure | Developer-context skill list with file paths | Compact skill catalog injected as `CONTEXT` |
+| Activation path | Open `SKILL.md` or contextual injection | Dedicated `activate_skill` tool |
+| Activated content rank | User-context `<skill>` fragment | `MessageCategory.CONTEXT` message |
+| Dedupe | Runtime injection state in Codex skill system | Per-session `SkillManager` activation tracking |
+| Resource loading | Progressive file reads from paths | Resources listed; normal file tools load specific files |
+| Security posture | Prompt rules plus client file/tool policy | Prompt rules plus Penguin permission gates |
+| UI/API future | Codex-specific client surface | CLI done; web/API and TUI explicitly deferred |
+
+### Gap To Watch
+
+Penguin now has prompt guidance equivalent to Codex's trigger/progressive-disclosure rules, but the web/API and TUI still need first-class skill visibility. Until those surfaces are implemented, CLI and model-tool usage are the strongest paths.
+
+
 ## Proposed Architecture
 
 Add `penguin/skills/`:

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-MVP runtime implemented in this branch. CLI commands, package-manager distribution, and eval runner remain deferred.
+MVP runtime and first CLI UX slice implemented in this branch. Web API, TUI, package-manager distribution, and eval runner remain deferred.
 
 ## Work Checklist
 
@@ -32,12 +32,30 @@ MVP runtime implemented in this branch. CLI commands, package-manager distributi
 
 ### CLI And UX
 
-- [ ] Add `penguin skill list`.
-- [ ] Add `penguin skill show <name>`.
-- [ ] Add `penguin skill activate <name>`.
-- [ ] Add `penguin skill doctor`.
-- [ ] Surface invalid skill diagnostics clearly.
-- [ ] Document manual install by copying folders into `~/.penguin/skills` or `.penguin/skills`.
+- [x] Add `penguin skill list`.
+- [x] Add `penguin skill show <name>`.
+- [x] Add `penguin skill activate <name>`.
+- [x] Add `penguin skill doctor`.
+- [x] Surface invalid skill diagnostics clearly.
+- [x] Document manual install by copying folders into `~/.penguin/skills` or `.penguin/skills`.
+
+### Web API Interface
+
+- [ ] Add `GET /api/v1/skills` for compact catalog and diagnostics.
+- [ ] Add `GET /api/v1/skills/{name}` for full `SKILL.md` inspection without activation.
+- [ ] Add `POST /api/v1/skills/{name}/activate` to load skill content as session-scoped `CONTEXT`.
+- [ ] Include duplicate activation status and skill metadata in activation responses.
+- [ ] Surface invalid skill diagnostics in structured JSON for web clients.
+- [ ] Emit SSE/OpenCode-compatible events when skills are activated or diagnostics change.
+
+### TUI Interface
+
+- [ ] Add a Skills panel/list using the web/API catalog endpoint.
+- [ ] Show invalid skill diagnostics with actionable file paths and validation errors.
+- [ ] Add explicit activation action that calls the web/API activation endpoint.
+- [ ] Show whether a skill is already active in the current session.
+- [ ] Display manual install guidance for user/project skill folders.
+- [ ] Avoid auto-activating skills from UI selection; require explicit user action.
 
 ### Security And Trust
 

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -1,0 +1,434 @@
+# Penguin Skills Integration
+
+## Status
+
+MVP runtime implemented in this branch. CLI commands, package-manager distribution, and eval runner remain deferred.
+
+## Work Checklist
+
+### Discovery And Planning
+
+- [x] Cache Agent Skills documentation under `context/docs_cache/agent_skills/`.
+- [x] Review Agent Skills specification and client implementation guidance.
+- [x] Map Penguin integration points for tools, context injection, config, and context-window truncation.
+- [x] Document package-manager distribution tradeoffs for `pip`, `uv`, `npm`, `npx`, git/archive, and OCI.
+- [x] Create this task brief at `context/tasks/skills.md`.
+
+### MVP Runtime
+
+- [x] Add `penguin/skills/models.py`.
+- [x] Add `penguin/skills/parser.py` with `SKILL.md` frontmatter validation.
+- [x] Add parser tests for valid skills, missing fields, invalid names, long descriptions, malformed YAML, and optional fields.
+- [x] Add `penguin/skills/discovery.py` for configured user/project scan paths.
+- [x] Add discovery tests for nested skills, invalid skills, collisions, max depth, and disabled project trust.
+- [x] Add `SkillManager` for catalog state, activation lookup, diagnostics, and per-session dedupe.
+- [x] Add structured activation renderer with `<skill_content>` and `<skill_resources>`.
+- [x] Add `list_skills` tool.
+- [x] Add `activate_skill` tool.
+- [x] Register skill tools in `ToolManager` registry and schema list.
+- [x] Inject compact skill catalog into startup/session context.
+- [x] Load activated skill content as `MessageCategory.CONTEXT` messages with skill metadata.
+- [x] Add tests for activation dedupe and CONTEXT-category truncation behavior.
+
+### CLI And UX
+
+- [ ] Add `penguin skill list`.
+- [ ] Add `penguin skill show <name>`.
+- [ ] Add `penguin skill activate <name>`.
+- [ ] Add `penguin skill doctor`.
+- [ ] Surface invalid skill diagnostics clearly.
+- [ ] Document manual install by copying folders into `~/.penguin/skills` or `.penguin/skills`.
+
+### Security And Trust
+
+- [ ] Add config defaults for `skills.enabled`, scan paths, max scan depth, max skill dirs, and project-skill trust.
+- [ ] Ensure project skills are disabled or require explicit trust by default.
+- [ ] Ensure relative skill resource paths cannot escape the skill directory.
+- [ ] Parse `allowed-tools` as advisory metadata only.
+- [ ] Verify skill scripts still go through normal Penguin command/file/network permission gates.
+
+### Deferred Distribution
+
+- [ ] Add `penguin skill install <local-path|git-url>`.
+- [ ] Evaluate Python entry point discovery via `penguin.skills`.
+- [ ] Prototype optional `npx` installer that copies static skill directories into Penguin's user skill path.
+- [ ] Decide whether installed package skills should be copied into Penguin-controlled storage or referenced in place.
+- [ ] Defer marketplace/registry design until local usage proves demand.
+
+### Evals Later
+
+- [ ] Add `penguin skill eval <name>`.
+- [ ] Support `evals/evals.json` test case discovery.
+- [ ] Run with-skill and baseline/no-skill comparisons in isolated sessions or subagents.
+- [ ] Capture token and duration metrics.
+- [ ] Grade assertions with scripts where possible and LLM judges where needed.
+- [ ] Add description trigger eval support.
+
+## Background
+
+Agent Skills define a portable convention for packaging agent instructions and reusable resources:
+
+```text
+skill-name/
+├── SKILL.md      # required: YAML frontmatter + Markdown instructions
+├── scripts/      # optional executable helpers
+├── references/   # optional detailed docs loaded on demand
+├── assets/       # optional templates/resources
+└── ...
+```
+
+Cached docs from `https://agentskills.io/home` live in `context/docs_cache/agent_skills/`.
+
+Useful cached references:
+
+- `context/docs_cache/agent_skills/specification.md`
+- `context/docs_cache/agent_skills/client-implementation_adding-skills-support.md`
+- `context/docs_cache/agent_skills/skill-creation_best-practices.md`
+- `context/docs_cache/agent_skills/skill-creation_using-scripts.md`
+- `context/docs_cache/agent_skills/skill-creation_evaluating-skills.md`
+- `context/docs_cache/agent_skills/skill-creation_optimizing-descriptions.md`
+
+## Core Thesis
+
+Penguin should support Skills as a runtime capability, not just as prompt text.
+
+Minimum useful flow:
+
+1. Discover installed skills from configured directories.
+2. Parse `SKILL.md` frontmatter into a compact catalog.
+3. Expose only skill `name` + `description` at startup.
+4. Activate a skill on demand through a dedicated tool.
+5. Inject full skill instructions using structured tags.
+6. List bundled resources without eagerly loading them.
+7. Load activated skill instructions as `CONTEXT` messages, not `SYSTEM` messages.
+8. Deduplicate already-activated skills per session.
+
+Do not start with marketplaces, auto-install, or fancy package-manager support. Those are distribution questions layered on top of a local runtime contract.
+
+## Proposed Architecture
+
+Add `penguin/skills/`:
+
+- `models.py`
+  - `Skill`
+  - `SkillCatalogEntry`
+  - `SkillResource`
+  - `SkillDiagnostic`
+- `parser.py`
+  - parse/validate `SKILL.md`
+  - support YAML frontmatter
+  - collect diagnostics without crashing the whole scan
+- `discovery.py`
+  - scan configured paths
+  - enforce max depth and directory count
+  - identify `SKILL.md` roots
+- `manager.py`
+  - maintain catalog
+  - resolve name collisions
+  - track activated skills per session/agent
+  - render activation payloads
+- `renderer.py`
+  - compact catalog prompt text
+  - structured `<skill_content>` activation wrapper
+- `evals.py` later
+  - trigger evals
+  - output evals
+  - baseline comparisons
+
+## Tool Integration
+
+Add native tools:
+
+- `list_skills`
+  - returns compact catalog and diagnostics
+- `activate_skill`
+  - input: `name`
+  - returns structured skill content and resource listing
+- optional later: `skill_resources`
+  - returns resource listing for a skill without activation
+
+Current hook points:
+
+- Tool registry: `penguin/tools/tool_manager.py`
+- Tool schema definitions: `ToolManager._define_tool_schemas()`
+- Conversation context insertion: `penguin/system/conversation.py`
+- Context-window truncation policy: `penguin/system/context_window.py`
+
+## Activation Payload Shape
+
+Use structured wrapping so the model and context manager can distinguish durable skill instructions from ordinary tool output:
+
+```xml
+<skill_content name="csv-analyzer">
+# CSV Analyzer
+
+[SKILL.md body]
+
+Skill directory: /absolute/path/to/skill
+Relative paths in this skill are relative to the skill directory.
+
+<skill_resources>
+<file>scripts/analyze.py</file>
+<file>references/schema.md</file>
+<file>assets/report-template.md</file>
+</skill_resources>
+</skill_content>
+```
+
+Resource files should be listed, not eagerly read. The agent can use normal file-read tools when the skill instructions tell it to load a specific file.
+
+## Config Sketch
+
+```yaml
+skills:
+  enabled: true
+  trust_project_skills: false
+  scan_paths:
+    project:
+      - .penguin/skills
+      - .agents/skills
+    user:
+      - ~/.penguin/skills
+      - ~/.agents/skills
+      - ~/.claude/skills
+  max_scan_depth: 6
+  max_skill_dirs: 2000
+  activation:
+    dedicated_tool: true
+    include_frontmatter: false
+    list_resources: true
+    max_resources: 200
+```
+
+Use existing config precedence: package defaults, user config, project config, project local overrides, `PENGUIN_CONFIG_PATH`.
+
+## Security Model
+
+Default stance: local skills are instruction bundles, not trusted code.
+
+Rules:
+
+- Do not auto-activate project skills from an untrusted repository.
+- User-level skill directories can be enabled by default, but executable scripts remain governed by normal Penguin tool/security policy.
+- Parse `allowed-tools` if present, but treat it as advisory until Penguin has a clear enforcement model.
+- Skill scripts should not bypass `execute_command`, filesystem, network, or approval gates.
+- Relative paths in skills must resolve inside the skill directory unless explicitly allowed.
+- Name collisions should be surfaced clearly; deterministic precedence is mandatory.
+
+## Context Window Requirements
+
+Penguin does not have generic context compaction. Its `ContextWindowManager` performs category-based truncation: oldest messages in over-budget categories are trimmed first, while `SYSTEM` is preserved.
+
+Skills should be loaded as `MessageCategory.CONTEXT` messages. They are reusable task instructions and references, but they are not as important as Penguin's agent system prompt and should not rank as `SYSTEM`.
+
+Required changes:
+
+- Add activated skill content through the existing context path, with metadata such as `{"type": "skill", "skill_name": "...", "skill_path": "..."}`.
+- Keep skills in the normal `CONTEXT` budget/truncation lane unless empirical usage shows a separate sub-budget is needed.
+- Do not create `MessageCategory.SKILL` for MVP.
+- Do not append activated skills to the system prompt.
+- Deduplicate activations so the same skill is not injected repeatedly.
+- Add observability for when activated skill context is truncated, using existing truncation tracking patterns.
+- If skill loss during long sessions becomes a practical issue, consider reactivation hints or a CONTEXT sub-budget later. Do not prematurely special-case it.
+
+## Package Manager Distribution
+
+Package-manager installation is possible, but should be deferred until the local runtime contract is stable.
+
+Important distinction:
+
+- **Skills format**: local directory with `SKILL.md` and optional resources.
+- **Skills distribution**: how that directory gets onto disk.
+
+Penguin is Python, but skill distribution is ecosystem-neutral if the final artifact is a directory. Installation can be handled by many package systems.
+
+### Possible Distribution Channels
+
+#### Python / pip
+
+Examples:
+
+```bash
+pip install penguin-skill-csv-analyzer
+uv tool install penguin-skill-csv-analyzer
+```
+
+A Python package could expose installed skill paths via entry points:
+
+```toml
+[project.entry-points."penguin.skills"]
+csv-analyzer = "penguin_skill_csv:path"
+```
+
+Penguin would discover entry points, resolve package resource paths, and add them to the skill catalog.
+
+Pros:
+
+- Native fit for Penguin.
+- Works with `pip`, `uv`, and Python packaging metadata.
+- Can support lockfiles and enterprise mirrors.
+
+Cons:
+
+- Less natural for JS/TS skill authors.
+- Python package resource paths can be awkward, especially for editable installs and zipped packages.
+
+#### npm / npx
+
+Examples:
+
+```bash
+npm install -g @penguin-skills/csv-analyzer
+npx @penguin-skills/install csv-analyzer
+```
+
+Possible designs:
+
+1. Global npm package installs skill files to an npm package directory, then Penguin discovers them through a generated registry file.
+2. `npx` installer copies a skill directory into `~/.penguin/skills/<name>`.
+3. A package exposes a manifest field pointing to skill directories.
+
+Pros:
+
+- Natural for frontend/web ecosystem skills.
+- Easy one-shot installers with `npx`.
+- Large package registry and existing versioning workflows.
+
+Cons:
+
+- Penguin would need cross-runtime discovery rules.
+- Global npm paths vary by platform and toolchain.
+- Running `npx` at activation time would be a security and reproducibility footgun.
+
+Recommendation: if npm support is added, prefer `npx ... install` copying static files into `~/.penguin/skills/`, not dynamic runtime loading from arbitrary npm paths.
+
+#### Standalone Git / Archive Install
+
+Examples:
+
+```bash
+penguin skill install https://github.com/org/skill-repo
+penguin skill install ./local-skill
+penguin skill install skill.tar.gz
+```
+
+Pros:
+
+- Ecosystem-neutral.
+- Simple mental model.
+- Good MVP after local discovery.
+
+Cons:
+
+- Needs checksum/signature story eventually.
+- Needs update/remove metadata.
+
+#### OCI / Artifact Registry Later
+
+A skill bundle could be published as an OCI artifact.
+
+Pros:
+
+- Enterprise-friendly.
+- Versioned, immutable, mirrorable.
+
+Cons:
+
+- Overkill for MVP.
+- More moving parts than the feature deserves right now.
+
+### Package Manager Recommendation
+
+Defer package-manager installs.
+
+Build the local substrate first:
+
+1. Stable skill directory contract.
+2. Parser/discovery/activation tools.
+3. CONTEXT-category truncation observability.
+4. CLI `skill list/show/activate/doctor`.
+5. Manual install by copying folders into `~/.penguin/skills` or project `.penguin/skills`.
+
+Then add distribution in this order:
+
+1. `penguin skill install <local-path|git-url>`
+2. Python entry point discovery via `penguin.skills`
+3. Optional `npx` installer that copies skills into Penguin’s user skill directory
+4. Registry/marketplace only after real usage proves the need
+
+Bluntly: package manager support before runtime semantics is yak shaving with better branding.
+
+## CLI Surface
+
+Initial commands:
+
+```bash
+penguin skill list
+penguin skill show <name>
+penguin skill activate <name>
+penguin skill doctor
+```
+
+Later:
+
+```bash
+penguin skill create <name>
+penguin skill install <source>
+penguin skill remove <name>
+penguin skill eval <name>
+penguin skill optimize-description <name>
+```
+
+## Evals
+
+Use Agent Skills' eval pattern:
+
+- `evals/evals.json` inside the skill directory.
+- Each test case has prompt, expected output, optional files, later assertions.
+- Run with and without skill, or current skill vs previous snapshot.
+- Capture timing/token data.
+- Grade assertions with scripts where possible, LLM judge where necessary.
+- Use Penguin subagents to isolate each eval run.
+
+This is a strong fit for Penguin's multi-agent runtime.
+
+## Acceptance Criteria For MVP
+
+- Penguin discovers valid skills from configured user/project paths.
+- Invalid skills produce diagnostics, not crashes.
+- Startup context includes compact skill catalog only.
+- `activate_skill` injects full skill content once per session.
+- Activation output lists resources without eager loading.
+- Activated skill content is stored as `CONTEXT` with skill metadata.
+- Project skills are disabled or require trust by default.
+- Tests cover parser, discovery, collision behavior, activation dedupe, and CONTEXT-category truncation behavior.
+
+## Non-Goals For MVP
+
+- Public skill marketplace.
+- Automatic remote install.
+- Runtime execution through npm/npx/pip.
+- Cross-machine sync.
+- Full `allowed-tools` enforcement.
+- UI-heavy skill browser.
+
+## Open Questions
+
+- Should the compact skill catalog be injected as one `CONTEXT` message or split into smaller per-skill `CONTEXT` messages for better truncation behavior?
+- Should activated skill messages receive a small reserved CONTEXT sub-budget later, or is normal CONTEXT truncation acceptable?
+- What is the cleanest trust UX for project skills?
+- Should `allowed-tools` narrow available tools during skill execution, or only annotate expected tools?
+- How should skill activation behave in shared-context subagents?
+- Should installed package skills be copied to a Penguin-controlled directory or referenced in-place?
+
+## First Implementation Slice
+
+1. Implement `penguin/skills/parser.py` and tests.
+2. Implement local discovery for `~/.penguin/skills` and `.penguin/skills`.
+3. Add `SkillManager` with activation dedupe.
+4. Add `list_skills` and `activate_skill` tools.
+5. Add compact catalog injection.
+6. Load activated skills as `CONTEXT` messages with skill metadata and truncation observability.
+7. Add `penguin skill list/show/doctor` CLI commands.
+
+Keep it boring. Boring means shippable.

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -39,6 +39,15 @@ MVP runtime and first CLI UX slice implemented in this branch. Web API, TUI, pac
 - [x] Surface invalid skill diagnostics clearly.
 - [x] Document manual install by copying folders into `~/.penguin/skills` or `.penguin/skills`.
 
+### Prompting And Agent Behavior
+
+- [x] Document skill-use rules in the generated tool guide.
+- [x] Add workflow guidance for when to activate skills from explicit mentions or matching descriptions.
+- [x] Instruct Penguin to activate the minimal relevant skill set, not every available skill.
+- [x] Clarify activated skills are `CONTEXT`, not `SYSTEM`, and lower priority than Penguin's system/developer instructions.
+- [x] Instruct Penguin to load referenced skill files progressively instead of bulk-loading resources.
+- [x] Add prompt regression tests covering skill tool docs and workflow guidance.
+
 ### Web API Interface
 
 - [ ] Add `GET /api/v1/skills` for compact catalog and diagnostics.

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -50,12 +50,12 @@ MVP runtime and first CLI UX slice implemented in this branch. Web API, TUI, pac
 
 ### Web API Interface
 
-- [ ] Add `GET /api/v1/skills` for compact catalog and diagnostics.
-- [ ] Add `GET /api/v1/skills/{name}` for full `SKILL.md` inspection without activation.
-- [ ] Add `POST /api/v1/skills/{name}/activate` to load skill content as session-scoped `CONTEXT`.
-- [ ] Include duplicate activation status and skill metadata in activation responses.
-- [ ] Surface invalid skill diagnostics in structured JSON for web clients.
-- [ ] Emit SSE/OpenCode-compatible events when skills are activated or diagnostics change.
+- [x] Add `GET /api/v1/skills` for compact catalog and diagnostics.
+- [x] Add `GET /api/v1/skills/{name}` for full `SKILL.md` inspection without activation.
+- [x] Add `POST /api/v1/skills/{name}/activate` to load skill content as session-scoped `CONTEXT`.
+- [x] Include duplicate activation status and skill metadata in activation responses.
+- [x] Surface invalid skill diagnostics in structured JSON for web clients.
+- [x] Emit SSE/OpenCode-compatible events when skills are activated or diagnostics change.
 
 ### TUI Interface
 

--- a/context/tasks/skills.md
+++ b/context/tasks/skills.md
@@ -59,12 +59,12 @@ MVP runtime and first CLI UX slice implemented in this branch. Web API, TUI, pac
 
 ### TUI Interface
 
-- [ ] Add a Skills panel/list using the web/API catalog endpoint.
-- [ ] Show invalid skill diagnostics with actionable file paths and validation errors.
-- [ ] Add explicit activation action that calls the web/API activation endpoint.
-- [ ] Show whether a skill is already active in the current session.
-- [ ] Display manual install guidance for user/project skill folders.
-- [ ] Avoid auto-activating skills from UI selection; require explicit user action.
+- [x] Add a Skills panel/list using the web/API catalog endpoint.
+- [x] Show invalid skill diagnostics with actionable file paths and validation errors.
+- [x] Add explicit activation action that calls the web/API activation endpoint.
+- [x] Show whether a skill is already active in the current session.
+- [x] Display manual install guidance for user/project skill folders.
+- [x] Avoid auto-activating skills from UI selection; require explicit user action.
 
 ### Security And Trust
 

--- a/docs/docs/advanced/future_considerations.md
+++ b/docs/docs/advanced/future_considerations.md
@@ -1,6 +1,6 @@
 # Future Considerations
 
-This document outlines planned and potential future enhancements for the Penguin AI Assistant platform.
+This document outlines planned and potential future enhancements for Penguin.
 
 ## Conversation and Memory Systems
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -2,9 +2,11 @@
 sidebar_position: 1
 ---
 
-# Penguin AI Assistant Documentation
+# Penguin Documentation
 
-Welcome to the documentation for Penguin! Penguin v0.4.0 is a modular, extensible AI coding agent with advanced conversation management, real-time streaming, comprehensive checkpoint/branching, and multi/sub-agent capabilities with coordinated orchestration.
+Penguin is an open-source coding agent built on a scalable cognitive architecture runtime.
+
+It is designed for long-running, tool-using, multi-agent software workflows: from interactive coding in the TUI to persistent sessions, subagent delegation, and API-driven automation. Penguin combines a coding-focused agent runtime with durable state, workspace-aware tools, and multiple interfaces on top of the same core.
 
 ## Features
 

--- a/docs/docs/usage/basic_usage.md
+++ b/docs/docs/usage/basic_usage.md
@@ -1,6 +1,6 @@
 # Basic Usage
 
-This guide covers the fundamental ways to interact with Penguin AI Assistant v0.2.0, from simple chat conversations to project management and automation.
+This guide covers the fundamental ways to interact with Penguin, from interactive coding sessions to project management and automation.
 
 ## Interactive Chat Mode
 

--- a/docs/docs/usage/cli_commands.md
+++ b/docs/docs/usage/cli_commands.md
@@ -108,6 +108,26 @@ Manage the Penguin configuration file and first-run setup wizard.
 | `penguin-cli config test-routing` | Debug provider/model routing logic |
 | `penguin-cli config debug`        | Print an extended diagnostic report |
 
+### `skill`
+Discover, inspect, activate, and diagnose local Agent Skills.
+
+| Command | What it does |
+|---------|--------------|
+| `penguin-cli skill list` | List discovered skills and surface a count of invalid skill diagnostics |
+| `penguin-cli skill list --json` | Emit compact catalog and diagnostics as JSON |
+| `penguin-cli skill show <NAME>` | Show the full `SKILL.md` body and metadata for a discovered skill |
+| `penguin-cli skill show <NAME> --json` | Emit full skill metadata and body as JSON |
+| `penguin-cli skill activate <NAME>` | Load the named skill into the current runtime session as `MessageCategory.CONTEXT` |
+| `penguin-cli skill activate <NAME> --show-content` | Print the rendered `<skill_content>` activation payload after loading it |
+| `penguin-cli skill doctor` | Validate discovered skill directories and print install guidance |
+| `penguin-cli skill doctor --json` | Emit diagnostics as structured JSON |
+
+The default `penguin` launcher routes the `skill` subcommand to the same headless CLI path, so `penguin skill list` also works. For scripts and automation, prefer `penguin-cli`.
+
+Manual install is currently folder-copy based: put skill directories containing `SKILL.md` under `~/.penguin/skills/<skill-name>/` for user skills or `.penguin/skills/<skill-name>/` for trusted project skills. Package-manager install flows are deferred.
+
+See [Agent Skills](./skills.md) for the runtime behavior and security model.
+
 ### Developer utilities
 | Command | Purpose |
 |---------|---------|
@@ -210,5 +230,5 @@ penguin-cli project task start <TASK_ID>
 Earlier versions of the docs referenced commands such as `penguin memory`, `penguin db`, advanced task dependency graphs, and full web-server management. These features are **work-in-progress** and are **not** available in the current release. Attempting to run them will result in a "No such command" error.
 ---
 
-*Last updated: April 15, 2026*  
+*Last updated: April 28, 2026*
 If you find inaccuracies, please open an issue.

--- a/docs/docs/usage/skills.md
+++ b/docs/docs/usage/skills.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 6
+---
+
+# Agent Skills
+
+Penguin includes an initial Agent Skills runtime for discovering reusable instruction bundles from local folders and loading selected skills into a conversation.
+
+Skills are based on the portable Agent Skills convention: each skill is a directory with a required `SKILL.md` file containing YAML frontmatter plus Markdown instructions.
+
+```text
+my-skill/
+├── SKILL.md      # required: frontmatter + instructions
+├── scripts/      # optional helper scripts
+├── references/   # optional detailed docs
+└── assets/       # optional templates/resources
+```
+
+## Current Status
+
+Implemented so far:
+
+- Local skill discovery from configured user/project scan paths
+- `SKILL.md` frontmatter validation
+- Compact skill catalog loading as `MessageCategory.CONTEXT`
+- Explicit skill activation through runtime tools
+- Activated skill content loaded as `MessageCategory.CONTEXT`
+- Per-session activation dedupe
+- CLI commands for listing, inspecting, activating, and diagnosing skills
+
+Not implemented yet:
+
+- Web API skill endpoints
+- TUI skill panel/actions
+- Package-manager based skill installation
+- Skill eval runner
+- Automatic skill-trigger heuristics
+
+## Skill File Format
+
+A minimal valid skill:
+
+```markdown
+---
+name: csv-cleanup
+description: Clean, validate, and summarize CSV files.
+---
+
+# CSV Cleanup
+
+Use this skill when the user asks to clean or analyze CSV data.
+
+1. Inspect the CSV headers.
+2. Check for missing values and inconsistent types.
+3. Produce a cleaned output file and a short summary.
+```
+
+Required frontmatter fields:
+
+| Field | Notes |
+|---|---|
+| `name` | Stable skill identifier. Use a lowercase slug such as `csv-cleanup`. |
+| `description` | Short catalog description used to help decide when the skill is relevant. |
+
+Optional frontmatter fields may be preserved as metadata. `allowed-tools`, when present, is treated as advisory metadata only; it does not bypass Penguin's normal tool permissions.
+
+## Manual Installation
+
+For now, install skills by copying folders into a local skill directory:
+
+```bash
+# User-level skills
+mkdir -p ~/.penguin/skills
+cp -R ./my-skill ~/.penguin/skills/my-skill
+
+# Project-level skills
+mkdir -p .penguin/skills
+cp -R ./my-skill .penguin/skills/my-skill
+```
+
+Project skills are intentionally trust-sensitive. Penguin should not treat arbitrary repository-owned instructions as trusted just because a folder exists. Enable or trust project skill loading deliberately in configuration when using project-local skills.
+
+## CLI Commands
+
+Skills are exposed through the headless CLI command group:
+
+```bash
+# List discovered skills and diagnostics
+penguin-cli skill list
+penguin-cli skill list --json
+
+# Show full SKILL.md content for a discovered skill
+penguin-cli skill show csv-cleanup
+penguin-cli skill show csv-cleanup --json
+
+# Activate a skill for the current runtime session
+penguin-cli skill activate csv-cleanup
+penguin-cli skill activate csv-cleanup --show-content
+penguin-cli skill activate csv-cleanup --json
+
+# Validate discovered skill directories and show install guidance
+penguin-cli skill doctor
+penguin-cli skill doctor --json
+```
+
+The default `penguin` launcher now routes the `skill` subcommand to the headless CLI path, so `penguin skill list` also works. For scripts, prefer `penguin-cli` because it is explicitly non-interactive.
+
+## Runtime Behavior
+
+At startup/session initialization, Penguin loads a compact skill catalog into conversation context when valid skills are found. The catalog contains the skill names, descriptions, sources, and paths. It does **not** load full instruction bodies.
+
+When a skill is activated, Penguin renders structured content similar to:
+
+```xml
+<skill_content name="csv-cleanup">
+...
+</skill_content>
+<skill_resources>
+...
+</skill_resources>
+```
+
+That rendered activation is added as a `MessageCategory.CONTEXT` message with skill metadata. Skills are not loaded as system prompts and do not outrank Penguin's system instructions.
+
+Penguin's context window manager uses category-based truncation. Since skills are `CONTEXT`, old skill catalog/activation messages can be truncated under normal `CONTEXT` pressure. That is intentional for the MVP; future work may add richer observability or a reserved `CONTEXT` sub-budget if real usage proves it is needed.
+
+## Tool Interface
+
+The runtime exposes two model-callable tools:
+
+| Tool | Purpose |
+|---|---|
+| `list_skills` | Return the current skill catalog and validation diagnostics. |
+| `activate_skill` | Load a named skill into the active session as `CONTEXT`. |
+
+Activation is explicit and deduped per session. Re-activating the same skill returns an `already_active` style result instead of repeatedly appending duplicate context.
+
+## Diagnostics
+
+Invalid skills are not silently ignored. Parser/discovery diagnostics include severity, code, source, path, and message. Use:
+
+```bash
+penguin-cli skill doctor
+```
+
+to inspect malformed frontmatter, invalid names, missing required fields, collisions, and ignored project skills.
+
+## Security Notes
+
+Skills are instruction bundles, not permission grants.
+
+- Do not auto-trust project skills from arbitrary repositories.
+- Treat `allowed-tools` as a hint, not an authorization bypass.
+- Scripts inside skill folders still need to go through Penguin's normal command/file/network permission model.
+- Package-manager installation is deferred; install by copying folders until local runtime semantics are stable.
+
+## Planned Interfaces
+
+### Web API
+
+Planned endpoints:
+
+- `GET /api/v1/skills` for compact catalog and diagnostics
+- `GET /api/v1/skills/{name}` for full `SKILL.md` inspection without activation
+- `POST /api/v1/skills/{name}/activate` to load skill content into a session as `CONTEXT`
+
+### TUI
+
+Planned TUI work:
+
+- Skills catalog panel
+- Invalid skill diagnostics display
+- Explicit activation action
+- Active/already-active status per session
+- Manual install guidance
+
+The TUI should not auto-activate a skill merely because the user selected it. Activation should remain explicit.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,6 +1,6 @@
 const config = {
-  title: 'Penguin AI Assistant',
-  tagline: 'A modular, extensible AI coding assistant',
+  title: 'Penguin',
+  tagline: 'Open-source coding agent built on a scalable cognitive architecture runtime.',
   url: 'https://maximooch.github.io',
   baseUrl: '/',
   onBrokenLinks: 'ignore',
@@ -32,10 +32,10 @@ const config = {
 
   themeConfig: {
     mermaid: {
-      theme: { light: 'neutral', dark: 'forest' },
+      theme: {light: 'neutral', dark: 'forest'},
     },
     navbar: {
-      title: 'Penguin AI Assistant',
+      title: 'Penguin',
       logo: {
         alt: 'Penguin',
         src: 'img/logo.svg',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -38,6 +38,7 @@ const sidebars: SidebarsConfig = {
         'usage/task_management',
         'usage/checkpointing',
         'usage/cli_commands',
+        'usage/skills',
         'usage/project_management',
         'usage/api_usage',
         'usage/python_api_reference'

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
 type FeatureItem = {
@@ -54,7 +53,7 @@ function Feature({title, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center padding-horiz--md">
-        <Heading as="h3">{title}</Heading>
+        <h3>{title}</h3>
         <p>{description}</p>
       </div>
     </div>

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,23 +1,580 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
-.heroBanner {
-  padding: 4rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
+.pageShell {
+  --penguin-bg: #07090d;
+  --penguin-bg-soft: #0c1017;
+  --penguin-panel: rgba(255, 255, 255, 0.045);
+  --penguin-panel-strong: rgba(255, 255, 255, 0.075);
+  --penguin-border: rgba(255, 255, 255, 0.1);
+  --penguin-border-soft: rgba(255, 255, 255, 0.065);
+  --penguin-text: #f7f8fb;
+  --penguin-muted: #a3abb9;
+  --penguin-dim: #697386;
+  --penguin-blue: #5f8cff;
+  --penguin-cyan: #41d7ff;
+  --penguin-green: #5df0a6;
+  --penguin-violet: #8e7dff;
+  --penguin-shadow: 0 24px 80px rgba(0, 0, 0, 0.36);
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
+.heroShell {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 16%, rgba(95, 140, 255, 0.26), transparent 28rem),
+    radial-gradient(circle at 82% 18%, rgba(65, 215, 255, 0.16), transparent 24rem),
+    linear-gradient(180deg, #06080c 0%, var(--penguin-bg) 100%);
+  color: var(--penguin-text);
+  border-bottom: 1px solid var(--penguin-border-soft);
+}
+
+.heroShell::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: '';
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.78), transparent 84%);
+}
+
+.heroGrid {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.76fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+  width: min(1180px, calc(100% - 2rem));
+  min-height: 720px;
+  margin: 0 auto;
+  padding: clamp(5rem, 10vw, 8rem) 0;
+}
+
+.heroCopy {
+  max-width: 760px;
+}
+
+.statusBadge {
+  display: inline-flex;
+  gap: 0.55rem;
+  align-items: center;
+  padding: 0.45rem 0.7rem;
+  margin-bottom: 1.6rem;
+  font: 600 0.78rem/1.2 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: #d7def0;
+  letter-spacing: 0.02em;
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid var(--penguin-border);
+  border-radius: 999px;
+}
+
+.statusDot {
+  width: 0.48rem;
+  height: 0.48rem;
+  background: var(--penguin-green);
+  border-radius: 999px;
+  box-shadow: 0 0 22px rgba(93, 240, 166, 0.8);
+}
+
+.heroTitle {
+  max-width: 780px;
+  margin: 0;
+  font-size: clamp(3.4rem, 8vw, 7.5rem);
+  font-weight: 750;
+  line-height: 0.92;
+  letter-spacing: -0.075em;
+  color: var(--penguin-text);
+  text-wrap: balance;
+}
+
+.heroSubtitle {
+  max-width: 680px;
+  margin: 1.6rem 0 0;
+  font-size: clamp(1.08rem, 1.7vw, 1.28rem);
+  line-height: 1.65;
+  color: var(--penguin-muted);
+  text-wrap: pretty;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.primaryAction,
+.secondaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0.78rem 1.05rem;
+  font-weight: 700;
+  line-height: 1;
+  border-radius: 10px;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.primaryAction,
+.primaryAction:hover {
+  color: #06101a;
+  text-decoration: none;
+  background: linear-gradient(135deg, var(--penguin-cyan), var(--penguin-blue));
+  box-shadow: 0 14px 34px rgba(95, 140, 255, 0.28);
+}
+
+.secondaryAction,
+.secondaryAction:hover {
+  color: var(--penguin-text);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--penguin-border);
+}
+
+.primaryAction:hover,
+.secondaryAction:hover {
+  transform: translateY(-1px);
+}
+
+.commandStack {
+  display: grid;
+  gap: 0.65rem;
+  max-width: 560px;
+  margin-top: 2rem;
+}
+
+.commandLine {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.82rem 0.95rem;
+  overflow: hidden;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: #dbe4f6;
+  background: rgba(3, 7, 14, 0.78);
+  border: 1px solid var(--penguin-border);
+  border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045);
+}
+
+.commandLine span {
+  color: var(--penguin-green);
+}
+
+.commandLine code {
+  overflow: hidden;
+  color: #dbe4f6;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: transparent;
+  border: 0;
+}
+
+.copyButton {
+  min-height: 32px;
+  padding: 0 0.62rem;
+  font: 700 0.72rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: #dbe4f6;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.075);
+  border: 1px solid var(--penguin-border);
+  border-radius: 8px;
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+  color: #06101a;
+  background: var(--penguin-green);
+  outline: none;
+}
+
+.terminalCard {
+  position: relative;
+  padding: 1rem;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.035)),
+    rgba(8, 12, 18, 0.84);
+  border: 1px solid var(--penguin-border);
+  border-radius: 24px;
+  box-shadow: var(--penguin-shadow);
+  backdrop-filter: blur(18px);
+}
+
+.terminalCard::after {
+  position: absolute;
+  inset: auto -16% -24% 16%;
+  height: 180px;
+  pointer-events: none;
+  content: '';
+  background: radial-gradient(circle, rgba(65, 215, 255, 0.23), transparent 70%);
+  filter: blur(12px);
+}
+
+.terminalChrome {
+  display: flex;
+  gap: 0.44rem;
+  align-items: center;
+  padding: 0.85rem;
+  color: var(--penguin-dim);
+  border-bottom: 1px solid var(--penguin-border-soft);
+}
+
+.terminalChrome span {
+  width: 0.68rem;
+  height: 0.68rem;
+  background: var(--penguin-dim);
+  border-radius: 999px;
+}
+
+.terminalChrome span:first-child {
+  background: #ff6b6b;
+}
+
+.terminalChrome span:nth-child(2) {
+  background: #ffd166;
+}
+
+.terminalChrome span:nth-child(3) {
+  background: var(--penguin-green);
+}
+
+.terminalChrome p {
+  margin: 0 0 0 auto;
+  font: 600 0.72rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.penguinMark {
+  display: grid;
+  place-items: center;
+  min-height: 420px;
+  padding: clamp(1.5rem, 4vw, 2.4rem) 0.6rem;
+  font-size: clamp(6rem, 14vw, 12rem);
+  line-height: 1;
+  text-shadow: 0 22px 70px rgba(65, 215, 255, 0.32);
+  background: transparent;
+}
+
+.terminalRows {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0 0.6rem 0.7rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.terminalRows p {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.76rem 0.85rem;
+  margin: 0;
+  color: #dbe4f6;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid var(--penguin-border-soft);
+  border-radius: 12px;
+}
+
+.terminalRows span {
+  color: var(--penguin-cyan);
+}
+
+.mainContent {
+  color: var(--penguin-text);
+  background:
+    linear-gradient(180deg, var(--penguin-bg) 0%, #090c12 52%, #05070a 100%);
+}
+
+.sectionBlock,
+.splitSection,
+.capabilitySection,
+.finalCta {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.sectionBlock,
+.capabilitySection {
+  padding: clamp(4.5rem, 8vw, 7.5rem) 0 0;
+}
+
+.sectionHeader {
+  max-width: 780px;
+  margin-bottom: 2rem;
+}
+
+.sectionKicker {
+  display: inline-block;
+  margin-bottom: 0.85rem;
+  font: 800 0.74rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: var(--penguin-green);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.sectionHeader h2,
+.splitSection h2,
+.workflowIntro h2,
+.finalCta h2 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4.8vw, 4.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+  color: var(--penguin-text);
+  text-wrap: balance;
+}
+
+.sectionHeader p,
+.splitSection > div > p,
+.workflowIntro p,
+.finalCta p {
+  max-width: 720px;
+  margin: 1rem 0 0;
+  font-size: 1.06rem;
+  line-height: 1.7;
+  color: var(--penguin-muted);
+  text-wrap: pretty;
+}
+
+.pillarGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.pillarCard,
+.workflowStep,
+.capabilityItem,
+.installStep {
+  background: var(--penguin-panel);
+  border: 1px solid var(--penguin-border-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.pillarCard {
+  min-height: 310px;
+  padding: 1.25rem;
+  border-radius: 20px;
+}
+
+.pillarCard > span,
+.workflowStep > span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  margin-bottom: 1.8rem;
+  font: 800 0.75rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: #06101a;
+  background: var(--penguin-green);
+  border-radius: 999px;
+}
+
+.pillarCard h3,
+.workflowStep h3 {
+  margin: 0 0 0.85rem;
+  font-size: 1.08rem;
+  line-height: 1.2;
+  color: var(--penguin-text);
+}
+
+.pillarCard p,
+.workflowStep p,
+.surfaceRow p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.62;
+  color: var(--penguin-muted);
+}
+
+.splitSection {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1fr);
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: start;
+  padding: clamp(5rem, 9vw, 8rem) 0;
+}
+
+.surfaceList {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--penguin-border-soft);
+  border-radius: 20px;
+}
+
+.surfaceRow {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1.15rem;
+  background: rgba(255, 255, 255, 0.035);
+  border-bottom: 1px solid var(--penguin-border-soft);
+}
+
+.surfaceRow:last-child {
+  border-bottom: 0;
+}
+
+.surfaceRow strong {
+  color: var(--penguin-cyan);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.workflowPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  padding: clamp(1.25rem, 4vw, 2rem);
+  background:
+    radial-gradient(circle at 15% 20%, rgba(142, 125, 255, 0.16), transparent 28rem),
+    rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--penguin-border-soft);
+  border-radius: 28px;
+}
+
+.workflowGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.workflowStep {
+  min-height: 220px;
+  padding: 1.15rem;
+  border-radius: 18px;
+}
+
+.installSteps {
+  display: grid;
+  gap: 1rem;
+}
+
+.installStep {
+  padding: 1.15rem;
+  border-radius: 18px;
+}
+
+.installStep strong {
+  display: block;
+  margin-bottom: 0.65rem;
+  color: var(--penguin-text);
+}
+
+.capabilityGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.capabilityItem {
+  min-height: 120px;
+  padding: 1.1rem;
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.45;
+  color: #dce5f8;
+  border-radius: 18px;
+}
+
+.finalCta {
+  padding: clamp(5rem, 10vw, 9rem) 0;
+  text-align: center;
+}
+
+.finalCta p {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.finalCta .heroActions {
+  justify-content: center;
+}
+
+@media (max-width: 1060px) {
+  .heroGrid,
+  .splitSection,
+  .workflowPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .heroGrid {
+    min-height: auto;
+  }
+
+  .terminalCard {
+    max-width: 720px;
+  }
+
+  .pillarGrid,
+  .capabilityGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-.buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+@media (max-width: 700px) {
+  .heroGrid,
+  .sectionBlock,
+  .splitSection,
+  .capabilitySection,
+  .finalCta {
+    width: min(100% - 1rem, 1180px);
+  }
+
+  .heroGrid {
+    padding-top: 3.2rem;
+  }
+
+  .heroTitle {
+    font-size: clamp(3rem, 17vw, 4.2rem);
+  }
+
+  .heroActions,
+  .finalCta .heroActions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .primaryAction,
+  .secondaryAction {
+    width: 100%;
+  }
+
+  .commandLine {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .copyButton {
+    grid-column: 2;
+    width: max-content;
+  }
+
+  .pillarGrid,
+  .workflowGrid,
+  .capabilityGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pillarCard,
+  .workflowStep {
+    min-height: auto;
+  }
+
+  .surfaceRow {
+    grid-template-columns: 1fr;
+  }
+
+  .terminalRows p {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primaryAction,
+  .secondaryAction {
+    transition: none;
+  }
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,43 +1,247 @@
-import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const installCommand = 'uv tool install penguin-ai';
+const launchCommand = 'penguin';
+
+const whyPenguin = [
+  'Purpose-built for software engineering workflows, with coding tools, sessions, and subagents.',
+  'Stateful runtime: sessions, checkpoints, tool history, and replayable transcripts.',
+  'Context Window Manager: long sessions stay coherent through category-aware token budgeting, truncation, and replay, preserving recency and message-category priorities across long-running sessions.',
+  'Multi-agent orchestration: planner/implementer/QA patterns, subagents, and scoped delegation.',
+  'Multiple surfaces: TUI, CLI, web API, and Python client on the same backend.',
+  'OpenCode-compatible TUI path: Penguin web/core now powers an OpenCode-style terminal UX.',
+];
+
+const whatYouGet = [
+  'Coding workflow tools: file reads/writes/diffs, shell commands, test execution, search, code analysis, and background process management.',
+  'Context Window Manager: category-based token budgets, multimodal truncation, and live usage reporting to keep histories within model limits. This supports theoretically infinite sessions.',
+  'Persistent memory and file-backed context: declarative notes, summary notes, context artifacts, docs cache, and daily journal continuity.',
+  'Multi-agent execution: isolated or shared-context subagents, delegation, planner/implementer/QA patterns, and background task execution.',
+  'Browser and research support: web search plus browser automation for documentation, web workflows, and UI testing.',
+  'Session durability: checkpoints, rollback, branching, transcript replay, and long-running task continuity.',
+  'Project and task orchestration backed by SQLite, including todo tracking and Run Mode.',
+  'Native and gateway model support across OpenAI, Anthropic, and OpenRouter by default, with LiteLLM available as an optional extra.',
+];
+
+const interfaces = [
+  ['penguin / ptui', 'Terminal-first coding workflow with streaming, tools, and session navigation.'],
+  ['penguin-cli', 'Scriptable CLI interface for prompts, tasks, config, and automation.'],
+  ['penguin-web', 'REST + WebSocket/SSE backend for the TUI and custom integrations.'],
+  ['Python API', 'PenguinAgent, PenguinClient, and PenguinAPI for embedding Penguin in code.'],
+];
+
+const quickStart = [
+  ['Recommended install', 'uv tool install penguin-ai'],
+  ['Alternative install', 'pip install penguin-ai'],
+  ['Set a model key', 'export OPENROUTER_API_KEY="your_api_key"'],
+  ['Launch Penguin', 'penguin'],
+];
+
+function CopyButton({value}: {value: string}) {
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <Heading as="h1" className="hero__title">
-          {siteConfig.title}
-        </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/intro">
-            Get started - 5min ⏱️
-          </Link>
-        </div>
+    <button
+      className={styles.copyButton}
+      type="button"
+      onClick={() => navigator.clipboard?.writeText(value)}>
+      Copy
+    </button>
+  );
+}
+
+function CommandLine({command}: {command: string}) {
+  return (
+    <div className={styles.commandLine}>
+      <span>$</span>
+      <code>{command}</code>
+      <CopyButton value={command} />
+    </div>
+  );
+}
+
+function HomepageHeader() {
+  return (
+    <header className={styles.heroShell}>
+      <div className={styles.heroGrid}>
+        <section className={styles.heroCopy}>
+          <div className={styles.statusBadge}>
+            <span className={styles.statusDot} />
+            Open-source coding agent built on a scalable cognitive architecture runtime
+          </div>
+          <h1 className={styles.heroTitle}>Penguin</h1>
+          <p className={styles.heroSubtitle}>
+            Penguin is designed for long-running, tool-using, multi-agent software
+            workflows: from interactive coding in the TUI to persistent sessions,
+            subagent delegation, and API-driven automation. It combines a
+            coding-focused agent runtime with durable state, workspace-aware tools,
+            and multiple interfaces on top of the same core.
+          </p>
+          <div className={styles.heroActions}>
+            <Link className={styles.primaryAction} to="/docs/intro">
+              Read the docs
+            </Link>
+            <Link
+              className={styles.secondaryAction}
+              to="https://github.com/maximooch/penguin">
+              View GitHub
+            </Link>
+          </div>
+          <div className={styles.commandStack} aria-label="Install commands">
+            <CommandLine command={installCommand} />
+            <CommandLine command={launchCommand} />
+          </div>
+        </section>
+
+        <aside className={styles.terminalCard} aria-label="Penguin runtime preview">
+          <div className={styles.terminalChrome}>
+            <span />
+            <span />
+            <span />
+            <p>penguin://session/runtime</p>
+          </div>
+          <div className={styles.penguinMark} aria-hidden="true">
+            🐧
+          </div>
+          {/* Reserved for a Penguin TUI screenshot.
+          <div className={styles.terminalRows}>
+            <p><span>runtime</span> scalable cognitive architecture</p>
+            <p><span>state</span> sessions · checkpoints · replay</p>
+            <p><span>tools</span> files · shell · tests · browser · web</p>
+            <p><span>agents</span> subagents · delegation · orchestration</p>
+          </div>
+          */}
+        </aside>
       </div>
     </header>
   );
 }
 
-export default function Home(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
+function WhyPenguin() {
   return (
-    <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-      </main>
+    <section className={styles.sectionBlock}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionKicker}>Why Penguin</span>
+        <h2>Purpose-built for software engineering workflows.</h2>
+        <p>
+          Penguin carries the README promise onto the homepage: coding tools,
+          sessions, subagents, long-session context management, and one backend
+          across every interface.
+        </p>
+      </div>
+      <div className={styles.pillarGrid}>
+        {whyPenguin.map((item, index) => (
+          <article className={styles.pillarCard} key={item}>
+            <span>{String(index + 1).padStart(2, '0')}</span>
+            <p>{item}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function InterfaceSection() {
+  return (
+    <section className={styles.splitSection}>
+      <div>
+        <span className={styles.sectionKicker}>Interfaces</span>
+        <h2>Same runtime. Multiple surfaces.</h2>
+        <p>
+          Penguin exposes the same runtime through several surfaces: terminal UI,
+          scriptable CLI, web/API backend, and Python embedding.
+        </p>
+      </div>
+      <div className={styles.surfaceList}>
+        {interfaces.map(([label, description]) => (
+          <article className={styles.surfaceRow} key={label}>
+            <strong>{label}</strong>
+            <p>{description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function WhatYouGet() {
+  return (
+    <section className={styles.capabilitySection}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionKicker}>What You Get</span>
+        <h2>Coding workflow tools, durable state, and orchestration.</h2>
+      </div>
+      <div className={styles.capabilityGrid}>
+        {whatYouGet.map((capability) => (
+          <div className={styles.capabilityItem} key={capability}>
+            {capability}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function QuickStart() {
+  return (
+    <section className={styles.sectionBlock}>
+      <div className={styles.workflowPanel}>
+        <div className={styles.workflowIntro}>
+          <span className={styles.sectionKicker}>Quick Start</span>
+          <h2>Install Penguin, set a model key, and launch.</h2>
+          <p>
+            The README recommends uv for faster installs, simpler Python environment
+            management, and this repo&apos;s safer dependency workflow. Plain pip still works.
+          </p>
+        </div>
+        <div className={styles.installSteps}>
+          {quickStart.map(([label, command]) => (
+            <article className={styles.installStep} key={label}>
+              <strong>{label}</strong>
+              <CommandLine command={command} />
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FinalCta() {
+  return (
+    <section className={styles.finalCta}>
+      <h2>Open-source coding agent. Scalable runtime. Real workflows.</h2>
+      <p>
+        Start in the TUI, automate through the CLI, serve it over the web/API, or
+        embed Penguin in Python. The point is continuity: durable state,
+        workspace-aware tools, and multiple interfaces on the same core.
+      </p>
+      <div className={styles.heroActions}>
+        <Link className={styles.primaryAction} to="/docs/getting_started">
+          Start building
+        </Link>
+        <Link className={styles.secondaryAction} to="/docs/intro">
+          Read the docs
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default function Home(): JSX.Element {
+  return (
+    <Layout>
+      <div className={styles.pageShell}>
+        <HomepageHeader />
+        <main className={styles.mainContent}>
+          <WhyPenguin />
+          <InterfaceSection />
+          <WhatYouGet />
+          <QuickStart />
+          <FinalCta />
+        </main>
+      </div>
     </Layout>
   );
 }

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -12,6 +12,7 @@ import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
+import { DialogSkills } from "@tui/component/dialog-skills"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogSettings } from "@tui/component/dialog-settings"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
@@ -420,6 +421,19 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogMcp />)
+      },
+    },
+    {
+      title: "Manage skills",
+      value: "skill.list",
+      category: "Agent",
+      enabled: sdk.penguin,
+      slash: {
+        name: "skills",
+        aliases: ["skill"],
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogSkills />)
       },
     },
     {

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
@@ -1,0 +1,188 @@
+import { TextAttributes } from "@opentui/core"
+import { createMemo, createSignal, onMount } from "solid-js"
+import { useSDK } from "@tui/context/sdk"
+import { useTheme } from "../context/theme"
+import { useToast } from "../ui/toast"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { Keybind } from "@/util/keybind"
+
+type SkillEntry = {
+  name: string
+  description: string
+  source?: string
+  path?: string
+  active?: boolean
+}
+
+type SkillDiagnostic = {
+  path?: string
+  message?: string
+  severity?: string
+}
+
+type SkillCatalogPayload = {
+  skills?: SkillEntry[]
+  diagnostics?: SkillDiagnostic[]
+  count?: number
+  diagnostic_count?: number
+  active?: string[]
+}
+
+type SkillOption =
+  | { kind: "skill"; name: string }
+  | { kind: "diagnostic"; index: number }
+  | { kind: "help" }
+
+function Status(props: { active?: boolean; loading?: boolean }) {
+  const { theme } = useTheme()
+  if (props.loading) return <span style={{ fg: theme.textMuted }}>⋯ Activating</span>
+  if (props.active) return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ Active</span>
+  return <span style={{ fg: theme.textMuted }}>○ Available</span>
+}
+
+function installGuidance() {
+  return "Install manually by copying a skill folder into ~/.penguin/skills or .penguin/skills, then refresh this panel."
+}
+
+export function DialogSkills() {
+  const sdk = useSDK()
+  const toast = useToast()
+  const { theme } = useTheme()
+  const [payload, setPayload] = createSignal<SkillCatalogPayload>({})
+  const [loading, setLoading] = createSignal(true)
+  const [activating, setActivating] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string>()
+
+  async function load(refresh = false) {
+    setLoading(true)
+    setError(undefined)
+    const url = new URL("/api/v1/skills", sdk.url)
+    if (sdk.sessionID) url.searchParams.set("session_id", sdk.sessionID)
+    if (refresh) url.searchParams.set("refresh", "true")
+
+    try {
+      const res = await sdk.fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setPayload((await res.json()) as SkillCatalogPayload)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(`Failed to load skills: ${message}`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function activate(name: string) {
+    if (activating() !== null) return
+    setActivating(name)
+    try {
+      const url = new URL(`/api/v1/skills/${encodeURIComponent(name)}/activate`, sdk.url)
+      const res = await sdk.fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sdk.sessionID ?? "default", load_into_context: true }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const result = (await res.json()) as { status?: string; duplicate?: boolean }
+      toast.show({
+        variant: result.duplicate ? "info" : "success",
+        message: result.duplicate ? `${name} already active` : `Activated ${name}`,
+      })
+      await load(false)
+    } catch (err) {
+      toast.error(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setActivating(null)
+    }
+  }
+
+  onMount(() => {
+    load(false)
+  })
+
+  const options = createMemo<DialogSelectOption<SkillOption>[]>(() => {
+    const diagnostics = payload().diagnostics ?? []
+    const skills = payload().skills ?? []
+    const result: DialogSelectOption<SkillOption>[] = []
+
+    if (error()) {
+      result.push({
+        title: "Skills unavailable",
+        value: { kind: "diagnostic", index: -1 },
+        description: error(),
+        footer: "Check penguin-web logs, then reopen this panel.",
+        category: "Diagnostics",
+      })
+    }
+
+    for (const [index, diagnostic] of diagnostics.entries()) {
+      result.push({
+        title: diagnostic.severity ? `${diagnostic.severity}: invalid skill` : "Invalid skill",
+        value: { kind: "diagnostic", index },
+        description: diagnostic.message ?? "Invalid skill diagnostic",
+        footer: diagnostic.path ?? "No path reported",
+        category: "Diagnostics",
+      })
+    }
+
+    for (const skill of skills) {
+      result.push({
+        title: skill.name,
+        value: { kind: "skill", name: skill.name },
+        description: skill.description,
+        footer: <Status active={skill.active} loading={activating() === skill.name} />,
+        category: skill.active ? "Active" : "Available",
+      })
+    }
+
+    result.push({
+      title: "Install skills manually",
+      value: { kind: "help" },
+      description: installGuidance(),
+      footer: "~/.penguin/skills · .penguin/skills",
+      category: "Help",
+    })
+
+    if (loading()) {
+      result.unshift({
+        title: "Loading skills...",
+        value: { kind: "help" },
+        description: "Fetching the Penguin skill catalog from the local server.",
+        footer: <span style={{ fg: theme.textMuted }}>Please wait</span>,
+        category: "Status",
+      })
+    }
+
+    return result
+  })
+
+  const keybinds = createMemo(() => [
+    {
+      keybind: Keybind.parse("space")[0],
+      title: "activate",
+      disabled: activating() !== null,
+      onTrigger: (option: DialogSelectOption<SkillOption>) => {
+        if (option.value.kind !== "skill") return
+        activate(option.value.name)
+      },
+    },
+    {
+      keybind: Keybind.parse("ctrl+r")[0],
+      title: "refresh",
+      disabled: loading(),
+      onTrigger: () => load(true),
+    },
+  ])
+
+  return (
+    <DialogSelect
+      title="Skills"
+      placeholder="Search skills"
+      options={options()}
+      keybind={keybinds()}
+      onSelect={() => {
+        // Deliberately no auto-activation on selection. Use Space to activate.
+      }}
+    />
+  )
+}

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
@@ -31,7 +31,8 @@ type SkillCatalogPayload = {
 type SkillOption =
   | { kind: "skill"; name: string }
   | { kind: "diagnostic"; index: number }
-  | { kind: "help" }
+  | { kind: "help"; id: "install" }
+  | { kind: "status"; id: "loading" | "error" }
 
 function Status(props: { active?: boolean; loading?: boolean }) {
   const { theme } = useTheme()
@@ -42,6 +43,13 @@ function Status(props: { active?: boolean; loading?: boolean }) {
 
 function installGuidance() {
   return "Install manually by copying a skill folder into ~/.penguin/skills or .penguin/skills, then refresh this panel."
+}
+
+function summarize(value: string | undefined, max = 42) {
+  if (!value) return undefined
+  const compact = value.replace(/\s+/g, " ").trim()
+  if (compact.length <= max) return compact
+  return `${compact.slice(0, Math.max(0, max - 1)).trimEnd()}…`
 }
 
 export function DialogSkills() {
@@ -78,10 +86,13 @@ export function DialogSkills() {
     try {
       const action = skill.active ? "deactivate" : "activate"
       const url = new URL(`/api/v1/skills/${encodeURIComponent(skill.name)}/${action}`, sdk.url)
+      const body = skill.active
+        ? { session_id: sdk.sessionID ?? "default" }
+        : { session_id: sdk.sessionID ?? "default", load_into_context: true }
       const res = await sdk.fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ session_id: sdk.sessionID ?? "default", load_into_context: true }),
+        body: JSON.stringify(body),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const result = (await res.json()) as { status?: string; duplicate?: boolean; was_active?: boolean }
@@ -109,8 +120,8 @@ export function DialogSkills() {
     if (error()) {
       result.push({
         title: "Skills unavailable",
-        value: { kind: "diagnostic", index: -1 },
-        description: error(),
+        value: { kind: "status", id: "error" },
+        description: summarize(error(), 52),
         footer: "Check penguin-web logs, then reopen this panel.",
         category: "Diagnostics",
       })
@@ -120,8 +131,8 @@ export function DialogSkills() {
       result.push({
         title: diagnostic.severity ? `${diagnostic.severity}: invalid skill` : "Invalid skill",
         value: { kind: "diagnostic", index },
-        description: diagnostic.message ?? "Invalid skill diagnostic",
-        footer: diagnostic.path ?? "No path reported",
+        description: summarize(diagnostic.message, 52),
+        footer: summarize(diagnostic.path, 48) ?? "No path reported",
         category: "Diagnostics",
       })
     }
@@ -130,7 +141,7 @@ export function DialogSkills() {
       result.push({
         title: skill.name,
         value: { kind: "skill", name: skill.name },
-        description: skill.description,
+        description: summarize(skill.description),
         footer: <Status active={skill.active} loading={activating() === skill.name} />,
         category: skill.active ? "Active" : "Available",
       })
@@ -138,17 +149,17 @@ export function DialogSkills() {
 
     result.push({
       title: "Install skills manually",
-      value: { kind: "help" },
-      description: installGuidance(),
+      value: { kind: "help", id: "install" },
+      description: summarize(installGuidance(), 52),
       footer: "~/.penguin/skills · .penguin/skills",
       category: "Help",
     })
 
-    if (loading()) {
+    if (loading() && skills.length === 0 && diagnostics.length === 0) {
       result.unshift({
         title: "Loading skills...",
-        value: { kind: "help" },
-        description: "Fetching the Penguin skill catalog from the local server.",
+        value: { kind: "status", id: "loading" },
+        description: "Fetching catalog",
         footer: <span style={{ fg: theme.textMuted }}>Please wait</span>,
         category: "Status",
       })
@@ -185,7 +196,7 @@ export function DialogSkills() {
       options={options()}
       keybind={keybinds()}
       onSelect={() => {
-        // Deliberately no auto-activation on selection. Use Space to activate.
+        // Deliberately no auto-activation on selection. Use Space to activate/deactivate.
       }}
     />
   )

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-skills.tsx
@@ -35,7 +35,7 @@ type SkillOption =
 
 function Status(props: { active?: boolean; loading?: boolean }) {
   const { theme } = useTheme()
-  if (props.loading) return <span style={{ fg: theme.textMuted }}>⋯ Activating</span>
+  if (props.loading) return <span style={{ fg: theme.textMuted }}>⋯ Updating</span>
   if (props.active) return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ Active</span>
   return <span style={{ fg: theme.textMuted }}>○ Available</span>
 }
@@ -72,21 +72,22 @@ export function DialogSkills() {
     }
   }
 
-  async function activate(name: string) {
+  async function toggleSkill(skill: SkillEntry) {
     if (activating() !== null) return
-    setActivating(name)
+    setActivating(skill.name)
     try {
-      const url = new URL(`/api/v1/skills/${encodeURIComponent(name)}/activate`, sdk.url)
+      const action = skill.active ? "deactivate" : "activate"
+      const url = new URL(`/api/v1/skills/${encodeURIComponent(skill.name)}/${action}`, sdk.url)
       const res = await sdk.fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ session_id: sdk.sessionID ?? "default", load_into_context: true }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const result = (await res.json()) as { status?: string; duplicate?: boolean }
+      const result = (await res.json()) as { status?: string; duplicate?: boolean; was_active?: boolean }
       toast.show({
-        variant: result.duplicate ? "info" : "success",
-        message: result.duplicate ? `${name} already active` : `Activated ${name}`,
+        variant: result.status === "not_active" || result.duplicate ? "info" : "success",
+        message: skill.active ? `Deactivated ${skill.name}` : `Activated ${skill.name}`,
       })
       await load(false)
     } catch (err) {
@@ -159,11 +160,14 @@ export function DialogSkills() {
   const keybinds = createMemo(() => [
     {
       keybind: Keybind.parse("space")[0],
-      title: "activate",
+      title: "toggle",
       disabled: activating() !== null,
       onTrigger: (option: DialogSelectOption<SkillOption>) => {
-        if (option.value.kind !== "skill") return
-        activate(option.value.name)
+        const selected = option.value
+        if (selected.kind !== "skill") return
+        const skill = payload().skills?.find((entry) => entry.name === selected.name)
+        if (!skill) return
+        toggleSkill(skill)
       },
     },
     {

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -362,6 +362,10 @@ app.add_typer(agent_app, name="agent")
 config_app = typer.Typer(help="Configuration management commands")
 app.add_typer(config_app, name="config")
 
+# Skills sub-application
+skill_app = typer.Typer(help="Agent Skills discovery and activation commands")
+app.add_typer(skill_app, name="skill")
+
 T = TypeVar("T")
 
 # Global core components - initialized by _initialize_core_components_globally
@@ -737,6 +741,212 @@ async def _run_penguin_direct_prompt(prompt_text: str, output_format: str):
             f"[red]Error: Unknown output format '{output_format}'. Valid options are 'text', 'json', 'stream-json'.[/red]"
         )
         raise typer.Exit(code=1)
+
+
+async def _get_skill_manager_for_cli(workspace: Optional[Path] = None):
+    """Initialize Penguin and return the runtime SkillManager for CLI commands."""
+    await _initialize_core_components_globally(workspace_override=workspace)
+    manager = None
+    if _core is not None:
+        conversation_manager = getattr(_core, "conversation_manager", None)
+        manager = getattr(conversation_manager, "skill_manager", None)
+    if manager is None and _tool_manager is not None:
+        manager = getattr(_tool_manager, "skill_manager", None)
+    if manager is None:
+        console.print("[red]Error: Skill manager not available[/red]")
+        raise typer.Exit(code=1)
+    manager.refresh()
+    return manager
+
+
+def _print_skill_diagnostics(diagnostics: List[Any]) -> None:
+    """Print skill diagnostics clearly for humans."""
+    if not diagnostics:
+        console.print("[green]✓ No invalid skill diagnostics.[/green]")
+        return
+
+    from rich.table import Table
+
+    table = Table(title="Skill Diagnostics")
+    table.add_column("Severity", style="bold")
+    table.add_column("Code")
+    table.add_column("Source")
+    table.add_column("Path")
+    table.add_column("Message")
+    for diagnostic in diagnostics:
+        severity = getattr(diagnostic, "severity", "unknown")
+        color = "red" if severity == "error" else "yellow"
+        table.add_row(
+            f"[{color}]{severity}[/{color}]",
+            str(getattr(diagnostic, "code", "")),
+            str(getattr(diagnostic, "source", "")),
+            str(getattr(diagnostic, "path", "")),
+            str(getattr(diagnostic, "message", "")),
+        )
+    console.print(table)
+
+
+def _manual_skill_install_message() -> str:
+    return (
+        "Manual install: copy a skill folder containing SKILL.md into "
+        "~/.penguin/skills/<skill-name>/ for user skills or "
+        ".penguin/skills/<skill-name>/ for trusted project skills."
+    )
+
+
+@skill_app.command("list")
+def skill_list(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    workspace: Optional[Path] = typer.Option(None, "--workspace", help="Workspace path override"),
+):
+    """List discovered Agent Skills."""
+
+    async def _run() -> None:
+        manager = await _get_skill_manager_for_cli(workspace)
+        payload = manager.list_payload()
+        if json_output:
+            console.print(json.dumps(payload, indent=2))
+            return
+
+        from rich.table import Table
+
+        skills = payload.get("skills", [])
+        if not skills:
+            console.print("[yellow]No skills discovered.[/yellow]")
+            console.print(f"[dim]{_manual_skill_install_message()}[/dim]")
+        else:
+            table = Table(title="Agent Skills")
+            table.add_column("Name", style="cyan")
+            table.add_column("Source")
+            table.add_column("Description")
+            table.add_column("Path", style="dim")
+            for skill in skills:
+                table.add_row(
+                    str(skill.get("name", "")),
+                    str(skill.get("source", "")),
+                    str(skill.get("description", "")),
+                    str(skill.get("path", "")),
+                )
+            console.print(table)
+
+        diagnostics = payload.get("diagnostics", [])
+        if diagnostics:
+            console.print(f"[yellow]{len(diagnostics)} invalid skill diagnostic(s). Run `penguin skill doctor` for details.[/yellow]")
+
+    asyncio.run(_run())
+
+
+@skill_app.command("show")
+def skill_show(
+    name: str = typer.Argument(..., help="Skill name"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    workspace: Optional[Path] = typer.Option(None, "--workspace", help="Workspace path override"),
+):
+    """Show full SKILL.md instructions for a discovered skill."""
+
+    async def _run() -> None:
+        manager = await _get_skill_manager_for_cli(workspace)
+        skill = manager.get(name)
+        if skill is None:
+            available = [entry.name for entry in manager.catalog()]
+            if json_output:
+                console.print(json.dumps({"error": f"Skill not found: {name}", "available_skills": available}, indent=2))
+            else:
+                console.print(f"[red]Skill not found:[/red] {name}")
+                if available:
+                    console.print(f"[dim]Available: {', '.join(available)}[/dim]")
+            raise typer.Exit(code=1)
+
+        payload = {
+            "name": skill.name,
+            "description": skill.description,
+            "source": skill.source,
+            "path": str(skill.path),
+            "skill_file": str(skill.skill_file),
+            "allowed_tools": skill.allowed_tools,
+            "frontmatter": skill.frontmatter,
+            "body": skill.body,
+        }
+        if json_output:
+            console.print(json.dumps(payload, indent=2))
+            return
+
+        console.print(Panel(
+            Markdown(skill.body or "_No body content._"),
+            title=f"Skill: {skill.name}",
+            subtitle=f"{skill.source} · {skill.path}",
+            border_style="cyan",
+        ))
+        console.print(f"[bold]Description:[/bold] {skill.description}")
+        if skill.allowed_tools:
+            console.print(f"[bold]Allowed tools hint:[/bold] {', '.join(skill.allowed_tools)}")
+
+    asyncio.run(_run())
+
+
+@skill_app.command("activate")
+def skill_activate(
+    name: str = typer.Argument(..., help="Skill name"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    show_content: bool = typer.Option(False, "--show-content", help="Print rendered activation content"),
+    workspace: Optional[Path] = typer.Option(None, "--workspace", help="Workspace path override"),
+):
+    """Activate a skill and load it into the current session as CONTEXT."""
+
+    async def _run() -> None:
+        await _get_skill_manager_for_cli(workspace)
+        skill_tools = getattr(_tool_manager, "skill_tools", None) if _tool_manager is not None else None
+        if skill_tools is None:
+            console.print("[red]Error: Skill tools not available[/red]")
+            raise typer.Exit(code=1)
+
+        result = json.loads(skill_tools.activate_skill(name))
+        if json_output:
+            console.print(json.dumps(result, indent=2))
+            return
+
+        status = result.get("status")
+        if status == "not_found":
+            console.print(f"[red]{result.get('error', 'Skill not found')}[/red]")
+            available = result.get("available_skills", [])
+            if available:
+                console.print(f"[dim]Available: {', '.join(available)}[/dim]")
+            raise typer.Exit(code=1)
+
+        skill = result.get("skill", {})
+        duplicate = bool(result.get("duplicate"))
+        verb = "Already active" if duplicate else "Activated"
+        console.print(f"[green]✓ {verb} skill:[/green] {skill.get('name', name)}")
+        console.print("[dim]Activation content is loaded as a MessageCategory.CONTEXT message for this runtime session.[/dim]")
+        console.print(f"[dim]Path: {skill.get('path', '')}[/dim]")
+        if show_content:
+            console.print(Panel(result.get("content", ""), title="Activation Content", border_style="cyan"))
+
+    asyncio.run(_run())
+
+
+@skill_app.command("doctor")
+def skill_doctor(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    workspace: Optional[Path] = typer.Option(None, "--workspace", help="Workspace path override"),
+):
+    """Validate discovered skill directories and show install guidance."""
+
+    async def _run() -> None:
+        manager = await _get_skill_manager_for_cli(workspace)
+        payload = manager.list_payload()
+        diagnostics = manager.diagnostics
+        if json_output:
+            console.print(json.dumps(payload, indent=2))
+            return
+
+        console.print("[bold cyan]Agent Skills Doctor[/bold cyan]")
+        console.print(f"Discovered valid skills: [bold]{len(payload.get('skills', []))}[/bold]")
+        _print_skill_diagnostics(diagnostics)
+        console.print(f"[dim]{_manual_skill_install_message()}[/dim]")
+        console.print("[dim]Project skills are ignored unless project skill trust is enabled in config.[/dim]")
+
+    asyncio.run(_run())
 
 
 async def _run_interactive_chat():

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -595,11 +595,12 @@ async def _initialize_core_components_globally(
 
     effective_fast_startup = fast_startup_override or config_fast_startup
 
-    # Convert config to dict format for ToolManager
+    # Convert config to dict format for ToolManager while preserving typed fields
+    # like `skills` that are not present in a raw dataclass `__dict__` shape.
     config_dict = (
-        _loaded_config.__dict__
-        if hasattr(_loaded_config, "__dict__")
-        else _loaded_config
+        _loaded_config.to_dict()
+        if hasattr(_loaded_config, "to_dict")
+        else (_loaded_config.__dict__ if hasattr(_loaded_config, "__dict__") else _loaded_config)
     )
     _tool_manager = ToolManager(
         config_dict, log_error, fast_startup=effective_fast_startup
@@ -805,7 +806,7 @@ def skill_list(
         manager = await _get_skill_manager_for_cli(workspace)
         payload = manager.list_payload()
         if json_output:
-            console.print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2))
             return
 
         from rich.table import Table
@@ -850,7 +851,7 @@ def skill_show(
         if skill is None:
             available = [entry.name for entry in manager.catalog()]
             if json_output:
-                console.print(json.dumps({"error": f"Skill not found: {name}", "available_skills": available}, indent=2))
+                print(json.dumps({"error": f"Skill not found: {name}", "available_skills": available}, indent=2))
             else:
                 console.print(f"[red]Skill not found:[/red] {name}")
                 if available:
@@ -868,7 +869,7 @@ def skill_show(
             "body": skill.body,
         }
         if json_output:
-            console.print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2))
             return
 
         console.print(Panel(
@@ -902,7 +903,7 @@ def skill_activate(
 
         result = json.loads(skill_tools.activate_skill(name))
         if json_output:
-            console.print(json.dumps(result, indent=2))
+            print(json.dumps(result, indent=2))
             return
 
         status = result.get("status")
@@ -937,7 +938,7 @@ def skill_doctor(
         payload = manager.list_payload()
         diagnostics = manager.diagnostics
         if json_output:
-            console.print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2))
             return
 
         console.print("[bold cyan]Agent Skills Doctor[/bold cyan]")

--- a/penguin/cli/entrypoint.py
+++ b/penguin/cli/entrypoint.py
@@ -24,6 +24,7 @@ _CLI_COMMANDS = {
     "perf_test",
     "profile",
     "project",
+    "skill",
 }
 
 _CLI_FLAGS = {

--- a/penguin/config.py
+++ b/penguin/config.py
@@ -1340,6 +1340,7 @@ class Config:
     fast_startup: bool = field(default=False)
     model_configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     agent_personas: Dict[str, AgentPersonaConfig] = field(default_factory=dict)
+    skills: Dict[str, Any] = field(default_factory=dict)
     
     # Dictionary-like access to model settings
     @property
@@ -1386,6 +1387,8 @@ class Config:
             self.model_configs = {}
         if self.agent_personas is None:
             self.agent_personas = {}
+        if self.skills is None:
+            self.skills = {}
         if self.output is None:
             self.output = OutputConfig()
 
@@ -1525,6 +1528,7 @@ class Config:
             diagnostics=diagnostics_config,
             security=security_config,
             output=output_config,
+            skills=config_data.get("skills", {}) if isinstance(config_data.get("skills", {}), dict) else {},
             fast_startup=config_data.get("performance", {}).get("fast_startup", False),
             model_configs=model_configs_section,
             agent_personas=agent_personas,
@@ -1552,6 +1556,7 @@ class Config:
                 "show_tool_results": getattr(self.output, "show_tool_results", True),
             },
             "workspace_dir": str(self.workspace_dir),
+            "skills": dict(self.skills),
             "cache_dir": str(self.cache_dir),
             "workspace_path": str(self.workspace_path),
             "model_configs": self.model_configs,

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -773,12 +773,18 @@ class PenguinCore:
             max_sessions_in_memory=20,
             auto_save_interval=60,
             checkpoint_config=checkpoint_config,
+            skills_config=self.config.to_dict() if hasattr(self.config, "to_dict") else {},
+            project_root=getattr(self.tool_manager, "project_root", None),
         )
         # Attach a back-reference so Engine (and other helpers) can emit UI events
-        # and finalize streaming messages via the Core.  Without this the Engine
+        # and finalize streaming messages via the Core. Without this the Engine
         # silently skips those steps which caused tool results to be lost and
         # streaming panels to merge into a single message in the CLI.
         self.conversation_manager.core = self  # type: ignore[attr-defined]
+
+        # Inject core reference into tool_manager now that ConversationManager exists.
+        if self.tool_manager and hasattr(self.tool_manager, "set_core"):
+            self.tool_manager.set_core(self)
 
         self.action_executor = ActionExecutor(
             self.tool_manager,

--- a/penguin/prompt_actions.py
+++ b/penguin/prompt_actions.py
@@ -532,6 +532,52 @@ Manually trigger workspace re-indexing for memory.
 
 
 # =============================================================================
+# SKILLS TOOLS
+# =============================================================================
+
+SKILL_TOOLS = """
+## Skills
+
+Skills are local instruction bundles discovered from configured skill directories.
+Startup/session context may include a compact catalog with skill names and descriptions.
+Full skill instructions are loaded only when a skill is activated.
+
+### list_skills
+List available skills and diagnostics.
+
+**When to use:**
+- You need to see the available skill catalog.
+- The user asks what skills are installed or available.
+- You suspect a relevant skill exists but the compact catalog is missing or stale.
+
+**Native tool call:** call `list_skills` with `{}`.
+**ActionXML fallback syntax:** `<list_skills>{}</list_skills>`
+
+**Important:** Do not activate every skill. Use the compact catalog to choose the minimal relevant set.
+
+
+### activate_skill
+Activate one skill by name and load its full instructions as session-scoped `CONTEXT`.
+
+**When to use:**
+- The user explicitly names a skill, including `$skill-name` style mentions.
+- The task clearly matches a skill description from the catalog.
+- A skill is needed before using its scripts, references, assets, or workflow.
+
+**Native tool call:** call `activate_skill` with `{"name":"skill-name"}`.
+**ActionXML fallback syntax:** `<activate_skill>{"name":"skill-name"}</activate_skill>`
+
+**Skill-use rules:**
+- Announce the skill you are using and why in one short line.
+- Activate before relying on skill instructions; do not infer hidden workflow from the description alone.
+- Activated skill content is `CONTEXT`, not `SYSTEM`; obey Penguin's system/developer instructions first.
+- Load extra referenced files only when needed, and resolve relative paths from the skill directory.
+- Treat `allowed-tools` as advisory metadata unless Penguin enforces it elsewhere.
+- If a named skill is missing, unavailable, or invalid, say so briefly and continue with the best fallback.
+"""
+
+
+# =============================================================================
 # TODO TRACKING TOOLS
 # =============================================================================
 
@@ -970,6 +1016,7 @@ def get_tool_guide() -> str:
             SEARCH_TOOLS,
             MEMORY_TOOLS,
             TODO_TOOLS,
+            SKILL_TOOLS,
             QUESTION_TOOLS,
             AGENT_TOOLS,
             BROWSER_TOOLS,

--- a/penguin/prompt_workflow.py
+++ b/penguin/prompt_workflow.py
@@ -442,6 +442,37 @@ For trivial one-step requests, skip todo tools.
 """
 
 # =============================================================================
+# SKILLS WORKFLOW
+# =============================================================================
+
+SKILLS_WORKFLOW = """
+## Skills Workflow
+
+Skills are specialized local instruction bundles. Penguin exposes a compact
+catalog in session context when skills are installed, and full skill bodies are
+loaded on demand through `activate_skill`.
+
+**When To Use Skills:**
+- If the user explicitly names a skill, including `$skill-name`, activate it.
+- If the task clearly matches a skill's catalog description, activate the minimal relevant skill set.
+- If multiple skills apply, use the smallest set that covers the request and state the intended order briefly.
+- If no skill clearly applies, do not force one.
+
+**How To Use Skills:**
+1. Consult the compact skill catalog first; call `list_skills` if the catalog is missing or stale.
+2. Call `activate_skill` before relying on a skill's workflow, scripts, references, or assets.
+3. Treat activated skill content as `CONTEXT`, not `SYSTEM`; Penguin's system/developer instructions remain higher priority.
+4. Resolve relative resource paths from the skill directory and load only the files needed for the current task.
+5. Prefer skill-provided scripts/templates over retyping large logic, but run them through normal Penguin tools and permission gates.
+6. If a named skill is unavailable, invalid, or missing files, say so briefly and continue with the best fallback.
+
+**Context Hygiene:**
+- Do not bulk-load every reference file in a skill.
+- Summarize long skill references when possible.
+- Do not carry skill activation assumptions across unrelated tasks unless the active context still contains the skill and it remains relevant.
+"""
+
+# =============================================================================
 # 247 JOURNAL SYSTEM (Session Continuity)
 # =============================================================================
 
@@ -575,6 +606,8 @@ WORKFLOW_GUIDE = (
     + CODE_FORMATTING
     + "\\n\\n"
     + TODO_WORKFLOW
+    + "\\n\\n"
+    + SKILLS_WORKFLOW
     + "\\n\\n"
     + COMPLETION_GUIDE
 )

--- a/penguin/skills/__init__.py
+++ b/penguin/skills/__init__.py
@@ -1,0 +1,6 @@
+"""Agent Skills support for Penguin."""
+
+from penguin.skills.manager import SkillManager
+from penguin.skills.models import Skill, SkillCatalogEntry, SkillDiagnostic
+
+__all__ = ["Skill", "SkillCatalogEntry", "SkillDiagnostic", "SkillManager"]

--- a/penguin/skills/discovery.py
+++ b/penguin/skills/discovery.py
@@ -1,0 +1,174 @@
+"""Skill discovery across configured user and project paths."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from penguin.skills.models import Skill, SkillDiagnostic
+from penguin.skills.parser import SkillParseError, parse_skill_file
+
+DEFAULT_USER_SCAN_PATHS = [
+    "~/.penguin/skills",
+    "~/.agents/skills",
+    "~/.claude/skills",
+]
+DEFAULT_PROJECT_SCAN_PATHS = [
+    ".penguin/skills",
+    ".agents/skills",
+]
+
+
+def _config_get(config: Any, *keys: str, default: Any = None) -> Any:
+    current = config
+    for key in keys:
+        if isinstance(current, dict):
+            current = current.get(key, default)
+        else:
+            current = getattr(current, key, default)
+        if current is default:
+            return default
+    return current
+
+
+def get_skills_config(config: Any) -> Dict[str, Any]:
+    """Return normalized skills configuration."""
+    raw = _config_get(config, "skills", default={}) or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    return {
+        "enabled": raw.get("enabled", True),
+        "trust_project_skills": raw.get("trust_project_skills", False),
+        "scan_paths": raw.get("scan_paths", {}) if isinstance(raw.get("scan_paths", {}), dict) else {},
+        "max_scan_depth": int(raw.get("max_scan_depth", 6)),
+        "max_skill_dirs": int(raw.get("max_skill_dirs", 2000)),
+    }
+
+
+def _expand_paths(paths: Iterable[str], *, root: Optional[Path] = None) -> List[Path]:
+    expanded: List[Path] = []
+    for raw_path in paths:
+        path = Path(os.path.expandvars(str(raw_path))).expanduser()
+        if not path.is_absolute() and root is not None:
+            path = root / path
+        expanded.append(path.resolve())
+    return expanded
+
+
+def configured_scan_roots(
+    config: Any,
+    *,
+    project_root: Optional[Union[str, Path]] = None,
+) -> List[Tuple[Path, str]]:
+    """Resolve configured scan roots as `(path, source)` tuples."""
+    skills_config = get_skills_config(config)
+    scan_paths = skills_config["scan_paths"]
+    project_base = Path(project_root or os.environ.get("PENGUIN_PROJECT_ROOT") or os.getcwd()).resolve()
+
+    user_paths = scan_paths.get("user", DEFAULT_USER_SCAN_PATHS)
+    project_paths = scan_paths.get("project", DEFAULT_PROJECT_SCAN_PATHS)
+
+    roots: List[Tuple[Path, str]] = [(path, "user") for path in _expand_paths(user_paths)]
+    if skills_config["trust_project_skills"]:
+        roots.extend((path, "project") for path in _expand_paths(project_paths, root=project_base))
+    return roots
+
+
+def _depth_from_root(path: Path, root: Path) -> int:
+    try:
+        return len(path.relative_to(root).parts)
+    except ValueError:
+        return 999999
+
+
+def discover_skills(
+    config: Any,
+    *,
+    project_root: Optional[Union[str, Path]] = None,
+) -> Tuple[List[Skill], List[SkillDiagnostic]]:
+    """Discover valid skills and diagnostics from configured roots."""
+    skills_config = get_skills_config(config)
+    diagnostics: List[SkillDiagnostic] = []
+    if not skills_config["enabled"]:
+        return [], diagnostics
+
+    max_depth = max(0, skills_config["max_scan_depth"])
+    max_skill_dirs = max(1, skills_config["max_skill_dirs"])
+    candidates: List[Tuple[Path, str]] = []
+
+    for root, source in configured_scan_roots(config, project_root=project_root):
+        if not root.exists():
+            continue
+        if not root.is_dir():
+            diagnostics.append(
+                SkillDiagnostic(
+                    path=str(root),
+                    severity="warning",
+                    code="scan_root_not_directory",
+                    message="Configured skill scan path is not a directory",
+                    source=source,
+                )
+            )
+            continue
+
+        for skill_file in root.rglob("SKILL.md"):
+            if _depth_from_root(skill_file.parent, root) > max_depth:
+                diagnostics.append(
+                    SkillDiagnostic(
+                        path=str(skill_file),
+                        severity="warning",
+                        code="max_depth_exceeded",
+                        message=f"Skill exceeds max_scan_depth={max_depth}",
+                        source=source,
+                    )
+                )
+                continue
+            candidates.append((skill_file, source))
+            if len(candidates) >= max_skill_dirs:
+                diagnostics.append(
+                    SkillDiagnostic(
+                        path=str(root),
+                        severity="warning",
+                        code="max_skill_dirs_reached",
+                        message=f"Stopped skill discovery after {max_skill_dirs} candidates",
+                        source=source,
+                    )
+                )
+                break
+
+    valid: List[Skill] = []
+    seen: Dict[str, Skill] = {}
+    for skill_file, source in candidates:
+        try:
+            skill = parse_skill_file(skill_file, source=source)
+        except SkillParseError as exc:
+            diagnostics.append(
+                SkillDiagnostic(
+                    path=str(skill_file),
+                    severity="error",
+                    code="invalid_skill",
+                    message=str(exc),
+                    source=source,
+                )
+            )
+            continue
+
+        previous = seen.get(skill.name)
+        if previous is not None:
+            diagnostics.append(
+                SkillDiagnostic(
+                    path=str(skill.skill_file),
+                    severity="warning",
+                    code="duplicate_skill_name",
+                    message=f"Duplicate skill name `{skill.name}` ignored; first match kept at {previous.skill_file}",
+                    source=source,
+                    skill_name=skill.name,
+                )
+            )
+            continue
+        seen[skill.name] = skill
+        valid.append(skill)
+
+    valid.sort(key=lambda item: item.name)
+    return valid, diagnostics

--- a/penguin/skills/manager.py
+++ b/penguin/skills/manager.py
@@ -96,3 +96,29 @@ class SkillManager:
             ).__dict__,
             "content": render_activation(skill, max_resources=max_resources),
         }
+
+    def deactivate(self, name: str, *, session_id: str = "default") -> Dict[str, Any]:
+        """Deactivate a skill for a session."""
+        skill = self.get(name)
+        if skill is None:
+            return {
+                "status": "not_found",
+                "error": f"Skill not found: {name}",
+                "available_skills": [entry.name for entry in self.catalog()],
+            }
+
+        activated = self._activated_by_session.setdefault(session_id, set())
+        was_active = name in activated
+        if was_active:
+            activated.remove(name)
+
+        return {
+            "status": "deactivated" if was_active else "not_active",
+            "was_active": was_active,
+            "skill": SkillCatalogEntry(
+                name=skill.name,
+                description=skill.description,
+                source=skill.source,
+                path=str(skill.path),
+            ).__dict__,
+        }

--- a/penguin/skills/manager.py
+++ b/penguin/skills/manager.py
@@ -1,0 +1,90 @@
+"""Skill manager for discovery, catalog state, activation, and session dedupe."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from penguin.skills.discovery import discover_skills
+from penguin.skills.models import Skill, SkillCatalogEntry, SkillDiagnostic
+from penguin.skills.renderer import render_activation, render_catalog
+
+
+class SkillManager:
+    """Coordinates skill discovery and activation for a Penguin runtime."""
+
+    def __init__(self, config: Any, *, project_root: Optional[Union[str, Path]] = None):
+        self.config = config
+        self.project_root = Path(project_root).resolve() if project_root is not None else None
+        self._skills: Dict[str, Skill] = {}
+        self._diagnostics: List[SkillDiagnostic] = []
+        self._activated_by_session: Dict[str, set[str]] = {}
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Refresh discovered skills from disk."""
+        skills, diagnostics = discover_skills(self.config, project_root=self.project_root)
+        self._skills = {skill.name: skill for skill in skills}
+        self._diagnostics = diagnostics
+
+    @property
+    def diagnostics(self) -> List[SkillDiagnostic]:
+        return list(self._diagnostics)
+
+    def catalog(self) -> List[SkillCatalogEntry]:
+        """Return compact catalog entries sorted by name."""
+        return [
+            SkillCatalogEntry(
+                name=skill.name,
+                description=skill.description,
+                source=skill.source,
+                path=str(skill.path),
+            )
+            for skill in sorted(self._skills.values(), key=lambda item: item.name)
+        ]
+
+    def render_catalog_context(self) -> str:
+        """Render compact catalog for startup/session CONTEXT loading."""
+        return render_catalog(self.catalog())
+
+    def get(self, name: str) -> Optional[Skill]:
+        return self._skills.get(name)
+
+    def list_payload(self) -> Dict[str, Any]:
+        return {
+            "skills": [entry.__dict__ for entry in self.catalog()],
+            "diagnostics": [diagnostic.__dict__ for diagnostic in self.diagnostics],
+        }
+
+    def activate(
+        self,
+        name: str,
+        *,
+        session_id: str = "default",
+        max_resources: int = 200,
+    ) -> Dict[str, Any]:
+        """Activate a skill for a session and return rendered content."""
+        skill = self.get(name)
+        if skill is None:
+            return {
+                "status": "not_found",
+                "error": f"Skill not found: {name}",
+                "available_skills": [entry.name for entry in self.catalog()],
+            }
+
+        activated = self._activated_by_session.setdefault(session_id, set())
+        duplicate = name in activated
+        if not duplicate:
+            activated.add(name)
+
+        return {
+            "status": "already_active" if duplicate else "activated",
+            "duplicate": duplicate,
+            "skill": SkillCatalogEntry(
+                name=skill.name,
+                description=skill.description,
+                source=skill.source,
+                path=str(skill.path),
+            ).__dict__,
+            "content": render_activation(skill, max_resources=max_resources),
+        }

--- a/penguin/skills/manager.py
+++ b/penguin/skills/manager.py
@@ -56,6 +56,14 @@ class SkillManager:
             "diagnostics": [diagnostic.__dict__ for diagnostic in self.diagnostics],
         }
 
+    def active_names(self, session_id: str = "default") -> List[str]:
+        """Return activated skill names for a session."""
+        return sorted(self._activated_by_session.get(session_id, set()))
+
+    def is_active(self, name: str, session_id: str = "default") -> bool:
+        """Check whether a skill is already active for a session."""
+        return name in self._activated_by_session.get(session_id, set())
+
     def activate(
         self,
         name: str,

--- a/penguin/skills/models.py
+++ b/penguin/skills/models.py
@@ -1,0 +1,43 @@
+"""Data models for Agent Skills integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class Skill:
+    """A parsed skill directory containing a valid SKILL.md file."""
+
+    name: str
+    description: str
+    path: Path
+    skill_file: Path
+    body: str
+    frontmatter: Dict[str, Any] = field(default_factory=dict)
+    allowed_tools: List[str] = field(default_factory=list)
+    source: str = "project"
+
+
+@dataclass(frozen=True)
+class SkillCatalogEntry:
+    """Compact skill information safe to disclose at startup."""
+
+    name: str
+    description: str
+    source: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillDiagnostic:
+    """Discovery or validation diagnostic for a candidate skill."""
+
+    path: str
+    severity: str
+    code: str
+    message: str
+    source: str = "unknown"
+    skill_name: Optional[str] = None

--- a/penguin/skills/parser.py
+++ b/penguin/skills/parser.py
@@ -1,0 +1,109 @@
+"""Parser and validation for Agent Skills `SKILL.md` files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, Tuple, Union
+
+import yaml
+
+from penguin.skills.models import Skill
+
+
+class SkillParseError(ValueError):
+    """Raised when a SKILL.md file is malformed or invalid."""
+
+
+_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+_MAX_DESCRIPTION_CHARS = 1024
+_OPTIONAL_LIST_FIELDS = ("allowed-tools", "allowed_tools")
+
+
+def split_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
+    """Split YAML frontmatter from markdown body."""
+    if not text.startswith("---\n") and text != "---":
+        raise SkillParseError("SKILL.md must start with YAML frontmatter")
+
+    end = text.find("\n---", 4)
+    if end == -1:
+        raise SkillParseError("SKILL.md frontmatter is missing a closing delimiter")
+
+    raw_frontmatter = text[4:end]
+    body_start = end + len("\n---")
+    if body_start < len(text) and text[body_start] == "\n":
+        body_start += 1
+
+    try:
+        frontmatter = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as exc:
+        raise SkillParseError(f"Invalid YAML frontmatter: {exc}") from exc
+
+    if not isinstance(frontmatter, dict):
+        raise SkillParseError("SKILL.md frontmatter must be a mapping")
+
+    return frontmatter, text[body_start:]
+
+
+def _validate_name(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SkillParseError("Skill frontmatter requires a non-empty string `name`")
+    name = value.strip()
+    if not _NAME_RE.match(name):
+        raise SkillParseError(
+            "Skill `name` must be lowercase kebab-case, 1-64 chars, using a-z, 0-9, and hyphen"
+        )
+    return name
+
+
+def _validate_description(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SkillParseError("Skill frontmatter requires a non-empty string `description`")
+    description = " ".join(value.strip().split())
+    if len(description) > _MAX_DESCRIPTION_CHARS:
+        raise SkillParseError(
+            f"Skill `description` must be <= {_MAX_DESCRIPTION_CHARS} characters"
+        )
+    return description
+
+
+def _validate_allowed_tools(frontmatter: Dict[str, Any]) -> list[str]:
+    tools_value = None
+    for field_name in _OPTIONAL_LIST_FIELDS:
+        if field_name in frontmatter:
+            tools_value = frontmatter[field_name]
+            break
+
+    if tools_value is None:
+        return []
+    if not isinstance(tools_value, list) or not all(
+        isinstance(item, str) and item.strip() for item in tools_value
+    ):
+        raise SkillParseError("Skill `allowed-tools` must be a list of non-empty strings")
+    return [item.strip() for item in tools_value]
+
+
+def parse_skill_file(path: Union[str, Path], *, source: str = "project") -> Skill:
+    """Parse and validate a SKILL.md file."""
+    skill_file = Path(path).expanduser().resolve()
+    if skill_file.name != "SKILL.md":
+        raise SkillParseError("Skill file must be named SKILL.md")
+    if not skill_file.exists() or not skill_file.is_file():
+        raise SkillParseError(f"Skill file not found: {skill_file}")
+
+    text = skill_file.read_text(encoding="utf-8")
+    frontmatter, body = split_frontmatter(text)
+    name = _validate_name(frontmatter.get("name"))
+    description = _validate_description(frontmatter.get("description"))
+    allowed_tools = _validate_allowed_tools(frontmatter)
+
+    return Skill(
+        name=name,
+        description=description,
+        path=skill_file.parent,
+        skill_file=skill_file,
+        body=body.strip(),
+        frontmatter=frontmatter,
+        allowed_tools=allowed_tools,
+        source=source,
+    )

--- a/penguin/skills/renderer.py
+++ b/penguin/skills/renderer.py
@@ -1,0 +1,60 @@
+"""Rendering helpers for skills catalog and activation payloads."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from penguin.skills.models import Skill, SkillCatalogEntry
+
+
+_RESOURCE_IGNORE_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv"}
+
+
+def render_catalog(entries: Iterable[SkillCatalogEntry]) -> str:
+    """Render compact skill catalog for CONTEXT injection."""
+    entries = list(entries)
+    if not entries:
+        return ""
+
+    lines = [
+        "# Available Agent Skills",
+        "",
+        "Skills are optional task-specific instructions. Use `activate_skill` to load full skill instructions when relevant.",
+        "",
+    ]
+    for entry in entries:
+        lines.append(f"- `{entry.name}` ({entry.source}): {entry.description}")
+    return "\n".join(lines)
+
+
+def list_skill_resources(skill: Skill, *, max_resources: int = 200) -> List[str]:
+    """List non-SKILL.md files under a skill directory."""
+    resources: List[str] = []
+    root = skill.path
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(root)
+        if rel.name == "SKILL.md" or any(part in _RESOURCE_IGNORE_DIRS for part in rel.parts):
+            continue
+        resources.append(str(rel))
+        if len(resources) >= max_resources:
+            break
+    return resources
+
+
+def render_activation(skill: Skill, *, max_resources: int = 200) -> str:
+    """Render an activated skill in structured XML-like wrappers."""
+    resources = list_skill_resources(skill, max_resources=max_resources)
+    lines = [
+        f'<skill_content name="{skill.name}" source="{skill.source}" path="{skill.path}">',
+        skill.body,
+        "</skill_content>",
+    ]
+    if resources:
+        lines.extend([
+            f'<skill_resources name="{skill.name}">',
+            *[f"- {resource}" for resource in resources],
+            "</skill_resources>",
+        ])
+    return "\n".join(lines).strip()

--- a/penguin/system/conversation_manager.py
+++ b/penguin/system/conversation_manager.py
@@ -50,6 +50,8 @@ class ConversationManager:
         max_sessions_in_memory: int = 20,
         auto_save_interval: int = 60,
         checkpoint_config: Optional[CheckpointConfig] = None,
+        skills_config: Optional[Dict[str, Any]] = None,
+        project_root: Optional[Path] = None,
     ):
         """
         Initialize the conversation manager.
@@ -61,6 +63,8 @@ class ConversationManager:
             system_prompt: Initial system prompt
             max_messages_per_session: Maximum messages before creating a new session
             max_sessions_in_memory: Maximum sessions to keep in memory cache
+            skills_config: Optional Skills subsystem configuration
+            project_root: Root used for project-local skill discovery
             auto_save_interval: Seconds between auto-saves (0 to disable)
             checkpoint_config: Configuration for checkpointing system
         """
@@ -167,6 +171,30 @@ class ConversationManager:
                     )
             except Exception as e:
                 logger.debug(f"Project docs autoload skipped due to error: {e}")
+
+        # Auto-load compact Agent Skills catalog into CONTEXT if skills are enabled.
+        # Full skill instructions are loaded later through activate_skill and remain
+        # normal CONTEXT messages, subject to existing category truncation rules.
+        self.skill_manager = None
+        try:
+            from penguin.skills.manager import SkillManager
+
+            skill_runtime_config = skills_config or global_config
+            skill_project_root = project_root or self.workspace_path
+            self.skill_manager = SkillManager(
+                skill_runtime_config,
+                project_root=skill_project_root,
+            )
+            catalog_context = self.skill_manager.render_catalog_context()
+            if catalog_context:
+                message = self.conversation.add_context(
+                    catalog_context,
+                    source="skills_catalog",
+                )
+                message.metadata["type"] = "skills_catalog"
+                logger.info("Skills catalog autoloaded into CONTEXT")
+        except Exception as e:
+            logger.debug(f"Skills catalog autoload skipped due to error: {e}")
 
         # -----------------------------------------------------------
         # Snapshot / Restore support (Phase 3)

--- a/penguin/tools/core/skill_tools.py
+++ b/penguin/tools/core/skill_tools.py
@@ -1,0 +1,59 @@
+"""Tool helpers for listing and activating Agent Skills."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from penguin.skills.manager import SkillManager
+from penguin.system.state import MessageCategory
+
+
+class SkillTools:
+    """Adapter exposing SkillManager operations as Penguin tools."""
+
+    def __init__(self, manager: SkillManager, *, conversation_manager: Any = None):
+        self.manager = manager
+        self.conversation_manager = conversation_manager
+
+    def list_skills(self, refresh: bool = False) -> str:
+        if refresh:
+            self.manager.refresh()
+        return json.dumps(self.manager.list_payload(), indent=2)
+
+    def activate_skill(
+        self,
+        name: str,
+        session_id: Optional[str] = None,
+        load_into_context: bool = True,
+    ) -> str:
+        resolved_session_id = session_id or self._current_session_id() or "default"
+        result = self.manager.activate(name, session_id=resolved_session_id)
+        if result.get("status") == "activated" and load_into_context:
+            self._add_skill_context(name, result["content"])
+        return json.dumps(result, indent=2)
+
+    def _current_session_id(self) -> Optional[str]:
+        try:
+            conversation = self.conversation_manager.conversation
+            return conversation.session.id
+        except Exception:
+            return None
+
+    def _add_skill_context(self, name: str, content: str) -> None:
+        if self.conversation_manager is None:
+            return
+        try:
+            message = self.conversation_manager.conversation.add_message(
+                "system",
+                content,
+                MessageCategory.CONTEXT,
+                {
+                    "source": f"skill:{name}",
+                    "type": "skill_activation",
+                    "skill_name": name,
+                },
+            )
+            message.metadata.setdefault("skill_name", name)
+        except Exception:
+            return

--- a/penguin/tools/core/skill_tools.py
+++ b/penguin/tools/core/skill_tools.py
@@ -16,10 +16,22 @@ class SkillTools:
         self.manager = manager
         self.conversation_manager = conversation_manager
 
-    def list_skills(self, refresh: bool = False) -> str:
+    def list_skills(
+        self,
+        refresh: bool = False,
+        session_id: Optional[str] = None,
+    ) -> str:
+        resolved_session_id = session_id or self._current_session_id() or "default"
         if refresh:
             self.manager.refresh()
-        return json.dumps(self.manager.list_payload(), indent=2)
+        payload = self.manager.list_payload()
+        active_names = set(self.manager.active_names(resolved_session_id))
+        payload["active"] = sorted(active_names)
+        payload["skills"] = [
+            {**skill, "active": skill.get("name") in active_names}
+            for skill in payload.get("skills", [])
+        ]
+        return json.dumps(payload, indent=2)
 
     def activate_skill(
         self,

--- a/penguin/tools/core/skill_tools.py
+++ b/penguin/tools/core/skill_tools.py
@@ -33,6 +33,17 @@ class SkillTools:
             self._add_skill_context(name, result["content"])
         return json.dumps(result, indent=2)
 
+    def deactivate_skill(
+        self,
+        name: str,
+        session_id: Optional[str] = None,
+    ) -> str:
+        resolved_session_id = session_id or self._current_session_id() or "default"
+        result = self.manager.deactivate(name, session_id=resolved_session_id)
+        if result.get("status") == "deactivated":
+            self._remove_skill_context(name)
+        return json.dumps(result, indent=2)
+
     def _current_session_id(self) -> Optional[str]:
         try:
             conversation = self.conversation_manager.conversation
@@ -55,5 +66,24 @@ class SkillTools:
                 },
             )
             message.metadata.setdefault("skill_name", name)
+        except Exception:
+            return
+
+    def _remove_skill_context(self, name: str) -> None:
+        if self.conversation_manager is None:
+            return
+        try:
+            conversation = self.conversation_manager.conversation
+            session = conversation.session
+            session.messages = [
+                message
+                for message in session.messages
+                if (
+                    message.metadata.get("skill_name") != name
+                    or message.metadata.get("type") != "skill_activation"
+                )
+            ]
+            if hasattr(conversation, "_modified"):
+                conversation._modified = True
         except Exception:
             return

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -1997,6 +1997,8 @@ class ToolManager:
             "grep_search",
             "finish_response",
             "finish_task",
+            "list_skills",
+            "activate_skill",
         ]
         allowed = {
             self._canonical_tool_name(name)

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -395,7 +395,11 @@ class ToolManager:
                         "refresh": {
                             "type": "boolean",
                             "description": "Refresh skill discovery from disk before listing (default: false)",
-                        }
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": "Optional session id for active-skill state. Defaults to the current conversation session.",
+                        },
                     },
                     "required": [],
                 },
@@ -3298,11 +3302,14 @@ class ToolManager:
                     tool_input.get("files_fixed"),
                 ),
                 "list_skills": lambda: self.skill_tools.list_skills(
-                    tool_input.get("refresh", False)
+                    refresh=tool_input.get("refresh", False),
+                    session_id=tool_input.get("session_id")
+                    or effective_context.get("session_id"),
                 ),
                 "activate_skill": lambda: self.skill_tools.activate_skill(
                     tool_input["name"],
-                    session_id=tool_input.get("session_id"),
+                    session_id=tool_input.get("session_id")
+                    or effective_context.get("session_id"),
                     load_into_context=tool_input.get("load_into_context", True),
                 ),
                 "get_repository_status": lambda: get_repository_status(

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -38,6 +38,7 @@ from penguin.tools.browser_tools import (
     BrowserInteractionTool,
     BrowserScreenshotTool,
 )
+from penguin.tools.core.skill_tools import SkillTools
 from penguin.tools.core.task_tools import TaskTools
 from penguin.tools.editing.registry import (
     get_edit_tool_public_names,
@@ -239,10 +240,12 @@ class ToolManager:
                 "memory_indexing": False,
                 "browser_tools": False,
                 "pydoll_tools": False,
+                "skill_tools": False,
                 "task_tools": False,
             }
 
             # Placeholder attributes for ALL lazy loading
+            self._skill_tools = None
             self._declarative_memory_tool = None
             self._task_tools = None
             self._grep_search = None
@@ -320,6 +323,8 @@ class ToolManager:
                 "pydoll_browser_scroll": "self.pydoll_browser_scroll_tool.execute",
                 "analyze_codebase": "self.analyze_codebase",
                 "reindex_workspace": "self.reindex_workspace",
+                "list_skills": "self.skill_tools.list_skills",
+                "activate_skill": "self.skill_tools.activate_skill",
                 "finish_response": "self.task_tools.finish_response",
                 "finish_task": "self.task_tools.finish_task",
                 "task_completed": "self.task_tools.task_completed",  # Deprecated alias
@@ -379,6 +384,42 @@ class ToolManager:
                     "type": "object",
                     "properties": {},
                     "required": [],
+                },
+            },
+            {
+                "name": "list_skills",
+                "description": "List discovered Agent Skills and discovery diagnostics. Use this before activating a skill when you need task-specific instructions.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "refresh": {
+                            "type": "boolean",
+                            "description": "Refresh skill discovery from disk before listing (default: false)",
+                        }
+                    },
+                    "required": [],
+                },
+            },
+            {
+                "name": "activate_skill",
+                "description": "Load full instructions for a discovered Agent Skill as CONTEXT. Activation is deduped per session.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The skill name to activate",
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": "Optional session id for activation dedupe; defaults to current session",
+                        },
+                        "load_into_context": {
+                            "type": "boolean",
+                            "description": "Add activated skill content to the conversation as CONTEXT (default: true)",
+                        },
+                    },
+                    "required": ["name"],
                 },
             },
             {
@@ -1586,6 +1627,29 @@ class ToolManager:
             self._task_tools = TaskTools()
             self._lazy_initialized["task_tools"] = True
         return self._task_tools
+
+    @property
+    def skill_tools(self):
+        """Lazy load skill tools."""
+        if not self._lazy_initialized["skill_tools"]:
+            with profile_operation("ToolManager.lazy_load_skill_tools"):
+                logger.debug("Lazy-loading skill tools")
+                from penguin.skills.manager import SkillManager
+
+                skill_manager = getattr(self, "skill_manager", None)
+                if skill_manager is None:
+                    skill_manager = SkillManager(
+                        self.config,
+                        project_root=getattr(self, "project_root", None),
+                    )
+                    self.skill_manager = skill_manager
+                conversation_manager = getattr(self._core, "conversation_manager", None)
+                self._skill_tools = SkillTools(
+                    skill_manager,
+                    conversation_manager=conversation_manager,
+                )
+                self._lazy_initialized["skill_tools"] = True
+        return self._skill_tools
 
     @property
     def declarative_memory_tool(self):
@@ -3231,6 +3295,14 @@ class ToolManager:
                     tool_input["fix_description"],
                     tool_input.get("files_fixed"),
                 ),
+                "list_skills": lambda: self.skill_tools.list_skills(
+                    tool_input.get("refresh", False)
+                ),
+                "activate_skill": lambda: self.skill_tools.activate_skill(
+                    tool_input["name"],
+                    session_id=tool_input.get("session_id"),
+                    load_into_context=tool_input.get("load_into_context", True),
+                ),
                 "get_repository_status": lambda: get_repository_status(
                     tool_input["repo_owner"], tool_input["repo_name"]
                 ),
@@ -4526,6 +4598,13 @@ class ToolManager:
             core: The PenguinCore instance
         """
         self._core = core
+        conversation_manager = getattr(core, "conversation_manager", None)
+        if conversation_manager is not None and hasattr(conversation_manager, "skill_manager"):
+            self.skill_manager = conversation_manager.skill_manager
+        if self._lazy_initialized.get("skill_tools") and self._skill_tools is not None:
+            self._skill_tools.conversation_manager = getattr(
+                core, "conversation_manager", None
+            )
 
     def _resolve_subagent_tool_call_id(
         self, tool_input: Optional[Dict[str, Any]]

--- a/penguin/utils/parser.py
+++ b/penguin/utils/parser.py
@@ -103,6 +103,9 @@ class ActionType(Enum):
     FINISH_TASK = "finish_task"
     # Legacy alias - kept for backward compatibility
     TASK_COMPLETED = "task_completed"  # Deprecated: use FINISH_TASK
+    # Agent Skills
+    LIST_SKILLS = "list_skills"
+    ACTIVATE_SKILL = "activate_skill"
     PROJECT_CREATE = "project_create"
     PROJECT_UPDATE = "project_update"
     PROJECT_DELETE = "project_delete"
@@ -1593,6 +1596,9 @@ class ActionExecutor:
             ActionType.FINISH_RESPONSE: self._finish_response,
             ActionType.FINISH_TASK: self._finish_task,
             ActionType.TASK_COMPLETED: self._finish_task,  # Deprecated alias
+            # Agent Skills
+            ActionType.LIST_SKILLS: self._list_skills,
+            ActionType.ACTIVATE_SKILL: self._activate_skill,
             ActionType.DEPENDENCY_DISPLAY: self._dependency_display,
             ActionType.ANALYZE_CODEBASE: self._analyze_codebase,
             ActionType.REINDEX_WORKSPACE: self._reindex_workspace,
@@ -3564,6 +3570,37 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
             )
         except Exception as e:
             return f"Error signaling task completion: {str(e)}"
+
+    def _list_skills(self, params: str) -> str:
+        """List discovered Agent Skills and diagnostics.
+
+        Format: optional JSON {"refresh": true}
+        """
+        try:
+            payload = _parse_json_payload(params) or {}
+            return self.tool_manager.skill_tools.list_skills(
+                refresh=bool(payload.get("refresh", False))
+            )
+        except Exception as e:
+            return f"Error listing skills: {str(e)}"
+
+    def _activate_skill(self, params: str) -> str:
+        """Activate an Agent Skill by name.
+
+        Format: JSON {"name": "skill-name"} or plain skill name
+        """
+        try:
+            payload = _parse_json_payload(params) or {}
+            name = str(payload.get("name") or params or "").strip()
+            if not name:
+                return "Error activating skill: missing required skill name"
+            return self.tool_manager.skill_tools.activate_skill(
+                name,
+                session_id=payload.get("session_id"),
+                load_into_context=bool(payload.get("load_into_context", True)),
+            )
+        except Exception as e:
+            return f"Error activating skill: {str(e)}"
 
     # Deprecated: kept for backward compatibility
     def _task_completed(self, params: str) -> str:

--- a/penguin/utils/parser.py
+++ b/penguin/utils/parser.py
@@ -3579,7 +3579,8 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
         try:
             payload = _parse_json_payload(params) or {}
             return self.tool_manager.skill_tools.list_skills(
-                refresh=bool(payload.get("refresh", False))
+                refresh=bool(payload.get("refresh", False)),
+                session_id=payload.get("session_id"),
             )
         except Exception as e:
             return f"Error listing skills: {str(e)}"

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -2143,6 +2143,7 @@ async def _emit_skill_event(
 @router.get("/api/v1/skills")
 async def list_skills(
     refresh: bool = False,
+    session_id: str = "default",
     core: PenguinCore = Depends(get_core),
 ) -> Dict[str, Any]:
     """Return compact skill catalog and diagnostics for web/TUI clients."""
@@ -2153,6 +2154,12 @@ async def list_skills(
     payload = manager.list_payload()
     payload["count"] = len(payload.get("skills", []))
     payload["diagnostic_count"] = len(payload.get("diagnostics", []))
+    active_names = set(manager.active_names(session_id))
+    payload["active"] = sorted(active_names)
+    payload["skills"] = [
+        {**skill, "active": skill.get("name") in active_names}
+        for skill in payload.get("skills", [])
+    ]
 
     if refresh:
         await _emit_skill_event(
@@ -2171,6 +2178,7 @@ async def list_skills(
 async def get_skill(
     name: str,
     max_resources: int = 200,
+    session_id: str = "default",
     core: PenguinCore = Depends(get_core),
 ) -> Dict[str, Any]:
     """Inspect a skill's full SKILL.md content without activating it."""
@@ -2188,6 +2196,7 @@ async def get_skill(
         "frontmatter": skill.frontmatter,
         "allowed_tools": skill.allowed_tools,
         "body": skill.body,
+        "active": manager.is_active(name, session_id),
         "resources": list_skill_resources(skill, max_resources=max_resources),
     }
 

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -2071,6 +2071,10 @@ def _setup_question_event_callbacks():
         logger.error("Failed to setup question callbacks: %s", e)
 
 
+class SkillDeactivateRequest(BaseModel):
+    session_id: str = "default"
+
+
 router = APIRouter()
 
 
@@ -2237,6 +2241,39 @@ async def activate_skill(
             "status": result.get("status"),
             "duplicate": result.get("duplicate", False),
             "load_into_context": request.load_into_context,
+        },
+    )
+
+    return result
+
+
+@router.post("/api/v1/skills/{name}/deactivate")
+async def deactivate_skill(
+    name: str,
+    request: SkillDeactivateRequest,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Deactivate a skill for a session and remove loaded CONTEXT when possible."""
+    manager = _get_skill_manager(core)
+    if manager.get(name) is None:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {name}")
+
+    tool_manager = getattr(core, "tool_manager", None)
+    skill_tools = getattr(tool_manager, "skill_tools", None)
+    if skill_tools is not None:
+        result = skill_tools.deactivate_skill(name=name, session_id=request.session_id)
+    else:
+        result = manager.deactivate(name, session_id=request.session_id)
+
+    result = _normalize_skill_activation_result(result)
+    await _emit_skill_event(
+        core,
+        "skill.deactivated",
+        {
+            "sessionID": request.session_id,
+            "skill": result.get("skill"),
+            "status": result.get("status"),
+            "was_active": result.get("was_active", False),
         },
     )
 

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -2215,7 +2215,7 @@ async def activate_skill(
     tool_manager = getattr(core, "tool_manager", None)
     skill_tools = getattr(tool_manager, "skill_tools", None)
     if skill_tools is not None:
-        result = await skill_tools.activate_skill(
+        result = skill_tools.activate_skill(
             name=name,
             session_id=request.session_id,
             load_into_context=request.load_into_context,

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -117,6 +117,8 @@ from penguin.system.execution_context import (
     execution_context_scope,
     normalize_directory,
 )
+from penguin.skills.manager import SkillManager
+from penguin.skills.renderer import list_skill_resources
 from penguin.utils.errors import AgentNotFoundError, PenguinError
 
 logger = logging.getLogger(__name__)
@@ -2081,6 +2083,155 @@ def _get_coordinator(core: PenguinCore):
         return core.get_coordinator()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Coordinator not available: {e}")
+
+
+class SkillActivateRequest(BaseModel):
+    session_id: str = "default"
+    load_into_context: bool = True
+    max_resources: int = 200
+
+
+def _get_skill_manager(core: PenguinCore) -> SkillManager:
+    """Resolve the runtime skill manager shared by chat, tools, and web routes."""
+    conversation_manager = getattr(core, "conversation_manager", None)
+    manager = getattr(conversation_manager, "skill_manager", None)
+    if manager is not None:
+        return manager
+
+    tool_manager = getattr(core, "tool_manager", None)
+    manager = getattr(tool_manager, "skill_manager", None)
+    if manager is not None:
+        return manager
+
+    raise HTTPException(status_code=503, detail="Skills are not initialized")
+
+
+def _normalize_skill_activation_result(result: Any) -> Dict[str, Any]:
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    raise HTTPException(status_code=500, detail="Invalid skill activation response")
+
+
+async def _emit_skill_event(
+    core: PenguinCore,
+    event_type: str,
+    properties: Dict[str, Any],
+) -> None:
+    """Emit OpenCode/SSE-compatible skill lifecycle events when available."""
+    emit = getattr(getattr(core, "event_bus", None), "emit", None)
+    if not callable(emit):
+        return
+    try:
+        await emit(
+            "opencode_event",
+            {
+                "type": event_type,
+                "properties": properties,
+            },
+        )
+    except Exception:
+        logger.debug("Failed to emit %s event", event_type, exc_info=True)
+
+
+@router.get("/api/v1/skills")
+async def list_skills(
+    refresh: bool = False,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Return compact skill catalog and diagnostics for web/TUI clients."""
+    manager = _get_skill_manager(core)
+    if refresh:
+        manager.refresh()
+
+    payload = manager.list_payload()
+    payload["count"] = len(payload.get("skills", []))
+    payload["diagnostic_count"] = len(payload.get("diagnostics", []))
+
+    if refresh:
+        await _emit_skill_event(
+            core,
+            "skills.diagnostics",
+            {
+                "diagnostics": payload.get("diagnostics", []),
+                "diagnostic_count": payload["diagnostic_count"],
+            },
+        )
+
+    return payload
+
+
+@router.get("/api/v1/skills/{name}")
+async def get_skill(
+    name: str,
+    max_resources: int = 200,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Inspect a skill's full SKILL.md content without activating it."""
+    manager = _get_skill_manager(core)
+    skill = manager.get(name)
+    if skill is None:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {name}")
+
+    return {
+        "name": skill.name,
+        "description": skill.description,
+        "source": skill.source,
+        "path": str(skill.path),
+        "skill_file": str(skill.skill_file),
+        "frontmatter": skill.frontmatter,
+        "allowed_tools": skill.allowed_tools,
+        "body": skill.body,
+        "resources": list_skill_resources(skill, max_resources=max_resources),
+    }
+
+
+@router.post("/api/v1/skills/{name}/activate")
+async def activate_skill(
+    name: str,
+    request: SkillActivateRequest,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Activate a skill and optionally inject it into session CONTEXT."""
+    manager = _get_skill_manager(core)
+    if manager.get(name) is None:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {name}")
+
+    tool_manager = getattr(core, "tool_manager", None)
+    skill_tools = getattr(tool_manager, "skill_tools", None)
+    if skill_tools is not None:
+        result = await skill_tools.activate_skill(
+            name=name,
+            session_id=request.session_id,
+            load_into_context=request.load_into_context,
+        )
+    else:
+        result = manager.activate(
+            name,
+            session_id=request.session_id,
+            max_resources=request.max_resources,
+        )
+
+    result = _normalize_skill_activation_result(result)
+    await _emit_skill_event(
+        core,
+        "skill.activated",
+        {
+            "sessionID": request.session_id,
+            "skill": result.get("skill"),
+            "status": result.get("status"),
+            "duplicate": result.get("duplicate", False),
+            "load_into_context": request.load_into_context,
+        },
+    )
+
+    return result
 
 
 def _validate_agent_id(agent_id: str) -> None:

--- a/tests/api/test_skill_routes.py
+++ b/tests/api/test_skill_routes.py
@@ -76,12 +76,16 @@ def test_skill_routes_list_show_and_activate(tmp_path: Path) -> None:
         assert data["diagnostic_count"] == 0
         skill_names = {skill["name"] for skill in data["skills"]}
         assert "demo" in skill_names
+        demo_entry = next(skill for skill in data["skills"] if skill["name"] == "demo")
+        assert demo_entry["active"] is False
+        assert data["active"] == []
 
         detail = client.get("/api/v1/skills/demo")
         assert detail.status_code == 200
         detail_data = detail.json()
         assert detail_data["body"].startswith("# Demo Skill")
         assert detail_data["allowed_tools"] == ["read_file"]
+        assert detail_data["active"] is False
         assert "references.md" in detail_data["resources"]
 
         activated = client.post(
@@ -93,6 +97,11 @@ def test_skill_routes_list_show_and_activate(tmp_path: Path) -> None:
         assert activated_data["status"] == "activated"
         assert activated_data["duplicate"] is False
 
+        active_catalog = client.get("/api/v1/skills", params={"session_id": "web-session"})
+        active_data = active_catalog.json()
+        active_demo = next(skill for skill in active_data["skills"] if skill["name"] == "demo")
+        assert active_data["active"] == ["demo"]
+        assert active_demo["active"] is True
         duplicate = client.post(
             "/api/v1/skills/demo/activate",
             json={"session_id": "web-session", "load_into_context": False},

--- a/tests/api/test_skill_routes.py
+++ b/tests/api/test_skill_routes.py
@@ -147,6 +147,29 @@ def test_skill_activation_route_handles_sync_skill_tool_adapter(tmp_path: Path) 
         assert data["skill"]["name"] == "demo"
 
 
+def test_skill_deactivation_route_toggles_active_state(tmp_path: Path) -> None:
+    client, _ = _build_client_with_skill_tools(tmp_path)
+    with client:
+        activate = client.post(
+            "/api/v1/skills/demo/activate",
+            json={"session_id": "tool-session", "load_into_context": False},
+        )
+        assert activate.status_code == 200
+
+        deactivate = client.post(
+            "/api/v1/skills/demo/deactivate",
+            json={"session_id": "tool-session"},
+        )
+        assert deactivate.status_code == 200
+        data = deactivate.json()
+        assert data["status"] == "deactivated"
+        assert data["was_active"] is True
+
+        catalog = client.get("/api/v1/skills", params={"session_id": "tool-session"})
+        active_demo = next(skill for skill in catalog.json()["skills"] if skill["name"] == "demo")
+        assert active_demo["active"] is False
+
+
 def test_skill_routes_emit_refresh_and_activation_events(tmp_path: Path) -> None:
     client, core = _build_client(tmp_path)
     with client:

--- a/tests/api/test_skill_routes.py
+++ b/tests/api/test_skill_routes.py
@@ -1,0 +1,124 @@
+"""Tests for Skills web API routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from penguin.skills.manager import SkillManager
+from penguin.web import routes as routes_module
+
+
+class _EventBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+
+class _Core:
+    def __init__(self, manager: SkillManager) -> None:
+        self.conversation_manager = SimpleNamespace(skill_manager=manager)
+        self.tool_manager = None
+        self.event_bus = _EventBus()
+
+
+def _write_skill(root: Path, name: str = "demo") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        "description: Demo skill for route tests.\n"
+        "allowed-tools:\n"
+        "  - read_file\n"
+        "---\n"
+        "# Demo Skill\n\nUse this for tests.\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "references.md").write_text("reference", encoding="utf-8")
+    return skill_dir
+
+
+def _build_client(tmp_path: Path) -> tuple[TestClient, _Core]:
+    skills_root = tmp_path / "skills"
+    _write_skill(skills_root)
+    manager = SkillManager(
+        {
+            "skills": {
+                "enabled": True,
+                "trust_project_skills": True,
+                "scan_paths": {
+                    "project": [str(skills_root)],
+                    "user": [],
+                },
+            }
+        },
+        project_root=tmp_path,
+    )
+    core = _Core(manager)
+    cast(Any, routes_module.router).core = cast(Any, core)
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    return TestClient(app), core
+
+
+def test_skill_routes_list_show_and_activate(tmp_path: Path) -> None:
+    with _build_client(tmp_path)[0] as client:
+        catalog = client.get("/api/v1/skills")
+        assert catalog.status_code == 200
+        data = catalog.json()
+        assert data["diagnostic_count"] == 0
+        skill_names = {skill["name"] for skill in data["skills"]}
+        assert "demo" in skill_names
+
+        detail = client.get("/api/v1/skills/demo")
+        assert detail.status_code == 200
+        detail_data = detail.json()
+        assert detail_data["body"].startswith("# Demo Skill")
+        assert detail_data["allowed_tools"] == ["read_file"]
+        assert "references.md" in detail_data["resources"]
+
+        activated = client.post(
+            "/api/v1/skills/demo/activate",
+            json={"session_id": "web-session", "load_into_context": False},
+        )
+        assert activated.status_code == 200
+        activated_data = activated.json()
+        assert activated_data["status"] == "activated"
+        assert activated_data["duplicate"] is False
+
+        duplicate = client.post(
+            "/api/v1/skills/demo/activate",
+            json={"session_id": "web-session", "load_into_context": False},
+        )
+        assert duplicate.status_code == 200
+        assert duplicate.json()["status"] == "already_active"
+
+
+def test_skill_routes_emit_refresh_and_activation_events(tmp_path: Path) -> None:
+    client, core = _build_client(tmp_path)
+    with client:
+        refresh = client.get("/api/v1/skills", params={"refresh": True})
+        assert refresh.status_code == 200
+
+        activate = client.post(
+            "/api/v1/skills/demo/activate",
+            json={"session_id": "s1", "load_into_context": False},
+        )
+        assert activate.status_code == 200
+
+    emitted_types = [event[1]["type"] for event in core.event_bus.events]
+    assert "skills.diagnostics" in emitted_types
+    assert "skill.activated" in emitted_types
+
+
+def test_skill_routes_return_404_for_missing_skill(tmp_path: Path) -> None:
+    with _build_client(tmp_path)[0] as client:
+        assert client.get("/api/v1/skills/missing").status_code == 404
+        assert client.post("/api/v1/skills/missing/activate", json={}).status_code == 404

--- a/tests/api/test_skill_routes.py
+++ b/tests/api/test_skill_routes.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from penguin.skills.manager import SkillManager
+from penguin.tools.core.skill_tools import SkillTools
 from penguin.web import routes as routes_module
 
 
@@ -26,6 +27,17 @@ class _Core:
         self.conversation_manager = SimpleNamespace(skill_manager=manager)
         self.tool_manager = None
         self.event_bus = _EventBus()
+
+
+class _CoreWithSkillTools(_Core):
+    def __init__(self, manager: SkillManager) -> None:
+        super().__init__(manager)
+        self.tool_manager = SimpleNamespace(
+            skill_tools=SkillTools(
+                manager,
+                conversation_manager=self.conversation_manager,
+            )
+        )
 
 
 def _write_skill(root: Path, name: str = "demo") -> Path:
@@ -45,10 +57,10 @@ def _write_skill(root: Path, name: str = "demo") -> Path:
     return skill_dir
 
 
-def _build_client(tmp_path: Path) -> tuple[TestClient, _Core]:
+def _build_manager(tmp_path: Path) -> SkillManager:
     skills_root = tmp_path / "skills"
     _write_skill(skills_root)
-    manager = SkillManager(
+    return SkillManager(
         {
             "skills": {
                 "enabled": True,
@@ -61,7 +73,18 @@ def _build_client(tmp_path: Path) -> tuple[TestClient, _Core]:
         },
         project_root=tmp_path,
     )
-    core = _Core(manager)
+
+
+def _build_client(tmp_path: Path) -> tuple[TestClient, _Core]:
+    core = _Core(_build_manager(tmp_path))
+    cast(Any, routes_module.router).core = cast(Any, core)
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    return TestClient(app), core
+
+
+def _build_client_with_skill_tools(tmp_path: Path) -> tuple[TestClient, _CoreWithSkillTools]:
+    core = _CoreWithSkillTools(_build_manager(tmp_path))
     cast(Any, routes_module.router).core = cast(Any, core)
     app = FastAPI()
     app.include_router(routes_module.router)
@@ -102,12 +125,26 @@ def test_skill_routes_list_show_and_activate(tmp_path: Path) -> None:
         active_demo = next(skill for skill in active_data["skills"] if skill["name"] == "demo")
         assert active_data["active"] == ["demo"]
         assert active_demo["active"] is True
+
         duplicate = client.post(
             "/api/v1/skills/demo/activate",
             json={"session_id": "web-session", "load_into_context": False},
         )
         assert duplicate.status_code == 200
         assert duplicate.json()["status"] == "already_active"
+
+
+def test_skill_activation_route_handles_sync_skill_tool_adapter(tmp_path: Path) -> None:
+    client, _ = _build_client_with_skill_tools(tmp_path)
+    with client:
+        activate = client.post(
+            "/api/v1/skills/demo/activate",
+            json={"session_id": "tool-session", "load_into_context": False},
+        )
+        assert activate.status_code == 200
+        data = activate.json()
+        assert data["status"] == "activated"
+        assert data["skill"]["name"] == "demo"
 
 
 def test_skill_routes_emit_refresh_and_activation_events(tmp_path: Path) -> None:

--- a/tests/test_cli_surface_audit_regressions.py
+++ b/tests/test_cli_surface_audit_regressions.py
@@ -95,12 +95,12 @@ def test_skill_list_command_outputs_catalog_json(tmp_path):
 
     manager = FakeSkillManager(make_skill(tmp_path))
 
-    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
-        cli_module, "console"
-    ) as console_mock:
-        cli_module.skill_list(json_output=True, workspace=None)
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)):
+        from io import StringIO
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            cli_module.skill_list(json_output=True, workspace=None)
+            printed = stdout.getvalue()
 
-    printed = console_mock.print.call_args.args[0]
     payload = json.loads(printed)
     assert payload["skills"][0]["name"] == "demo-skill"
     assert payload["skills"][0]["source"] == "user"
@@ -112,16 +112,16 @@ def test_skill_show_command_surfaces_skill_body(tmp_path):
     skill = make_skill(tmp_path)
     manager = FakeSkillManager(skill)
 
-    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
-        cli_module, "console"
-    ) as console_mock:
-        cli_module.skill_show(name="demo-skill", json_output=True, workspace=None)
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)):
+        from io import StringIO
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            cli_module.skill_show(name="demo-skill", json_output=True, workspace=None)
+            printed = stdout.getvalue()
 
-    payload = json.loads(console_mock.print.call_args.args[0])
+    payload = json.loads(printed)
     assert payload["name"] == "demo-skill"
     assert "Use this skill" in payload["body"]
     assert payload["allowed_tools"] == ["read_file"]
-
 
 def test_skill_activate_command_uses_runtime_skill_tool(tmp_path):
     from penguin.cli import cli as cli_module
@@ -138,11 +138,14 @@ def test_skill_activate_command_uses_runtime_skill_tool(tmp_path):
 
     with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
         cli_module, "_tool_manager", tool_manager
-    ), patch.object(cli_module, "console") as console_mock:
-        cli_module.skill_activate(name="demo-skill", json_output=True, show_content=False, workspace=None)
+    ):
+        from io import StringIO
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            cli_module.skill_activate(name="demo-skill", json_output=True, show_content=False, workspace=None)
+            printed = stdout.getvalue()
 
     skill_tools.activate_skill.assert_called_once_with("demo-skill")
-    payload = json.loads(console_mock.print.call_args.args[0])
+    payload = json.loads(printed)
     assert payload["status"] == "activated"
 
 
@@ -158,12 +161,13 @@ def test_skill_doctor_surfaces_invalid_skill_diagnostics(tmp_path):
     )
     manager = FakeSkillManager(make_skill(tmp_path), diagnostics=[diagnostic])
 
-    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
-        cli_module, "console"
-    ) as console_mock:
-        cli_module.skill_doctor(json_output=True, workspace=None)
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)):
+        from io import StringIO
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            cli_module.skill_doctor(json_output=True, workspace=None)
+            printed = stdout.getvalue()
 
-    payload = json.loads(console_mock.print.call_args.args[0])
+    payload = json.loads(printed)
     assert payload["diagnostics"][0]["code"] == "invalid_frontmatter"
     assert "Malformed YAML" in payload["diagnostics"][0]["message"]
 

--- a/tests/test_cli_surface_audit_regressions.py
+++ b/tests/test_cli_surface_audit_regressions.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import importlib
 import asyncio
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -12,6 +13,7 @@ import pytest
 from penguin.cli.event_manager import EventManager
 from penguin.cli.interface import PenguinInterface
 from penguin.project.models import Project, Task, TaskPhase, TaskStatus
+from penguin.skills.models import Skill, SkillCatalogEntry, SkillDiagnostic
 
 
 def make_task(task_id: str, status: TaskStatus) -> Task:
@@ -39,6 +41,131 @@ def make_project() -> Project:
         updated_at=now,
         status="active",
     )
+
+
+def make_skill(tmp_path, name="demo-skill") -> Skill:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\nname: demo-skill\ndescription: Demo skill\n---\n# Demo\nUse this skill.")
+    return Skill(
+        name=name,
+        description="Demo skill",
+        path=skill_dir,
+        skill_file=skill_file,
+        body="# Demo\nUse this skill.",
+        frontmatter={"name": name, "description": "Demo skill"},
+        allowed_tools=["read_file"],
+        source="user",
+    )
+
+
+class FakeSkillManager:
+    def __init__(self, skill: Skill, diagnostics=None):
+        self.skill = skill
+        self.diagnostics = diagnostics or []
+
+    def refresh(self):
+        return None
+
+    def catalog(self):
+        return [
+            SkillCatalogEntry(
+                name=self.skill.name,
+                description=self.skill.description,
+                source=self.skill.source,
+                path=str(self.skill.path),
+            )
+        ]
+
+    def get(self, name: str):
+        if name == self.skill.name:
+            return self.skill
+        return None
+
+    def list_payload(self):
+        return {
+            "skills": [entry.__dict__ for entry in self.catalog()],
+            "diagnostics": [diagnostic.__dict__ for diagnostic in self.diagnostics],
+        }
+
+
+def test_skill_list_command_outputs_catalog_json(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    manager = FakeSkillManager(make_skill(tmp_path))
+
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
+        cli_module, "console"
+    ) as console_mock:
+        cli_module.skill_list(json_output=True, workspace=None)
+
+    printed = console_mock.print.call_args.args[0]
+    payload = json.loads(printed)
+    assert payload["skills"][0]["name"] == "demo-skill"
+    assert payload["skills"][0]["source"] == "user"
+
+
+def test_skill_show_command_surfaces_skill_body(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    skill = make_skill(tmp_path)
+    manager = FakeSkillManager(skill)
+
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
+        cli_module, "console"
+    ) as console_mock:
+        cli_module.skill_show(name="demo-skill", json_output=True, workspace=None)
+
+    payload = json.loads(console_mock.print.call_args.args[0])
+    assert payload["name"] == "demo-skill"
+    assert "Use this skill" in payload["body"]
+    assert payload["allowed_tools"] == ["read_file"]
+
+
+def test_skill_activate_command_uses_runtime_skill_tool(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    manager = FakeSkillManager(make_skill(tmp_path))
+    activation_payload = {
+        "status": "activated",
+        "duplicate": False,
+        "skill": {"name": "demo-skill", "path": str(tmp_path / "demo-skill")},
+        "content": "<skill_content name=\"demo-skill\">content</skill_content>",
+    }
+    skill_tools = SimpleNamespace(activate_skill=Mock(return_value=json.dumps(activation_payload)))
+    tool_manager = SimpleNamespace(skill_tools=skill_tools)
+
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
+        cli_module, "_tool_manager", tool_manager
+    ), patch.object(cli_module, "console") as console_mock:
+        cli_module.skill_activate(name="demo-skill", json_output=True, show_content=False, workspace=None)
+
+    skill_tools.activate_skill.assert_called_once_with("demo-skill")
+    payload = json.loads(console_mock.print.call_args.args[0])
+    assert payload["status"] == "activated"
+
+
+def test_skill_doctor_surfaces_invalid_skill_diagnostics(tmp_path):
+    from penguin.cli import cli as cli_module
+
+    diagnostic = SkillDiagnostic(
+        path=str(tmp_path / "bad-skill" / "SKILL.md"),
+        severity="error",
+        code="invalid_frontmatter",
+        message="Malformed YAML frontmatter",
+        source="project",
+    )
+    manager = FakeSkillManager(make_skill(tmp_path), diagnostics=[diagnostic])
+
+    with patch.object(cli_module, "_get_skill_manager_for_cli", AsyncMock(return_value=manager)), patch.object(
+        cli_module, "console"
+    ) as console_mock:
+        cli_module.skill_doctor(json_output=True, workspace=None)
+
+    payload = json.loads(console_mock.print.call_args.args[0])
+    assert payload["diagnostics"][0]["code"] == "invalid_frontmatter"
+    assert "Malformed YAML" in payload["diagnostics"][0]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompt_actions.py
+++ b/tests/test_prompt_actions.py
@@ -51,3 +51,13 @@ def test_tool_guide_promotes_canonical_names_over_legacy_headers() -> None:
     assert "### enhanced_write" not in guide
     assert "### apply_diff" not in guide
     assert "### multiedit" not in guide
+
+
+def test_tool_guide_documents_skills_tools_and_rules() -> None:
+    guide = get_tool_guide()
+
+    assert "## Skills" in guide
+    assert "### list_skills" in guide
+    assert "### activate_skill" in guide
+    assert "Activated skill content is `CONTEXT`, not `SYSTEM`" in guide
+    assert "Do not activate every skill" in guide

--- a/tests/test_prompt_building.py
+++ b/tests/test_prompt_building.py
@@ -92,6 +92,19 @@ def test_prompt_building():
         traceback.print_exc()
         return False
 
+
+
+def test_system_prompt_includes_skills_workflow_guidance() -> None:
+    from penguin.system_prompt import get_system_prompt
+
+    prompt = get_system_prompt(mode="direct")
+
+    assert "## Skills Workflow" in prompt
+    assert "activate_skill" in prompt
+    assert "Treat activated skill content as `CONTEXT`, not `SYSTEM`" in prompt
+    assert "Do not bulk-load every reference file in a skill" in prompt
+
+
 if __name__ == "__main__":
     success = test_prompt_building()
     sys.exit(0 if success else 1)

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from penguin.skills.manager import SkillManager
+from penguin.system.conversation import ConversationSystem
+from penguin.system.state import MessageCategory
+from penguin.tools.core.skill_tools import SkillTools
+
+
+class ConversationManagerStub:
+    def __init__(self) -> None:
+        self.conversation = ConversationSystem()
+
+
+def make_skill(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Desc\n---\nInstructions.\n",
+        encoding="utf-8",
+    )
+
+
+def test_activate_skill_tool_loads_context_message_once(tmp_path: Path) -> None:
+    make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = SkillManager({"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}})
+    conversation_manager = ConversationManagerStub()
+    tools = SkillTools(manager, conversation_manager=conversation_manager)
+
+    tools.activate_skill("demo-skill")
+    tools.activate_skill("demo-skill")
+
+    skill_messages = [
+        msg for msg in conversation_manager.conversation.session.messages
+        if msg.metadata.get("type") == "skill_activation"
+    ]
+    assert len(skill_messages) == 1
+    assert skill_messages[0].category == MessageCategory.CONTEXT

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -34,3 +34,25 @@ def test_activate_skill_tool_loads_context_message_once(tmp_path: Path) -> None:
     ]
     assert len(skill_messages) == 1
     assert skill_messages[0].category == MessageCategory.CONTEXT
+
+
+def test_deactivate_skill_tool_removes_loaded_context_message(tmp_path: Path) -> None:
+    make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = SkillManager({"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}})
+    conversation_manager = ConversationManagerStub()
+    tools = SkillTools(manager, conversation_manager=conversation_manager)
+
+    tools.activate_skill("demo-skill", session_id="s1")
+    assert manager.is_active("demo-skill", "s1")
+    assert any(
+        msg.metadata.get("type") == "skill_activation"
+        for msg in conversation_manager.conversation.session.messages
+    )
+
+    tools.deactivate_skill("demo-skill", session_id="s1")
+
+    assert not manager.is_active("demo-skill", "s1")
+    assert not any(
+        msg.metadata.get("type") == "skill_activation"
+        for msg in conversation_manager.conversation.session.messages
+    )

--- a/tests/test_skills_context_runtime.py
+++ b/tests/test_skills_context_runtime.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from penguin.system.context_window import ContextWindowManager
+from penguin.system.conversation import ConversationSystem
+from penguin.system.state import Message, MessageCategory, Session
+
+
+def test_skill_context_message_uses_context_category() -> None:
+    conversation = ConversationSystem()
+
+    message = conversation.add_context(
+        '<skill_content name="demo">Instructions</skill_content>',
+        source="skill:demo",
+    )
+    message.metadata.update({"type": "skill_activation", "skill_name": "demo"})
+
+    assert message.category == MessageCategory.CONTEXT
+    assert message.metadata["skill_name"] == "demo"
+
+
+def test_context_truncation_can_trim_old_skill_context_messages() -> None:
+    cwm = ContextWindowManager(token_counter=lambda content: len(str(content)))
+    cwm.max_context_window_tokens = 120
+    cwm._initialize_token_budgets()
+    session = Session()
+    session.messages = [
+        Message(
+            role="system",
+            content="old skill instructions " * 5,
+            category=MessageCategory.CONTEXT,
+            metadata={"type": "skill_activation", "skill_name": "old"},
+            tokens=110,
+            timestamp="2026-01-01T00:00:00",
+        ),
+        Message(
+            role="system",
+            content="new skill instructions",
+            category=MessageCategory.CONTEXT,
+            metadata={"type": "skill_activation", "skill_name": "new"},
+            tokens=10,
+            timestamp="2026-01-02T00:00:00",
+        ),
+    ]
+
+    trimmed = cwm.process_session(session)
+
+    assert [msg.metadata.get("skill_name") for msg in trimmed.messages] == ["new"]

--- a/tests/test_skills_conversation_manager.py
+++ b/tests/test_skills_conversation_manager.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from penguin.system.conversation_manager import ConversationManager
+from penguin.system.state import MessageCategory
+
+
+def make_skill(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Desc\n---\nInstructions.\n",
+        encoding="utf-8",
+    )
+
+
+def test_conversation_manager_injects_compact_skill_catalog(tmp_path: Path) -> None:
+    make_skill(tmp_path / ".penguin" / "skills" / "demo", "demo-skill")
+    config = {
+        "skills": {
+            "enabled": True,
+            "trust_project_skills": True,
+            "scan_paths": {"user": [], "project": [".penguin/skills"]},
+        },
+        "context": {"autoload_project_docs": False},
+    }
+
+    manager = ConversationManager(
+        workspace_path=tmp_path,
+        skills_config=config,
+        project_root=tmp_path,
+    )
+
+    messages = [msg for msg in manager.conversation.session.messages if msg.metadata.get("source") == "skills_catalog"]
+    assert len(messages) == 1
+    assert messages[0].category == MessageCategory.CONTEXT
+    assert "demo-skill" in messages[0].content

--- a/tests/test_skills_discovery.py
+++ b/tests/test_skills_discovery.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from penguin.skills.discovery import discover_skills
+
+
+def make_skill(path: Path, name: str, description: str = "Desc") -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nBody for {name}\n",
+        encoding="utf-8",
+    )
+
+
+def test_discover_nested_skills(tmp_path: Path) -> None:
+    make_skill(tmp_path / "user" / "nested" / "skill", "nested-skill")
+    config = {"skills": {"scan_paths": {"user": [str(tmp_path / "user")]}}}
+
+    skills, diagnostics = discover_skills(config)
+
+    assert [skill.name for skill in skills] == ["nested-skill"]
+    assert diagnostics == []
+
+
+def test_discover_invalid_skill_reports_diagnostic(tmp_path: Path) -> None:
+    bad = tmp_path / "user" / "bad"
+    bad.mkdir(parents=True)
+    (bad / "SKILL.md").write_text("---\nname: Bad\n---\nBody\n", encoding="utf-8")
+    config = {"skills": {"scan_paths": {"user": [str(tmp_path / "user")]}}}
+
+    skills, diagnostics = discover_skills(config)
+
+    assert skills == []
+    assert diagnostics[0].code == "invalid_skill"
+
+
+def test_discover_collisions_keep_first(tmp_path: Path) -> None:
+    make_skill(tmp_path / "a", "same-name", "First")
+    make_skill(tmp_path / "b", "same-name", "Second")
+    config = {"skills": {"scan_paths": {"user": [str(tmp_path / "a"), str(tmp_path / "b")]}}}
+
+    skills, diagnostics = discover_skills(config)
+
+    assert len(skills) == 1
+    assert skills[0].description == "First"
+    assert any(diagnostic.code == "duplicate_skill_name" for diagnostic in diagnostics)
+
+
+def test_discover_max_depth(tmp_path: Path) -> None:
+    make_skill(tmp_path / "root" / "one" / "two", "too-deep")
+    config = {
+        "skills": {
+            "scan_paths": {"user": [str(tmp_path / "root")]},
+            "max_scan_depth": 1,
+        }
+    }
+
+    skills, diagnostics = discover_skills(config)
+
+    assert skills == []
+    assert diagnostics[0].code == "max_depth_exceeded"
+
+
+def test_project_skills_ignored_when_not_trusted(tmp_path: Path) -> None:
+    make_skill(tmp_path / ".penguin" / "skills" / "project", "project-skill")
+    config = {"skills": {"trust_project_skills": False, "scan_paths": {"user": [], "project": [".penguin/skills"]}}}
+
+    skills, diagnostics = discover_skills(config, project_root=tmp_path)
+
+    assert skills == []
+    assert diagnostics == []
+
+
+def test_project_skills_loaded_when_trusted(tmp_path: Path) -> None:
+    make_skill(tmp_path / ".penguin" / "skills" / "project", "project-skill")
+    config = {"skills": {"trust_project_skills": True, "scan_paths": {"user": [], "project": [".penguin/skills"]}}}
+
+    skills, _ = discover_skills(config, project_root=tmp_path)
+
+    assert [skill.name for skill in skills] == ["project-skill"]

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from penguin.skills.manager import SkillManager
+
+
+def make_skill(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Desc for {name}\n---\n# {name}\nInstructions.\n",
+        encoding="utf-8",
+    )
+    (path / "references" / "guide.md").parent.mkdir(parents=True, exist_ok=True)
+    (path / "references" / "guide.md").write_text("Guide", encoding="utf-8")
+
+
+def test_manager_catalog_and_activation_dedupe(tmp_path: Path) -> None:
+    make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = SkillManager({"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}})
+
+    catalog = manager.catalog()
+    first = manager.activate("demo-skill", session_id="s1")
+    second = manager.activate("demo-skill", session_id="s1")
+
+    assert catalog[0].name == "demo-skill"
+    assert first["status"] == "activated"
+    assert first["duplicate"] is False
+    assert '<skill_content name="demo-skill"' in first["content"]
+    assert "<skill_resources" in first["content"]
+    assert second["status"] == "already_active"
+    assert second["duplicate"] is True
+
+
+def test_manager_dedupe_is_per_session(tmp_path: Path) -> None:
+    make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = SkillManager({"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}})
+
+    manager.activate("demo-skill", session_id="s1")
+    other_session = manager.activate("demo-skill", session_id="s2")
+
+    assert other_session["status"] == "activated"

--- a/tests/test_skills_parser.py
+++ b/tests/test_skills_parser.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import pytest
+
+from penguin.skills.parser import SkillParseError, parse_skill_file
+
+
+def write_skill(root: Path, content: str) -> Path:
+    path = root / "SKILL.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_parse_valid_skill(tmp_path: Path) -> None:
+    path = write_skill(
+        tmp_path,
+        "---\nname: demo-skill\ndescription: Demo skill.\n---\n# Body\nDo work.\n",
+    )
+
+    skill = parse_skill_file(path)
+
+    assert skill.name == "demo-skill"
+    assert skill.description == "Demo skill."
+    assert skill.body == "# Body\nDo work."
+
+
+@pytest.mark.parametrize(
+    "frontmatter",
+    [
+        "description: Missing name",
+        "name: missing-description",
+    ],
+)
+def test_parse_missing_required_fields(tmp_path: Path, frontmatter: str) -> None:
+    path = write_skill(tmp_path, f"---\n{frontmatter}\n---\nBody\n")
+
+    with pytest.raises(SkillParseError):
+        parse_skill_file(path)
+
+
+@pytest.mark.parametrize("name", ["BadName", "bad_name", "-bad", "bad-", "bad skill"])
+def test_parse_invalid_names(tmp_path: Path, name: str) -> None:
+    path = write_skill(tmp_path, f"---\nname: {name}\ndescription: Desc\n---\nBody\n")
+
+    with pytest.raises(SkillParseError):
+        parse_skill_file(path)
+
+
+def test_parse_long_description(tmp_path: Path) -> None:
+    path = write_skill(
+        tmp_path,
+        f"---\nname: long-desc\ndescription: {'x' * 1025}\n---\nBody\n",
+    )
+
+    with pytest.raises(SkillParseError):
+        parse_skill_file(path)
+
+
+def test_parse_malformed_yaml(tmp_path: Path) -> None:
+    path = write_skill(tmp_path, "---\nname: [broken\ndescription: Desc\n---\nBody\n")
+
+    with pytest.raises(SkillParseError):
+        parse_skill_file(path)
+
+
+def test_parse_optional_fields(tmp_path: Path) -> None:
+    path = write_skill(
+        tmp_path,
+        "---\nname: optional-fields\ndescription: Has optional fields.\nallowed-tools:\n  - read_file\n  - grep_search\nmetadata:\n  owner: test\n---\nBody\n",
+    )
+
+    skill = parse_skill_file(path)
+
+    assert skill.allowed_tools == ["read_file", "grep_search"]
+    assert skill.frontmatter["metadata"]["owner"] == "test"

--- a/tests/test_tool_manager_skills.py
+++ b/tests/test_tool_manager_skills.py
@@ -1,4 +1,18 @@
+import json
+from pathlib import Path
+
+import pytest
+
 from penguin.tools.tool_manager import ToolManager
+from penguin.utils.parser import ActionExecutor, ActionType, CodeActAction, parse_action
+
+
+def _skill_names_from_responses_tools(manager: ToolManager) -> set[str]:
+    names = set()
+    for tool in manager.get_responses_tools(include_web_search=False):
+        if tool.get("type") == "function":
+            names.add(str(tool.get("name")))
+    return names
 
 
 def test_tool_manager_exposes_skill_tools() -> None:
@@ -9,3 +23,50 @@ def test_tool_manager_exposes_skill_tools() -> None:
     assert "activate_skill" in names
     assert "list_skills" in manager._tool_registry
     assert "activate_skill" in manager._tool_registry
+
+
+def test_tool_manager_exposes_skill_tools_to_native_payload() -> None:
+    manager = ToolManager({"skills": {"enabled": False}}, lambda *args, **kwargs: None, fast_startup=True)
+
+    names = _skill_names_from_responses_tools(manager)
+
+    assert "list_skills" in names
+    assert "activate_skill" in names
+
+
+def test_parser_detects_skill_actionxml_fallback_tags() -> None:
+    actions = parse_action(
+        '<list_skills>{"refresh": true}</list_skills>'
+        '<activate_skill>{"name": "demo-skill"}</activate_skill>'
+    )
+
+    assert [action.action_type for action in actions] == [
+        ActionType.LIST_SKILLS,
+        ActionType.ACTIVATE_SKILL,
+    ]
+
+
+def _make_skill(path: Path, name: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Demo skill\n---\nUse this skill.\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_action_executor_runs_list_skills_fallback_tag(tmp_path: Path) -> None:
+    _make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = ToolManager(
+        {"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}},
+        lambda *args, **kwargs: None,
+        fast_startup=True,
+    )
+    executor = ActionExecutor(tool_manager=manager, task_manager=None)
+
+    result = await executor.execute_action(
+        CodeActAction(ActionType.LIST_SKILLS, '{"refresh": true}')
+    )
+    payload = json.loads(result)
+
+    assert payload["skills"][0]["name"] == "demo-skill"

--- a/tests/test_tool_manager_skills.py
+++ b/tests/test_tool_manager_skills.py
@@ -1,0 +1,11 @@
+from penguin.tools.tool_manager import ToolManager
+
+
+def test_tool_manager_exposes_skill_tools() -> None:
+    manager = ToolManager({"skills": {"enabled": False}}, lambda *args, **kwargs: None, fast_startup=True)
+    names = {schema["name"] for schema in manager.tools}
+
+    assert "list_skills" in names
+    assert "activate_skill" in names
+    assert "list_skills" in manager._tool_registry
+    assert "activate_skill" in manager._tool_registry

--- a/tests/test_tool_manager_skills.py
+++ b/tests/test_tool_manager_skills.py
@@ -70,3 +70,30 @@ async def test_action_executor_runs_list_skills_fallback_tag(tmp_path: Path) -> 
     payload = json.loads(result)
 
     assert payload["skills"][0]["name"] == "demo-skill"
+
+
+def test_tool_manager_list_skills_reports_current_session_active_state(tmp_path: Path) -> None:
+    _make_skill(tmp_path / "skills" / "demo", "demo-skill")
+    manager = ToolManager(
+        {"skills": {"scan_paths": {"user": [str(tmp_path / "skills")]}}},
+        lambda *args, **kwargs: None,
+        fast_startup=True,
+    )
+
+    json.loads(
+        manager.execute_tool(
+            "activate_skill",
+            {"name": "demo-skill", "load_into_context": False},
+            context={"session_id": "session-a"},
+        )
+    )
+    payload = json.loads(
+        manager.execute_tool(
+            "list_skills",
+            {"refresh": True},
+            context={"session_id": "session-a"},
+        )
+    )
+
+    assert payload["active"] == ["demo-skill"]
+    assert payload["skills"][0]["active"] is True


### PR DESCRIPTION
## Summary
- Add Skills runtime: parser, discovery, manager, renderer, context injection, and native tool support.
- Add CLI, Web API, and TUI Skills interfaces with activation/deactivation and active-state reporting.
- Add prompt guidance, docs, and regression tests for Skills behavior.

## Validation
- Python focused Skills/API/tool tests pass.
- TUI typecheck passes.
- Docs build was validated during docs update.

## Notes
- Local web-server logs are intentionally untracked and excluded.
- Follow-up work remains for permission/trust policy, path hardening, skill install, and eval runner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agent Skills system with CLI commands for listing, showing, activating, and diagnosing skills
  * TUI dialog for browsing and managing skills
  * Web API endpoints for skill lifecycle management (list, activate, deactivate)
  * Runtime skill discovery, validation, context injection, and session-scoped activation tracking

* **Documentation**
  * New comprehensive Agent Skills usage guide
  * Updated platform branding and homepage
  * CLI documentation for skills commands
  * Task specification for Agent Skills MVP

<!-- end of auto-generated comment: release notes by coderabbit.ai -->