### PR TITLE
feat: add MCP host and server integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@ Fast Reference for Agents
 
 Commands
 - Install dev deps: pip install -e .[dev] (use uv/pipx if available)
+- Development workflow preference: use `uv` for installs and running Penguin (`uv sync`, `uv pip install ...`, `uv run penguin...`); plain `pytest` is fine for tests.
 - Lint (Ruff): ruff check . ; ruff format .
 - Format (Black + isort profile via Ruff): black . ; ruff check --fix .
 - Type hints policy: use typing, no strict mypy configured; prefer Pydantic types where relevant.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Under the hood, the `latest` targets override the project default with `--exclud
 | `[memory_faiss]` | FAISS vector search + embeddings |
 | `[memory_lance]` | LanceDB vector database |
 | `[memory_chroma]` | ChromaDB integration |
+| `[mcp]` | Model Context Protocol client/server dependencies (Python 3.10+ for the MCP SDK) |
 | `[browser]` | Browser automation (Python 3.11+ only) |
 | `[all]` | Everything above |
 

--- a/context/architecture/mcp-runtime-job-records.md
+++ b/context/architecture/mcp-runtime-job-records.md
@@ -1,0 +1,208 @@
+# MCP Runtime Job Records Contract
+
+## Status
+
+- Created: 2026-05-04
+- Scope: Slice 5B durable runtime job records for Penguin's MCP runtime server
+- State: proposed contract before implementation
+
+## Purpose
+
+Slice 3 introduced RunMode MCP tools that can start, list, inspect, cancel, and resume runtime jobs. Today those records are in-memory only.
+
+That is acceptable for live testing, but not enough for serious orchestration. If the MCP server process restarts, an external host loses job IDs, results, cancellation state, and status history.
+
+Slice 5B must persist runtime job records.
+
+## Storage Decision
+
+For local Penguin, runtime job records should live in the project persistence layer, not a sidecar JSON file or unrelated SQLite DB.
+
+Current local ProjectManager initializes storage at:
+
+```text
+<workspace>/projects.db
+```
+
+So local runtime job records should persist in that DB through `ProjectStorage` / `ProjectManager` facade methods.
+
+For Link/cloud, this same domain model should map to Link's database rather than local SQLite. The key requirement is the model contract, not SQLite itself.
+
+## Non-Goals
+
+Slice 5B should not attempt to solve:
+
+- distributed worker coordination
+- cloud multi-tenant auth
+- resumable Python thread execution after process death
+- full raw transcript/artifact storage
+- long-term analytics
+
+It should persist enough truth for external hosts to recover job history and reconcile current project/task state.
+
+## Record Schema
+
+Minimum fields:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `job_id` | string | yes | Stable primary ID returned to MCP callers |
+| `kind` | string | yes | `task`, `project`, `clarification_resume`, future kinds |
+| `status` | string | yes | Lifecycle status; see below |
+| `project_id` | string/null | no | Associated project |
+| `task_id` | string/null | no | Associated task |
+| `session_id` | string/null | no | Associated Penguin conversation/session if known |
+| `started_at` | ISO timestamp | yes | UTC preferred |
+| `updated_at` | ISO timestamp | yes | Every status change updates this |
+| `finished_at` | ISO timestamp/null | no | Terminal jobs only |
+| `cancel_requested` | boolean | yes | Operator requested cancellation |
+| `cancel_reason` | string/null | no | Human/MCP-supplied reason |
+| `result_summary` | string/null | no | Compact summary suitable for list views |
+| `result_json` | JSON string/null | no | Capped structured result when safe/serializable |
+| `error` | string/null | no | Failure detail, size-capped |
+| `metadata_json` | JSON string | yes | Extensible metadata |
+
+Recommended SQLite table name:
+
+```sql
+runtime_jobs
+```
+
+Recommended primary key:
+
+```sql
+job_id TEXT PRIMARY KEY
+```
+
+## Status Values
+
+Initial status enum:
+
+- `pending`
+- `running`
+- `waiting_input`
+- `completed`
+- `failed`
+- `cancel_requested`
+- `cancelled`
+
+Guidance:
+
+- `cancel_requested` means a cooperative cancellation signal was sent but the underlying job has not yet stopped.
+- `cancelled` means the job ended due to cancellation.
+- `waiting_input` should preserve clarification metadata when available.
+- Terminal statuses are `completed`, `failed`, and `cancelled`.
+
+## Result Storage Policy
+
+Do not blindly persist massive raw model responses or arbitrary Python reprs.
+
+Recommended policy:
+
+1. Always persist `result_summary` when a job reaches a terminal or waiting state.
+2. Persist `result_json` only when:
+   - JSON-serializable
+   - under a configured size cap
+   - not obviously binary/blob content
+3. If result is too large:
+   - store a truncated summary
+   - store metadata indicating truncation
+   - leave full artifacts to future artifact/evidence storage
+4. Store `error` with a size cap.
+
+Suggested caps:
+
+- `result_summary`: 4 KB
+- `result_json`: 64 KB initially
+- `error`: 16 KB
+
+These are product defaults, not hard protocol limits.
+
+## Relationship To Project/Task State
+
+Runtime job records should not replace task state.
+
+Examples:
+
+- A job completes and marks a task `pending_review`; the task status/phase persists separately.
+- A job fails; the job record stores failure details, while task state may remain active/running/failed depending on RunMode/PM semantics.
+- A job is cancelled; cancellation intent persists in the job record, while the task may need a separate status/phase update.
+
+External clients should use both:
+
+- runtime job record for execution attempt truth
+- task/project payload for durable work item state
+
+## ProjectManager Facade
+
+Add ProjectManager methods rather than making MCP tools talk to storage directly:
+
+```python
+create_runtime_job(...)
+update_runtime_job(...)
+get_runtime_job(job_id)
+list_runtime_jobs(project_id=None, task_id=None, status=None, limit=50)
+request_runtime_job_cancel(job_id, reason=None)
+```
+
+The MCP RunMode registry can keep live thread handles in memory, but persistence should flow through these facade methods.
+
+## MCP Tool Implications
+
+Existing Slice 3 tools should be backed by durable records:
+
+- `penguin_runmode_start_task`
+- `penguin_runmode_start_project`
+- `penguin_runmode_list_jobs`
+- `penguin_runmode_get_job`
+- `penguin_runmode_cancel_job`
+- `penguin_runmode_resume_clarification`
+
+Add or align Slice 5 tools:
+
+- `penguin_runtime_jobs_list`
+- `penguin_runtime_job_get`
+
+Implementation choice:
+
+- Either alias these to the RunMode tools,
+- or keep RunMode tools as live-control and runtime tools as durable historical query.
+
+Preferred: keep one shared underlying ProjectManager-backed store and expose both views consistently.
+
+## Recovery Semantics
+
+After MCP server restart:
+
+- completed/failed/cancelled jobs should still be listable.
+- running jobs from the old process should not be reported as definitely running.
+- stale non-terminal records should be marked or surfaced as `unknown_after_restart` / `failed` / `orphaned` depending on final policy.
+
+Recommended first policy:
+
+- On startup, detect non-terminal jobs older than process start without a live in-memory handle.
+- Surface them as `orphaned` in metadata while preserving original status.
+- Do not pretend they are still controllable.
+
+## Cloud / Link Mapping
+
+In Link/cloud, these records likely map to a real jobs table keyed by tenant/user/project. Additional cloud fields may include:
+
+- `tenant_id`
+- `user_id`
+- `worker_id`
+- `queue_id`
+- `lease_expires_at`
+- `event_stream_id`
+
+Local Penguin should not implement that complexity now, but the local schema should not block it.
+
+## Acceptance Criteria For Slice 5B
+
+- Runtime job records persist in the project DB.
+- Starting a RunMode MCP job creates a durable record.
+- Completion/failure/cancel updates the durable record.
+- `list_jobs` merges durable records with live in-memory handles.
+- After MCP server restart, terminal job records remain queryable.
+- Non-terminal orphaned jobs are clearly labeled, not silently shown as controllable.
+- Tests cover create/update/list/get and restart-style recovery.

--- a/context/architecture/mcp-runtime-job-records.md
+++ b/context/architecture/mcp-runtime-job-records.md
@@ -4,7 +4,7 @@
 
 - Created: 2026-05-04
 - Scope: Slice 5B durable runtime job records for Penguin's MCP runtime server
-- State: proposed contract before implementation
+- State: implemented locally in Slice 5B
 
 ## Purpose
 
@@ -12,7 +12,7 @@ Slice 3 introduced RunMode MCP tools that can start, list, inspect, cancel, and 
 
 That is acceptable for live testing, but not enough for serious orchestration. If the MCP server process restarts, an external host loses job IDs, results, cancellation state, and status history.
 
-Slice 5B must persist runtime job records.
+Slice 5B persists runtime job records in local ProjectStorage and merges them with the live in-process registry exposed by RunMode MCP tools.
 
 ## Storage Decision
 

--- a/context/architecture/mcp-runtime-surface.md
+++ b/context/architecture/mcp-runtime-surface.md
@@ -1,0 +1,272 @@
+# MCP Runtime Surface Architecture
+
+## Status
+
+- Created: 2026-05-04
+- Scope: Penguin MCP host/client and server/runtime-control-plane architecture
+- Audience: Penguin maintainers, Link/orchestration integrators, future agent implementers
+
+## Executive Summary
+
+Penguin now has two MCP roles:
+
+1. **MCP host/client** — Penguin consumes external MCP servers and exposes their tools to Penguin's normal ToolManager path.
+2. **MCP server** — Penguin exposes selected Penguin capabilities to external MCP hosts.
+
+The strategic value is not only exposing low-level file/search tools. The differentiated surface is Penguin's durable software-engineering runtime:
+
+- Project Management (PM)
+- Blueprints
+- RunMode
+- ITUV lifecycle state
+- artifacts/evidence
+- sessions/checkpoints
+- runtime job records
+
+A host like Link, Claude Desktop, an IDE, or another agent should be able to use Penguin as a specialized software-engineering runtime, not merely as a bag of file tools.
+
+## Layer Model
+
+```text
+External MCP Hosts
+  ├── Claude Desktop / Inspector / Link / IDEs / other agents
+  │
+  ▼
+Penguin MCP Server
+  ├── Phase 2A: safe low-level tools
+  ├── Phase 2B: PM / Blueprint / RunMode / ITUV runtime tools
+  │
+  ▼
+Penguin Runtime
+  ├── ToolManager
+  ├── ProjectManager / ProjectStorage
+  ├── RunMode
+  ├── Workflow / ITUV state
+  ├── Conversation/session/checkpoint systems
+  └── file/tool/security boundaries
+```
+
+For consuming external MCP servers:
+
+```text
+Penguin ToolManager
+  └── MCP tool provider
+        └── MCP client manager
+              ├── stdio MCP server sessions
+              └── future remote transports
+```
+
+## Host vs Server Distinction
+
+### Penguin As MCP Host / Client
+
+This is Phase 1 / 1.5.
+
+Penguin connects to external MCP servers such as:
+
+- Chrome DevTools MCP
+- GitHub MCP
+- filesystem MCP
+- Sentry MCP
+- database/search/browser MCP servers
+
+Those tools appear to Penguin as dynamically discovered tools using model-safe names like:
+
+```text
+mcp__chrome_devtools__navigate
+mcp__chrome_devtools__evaluate
+```
+
+Important properties:
+
+- dynamic tool discovery
+- STDIO sessions are persistent for process lifetime
+- calls route through `ToolManager.execute_tool()` permission semantics
+- configured servers expose diagnostics/status
+
+### Penguin As MCP Server
+
+This is Phase 2A / 2B.
+
+External MCP hosts connect to Penguin and see Penguin-native capabilities.
+
+#### Phase 2A: Tool-Level Server
+
+Safe low-level tools, default-on:
+
+- `read_file`
+- `list_files`
+- `find_file`
+- `grep_search`
+- `analyze_project`
+
+This validates protocol compliance and enables basic workspace introspection.
+
+#### Phase 2B: Runtime / Control-Plane Server
+
+Penguin-specific runtime tools:
+
+- PM tools: projects and tasks
+- Blueprint tools: lint, graph, sync, status
+- RunMode tools: start/status/cancel/resume clarification
+- ITUV tools: lifecycle status, frontier, mutation guardrails
+- future Session/Artifact/Checkpoint/runtime job records
+
+This is the strategic surface.
+
+## Default-On vs Runtime-Gated Tools
+
+### Default-On
+
+Default-on means: if a user intentionally starts Penguin's MCP server, these tools appear without extra flags.
+
+Current default-on groups:
+
+- safe low-level read/search tools
+- PM control-plane tools
+- Blueprint tools
+
+Rationale:
+
+- PM and Blueprint tools define and inspect intended work.
+- They are central to Penguin's differentiated value.
+- They do not directly launch autonomous execution.
+
+### Runtime-Gated
+
+Runtime-gated tools require:
+
+```bash
+scripts/penguin_mcp_server.py --allow-runtime-tools
+```
+
+Current runtime-gated groups:
+
+- RunMode tools
+- ITUV tools
+
+Rationale:
+
+- These can start work, mutate lifecycle state, cancel jobs, or mark tasks review-ready.
+- They need explicit operator intent.
+- Future public/remote deployments may need stronger policy controls.
+
+## Current Implemented Slices
+
+### Phase 1: MCP Host / Client
+
+- optional MCP SDK dependency
+- local STDIO MCP client support
+- dynamic names `mcp__server__tool`
+- ToolManager provider bridge
+- permission mapping
+
+### Phase 1.5: Host Diagnostics / Smoke
+
+- config aliases: `mcp.servers`, `mcpServers`, `mcp_servers`
+- status/reconnect/refresh APIs
+- product smoke script
+- real E2E with `@modelcontextprotocol/server-everything` and Chrome DevTools MCP
+
+### Phase 2A: Penguin Tool-Level Server
+
+- FastMCP-backed stdio server
+- safe read/search tools exposed
+- MCP Inspector validated
+
+### Phase 2B Slice 1: PM Tools
+
+Default-on:
+
+- `penguin_pm_list_projects`
+- `penguin_pm_create_project`
+- `penguin_pm_get_project`
+- `penguin_pm_list_tasks`
+- `penguin_pm_create_task`
+- `penguin_pm_get_task`
+
+### Phase 2B Slice 2 / 2.5: Blueprint Tools
+
+Default-on:
+
+- `penguin_blueprint_lint`
+- `penguin_blueprint_graph`
+- `penguin_blueprint_status`
+- `penguin_blueprint_sync`
+
+`penguin_blueprint_sync` defaults to dry-run and refuses invalid blueprints.
+
+### Phase 2B Slice 3: RunMode Tools
+
+Runtime-gated:
+
+- `penguin_runmode_capabilities`
+- `penguin_runmode_list_jobs`
+- `penguin_runmode_get_job`
+- `penguin_runmode_start_task`
+- `penguin_runmode_start_project`
+- `penguin_runmode_cancel_job`
+- `penguin_runmode_resume_clarification`
+
+Current job registry is in-memory only. Durable records are planned for Slice 5.
+
+### Phase 2B Slice 4: ITUV Tools
+
+Runtime-gated:
+
+- `penguin_ituv_capabilities`
+- `penguin_ituv_status`
+- `penguin_ituv_frontier`
+- `penguin_ituv_signal`
+- `penguin_ituv_mark_ready_for_review`
+- `penguin_ituv_record_artifact`
+
+Mutation tools default to dry-run and enforce conservative transition semantics.
+
+## State Preservation
+
+| State | Current Preservation |
+| --- | --- |
+| Projects | durable in project DB |
+| Tasks | durable in project DB |
+| Blueprint sync results | durable as tasks/dependencies |
+| External MCP server sessions | process-lifetime |
+| RunMode MCP job records | in-memory only today |
+| Job cancellation handles | in-memory only today |
+| Conversation/session history | Penguin has persistence, but MCP runtime-job recovery is not wired yet |
+
+## Local vs Cloud / Link Considerations
+
+For local Penguin, project/task/runtime job state should live close to `ProjectStorage`.
+
+For Link/cloud:
+
+- runtime jobs should become first-class DB records
+- project/task/session IDs should be explicit and stable
+- job status should be evented/streamed
+- artifacts/evidence should be addressable separately
+- cancellation should coordinate with worker processes, not local threads only
+
+Do not overbuild Link's distributed runtime inside local Penguin, but keep the local model mirrorable:
+
+- stable job IDs
+- explicit foreign keys
+- structured status enum
+- compact summaries
+- JSON metadata
+- no arbitrary Python object persistence
+
+## Security Notes
+
+- Default-on does not mean unrestricted.
+- Runtime mutation/execution stays CLI-gated.
+- Browser/Chrome MCP tools can inspect browser state; use isolated profiles for tests.
+- External MCP tools route through permission checks.
+- Penguin-as-server low-level writes/shell/browser/subagents remain denied by default unless explicitly allowlisted.
+
+## Known Debt
+
+- Runtime job records are not durable yet.
+- ITUV phase transition policy is currently MCP-local; ProjectManager should eventually own it.
+- Artifact evidence writes currently touch task storage directly from the MCP ITUV tool layer; ProjectManager needs a public helper.
+- MCP server tool catalog should become public docs/reference before release.

--- a/context/bugs/read-tool-empty-loop.md
+++ b/context/bugs/read-tool-empty-loop.md
@@ -1,0 +1,38 @@
+# Bug: Read Tool Can Trigger Empty Assistant Loops
+
+## Status
+Open
+
+## Summary
+During MCP implementation work on 2026-05-01, repeated `read_file` / read-heavy tool usage appeared to correlate with assistant turns returning `[Empty response from model]` instead of normal tool-call/result continuation. The issue looked like a runtime/tool-loop handling bug, not a filesystem permission failure.
+
+## Observed Behavior
+- Assistant emitted short preambles and attempted read/exploration tool calls.
+- Runtime returned `[Empty response from model]` for multiple turns.
+- Later `patch_file` worked successfully, confirming writes were not globally blocked.
+- A unified diff failed only because of stale context; line insert succeeded immediately afterward.
+
+## Expected Behavior
+Read tools should return a tool result or a structured error. The assistant loop should not advance into empty model responses without exposing the failed tool call/result state.
+
+## Suspected Area
+Likely one of:
+- native tool-call adjacency / transcript replay handling after read results
+- read result truncation or serialization path
+- provider adapter handling for tool-only turns
+- engine loop termination behavior when the model emits no content after a tool result
+
+## Reproduction Notes
+Not yet deterministic. The observed pattern happened during a read-heavy repo survey using multiple `read_file` and shell read commands in sequence.
+
+## Impact
+Medium-high for coding workflows. Exploration is foundational; empty loops make the agent appear stuck and can hide whether tools actually ran.
+
+## Suggested Investigation
+1. Add logging around read tool dispatch, tool-result insertion, and the next model request payload.
+2. Capture whether the next assistant message has tool calls, text, or neither.
+3. Add a regression test for read-heavy multi-tool sequences followed by normal continuation.
+4. Verify tool-result adjacency rules for OpenAI/Codex/native tool-call adapters.
+
+## Notes
+Do not confuse this with permission failure. A subsequent `patch_file` succeeded in the same session.

--- a/context/tasks/mcp-ituv-audit.md
+++ b/context/tasks/mcp-ituv-audit.md
@@ -122,16 +122,25 @@ Expose behind `--allow-runtime-tools`:
 
 All Slice 4A tools must be read-only.
 
-## Slice 4B Preconditions
+## Slice 4B Implementation Decision
 
-Before mutation/signaling tools:
+Slice 4B now exposes guarded mutation tools behind the same runtime opt-in flag:
 
-1. Define legal phase transition rules as explicitly as `TaskStatus.valid_transitions()`.
-2. Decide whether MCP may call `update_task_status` / `update_task_phase` directly or must route through an orchestrator/service.
-3. Define artifact evidence write schema and validation.
-4. Make pending-review vs completed semantics impossible to confuse.
-5. Decide whether mutation tools need a separate flag beyond `--allow-runtime-tools`.
+- `penguin_ituv_signal`
+- `penguin_ituv_record_artifact`
+- `penguin_ituv_mark_ready_for_review`
 
-## Decision
+Rules:
 
-Proceed with Slice 4A only. Pause before Slice 4B.
+1. All mutation tools default to `dry_run=true`.
+2. Applying mutations requires explicit `dry_run=false`.
+3. `penguin_ituv_signal` validates status transitions with `TaskStatus.valid_transitions()`.
+4. `penguin_ituv_signal` validates phase transitions with a conservative MCP-local transition map until ProjectManager exposes a first-class phase-transition policy.
+5. Direct `status=pending_review|completed` and direct `phase=done` are rejected unless lifecycle state is already legal; normal successful execution should use `penguin_ituv_mark_ready_for_review`.
+6. `penguin_ituv_record_artifact` persists `ArtifactEvidence` directly through task storage because ProjectManager does not yet expose a public artifact-evidence method.
+
+## Remaining Debt Before Wider Mutation Use
+
+- Extract ProjectManager public helpers for task readiness, phase transition validation, and artifact evidence writes.
+- Decide whether ITUV mutation tools need a stricter flag than `--allow-runtime-tools` before public release.
+- Add durable runtime job records in Slice 5 so external orchestrators can reconstruct run history after process restart.

--- a/context/tasks/mcp-ituv-audit.md
+++ b/context/tasks/mcp-ituv-audit.md
@@ -1,0 +1,137 @@
+# MCP ITUV Audit
+
+## Status
+
+- Created: 2026-05-04
+- Scope: Phase 2B Slice 4 planning for Penguin's MCP server surface
+- Bias: expose read/status truth before mutation
+
+## Context
+
+The broad system model lives in `context/architecture/runmode-project-ituv-system-map.md`. That file is useful orientation, but the implementation truth comes from code.
+
+Relevant code checked for Slice 4A:
+
+- `penguin/project/models.py`
+  - `TaskStatus`
+  - `TaskPhase`
+  - `DependencyPolicy`
+  - `ArtifactEvidence`
+- `penguin/project/manager.py`
+  - `get_ready_tasks`
+  - `get_blocked_ready_candidates`
+  - `get_next_task_dag`
+  - `get_dag_stats`
+  - `_is_dependency_satisfied`
+  - `_get_unsatisfied_dependencies`
+- `penguin/web/services/project_payloads.py`
+  - shared task/project serializers already used by MCP PM and Blueprint tools
+
+## State Model
+
+Penguin task lifecycle has two axes:
+
+- `status`: operational/review state
+- `phase`: ITUV workflow phase
+
+Current `TaskPhase` values:
+
+- `pending`
+- `implement`
+- `test`
+- `use`
+- `verify`
+- `done`
+- `blocked`
+
+Current `TaskStatus` values:
+
+- `active`
+- `running`
+- `pending_review`
+- `completed`
+- `cancelled`
+- `failed`
+- `archived`
+
+Important semantic warning:
+
+- `phase=done` is not the same thing as `status=completed`.
+- Successful execution normally reaches `phase=done` and `status=pending_review` before human/trusted approval completes the task.
+
+## Dependency Readiness Semantics
+
+Current central dependency check is `ProjectManager._is_dependency_satisfied(...)`.
+
+Policies:
+
+- `completion_required`: upstream `status == completed`
+- `review_ready_ok`: upstream `phase == done` and `status in {pending_review, completed}`
+- `artifact_ready`: valid matching artifact evidence on the upstream dependency task
+
+This is the source of truth for DAG frontier/readiness. MCP should not duplicate this logic when a `ProjectManager` method can answer the question.
+
+## Public/Usable Read APIs
+
+Safe to expose read-only in Slice 4A:
+
+- `ProjectManager.get_dag_stats(project_id)`
+- `ProjectManager.get_ready_tasks(project_id)`
+- `ProjectManager.get_next_task_dag(project_id)`
+- `ProjectManager.get_blocked_ready_candidates(project_id)`
+- task/project serializers from `penguin.web.services.project_payloads`
+
+Useful but private:
+
+- `_get_unsatisfied_dependencies(task, task_map)`
+
+Slice 4A may use `_get_unsatisfied_dependencies` defensively for task-specific readiness, but this should be treated as an implementation detail. If the surface becomes important, extract a public ProjectManager method later.
+
+## Mutation APIs To Avoid For Slice 4A
+
+Do not expose yet:
+
+- `update_task_status`
+- `update_task_phase`
+- `mark_task_execution_ready_for_review`
+- artifact evidence writes
+- ITUV workflow signaling
+
+Reason: these mutate lifecycle state and require legal transition validation plus a policy story. Exposing them before read/status is solid is a foot-gun.
+
+## Slice 4A Tool Recommendation
+
+Expose behind `--allow-runtime-tools`:
+
+- `penguin_ituv_capabilities`
+  - status values
+  - phase values
+  - status transition map
+  - dependency policies
+  - known gaps
+- `penguin_ituv_status`
+  - task/project lifecycle truth
+  - dependency specs
+  - artifact evidence
+  - DAG stats
+  - ready tasks and blocked candidates when scoped to a project
+- `penguin_ituv_frontier`
+  - dependency-aware ready task frontier
+  - next DAG task
+  - blocked candidates
+
+All Slice 4A tools must be read-only.
+
+## Slice 4B Preconditions
+
+Before mutation/signaling tools:
+
+1. Define legal phase transition rules as explicitly as `TaskStatus.valid_transitions()`.
+2. Decide whether MCP may call `update_task_status` / `update_task_phase` directly or must route through an orchestrator/service.
+3. Define artifact evidence write schema and validation.
+4. Make pending-review vs completed semantics impossible to confuse.
+5. Decide whether mutation tools need a separate flag beyond `--allow-runtime-tools`.
+
+## Decision
+
+Proceed with Slice 4A only. Pause before Slice 4B.

--- a/context/tasks/mcp-runmode-audit.md
+++ b/context/tasks/mcp-runmode-audit.md
@@ -1,0 +1,152 @@
+# MCP RunMode Audit
+
+- Created: 2026-05-04
+- Branch: `feature-mcp-system`
+- Purpose: identify what Penguin can truthfully expose as Phase 2B Slice 3 runtime MCP tools.
+
+## Executive Summary
+
+RunMode should not be exposed as a one-shot `start` tool until Penguin has an
+explicit job/status/cancel contract for MCP. The current web surface can start
+execution and resume clarification, but it does not provide a durable RunMode job
+registry or a clean cancellation/status API for arbitrary runs.
+
+The safe next runtime step is not `penguin_runmode_start_task`. It is a small
+capabilities/status surface that reports what can be started, what execution
+routes exist, and what lifecycle truth is currently observable.
+
+## Evidence From Current Code
+
+### Web/API Surfaces
+
+- `penguin/web/services/projects.py` contains the current project execution service.
+  `start_project_execution(...)` resolves a project, checks tasks/ready tasks, builds
+  an `ExecutionContext`, and calls `core.start_run_mode(...)` with `mode_type="project"`.
+- `penguin/web/routes.py` exposes `POST /api/v1/projects/{project_identifier}/start`
+  through `start_project_execution(...)`.
+- `penguin/web/routes.py` exposes `POST /api/v1/tasks/{task_id}/execute`, which:
+  - resolves the task,
+  - checks that `core.engine` exists,
+  - builds an `ExecutionContext`,
+  - creates a fresh `RunMode(core=core)`,
+  - calls `run_mode.start(...)`,
+  - returns `{task_id, result, task}`.
+- `penguin/web/routes.py` exposes `POST /api/v1/tasks/{task_id}/clarification/resume`,
+  which creates a fresh `RunMode(core=core)` and calls
+  `run_mode.resume_with_clarification(...)`.
+- `penguin/web/routes.py` still exposes older background/sync execution paths:
+  - `POST /api/v1/tasks/execute` uses FastAPI `BackgroundTasks` with no returned job ID.
+  - `POST /api/v1/tasks/execute-sync` has separate engine/runmode fallback behavior.
+
+### RunMode Internals
+
+- `penguin/run_mode.py` has `RunMode.start(...)` for single task execution.
+- `RunMode.resume_with_clarification(...)` persists the clarification answer, emits
+  `clarification_answered`, and immediately resumes execution via `start(...)`.
+- Continuous mode uses `_shutdown_requested` internally and checks `core._interrupted`,
+  but there is no obvious public `cancel(job_id)` API.
+- RunMode emits status events, but there is no dedicated durable MCP/job registry that
+  can be queried by an external MCP host after a start call returns or while it runs.
+- The current task/project web routes are richer and more current than the older
+  programmatic `PenguinAPI` surface, even though `PenguinAPI.run_task(...)` and
+  `resume_with_clarification(...)` now route through RunMode.
+
+## What Works Today
+
+These capabilities have current implementation paths and can be tested without inventing
+new runtime semantics:
+
+1. Project/task creation and listing through `ProjectManager`.
+2. Blueprint lint/graph/status/sync through `ProjectManager.sync_blueprint(...)`.
+3. Task execution through web route/service paths, but it is synchronous from the caller's
+   perspective and model-dependent.
+4. Clarification resume for tasks with an open persisted clarification request.
+
+## What Is Missing For Runtime MCP Tools
+
+Before exposing autonomous runtime controls over MCP, Penguin needs:
+
+1. **Runtime tool opt-in gate**
+   - CLI-only initially: `scripts/penguin_mcp_server.py --allow-runtime-tools`.
+   - Do not expose runtime start/cancel by default.
+
+2. **Job/status model**
+   - A small in-process registry is enough for MVP.
+   - It should track `job_id`, `kind`, `project_id`, `task_id`, `status`, `started_at`,
+     `finished_at`, `result`, `error`, and latest event/status payload.
+
+3. **Cancellation semantics**
+   - Need a real cancellation path, not just a flag nobody checks.
+   - Continuous mode checks `_shutdown_requested`; single-task execution likely needs
+     task cancellation via the asyncio task/job registry.
+
+4. **Lifecycle-aligned payloads**
+   - MCP responses must match web lifecycle truth: status, phase, dependencies,
+     artifact evidence, recipe metadata, clarification requests.
+
+5. **Deterministic tests**
+   - Runtime execution is model-dependent. Unit tests should use a fake core/runmode or
+     a no-op/failing engine path to validate job lifecycle without spending model calls.
+   - Product smoke can remain opt-in/manual.
+
+## Recommended Slice 3 Shape
+
+### Slice 3A: Runtime Capabilities And Readiness
+
+Default exposure: only if runtime tools are enabled with CLI flag.
+
+Tools:
+
+- `penguin_runmode_capabilities`
+  - Reports supported start modes, required opt-in, whether engine/project manager exist,
+    whether job registry is active, and known gaps.
+- `penguin_runmode_list_jobs`
+  - Lists in-process jobs once a registry exists. Initially returns an empty list with
+    registry metadata.
+- `penguin_runmode_get_job`
+  - Gets one job by ID. Initially useful once `start` exists.
+
+Acceptance criteria:
+
+- Tools are absent unless `--allow-runtime-tools` is set.
+- Capabilities tool returns truthful unsupported/missing state rather than optimistic claims.
+- No model call required.
+
+### Slice 3B: Runtime Start Behind Opt-In
+
+Tools:
+
+- `penguin_runmode_start_task`
+  - Starts project task execution in a background job.
+  - Requires `task_id` or `{project_id, task_title}`.
+  - Returns `job_id` immediately.
+- `penguin_runmode_start_project`
+  - Starts project-scoped execution through the same service path as web project start.
+  - Requires `project_id` or exact project name.
+  - Returns `job_id` immediately.
+
+Acceptance criteria:
+
+- Uses existing web service functions where possible.
+- Returns a job record, not a blocking model result.
+- Captures final result/error into job registry.
+
+### Slice 3C: Cancel And Resume Clarification
+
+Tools:
+
+- `penguin_runmode_cancel_job`
+  - Cancels a registered background job.
+- `penguin_runmode_resume_clarification`
+  - Routes to the same RunMode clarification path as the web route.
+  - Might create a new job or return direct result depending on implementation choice.
+
+Acceptance criteria:
+
+- Cancellation is real for background jobs.
+- Clarification resume returns the updated task payload and runtime result.
+
+## Recommendation
+
+Proceed with Slice 2.75 smoke first, then implement Slice 3A only. Do not expose
+`start` until a job registry exists and cancellation semantics are explicit.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -485,17 +485,20 @@ Task creation should support rich fields immediately. Fields that are first-clas
 
 #### Slice 2: Blueprint Tools Default-On
 
+Status: implemented in `penguin/integrations/mcp/server_tools/blueprints.py` with shared Blueprint payload serializers in `penguin/web/services/blueprint_payloads.py`.
+
 Expose Penguin's spec-to-task DAG capability.
 
 Tools:
 
 - `penguin_blueprint_lint` — parse/lint Markdown/YAML/JSON blueprints and return structured diagnostics for duplicate IDs, missing deps, cycles, and missing acceptance criteria.
 - `penguin_blueprint_graph` — return the dependency DAG in a machine-readable form, optionally DOT/JSON.
-- `penguin_blueprint_status` — map blueprint items to project tasks and report sync/execution status.
+- `penguin_blueprint_status` — map blueprint-derived project tasks to current DAG/status data.
 
 Defer until internals are verified and idempotency is clear:
 
 - `penguin_blueprint_sync` — import/sync a blueprint into a project as tasks/dependency graph without executing it.
+- Phase/dependency-readiness filters and richer blueprint/task status correlation.
 
 #### Slice 3: Runtime / RunMode Explicit Opt-In
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -520,17 +520,39 @@ Acceptance criteria:
 
 #### Slice 3: Runtime / RunMode Explicit Opt-In
 
-Expose long-running execution as durable jobs, not blocking tool calls. These tools are not registered unless runtime tools are explicitly enabled.
+Expose long-running execution as durable jobs, not blocking tool calls. Runtime tools are not registered unless explicitly enabled with `scripts/penguin_mcp_server.py --allow-runtime-tools`.
+
+##### Slice 3A: Runtime Capabilities And Readiness
+
+Status: implemented in `penguin/integrations/mcp/server_tools/runmode.py`.
 
 Tools:
 
+- `penguin_runmode_capabilities` — reports current RunMode readiness, core/engine/project-manager availability, registry metadata, and known gaps. It never starts execution.
+- `penguin_runmode_list_jobs` — lists the in-process runtime MCP job registry. In Slice 3A this registry is read-only and usually empty.
+- `penguin_runmode_get_job` — returns one in-process runtime MCP job by ID if it exists.
+
+Acceptance criteria:
+
+- Runtime tools are absent unless `--allow-runtime-tools` is set.
+- Capabilities tool is truthful: `start_supported=false`, `cancel_supported=false`, and gaps are reported.
+- No model call is required.
+
+##### Slice 3B: Runtime Start Behind Opt-In
+
+Future tools:
+
 - `penguin_runmode_start_task` — start a bounded RunMode task with name, description, context, max iterations, time limit, and optional project/task binding.
-- `penguin_runmode_start_continuous` — start continuous task processing for a project or named task queue, with explicit time/resource limits.
-- `penguin_runmode_status` — return status, phase, current iteration, active task, stop reason, waiting-input state, and latest artifact evidence.
-- `penguin_runmode_cancel` — cancel or interrupt a running RunMode job.
+- `penguin_runmode_start_project` — start project-scoped execution through the same service path as the web project start route.
+
+##### Slice 3C: Cancel And Resume Clarification
+
+Future tools:
+
+- `penguin_runmode_cancel_job` — cancel a registered background job.
 - `penguin_runmode_resume_clarification` — answer a clarification request and resume through the same lifecycle path.
 
-Implementation note: this slice needs a durable-ish job registry/status handle before exposing start operations. Do not implement it as a blocking `process_message("do task")` wrapper.
+Implementation note: Slice 3B/3C need real background job start/cancel semantics before exposing start operations. Do not implement them as blocking `process_message("do task")` wrappers.
 
 #### Slice 4: Orchestration / ITUV Explicit Opt-In
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -325,6 +325,42 @@ Penguin can connect to configured MCP servers and use their tools as normal Peng
 - Integration test uses a tiny Python FastMCP/stdio server.
 - Tool list changes from an MCP server invalidate cached schemas or are explicitly documented as unsupported in MVP.
 
+## Phase 1.5: MCP Host Hardening And E2E Validation
+
+### Scope
+
+Make Penguin comfortable to test as an MCP host/client before exposing Penguin itself as an MCP server. This phase is about diagnostics, real config shapes, and one-command smoke validation against real STDIO servers such as `@modelcontextprotocol/server-everything` and `chrome-devtools-mcp`.
+
+### Implementation Steps
+
+1. Accept common host config shapes:
+   - Penguin-native `mcp.servers`.
+   - Claude-style top-level `mcpServers`.
+   - Codex-style top-level `mcp_servers` where practical.
+   - Keep Streamable HTTP/SSE rejected with a clear unsupported-transport error until that phase lands.
+
+2. Add diagnostics and lifecycle controls:
+   - ToolManager facade methods for MCP status, refresh, reconnect, and close.
+   - Web/API endpoints for `/api/v1/mcp`, reconnect, and close, following the skills-route precedent.
+   - Status payload should include availability, initialized/discovered state, server status, transport, command, tool count, and last error.
+
+3. Add smoke validation tooling:
+   - Scriptable STDIO smoke runner using Penguin's `MCPClientManager`, not Inspector only.
+   - Example target: `npx -y @modelcontextprotocol/server-everything`.
+   - Example high-value target: `npx -y chrome-devtools-mcp@latest --no-usage-statistics --no-update-checks`.
+
+4. Preserve permission and provider boundaries:
+   - MCP tool execution still routes through `ToolManager.execute_tool()`.
+   - Browser/Chrome MCP tools should remain high-risk and prompt/deny according to permission policy.
+
+### Acceptance Criteria
+
+- Penguin can parse `mcp.servers`, `mcpServers`, and `mcp_servers` config shapes.
+- `/api/v1/mcp?refresh=true` reports configured server status without hiding errors.
+- ToolManager can refresh/reconnect/close MCP sessions without restarting Penguin.
+- A local smoke script can list tools from a real STDIO MCP server when `penguin-ai[mcp]` is installed on Python 3.10+.
+- Focused tests cover config aliases, diagnostics, refresh/reconnect/close facades, and disabled/no-SDK behavior.
+
 ## Phase 2: Real MCP Server For Penguin Tools
 
 ### Scope
@@ -444,6 +480,13 @@ Potential mappings:
 - One MCP tool can be called as `mcp__<server>__<tool>`.
 - Basic tests pass.
 
+### Milestone 1.5: Host Hardening And Real-Server Smoke
+
+- Common config aliases parse correctly.
+- MCP status/refresh/reconnect/close surfaces exist in ToolManager and web/API.
+- Smoke script validates STDIO discovery against `server-everything` and Chrome DevTools MCP.
+- Diagnostics clearly show missing SDK, failed command startup, unsupported transport, and tool counts.
+
 ### Milestone 2: Robust Client
 
 - Reconnect/cleanup.
@@ -478,4 +521,4 @@ Potential mappings:
 
 ## Recommendation
 
-Start with Milestone 1 only, but include the reference-agent basics that prevent pain later: explicit status states, conservative `mcp__server__tool` naming, raw-name reverse lookup, separate startup/tool timeouts, and STDIO process cleanup. Do not touch resources, prompts, OAuth, or server exposure until a local STDIO MCP tool can be discovered and called through Penguin's existing ToolManager with tests. Anything else is scope creep wearing a fake mustache.
+Start with Milestone 1, immediately follow with Milestone 1.5 for real-server validation, and include the reference-agent basics that prevent pain later: explicit status states, conservative `mcp__server__tool` naming, raw-name reverse lookup, separate startup/tool timeouts, and STDIO process cleanup. Do not touch resources, prompts, OAuth, or server exposure until a local STDIO MCP tool can be discovered and called through Penguin's existing ToolManager with tests. Anything else is scope creep wearing a fake mustache.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -556,12 +556,19 @@ Slice 3B caveats:
 
 ##### Slice 3C: Cancel And Resume Clarification
 
-Future tools:
+Status: implemented with cooperative cancellation and clarification resume jobs.
+
+Tools:
 
 - `penguin_runmode_cancel_job` — cancel a registered background job.
 - `penguin_runmode_resume_clarification` — answer a clarification request and resume through the same lifecycle path.
 
-Implementation note: Slice 3B/3C need real background job start/cancel semantics before exposing start operations. Do not implement them as blocking `process_message("do task")` wrappers.
+Slice 3C caveats:
+
+- Cancellation is cooperative/best-effort. Python threads are not force-killed.
+- `penguin_runmode_cancel_job` records cancellation intent and signals a RunMode instance when a job exposes one.
+- `penguin_runmode_resume_clarification` answers the latest open clarification request and resumes execution in a background job.
+- Job registry remains in-process and non-durable.
 
 #### Slice 4: Orchestration / ITUV Explicit Opt-In
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -464,13 +464,16 @@ Shared helpers should prefer web/API service-layer payload construction when ava
 
 #### Slice 1: PM Tools Default-On
 
+Status: implemented in `penguin/integrations/mcp/server_tools/pm.py` with shared web/MCP payload serializers in `penguin/web/services/project_payloads.py`.
+
 Expose Penguin's project/task truth as the first Phase 2B control-plane surface.
 
 Tools:
 
 - `penguin_pm_list_projects` — list project containers and lifecycle summaries.
 - `penguin_pm_create_project` — create a project with name, description, workspace/root metadata.
-- `penguin_pm_list_tasks` — list tasks by project/status/phase/dependency readiness.
+- `penguin_pm_get_project` — return one project by ID with tasks included by default.
+- `penguin_pm_list_tasks` — list tasks by project/status/parent task. Phase/dependency-readiness filters remain future work.
 - `penguin_pm_create_task` — create tasks with description, priority, dependencies, acceptance criteria, resource constraints, and metadata.
 - `penguin_pm_get_task` — return rich task truth: status, phase, dependency specs, artifact evidence, recipe, metadata, clarification requests.
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -588,17 +588,20 @@ Slice 4A tools are exposed only when `--allow-runtime-tools` is set and must not
 
 ##### Slice 4B: ITUV Mutation / Signaling
 
-Future gated tools:
+Status: implemented in `penguin/integrations/mcp/server_tools/ituv.py`.
 
-- `penguin_ituv_signal` — validated status/phase/workflow signal transitions.
-- `penguin_ituv_record_artifact` — attach validated artifact evidence.
-- `penguin_ituv_mark_ready_for_review` — route successful execution into review state through existing PM semantics.
+Gated mutation tools:
 
-Slice 4B preconditions:
+- `penguin_ituv_signal` — dry-run/apply validated status and phase signals. Defaults to `dry_run=true` and enforces status + phase transition guards before calling ProjectManager.
+- `penguin_ituv_record_artifact` — dry-run/apply artifact evidence writes. Defaults to `dry_run=true` and persists `ArtifactEvidence` on the task.
+- `penguin_ituv_mark_ready_for_review` — dry-run/apply the ProjectManager-owned successful-execution bridge into `phase=done` and `status=pending_review`.
 
-- Define legal phase transition rules as explicitly as `TaskStatus.valid_transitions()`.
-- Decide whether mutation uses direct `ProjectManager` methods or an orchestration service.
-- Make `phase=done` vs `status=completed` impossible to confuse.
+Current guardrails:
+
+- Tools are exposed only when `--allow-runtime-tools` is set.
+- Mutation tools default to `dry_run=true`; callers must explicitly pass `dry_run=false` to apply.
+- Direct `status=pending_review|completed` and direct `phase=done` are rejected unless using the review bridge or already in a legal state.
+- Phase transitions use an explicit conservative transition map in the MCP server tool layer until ProjectManager owns public phase-transition policy.
 
 #### Slice 5: Sessions / Context / Evidence / Durable Runtime Records
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -485,7 +485,7 @@ Task creation should support rich fields immediately. Fields that are first-clas
 
 #### Slice 2: Blueprint Tools Default-On
 
-Status: implemented in `penguin/integrations/mcp/server_tools/blueprints.py` with shared Blueprint payload serializers in `penguin/web/services/blueprint_payloads.py`.
+Status: implemented in `penguin/integrations/mcp/server_tools/blueprints.py` with shared Blueprint payload serializers in `penguin/web/services/blueprint_payloads.py`. Slice 2.5 adds guarded sync with `dry_run=true` and `update_existing=false` defaults.
 
 Expose Penguin's spec-to-task DAG capability.
 
@@ -494,11 +494,12 @@ Tools:
 - `penguin_blueprint_lint` — parse/lint Markdown/YAML/JSON blueprints and return structured diagnostics for duplicate IDs, missing deps, cycles, and missing acceptance criteria.
 - `penguin_blueprint_graph` — return the dependency DAG in a machine-readable form, optionally DOT/JSON.
 - `penguin_blueprint_status` — map blueprint-derived project tasks to current DAG/status data.
+- `penguin_blueprint_sync` — dry-run or sync a blueprint into a project as tasks/dependency graph without executing it. Defaults to `dry_run=true`, requires `project_id` unless `create_project=true`, refuses lint errors, and defaults `update_existing=false`.
 
 Defer until internals are verified and idempotency is clear:
 
-- `penguin_blueprint_sync` — import/sync a blueprint into a project as tasks/dependency graph without executing it.
 - Phase/dependency-readiness filters and richer blueprint/task status correlation.
+- More detailed id mapping/result metadata from `ProjectManager.sync_blueprint` if/when the manager exposes it.
 
 #### Slice 3: Runtime / RunMode Explicit Opt-In
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -655,6 +655,8 @@ Gated:
 
 ## Phase 3: Resources, Prompts, Notifications
 
+Status: implemented initial conservative resources and prompts. Tool-list change notifications remain future Phase 4/product-polish work.
+
 ### Resources
 
 Potential mappings:

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -761,13 +761,15 @@ Still deferred:
 
 ### Milestone 2: Robust Client
 
-- Reconnect/cleanup.
-- Diagnostics.
-- Allow/deny policy.
-- Result normalization.
-- Streamable HTTP and SSE support implemented; OAuth remains deferred.
-- Connect/close/reconnect controls.
-- Tool-list-changed cache invalidation.
+Status: mostly implemented for practical host/client use. Remaining items are listed under deferred follow-ups below.
+
+- Reconnect/cleanup implemented for configured servers.
+- Diagnostics/status/refresh/reconnect/close implemented in ToolManager, web service, and CLI.
+- Allow/deny policy implemented with wildcard support.
+- Result normalization and output caps implemented.
+- Streamable HTTP and SSE support implemented; OpenAI Docs MCP live-smoked over Streamable HTTP.
+- Full OAuth/client registration remains deferred.
+- Dynamic list-change notification parity remains deferred beyond best-effort SDK hook groundwork.
 
 ### Milestone 3: Penguin As MCP Server
 
@@ -777,10 +779,67 @@ Still deferred:
 
 ### Milestone 4: Product Polish
 
-- CLI/TUI settings/status.
-- Web API status surface.
-- Docs.
-- Example configs.
+Status: partially implemented.
+
+- CLI `penguin-cli mcp status|refresh|reconnect|close` implemented.
+- Web API status/reconnect/close service implemented.
+- Docs and example configs added for host/server usage, Chrome DevTools, and OpenAI Docs MCP.
+- TUI-facing MCP UX remains deferred.
+- Rich server trust/risk labels and audit UI remain deferred.
+
+
+## Deferred Follow-Ups After PR Review
+
+These findings were verified as directionally valid but intentionally deferred because
+they are broader refactors or product/security work rather than minimal PR fixes.
+They should be tracked after the initial MCP system lands.
+
+### F1 — ToolManager MCP Facade Extraction
+
+`ToolManager` still owns small MCP lifecycle delegate methods
+(`get_mcp_status`, `refresh_mcp_tools`, `reconnect_mcp`, `close_mcp`) and merges
+MCP schemas in `get_tools()`. This works, but the cleaner shape is a dedicated
+`MCPAdapter`/`MCPService` owned by ToolManager that wraps `MCPToolProvider` and
+exposes `get_tool_schemas()`, `status()`, `refresh()`, `reconnect()`, and
+`close()`. Defer until after merge to avoid a high-risk file-size refactor in
+the review-fix pass.
+
+### F2 — MCP Route Extraction
+
+The MCP web endpoints still live in `penguin/web/routes.py`. They should move to
+a focused router module such as `penguin/web/mcp_routes.py` and be mounted from
+application initialization. This is valid architecture cleanup, but it touches
+route registration and should be handled as a separate web-surface refactor.
+
+### F3 — Shared Approval Flow For MCP `ASK`
+
+MCP tools currently go through permission classification and deny handling, but
+the `ASK` branch is not fully unified with the native ToolManager approval
+workflow. Fixing this properly requires untangling ToolManager's approval and
+dispatch flow so MCP execution can enter the same approval/audit path as native
+tools without duplicating it. This is important but non-minimal; track as a
+focused permission-system follow-up.
+
+### F4 — Full Dynamic MCP Notifications
+
+Best-effort list-change callback hooks and status fields exist, but Penguin does
+not yet have full parity for `tools/list_changed`, `resources/list_changed`, and
+`prompts/list_changed` across all SDK transports. A complete version should
+invalidate caches, refresh schemas/resources/prompts, and emit web/TUI events.
+
+### F5 — Full OAuth / Client Registration
+
+Env-backed bearer/header auth is implemented and enough for the first serious
+host release. Full OAuth 2.1 / PKCE / Dynamic Client Registration remains
+deferred until remote SaaS connector UX needs it. This belongs with Penguin's
+web/security hardening work and Link/cloud connector design, not the initial MCP
+landing PR.
+
+### F6 — TUI MCP UX And Trust Labels
+
+CLI and web status surfaces exist, but TUI-native status/config controls,
+server-level risk labels, and richer MCP audit views are still product polish.
+These matter for day-to-day host usage but do not block the first MCP release.
 
 ## Decisions And Remaining Open Questions
 
@@ -800,19 +859,16 @@ The current product priority is Penguin **using external MCP servers** well. Pen
 Priority order before more server-surface work:
 
 1. **P0 — Product-path MCP host UX**
-   - CLI/TUI/web status surfaces for configured MCP servers.
-   - Refresh/reconnect/close controls.
-   - Clear examples for Chrome DevTools, GitHub, Sentry, OpenAI Docs, and filesystem scratch servers.
+   - CLI status/refresh/reconnect/close implemented. Web service/status controls implemented. TUI UX remains deferred.
+   - Clear examples added for Chrome DevTools and OpenAI Docs MCP; GitHub/Sentry examples remain useful follow-ups.
 2. **P1 — Real remote smoke tests**
-   - Validate Streamable HTTP/SSE against at least one live remote server.
-   - Keep env-backed auth examples for token-based servers.
+   - Streamable HTTP live-smoked against OpenAI Docs MCP.
+   - Token/header examples exist; authenticated SaaS smoke tests remain follow-up work.
 3. **P2 — Dynamic list-change handling**
-   - Handle `tools/list_changed`, `resources/list_changed`, and `prompts/list_changed` notifications where the Python SDK exposes callbacks.
-   - Invalidate MCP tool caches and surface diagnostics/events.
+   - Best-effort SDK callback groundwork exists. Full cache invalidation + web/TUI event propagation remains deferred.
 4. **P3 — Better permission/output UX**
-   - Server-level allow/deny controls and risk labels.
-   - Conservative output caps/truncation for noisy MCP tools.
-   - Better audit/diagnostic data for external MCP tool calls.
+   - Wildcard allow/deny and output caps implemented.
+   - Risk labels, richer audit views, and unified ASK approval remain deferred follow-ups.
 
 Full OAuth/client-registration remains deferred. Token/header config is enough to ship useful MCP host support; OAuth becomes necessary for polished remote SaaS connector UX, not for the first serious host release.
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -88,7 +88,7 @@ Useful takeaways to steal shamelessly, minus language/runtime mismatch:
 - Tool naming must be collision-safe and model-safe. Codex uses `mcp__<server>__<tool>`, sanitizes names, hashes collisions, and caps model-visible names at 64 chars. Penguin should use this form, not `mcp::<server>::<tool>`, unless existing provider constraints prove colons are accepted everywhere.
 - Preserve raw MCP identities separately from model-visible names. The callable name can be sanitized/hashed; the protocol call must still send the raw MCP `tool.name` to the owning server.
 - Process lifecycle is not optional. Local STDIO server launch should set cwd/env deliberately, pipe stdout for protocol, capture stderr for logs, kill on drop, and on Unix prefer process-group cleanup for child subprocesses.
-- Add status/connect/disconnect APIs early. OpenCode has `/mcp`, add, auth, connect, disconnect routes; Penguin does not need the full OAuth flow in phase 1, but status and reconnect controls are worth having.
+- Add status/refresh/reconnect/close APIs early. OpenCode has `/mcp`, add, auth, connect, disconnect routes; Penguin does not need the full OAuth flow in phase 1, but status, reconnect, and close controls are worth having.
 - Cache only as an optimization. Codex has startup snapshots/caches for hosted connector tools; Penguin should avoid cache complexity in the MVP but design the manager so cache can be added without changing ToolManager contracts.
 - Resources/prompts are second-pass. Both reference agents support or plan resources/prompts, but tools are the leverage point. Do not let resource/prompt support block tool calls.
 
@@ -254,7 +254,7 @@ Eager startup cons:
 - Remote/auth failures can make Penguin feel broken even when MCP is irrelevant to the current session.
 - More painful in web/server mode where many sessions may not need MCP.
 
-Recommendation: default `lazy`, support `startup`, and expose `penguin mcp status/connect/reconnect` plus web/TUI status so failures are visible without forcing everyone to pay startup cost.
+Recommendation: default `lazy`, support `startup`, and expose `penguin mcp status/reconnect/close` plus web/TUI status so failures are visible without forcing everyone to pay startup cost.
 
 ## Phase 1: MCP Host / Client Support
 
@@ -314,7 +314,7 @@ Penguin can connect to configured MCP servers and use their tools as normal Peng
 8. Diagnostics:
    - Add status endpoint/API method listing configured servers, connection state, tools discovered, last error.
    - CLI/TUI should show MCP server failures rather than silently continuing.
-   - Add connect/disconnect/reconnect controls for configured servers.
+   - Add refresh/reconnect/close controls for configured servers.
 
 9. Skills-era ToolManager integration:
    - Follow the skills-manager shape: runtime-owned MCP manager, `ToolManager.set_core()` access where needed, `penguin/tools/providers/mcp.py` facade methods, and web/TUI route visibility.
@@ -537,7 +537,7 @@ Tools:
 
 - `penguin_runmode_capabilities` — reports current RunMode readiness, core/engine/project-manager availability, registry metadata, and known gaps. It never starts execution.
 - `penguin_runmode_list_jobs` — lists the in-process runtime MCP job registry. In Slice 3A this registry is read-only and usually empty.
-- `penguin_runmode_get_job` — returns one in-process runtime MCP job by ID if it exists.
+- `penguin_runmode_get_job` — returns one merged durable + live runtime MCP job by ID if it exists.
 
 Acceptance criteria:
 
@@ -557,7 +557,7 @@ Tools:
 Slice 3B caveats:
 
 - Job registry is in-process and non-durable.
-- Jobs start in daemon threads and report result/error through `penguin_runmode_get_job`.
+- Jobs start in daemon threads and report result/error through `penguin_runmode_get_job`, with durable records persisted through ProjectStorage.
 - Cancellation is still unavailable until Slice 3C.
 - Execution remains model-dependent; tests cover job lifecycle with mocked execution plus capabilities/listing via MCP Inspector.
 
@@ -722,7 +722,7 @@ Still deferred:
 - Simulate malformed tool result.
 - Simulate duplicate/sanitized tool names from two servers.
 - Confirm STDIO stderr is captured and stdout remains protocol-only.
-- Confirm disconnect/reconnect updates status and rediscovery.
+- Confirm close/reconnect updates status and rediscovery.
 - Confirm static tools, skills tools, and MCP tools all appear without clobbering each other.
 
 ### Manual Validation
@@ -766,7 +766,7 @@ Still deferred:
 - Allow/deny policy.
 - Result normalization.
 - Streamable HTTP and SSE support implemented; OAuth remains deferred.
-- Connect/disconnect/reconnect controls.
+- Connect/close/reconnect controls.
 - Tool-list-changed cache invalidation.
 
 ### Milestone 3: Penguin As MCP Server

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -3,6 +3,7 @@
 ## Status
 
 - Created: 2026-05-01
+- Updated: 2026-05-01
 - Owner: Penguin runtime/tooling
 - State: proposed
 - Bias: rewrite existing MCP integration instead of patching current stubs
@@ -12,6 +13,8 @@
 Current MCP integration should be treated as disposable. It exposes and consumes a custom HTTP/JSON-lines shape that resembles MCP vocabulary but does not implement the real MCP protocol. The rewrite should make Penguin a real MCP host first: connect to external MCP servers and expose their tools as Penguin tools. Exposing Penguin itself as an MCP server is useful, but it is phase 2.
 
 The leverage point is `ToolManager`: Penguin already has tool schemas, permission enforcement, path/context normalization, and execution dispatch. MCP should plug into that system rather than invent a parallel tool layer.
+
+Post-skills-merge adjustment: the new skills runtime pattern is the right precedent. MCP should be a runtime-owned manager with small ToolManager facade methods, explicit status/diagnostics, and web/TUI visibility. Do not hardcode MCP tools only into the static registry and call it done.
 
 ## Goals
 
@@ -41,6 +44,8 @@ The leverage point is `ToolManager`: Penguin already has tool schemas, permissio
 - `penguin/integrations/mcp/stdio_server.py` uses custom JSON-line methods `list_tools` and `call_tool`; this is not MCP `tools/list` / `tools/call` JSON-RPC.
 - `penguin/integrations/mcp/adapter.py` imports `ModelContextProtocol`, which is not the Python SDK usage shown in current MCP docs.
 - `pyproject.toml` has an `[mcp]` extra with auth dependencies but does not include the `mcp` SDK itself.
+- Recent skills-system work added a useful integration pattern: a runtime-owned manager, ToolManager facade tools, core wiring, and web/TUI diagnostics. MCP should follow that pattern instead of becoming another isolated subsystem.
+- MCP dynamic tool registration must coexist cleanly with static native tools and skills tools in ToolManager listing/execution paths.
 
 ## Evidence From Cached MCP Docs
 
@@ -57,17 +62,51 @@ Key points:
 - Python server docs use `mcp.server.fastmcp.FastMCP`.
 - STDIO servers must not write logs to stdout because stdout carries protocol frames.
 
+## Reference-Agent Lessons
+
+Reviewed these reference implementations:
+
+- `reference/opencode/packages/opencode/src/mcp/index.ts`
+- `reference/opencode/packages/opencode/src/server/routes/mcp.ts`
+- `reference/codex/codex-rs/codex-mcp/src/mcp_connection_manager.rs`
+- `reference/codex/codex-rs/codex-mcp/src/mcp_tool_names.rs`
+- `reference/codex/codex-rs/rmcp-client/src/stdio_server_launcher.rs`
+
+Useful takeaways to steal shamelessly, minus language/runtime mismatch:
+
+- Maintain explicit server status states: `connected`, `disabled`, `failed`, `needs_auth`, and later `needs_client_registration`. This is cleaner than boolean connected/not connected.
+- Treat `tools/list_changed` notifications as a real cache invalidation event. OpenCode publishes a tools-changed bus event when a server says its tool list changed.
+- Normalize MCP schemas defensively. OpenCode forces tool input schemas to object-shaped schemas with `properties` and `additionalProperties: false`; Penguin should do equivalent validation where safe.
+- Timeouts need two separate knobs: startup/listing timeout and per-tool-call timeout. Codex defaults are roughly 30 seconds startup and 120 seconds tool calls; Penguin config should distinguish them.
+- Tool naming must be collision-safe and model-safe. Codex uses `mcp__<server>__<tool>`, sanitizes names, hashes collisions, and caps model-visible names at 64 chars. Penguin should use this form, not `mcp::<server>::<tool>`, unless existing provider constraints prove colons are accepted everywhere.
+- Preserve raw MCP identities separately from model-visible names. The callable name can be sanitized/hashed; the protocol call must still send the raw MCP `tool.name` to the owning server.
+- Process lifecycle is not optional. Local STDIO server launch should set cwd/env deliberately, pipe stdout for protocol, capture stderr for logs, kill on drop, and on Unix prefer process-group cleanup for child subprocesses.
+- Add status/connect/disconnect APIs early. OpenCode has `/mcp`, add, auth, connect, disconnect routes; Penguin does not need the full OAuth flow in phase 1, but status and reconnect controls are worth having.
+- Cache only as an optimization. Codex has startup snapshots/caches for hosted connector tools; Penguin should avoid cache complexity in the MVP but design the manager so cache can be added without changing ToolManager contracts.
+- Resources/prompts are second-pass. Both reference agents support or plan resources/prompts, but tools are the leverage point. Do not let resource/prompt support block tool calls.
+
+Codex config precedents worth copying in spirit:
+
+- Uses a top-level `mcp_servers` map keyed by server name. Penguin can use nested `mcp.servers` if that fits existing config style, but should support import/export from `mcp_servers`-style configs later.
+- STDIO server fields: `command`, `args`, `env`, optional `env_vars`, and `cwd`.
+- Streamable HTTP fields: `url`, `bearer_token_env_var`, `http_headers`, and `env_http_headers`.
+- Reject inline plaintext bearer tokens; prefer env-var indirection for secrets.
+- Per-server fields include `enabled`, `startup_timeout_sec`, `tool_timeout_sec`, tool allow/deny lists, and a default tool approval mode.
+- Codex supports both global config and project/plugin-derived MCP servers; Penguin should plan for user-global plus project-local config, with project-local gated by trust/permissions.
+
 ## Proposed Architecture
 
 ```text
 PenguinCore
   └── ToolManager
         ├── Native Penguin tools
+        ├── Skills tools / skill facade
         └── MCPToolProvider
               ├── MCPConnectionManager
               │     ├── stdio server sessions
               │     └── streamable HTTP server sessions
               ├── tool discovery/cache
+              ├── model-safe name allocation
               ├── schema conversion
               └── call dispatch to MCP sessions
 ```
@@ -79,22 +118,33 @@ penguin/integrations/mcp/
   __init__.py
   config.py              # typed config models and validation
   manager.py             # MCPConnectionManager lifecycle
-  provider.py            # registers MCP tools into ToolManager
+  names.py               # model-safe tool-name allocation and reverse lookup
   schema.py              # MCP inputSchema -> Penguin tool schema conversion
   transports.py          # stdio/http transport helpers
-  errors.py              # explicit error types
+  diagnostics.py         # status snapshots and error formatting
+  errors.py              # explicit integration exceptions
   server.py              # phase 2: expose Penguin via FastMCP
 ```
 
-The exact file split can change, but the boundaries should not.
+Companion Penguin-facing provider code should live with tools, not inside the protocol adapter:
+
+```text
+penguin/tools/providers/
+  mcp.py                 # dynamic MCP tools as Penguin tools
+```
+
+The exact file split can change, but the boundary should not: `integrations/mcp/` owns MCP protocol/client/server concerns; `tools/providers/mcp.py` owns ToolManager-facing registration, schema exposure, and dispatch facade.
 
 ## Configuration Shape
 
-Initial user-facing config should mirror common MCP host configs:
+Initial user-facing config should mirror common MCP host configs while fitting Penguin's config style. Prefer a nested shape for Penguin-native config, but design import/export so Codex/Claude-style `mcp_servers` maps are easy to ingest later.
 
 ```yaml
 mcp:
   enabled: true
+  initialize: lazy        # lazy | startup
+  fail_on_startup_error: true
+  tool_prefix: mcp
   servers:
     filesystem:
       transport: stdio
@@ -104,20 +154,100 @@ mcp:
         - '@modelcontextprotocol/server-filesystem'
         - /safe/root
       env: {}
+      env_vars: []        # optional allowlist/inheritance descriptors, if supported
       cwd: null
-      timeout_seconds: 30
+      startup_timeout_sec: 30
+      tool_timeout_sec: 120
+      enabled: true
+      default_tools_approval_mode: prompt
+      enabled_tools: null
+      disabled_tools: null
 
     sentry:
       transport: streamable_http
       url: https://mcp.sentry.dev/mcp
-      headers:
-        Authorization: Bearer ${SENTRY_MCP_TOKEN}
-      timeout_seconds: 30
-  tool_prefix: mcp
-  fail_on_startup_error: true
+      bearer_token_env_var: SENTRY_MCP_TOKEN
+      http_headers: {}
+      env_http_headers: {}
+      startup_timeout_sec: 30
+      tool_timeout_sec: 120
+      enabled: true
 ```
 
+Security rule: do not support inline plaintext bearer tokens. Use `bearer_token_env_var` / env-backed headers. Secrets in config files are foot-guns with a nice YAML hat.
+
+Config scope target:
+
+- User-global MCP config for durable personal/server setup.
+- Project-local MCP config for repo-specific servers, gated by project trust and permission policy.
+- Later: config import from Claude Desktop/Codex-style configs.
+
 Do not bury errors. If a configured MCP server cannot start/connect, report it clearly in CLI/TUI/web diagnostics.
+
+### Status Shape
+
+Use explicit states, not boolean soup:
+
+```json
+{
+  "filesystem": {
+    "status": "connected",
+    "transport": "stdio",
+    "tool_count": 4,
+    "last_error": null
+  },
+  "sentry": {
+    "status": "failed",
+    "transport": "streamable_http",
+    "tool_count": 0,
+    "last_error": "401 Unauthorized"
+  }
+}
+```
+
+Allowed initial states:
+
+- `connected`
+- `disabled`
+- `failed`
+- `connecting`
+- `disconnected`
+
+Reserve these for remote auth work:
+
+- `needs_auth`
+- `needs_client_registration`
+
+## Initialization Strategy
+
+Default to lazy initialization on first tool-schema build or first MCP status request, with an explicit `mcp.initialize: startup` option for users who prefer fail-fast behavior.
+
+Lazy initialization pros:
+
+- Preserves Penguin startup time when MCP is installed but unused.
+- Avoids launching long-lived STDIO subprocesses for sessions that never need external tools.
+- Makes optional-extra behavior cleaner: no MCP SDK import or process startup unless MCP is configured/enabled.
+- Better for large server sets and remote servers with auth/network latency.
+
+Lazy initialization cons:
+
+- First model turn that needs tool schemas may pay startup/listing latency.
+- Failures appear later, which can feel spooky if diagnostics are weak.
+- Tool schema generation becomes async/failure-prone; caching and status states must be tight.
+
+Eager startup pros:
+
+- Fail-fast diagnostics before a user asks the model to do work.
+- Tool list is ready for the first completion request.
+- Simpler mental model for status: configured servers connect at boot.
+
+Eager startup cons:
+
+- Slower startup and more background processes.
+- Remote/auth failures can make Penguin feel broken even when MCP is irrelevant to the current session.
+- More painful in web/server mode where many sessions may not need MCP.
+
+Recommendation: default `lazy`, support `startup`, and expose `penguin mcp status/connect/reconnect` plus web/TUI status so failures are visible without forcing everyone to pay startup cost.
 
 ## Phase 1: MCP Host / Client Support
 
@@ -128,8 +258,9 @@ Penguin can connect to configured MCP servers and use their tools as normal Peng
 ### Implementation Steps
 
 1. Add dependency:
-   - `mcp>=1.2.0` or current compatible version.
-   - Put it in `[project.optional-dependencies].mcp` first unless product decision says base install should include it.
+   - Add the official Python SDK to `[project.optional-dependencies].mcp` first, not the base install.
+   - Use docs language like: `pip install "penguin-ai[mcp]"` or `uv sync --extra mcp` if you want MCP support.
+   - Pin a compatible SDK range once tested; do not leave this floating forever.
 
 2. Delete or quarantine current fake implementation:
    - Replace `client.py`, `stdio_server.py`, and `adapter.py` behavior.
@@ -140,24 +271,31 @@ Penguin can connect to configured MCP servers and use their tools as normal Peng
    - Validate command/args for STDIO.
    - Validate URL/headers for Streamable HTTP.
    - Expand env vars safely.
+   - Support per-server `enabled`, `startup_timeout_sec`, and `tool_timeout_sec`.
 
 4. Implement connection lifecycle:
    - One session per configured server.
    - Initialize sessions on demand or at app startup based on config.
    - Support cleanup on shutdown.
    - Support reconnect after failure.
+   - Separate startup/listing timeout from per-tool timeout.
+   - Capture STDIO stderr into logs/diagnostics; never let server logs contaminate stdout protocol frames.
+   - Use explicit cwd/env resolution and avoid inheriting the whole host environment unless configured.
 
 5. Tool discovery:
    - Call `session.list_tools()`.
-   - Register each as `mcp::<server>::<tool>`.
+   - Register each as `mcp__<server>__<tool>` unless tool-name constraints prove another separator is required.
    - Store original MCP server/tool metadata.
    - Convert `inputSchema` to Penguin's `input_schema` field without lossy hacks.
+   - Sanitize model-visible names, hash collisions, and preserve a reverse lookup from model-visible tool name to `(server_name, raw_tool_name)`.
+   - Handle `tools/list_changed` notifications by invalidating the provider's tool cache and emitting a Penguin UI/event-bus diagnostic.
 
 6. Tool call dispatch:
-   - Route `mcp::<server>::<tool>` to `session.call_tool(tool_name, arguments)`.
+   - Route `mcp__<server>__<tool>` to the owning session and raw MCP tool name.
    - Normalize result content into Penguin tool result text/dict.
    - Preserve structured content where possible.
-   - Apply timeouts.
+   - Apply per-tool timeout.
+   - Include server name and raw tool name in error/debug metadata.
 
 7. Permission integration:
    - MCP tools should go through `ToolManager.execute_tool()` permission flow.
@@ -169,16 +307,23 @@ Penguin can connect to configured MCP servers and use their tools as normal Peng
 8. Diagnostics:
    - Add status endpoint/API method listing configured servers, connection state, tools discovered, last error.
    - CLI/TUI should show MCP server failures rather than silently continuing.
+   - Add connect/disconnect/reconnect controls for configured servers.
+
+9. Skills-era ToolManager integration:
+   - Follow the skills-manager shape: runtime-owned MCP manager, `ToolManager.set_core()` access where needed, `penguin/tools/providers/mcp.py` facade methods, and web/TUI route visibility.
+   - Ensure static tools, skills tools, and dynamic MCP tools are merged deterministically in listing and schema generation.
+   - Do not let MCP bypass `ToolManager.execute_tool()` permission and context paths.
 
 ### Acceptance Criteria
 
 - A configured local STDIO MCP test server appears as Penguin tools.
 - Penguin can call one MCP tool and return its output in a normal assistant turn.
 - Failed server startup produces a visible diagnostic with server name and error.
-- MCP tool names are stable and collision-safe.
+- MCP tool names are stable, model-safe, length-bounded where required, and collision-safe.
 - Permission-denied MCP tool calls fail through the same shape as native tools.
 - Unit tests cover config validation, discovery, dispatch, timeout, and failure state.
 - Integration test uses a tiny Python FastMCP/stdio server.
+- Tool list changes from an MCP server invalidate cached schemas or are explicitly documented as unsupported in MVP.
 
 ## Phase 2: Real MCP Server For Penguin Tools
 
@@ -251,10 +396,13 @@ Potential mappings:
 
 - Config parsing and env expansion.
 - Server name/tool name normalization.
+- Name collision hashing and raw-name reverse lookup.
 - Schema conversion.
 - Result normalization.
 - Permission policy decisions.
 - Error classification.
+- Status-state transitions.
+- Tool-list-changed invalidation.
 
 ### Integration Tests
 
@@ -264,6 +412,10 @@ Potential mappings:
 - Simulate startup failure.
 - Simulate tool timeout.
 - Simulate malformed tool result.
+- Simulate duplicate/sanitized tool names from two servers.
+- Confirm STDIO stderr is captured and stdout remains protocol-only.
+- Confirm disconnect/reconnect updates status and rediscovery.
+- Confirm static tools, skills tools, and MCP tools all appear without clobbering each other.
 
 ### Manual Validation
 
@@ -279,6 +431,8 @@ Potential mappings:
 - OAuth/remote auth can balloon scope fast. Keep first pass token/header based.
 - Permission semantics are easy to bypass if MCP tools are registered outside `ToolManager.execute_tool()`.
 - Silent optional imports will create ghost bugs. Kill silent failure for configured MCP.
+- Tool-name constraints differ across model/provider surfaces. Use conservative names and tests; do not assume colons/slashes survive every schema path.
+- STDIO process cleanup is easy to get 90% right and still leak grandchildren. Test it.
 
 ## Suggested Milestones
 
@@ -287,7 +441,7 @@ Potential mappings:
 - Dependency added.
 - Config model added.
 - One local STDIO server can be discovered.
-- One MCP tool can be called as `mcp::<server>::<tool>`.
+- One MCP tool can be called as `mcp__<server>__<tool>`.
 - Basic tests pass.
 
 ### Milestone 2: Robust Client
@@ -297,6 +451,8 @@ Potential mappings:
 - Allow/deny policy.
 - Result normalization.
 - Streamable HTTP support if SDK support is stable.
+- Connect/disconnect/reconnect controls.
+- Tool-list-changed cache invalidation.
 
 ### Milestone 3: Penguin As MCP Server
 
@@ -311,14 +467,15 @@ Potential mappings:
 - Docs.
 - Example configs.
 
-## Open Questions
+## Decisions And Remaining Open Questions
 
-1. Should `mcp` be a base dependency or optional extra?
-2. Should MCP servers initialize eagerly at Penguin startup or lazily on first tool-schema build?
-3. Do we want project-local MCP config, user-global MCP config, or both?
-4. Should external MCP tools default to ask-before-call, or should trust be per-server?
-5. How much Streamable HTTP/OAuth should be in the first production cut?
+1. Dependency packaging: MCP starts as an optional extra. Docs should say `install Penguin with MCP support` and show the appropriate extra install command.
+2. Initialization: default lazy on first tool-schema build/status request; support eager startup via config for fail-fast users.
+3. Config scope: support both user-global and project-local MCP config. Use Codex/Claude patterns as import/export references where practical.
+4. Permissions: external MCP default approval depends on Penguin's permission system, but MVP should route every MCP call through `ToolManager.execute_tool()` and support per-server/per-tool approval policy.
+5. Streamable HTTP/OAuth: token/env-header support can land in robust client phase; full OAuth/client registration belongs in the final/security-focused phase.
+6. Tool-name constraints: still open. Assume conservative `mcp__server__tool`, length cap, sanitization, hash collisions, and reverse lookup until provider paths are empirically tested.
 
 ## Recommendation
 
-Start with Milestone 1 only. Do not touch resources, prompts, OAuth, or server exposure until a local STDIO MCP tool can be discovered and called through Penguin's existing ToolManager with tests. Anything else is scope creep wearing a fake mustache.
+Start with Milestone 1 only, but include the reference-agent basics that prevent pain later: explicit status states, conservative `mcp__server__tool` naming, raw-name reverse lookup, separate startup/tool timeouts, and STDIO process cleanup. Do not touch resources, prompts, OAuth, or server exposure until a local STDIO MCP tool can be discovered and called through Penguin's existing ToolManager with tests. Anything else is scope creep wearing a fake mustache.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -8,6 +8,13 @@
 - State: proposed
 - Bias: rewrite existing MCP integration instead of patching current stubs
 
+## Documentation Map
+
+- `context/architecture/mcp-runtime-surface.md` — architecture and exposure policy for Penguin as MCP host/server/runtime surface.
+- `context/architecture/mcp-runtime-job-records.md` — Slice 5B durable runtime job record contract.
+- `docs/docs/api_reference/mcp-tools.md` — implemented MCP server tool catalog.
+- `docs/docs/system/mcp.md` — user/developer docs for installing, running, and testing MCP support.
+
 ## Executive Summary
 
 Current MCP integration should be treated as disposable. It exposes and consumes a custom HTTP/JSON-lines shape that resembles MCP vocabulary but does not implement the real MCP protocol. The rewrite should make Penguin a real MCP host first: connect to external MCP servers and expose their tools as Penguin tools. Exposing Penguin itself as an MCP server is useful, but it is phase 2.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -361,23 +361,27 @@ Make Penguin comfortable to test as an MCP host/client before exposing Penguin i
 - A local smoke script can list tools from a real STDIO MCP server when `penguin-ai[mcp]` is installed on Python 3.10+.
 - Focused tests cover config aliases, diagnostics, refresh/reconnect/close facades, and disabled/no-SDK behavior.
 
-## Phase 2: Real MCP Server For Penguin Tools
+## Phase 2: Penguin As An MCP Server
 
-### Scope
+Expose Penguin through a real SDK-backed MCP server. Split this into two tracks: a narrow tool-level server for protocol correctness, then an agent-level server that exposes Penguin as a software-engineering runtime.
 
-Expose selected Penguin tools through an SDK-backed MCP server.
+### Phase 2A: Tool-Level MCP Server
 
-### Implementation Steps
+#### Scope
+
+Expose selected low-risk Penguin tools through an SDK-backed MCP server. This is a protocol foundation, not the final product shape.
+
+#### Implementation Steps
 
 1. Build `FastMCP` server wrapper.
 2. Register allowlisted Penguin tools as MCP tools.
-3. Convert Penguin tool schemas to MCP `inputSchema`.
+3. Convert Penguin tool schemas to MCP-friendly function signatures/input schemas where practical.
 4. Route calls into `ToolManager.execute_tool()`.
 5. Preserve permission checks and workspace restrictions.
 6. Support STDIO first; Streamable HTTP second.
 7. Ensure all server logging goes to stderr for STDIO.
 
-### Default Exposure Policy
+#### Default Exposure Policy
 
 Deny by default for dangerous tools:
 
@@ -386,6 +390,7 @@ Deny by default for dangerous tools:
 - file writes/patches unless explicitly allowed
 - workspace reindexing
 - sub-agent spawning/delegation unless explicitly allowed
+- external MCP-hosted tools (`mcp__*`) unless explicitly allowed
 
 Expose read-only tools first:
 
@@ -395,12 +400,44 @@ Expose read-only tools first:
 - `grep_search`
 - `analyze_project`
 
-### Acceptance Criteria
+#### Acceptance Criteria
 
-- Claude Desktop or MCP Inspector can discover Penguin tools via real `tools/list`.
+- MCP Inspector can discover Penguin tools via real `tools/list`.
 - A read-only Penguin tool can be called via real `tools/call`.
 - STDIO mode emits no protocol-breaking stdout logs.
 - Denied tools are absent or fail with clear permission errors.
+- Tool calls route through `ToolManager.execute_tool()`, not direct private registry calls.
+
+### Phase 2B: Agent-Level MCP Server
+
+#### Scope
+
+Expose Penguin as an agent-like runtime rather than merely a low-level tool registry. This is the strategic surface for Link, Claude Desktop, IDEs, and other agent hosts that want to delegate software work to Penguin.
+
+#### Candidate Tools
+
+- `penguin_chat` — send a message to a Penguin session and receive a response.
+- `penguin_run_task` — start a Run Mode task with objective, constraints, and optional project context.
+- `penguin_get_task_status` — poll task/run status, phase, blockers, and artifact evidence.
+- `penguin_cancel_task` — cancel a long-running task.
+- `penguin_resume_with_clarification` — answer a pending clarification request and resume execution.
+- `penguin_list_sessions` — discover available sessions/projects.
+- `penguin_get_context_summary` — retrieve a concise state summary for coordination.
+
+#### Design Requirements
+
+- Long-running tools must return durable IDs/status, not block forever.
+- Session/project scope must be explicit.
+- Cancellation and clarification must be first-class.
+- Permission boundaries must be stricter than direct local Penguin usage because another host/agent may be driving it.
+- Outputs should include artifact paths/evidence, not just prose.
+
+#### Acceptance Criteria
+
+- External MCP clients can delegate a bounded task to Penguin and poll status.
+- Clarification-needed states survive across MCP calls.
+- The surface does not expose dangerous low-level tools by accident.
+- Link can eventually use this as a deep Penguin orchestration bridge.
 
 ## Phase 3: Resources, Prompts, Notifications
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -501,6 +501,23 @@ Defer until internals are verified and idempotency is clear:
 - Phase/dependency-readiness filters and richer blueprint/task status correlation.
 - More detailed id mapping/result metadata from `ProjectManager.sync_blueprint` if/when the manager exposes it.
 
+#### Slice 2.75: Control-Plane Smoke And RunMode Audit
+
+Status: implemented with `scripts/mcp_control_plane_smoke.py` and `context/tasks/mcp-runmode-audit.md`.
+
+Before exposing runtime execution, validate the MCP control-plane as a coherent external API and audit the existing RunMode surface empirically.
+
+Deliverables:
+
+- `scripts/mcp_control_plane_smoke.py` — starts Penguin's MCP server over STDIO in an isolated workspace and runs project creation, Blueprint dry-run sync, Blueprint apply sync, task listing, and Blueprint status through real MCP calls.
+- `context/tasks/mcp-runmode-audit.md` — records current web/API RunMode routes, Python API caveats, missing job/status/cancel semantics, and the recommended Slice 3A/3B/3C split.
+
+Acceptance criteria:
+
+- Smoke script can run with `uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py`.
+- Smoke script validates PM + Blueprint tools through MCP protocol, not direct Python calls.
+- Audit confirms what runtime capabilities are currently real versus aspirational before any RunMode start tool is exposed.
+
 #### Slice 3: Runtime / RunMode Explicit Opt-In
 
 Expose long-running execution as durable jobs, not blocking tool calls. These tools are not registered unless runtime tools are explicitly enabled.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -793,4 +793,27 @@ Still deferred:
 
 ## Recommendation
 
+## Current Host-Side Priority
+
+The current product priority is Penguin **using external MCP servers** well. Penguin exposing itself as an MCP server is valuable, but the 90% user-value path is host/client polish.
+
+Priority order before more server-surface work:
+
+1. **P0 — Product-path MCP host UX**
+   - CLI/TUI/web status surfaces for configured MCP servers.
+   - Refresh/reconnect/close controls.
+   - Clear examples for Chrome DevTools, GitHub, Sentry, OpenAI Docs, and filesystem scratch servers.
+2. **P1 — Real remote smoke tests**
+   - Validate Streamable HTTP/SSE against at least one live remote server.
+   - Keep env-backed auth examples for token-based servers.
+3. **P2 — Dynamic list-change handling**
+   - Handle `tools/list_changed`, `resources/list_changed`, and `prompts/list_changed` notifications where the Python SDK exposes callbacks.
+   - Invalidate MCP tool caches and surface diagnostics/events.
+4. **P3 — Better permission/output UX**
+   - Server-level allow/deny controls and risk labels.
+   - Conservative output caps/truncation for noisy MCP tools.
+   - Better audit/diagnostic data for external MCP tool calls.
+
+Full OAuth/client-registration remains deferred. Token/header config is enough to ship useful MCP host support; OAuth becomes necessary for polished remote SaaS connector UX, not for the first serious host release.
+
 Start with Milestone 1, immediately follow with Milestone 1.5 for real-server validation, and include the reference-agent basics that prevent pain later: explicit status states, conservative `mcp__server__tool` naming, raw-name reverse lookup, separate startup/tool timeouts, and STDIO process cleanup. Do not touch resources, prompts, OAuth, or server exposure until a local STDIO MCP tool can be discovered and called through Penguin's existing ToolManager with tests. Anything else is scope creep wearing a fake mustache.

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -408,36 +408,152 @@ Expose read-only tools first:
 - Denied tools are absent or fail with clear permission errors.
 - Tool calls route through `ToolManager.execute_tool()`, not direct private registry calls.
 
-### Phase 2B: Agent-Level MCP Server
+### Phase 2B: Penguin Runtime MCP Server
 
 #### Scope
 
-Expose Penguin as an agent-like runtime rather than merely a low-level tool registry. This is the strategic surface for Link, Claude Desktop, IDEs, and other agent hosts that want to delegate software work to Penguin.
+Expose Penguin's differentiated runtime surfaces, not a generic chat wrapper. The target audience is Link, IDEs, Claude Desktop, and other agent hosts that want to delegate durable software work into Penguin's project/task/runtime system.
 
-#### Candidate Tools
+Primary docs to keep aligned:
 
-- `penguin_chat` — send a message to a Penguin session and receive a response.
-- `penguin_run_task` — start a Run Mode task with objective, constraints, and optional project context.
-- `penguin_get_task_status` — poll task/run status, phase, blockers, and artifact evidence.
-- `penguin_cancel_task` — cancel a long-running task.
-- `penguin_resume_with_clarification` — answer a pending clarification request and resume execution.
-- `penguin_list_sessions` — discover available sessions/projects.
-- `penguin_get_context_summary` — retrieve a concise state summary for coordination.
+- `docs/docs/system/run-mode.md` — autonomous execution and continuous task processing.
+- `docs/docs/usage/project_management.md` — SQLite-backed projects/tasks, dependency metadata, task truth.
+- `docs/docs/usage/task_management.md` — lifecycle status plus ITUV phase semantics.
+- `docs/docs/system/blueprints.md` — spec-driven task DAGs, recipes, acceptance criteria, agent hints.
+- `docs/docs/system/orchestration.md` — ITUV workflow phases, native/Temporal backend shape.
+- `features.md` — competitive feature bar and Penguin differentiators.
+
+#### Default Exposure Policy
+
+If a user intentionally connects a Penguin MCP server, it should expose Penguin's differentiated control-plane by default. Hiding everything creates a bad first-run experience. However, autonomous execution and high-risk mutation still need explicit opt-in.
+
+Default-on Phase 2B surfaces:
+
+- Project/task management tools.
+- Blueprint lint/status/graph tools, and sync once its internals are verified.
+- Read-only session/context/evidence/checkpoint listing tools.
+
+Explicit opt-in surfaces:
+
+- RunMode execution tools.
+- ITUV workflow start/signal tools.
+- Cancellation/resume operations that mutate active execution state.
+- Raw dangerous low-level tools: shell, writes, patches, browser, subagents, external MCP-hosted tools.
+
+Runtime opt-in should support at least one explicit flag/config/env path, for example:
+
+- `scripts/penguin_mcp_server.py --allow-runtime-tools`
+- `mcp.server.expose_runtime_tools: true`
+- `PENGUIN_MCP_ALLOW_RUNTIME_TOOLS=1`
+
+#### Implementation Layout
+
+Use focused tool modules rather than growing `server.py` into a god file:
+
+```text
+penguin/integrations/mcp/server_tools/
+  __init__.py
+  pm.py
+  blueprints.py
+  runmode.py
+  sessions.py
+  artifacts.py
+```
+
+Shared helpers should prefer web/API service-layer payload construction when available. If route logic contains the current truth, extract small shared service functions instead of duplicating stale Python API behavior in MCP.
+
+#### Slice 1: PM Tools Default-On
+
+Expose Penguin's project/task truth as the first Phase 2B control-plane surface.
+
+Tools:
+
+- `penguin_pm_list_projects` — list project containers and lifecycle summaries.
+- `penguin_pm_create_project` — create a project with name, description, workspace/root metadata.
+- `penguin_pm_list_tasks` — list tasks by project/status/phase/dependency readiness.
+- `penguin_pm_create_task` — create tasks with description, priority, dependencies, acceptance criteria, resource constraints, and metadata.
+- `penguin_pm_get_task` — return rich task truth: status, phase, dependency specs, artifact evidence, recipe, metadata, clarification requests.
+
+Defer or gate until lifecycle validation is confirmed:
+
+- `penguin_pm_update_task` — update status, phase, metadata, dependency specs, recipe, or artifact evidence through validated lifecycle paths.
+
+Task creation should support rich fields immediately. Fields that are first-class in `ProjectManager` should be stored first-class; unsupported-but-useful fields should be preserved under metadata and reported as metadata-preserved, not silently dropped or faked.
+
+#### Slice 2: Blueprint Tools Default-On
+
+Expose Penguin's spec-to-task DAG capability.
+
+Tools:
+
+- `penguin_blueprint_lint` — parse/lint Markdown/YAML/JSON blueprints and return structured diagnostics for duplicate IDs, missing deps, cycles, and missing acceptance criteria.
+- `penguin_blueprint_graph` — return the dependency DAG in a machine-readable form, optionally DOT/JSON.
+- `penguin_blueprint_status` — map blueprint items to project tasks and report sync/execution status.
+
+Defer until internals are verified and idempotency is clear:
+
+- `penguin_blueprint_sync` — import/sync a blueprint into a project as tasks/dependency graph without executing it.
+
+#### Slice 3: Runtime / RunMode Explicit Opt-In
+
+Expose long-running execution as durable jobs, not blocking tool calls. These tools are not registered unless runtime tools are explicitly enabled.
+
+Tools:
+
+- `penguin_runmode_start_task` — start a bounded RunMode task with name, description, context, max iterations, time limit, and optional project/task binding.
+- `penguin_runmode_start_continuous` — start continuous task processing for a project or named task queue, with explicit time/resource limits.
+- `penguin_runmode_status` — return status, phase, current iteration, active task, stop reason, waiting-input state, and latest artifact evidence.
+- `penguin_runmode_cancel` — cancel or interrupt a running RunMode job.
+- `penguin_runmode_resume_clarification` — answer a clarification request and resume through the same lifecycle path.
+
+Implementation note: this slice needs a durable-ish job registry/status handle before exposing start operations. Do not implement it as a blocking `process_message("do task")` wrapper.
+
+#### Slice 4: Orchestration / ITUV Explicit Opt-In
+
+Expose the ITUV lifecycle explicitly instead of hiding it behind prose. Starting/signaling workflows mutates execution state, so keep this behind runtime opt-in until policy is nailed down.
+
+Tools:
+
+- `penguin_ituv_start_workflow` — start an ITUV workflow for a task or blueprint item.
+- `penguin_ituv_status` — return implement/test/use/verify phase, retry state, blockers, and artifact evidence.
+- `penguin_ituv_signal` — pause, resume, cancel, or nudge a workflow.
+
+#### Slice 5: Sessions / Context / Evidence Default-On Read Paths
+
+Expose enough runtime context for another host to coordinate safely. Keep listing/summarization default-on; restoration/mutation should be opt-in or separately gated.
+
+Tools:
+
+- `penguin_session_list` — list active/recent sessions and associated projects/tasks.
+- `penguin_session_summary` — return a compact session/context summary suitable for handoff.
+- `penguin_artifacts_list` — list files, diffs, command outputs, screenshots, or evidence attached to a task/run.
+- `penguin_checkpoints_list` — list checkpoints for audit/handoff.
+
+Gated:
+
+- `penguin_checkpoint_restore` — controlled rollback.
 
 #### Design Requirements
 
-- Long-running tools must return durable IDs/status, not block forever.
-- Session/project scope must be explicit.
-- Cancellation and clarification must be first-class.
+- Long-running tools must return durable IDs and status handles. Do not block an MCP call for an entire autonomous run.
+- Every task/run payload should expose lifecycle truth: `status`, `phase`, dependencies, artifact evidence, recipe, metadata, and clarification state.
+- Project/task scope must be explicit; defaulting to a hidden global project is a foot-gun.
+- Clarification-needed states must survive as first-class MCP results, not become fake failures.
+- Cancellation must be explicit and reliable.
 - Permission boundaries must be stricter than direct local Penguin usage because another host/agent may be driving it.
-- Outputs should include artifact paths/evidence, not just prose.
+- Outputs should include artifact paths/evidence and machine-readable state, not just prose.
+- Phase 2B should prefer existing web/API and `PenguinAPI` lifecycle semantics where those are truthful, rather than inventing another parallel task API.
 
 #### Acceptance Criteria
 
-- External MCP clients can delegate a bounded task to Penguin and poll status.
-- Clarification-needed states survive across MCP calls.
-- The surface does not expose dangerous low-level tools by accident.
-- Link can eventually use this as a deep Penguin orchestration bridge.
+- External MCP clients can create/list projects and tasks with rich lifecycle fields.
+- External MCP clients can start a bounded RunMode job and receive a durable run/task ID.
+- Polling returns truthful non-terminal states including `running`, `pending_review`, `waiting_input`, `failed`, `cancelled`, and `completed`.
+- Clarification-needed states can be resumed via MCP.
+- Blueprint lint/sync can create dependency-aware task graphs without execution.
+- Artifact evidence is visible through MCP for completed or pending-review work.
+- Dangerous low-level tools remain unavailable unless explicitly exposed.
+- Link can use this as a deep Penguin orchestration bridge rather than a generic chat endpoint.
 
 ## Phase 3: Resources, Prompts, Notifications
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -612,6 +612,8 @@ Current guardrails:
 
 #### Slice 5: Sessions / Context / Evidence / Durable Runtime Records
 
+Slice 5B durable runtime job records are implemented in `penguin/project/runtime_jobs.py`, `ProjectStorage`, and the RunMode MCP registry. Session/context/evidence listing remains future Slice 5A work.
+
 Expose enough runtime context for another host to coordinate safely. Keep listing/summarization default-on; restoration/mutation should be opt-in or separately gated.
 
 Tools:
@@ -623,7 +625,7 @@ Tools:
 - `penguin_runtime_jobs_list` — list durable runtime job records, merging persisted records with any in-process active jobs.
 - `penguin_runtime_job_get` — retrieve one durable runtime job record by ID.
 
-Durable runtime job records should preserve at least `job_id`, `kind`, `project_id`, `task_id`, `session_id`, `status`, `started_at`, `finished_at`, `result_summary`, `error`, and cancellation state. Current Slice 3 job records are in-process only and must be persisted here before serious external orchestration depends on them.
+Durable runtime job records preserve `job_id`, `kind`, `project_id`, `task_id`, `session_id`, `status`, `started_at`, `updated_at`, `finished_at`, `result_summary`, capped `result_json`, `error`, metadata, and cancellation state in the local ProjectStorage `runtime_jobs` table. Live jobs are merged with persisted records; non-terminal records without a live in-process handle are marked orphaned and non-controllable.
 
 Gated:
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -679,6 +679,25 @@ Potential mappings:
 - Support `tools/list_changed` when Penguin tool registry changes.
 - Emit diagnostics when MCP server capabilities change.
 
+## Phase 4: Robust Remote MCP Client
+
+Status: implemented Streamable HTTP and legacy SSE client transports with env-backed bearer/header config. Full OAuth/client-registration and `tools/list_changed` notifications remain future security/product-polish work.
+
+Implemented:
+
+- `transport: streamable_http` remote MCP clients.
+- `transport: sse` legacy remote MCP clients.
+- `url` validation for remote transports.
+- `bearer_token_env_var` and `env_http_headers` for secret indirection.
+- Remote transport diagnostics in MCP status payloads.
+
+Still deferred:
+
+- Full OAuth/client registration flows.
+- Streaming auth refresh semantics.
+- Dynamic `tools/list_changed` notifications.
+- Remote server marketplace/import UI.
+
 ## Test Plan
 
 ### Unit Tests
@@ -746,7 +765,7 @@ Potential mappings:
 - Diagnostics.
 - Allow/deny policy.
 - Result normalization.
-- Streamable HTTP support if SDK support is stable.
+- Streamable HTTP and SSE support implemented; OAuth remains deferred.
 - Connect/disconnect/reconnect controls.
 - Tool-list-changed cache invalidation.
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -574,13 +574,33 @@ Slice 3C caveats:
 
 Expose the ITUV lifecycle explicitly instead of hiding it behind prose. Starting/signaling workflows mutates execution state, so keep this behind runtime opt-in until policy is nailed down.
 
-Tools:
+##### Slice 4A: ITUV Readiness And Status
 
-- `penguin_ituv_start_workflow` — start an ITUV workflow for a task or blueprint item.
-- `penguin_ituv_status` — return implement/test/use/verify phase, retry state, blockers, and artifact evidence.
-- `penguin_ituv_signal` — pause, resume, cancel, or nudge a workflow.
+Status: implemented in `penguin/integrations/mcp/server_tools/ituv.py` and audited in `context/tasks/mcp-ituv-audit.md`.
 
-#### Slice 5: Sessions / Context / Evidence Default-On Read Paths
+Read-only tools:
+
+- `penguin_ituv_capabilities` — report status values, phase values, status transition map, dependency policies, and known gaps.
+- `penguin_ituv_status` — return project/task lifecycle truth, dependency specs, artifact evidence, DAG stats, ready tasks, and blocked candidates.
+- `penguin_ituv_frontier` — return the current dependency-aware ready-task frontier and next DAG task.
+
+Slice 4A tools are exposed only when `--allow-runtime-tools` is set and must not mutate project/task state.
+
+##### Slice 4B: ITUV Mutation / Signaling
+
+Future gated tools:
+
+- `penguin_ituv_signal` — validated status/phase/workflow signal transitions.
+- `penguin_ituv_record_artifact` — attach validated artifact evidence.
+- `penguin_ituv_mark_ready_for_review` — route successful execution into review state through existing PM semantics.
+
+Slice 4B preconditions:
+
+- Define legal phase transition rules as explicitly as `TaskStatus.valid_transitions()`.
+- Decide whether mutation uses direct `ProjectManager` methods or an orchestration service.
+- Make `phase=done` vs `status=completed` impossible to confuse.
+
+#### Slice 5: Sessions / Context / Evidence / Durable Runtime Records
 
 Expose enough runtime context for another host to coordinate safely. Keep listing/summarization default-on; restoration/mutation should be opt-in or separately gated.
 
@@ -590,6 +610,10 @@ Tools:
 - `penguin_session_summary` — return a compact session/context summary suitable for handoff.
 - `penguin_artifacts_list` — list files, diffs, command outputs, screenshots, or evidence attached to a task/run.
 - `penguin_checkpoints_list` — list checkpoints for audit/handoff.
+- `penguin_runtime_jobs_list` — list durable runtime job records, merging persisted records with any in-process active jobs.
+- `penguin_runtime_job_get` — retrieve one durable runtime job record by ID.
+
+Durable runtime job records should preserve at least `job_id`, `kind`, `project_id`, `task_id`, `session_id`, `status`, `started_at`, `finished_at`, `result_summary`, `error`, and cancellation state. Current Slice 3 job records are in-process only and must be persisted here before serious external orchestration depends on them.
 
 Gated:
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -540,10 +540,19 @@ Acceptance criteria:
 
 ##### Slice 3B: Runtime Start Behind Opt-In
 
-Future tools:
+Status: implemented with in-process background jobs.
+
+Tools:
 
 - `penguin_runmode_start_task` — start a bounded RunMode task with name, description, context, max iterations, time limit, and optional project/task binding.
 - `penguin_runmode_start_project` — start project-scoped execution through the same service path as the web project start route.
+
+Slice 3B caveats:
+
+- Job registry is in-process and non-durable.
+- Jobs start in daemon threads and report result/error through `penguin_runmode_get_job`.
+- Cancellation is still unavailable until Slice 3C.
+- Execution remains model-dependent; tests cover job lifecycle with mocked execution plus capabilities/listing via MCP Inspector.
 
 ##### Slice 3C: Cancel And Resume Clarification
 

--- a/context/tasks/mcp.md
+++ b/context/tasks/mcp.md
@@ -612,7 +612,7 @@ Current guardrails:
 
 #### Slice 5: Sessions / Context / Evidence / Durable Runtime Records
 
-Slice 5B durable runtime job records are implemented in `penguin/project/runtime_jobs.py`, `ProjectStorage`, and the RunMode MCP registry. Session/context/evidence listing remains future Slice 5A work.
+Slice 5B durable runtime job records are implemented in `penguin/project/runtime_jobs.py`, `ProjectStorage`, and the RunMode MCP registry. Slice 5A status: implemented with default-on read-only session, artifact, and checkpoint listing tools.
 
 Expose enough runtime context for another host to coordinate safely. Keep listing/summarization default-on; restoration/mutation should be opt-in or separately gated.
 

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -98,3 +98,15 @@ These route through Penguin's ToolManager and permission semantics.
 - Full JSON input/output examples should be added before public release.
 - Runtime job records persist locally in ProjectStorage when a ProjectManager is available. Live records are merged with durable records; orphaned non-terminal records are visible but not controllable.
 - Remote MCP transport/OAuth docs are future work.
+
+
+## Session / Context / Evidence Tools
+
+Default-on, read-only surfaces for handoff and audit.
+
+| Tool | Purpose | Mutates | Gated |
+|---|---|---:|---:|
+| `penguin_session_list` | List Penguin sessions. | No | No |
+| `penguin_session_summary` | Return compact recent session message previews. | No | No |
+| `penguin_artifacts_list` | List task artifact evidence. | No | No |
+| `penguin_checkpoints_list` | List conversation checkpoints and stats. | No | No |

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -1,0 +1,100 @@
+# MCP Tool Catalog
+
+## Status
+
+- Created: 2026-05-04
+- Scope: currently implemented Penguin MCP server tools
+
+## Exposure Classes
+
+| Class | Meaning |
+| --- | --- |
+| default-on | exposed when Penguin MCP server starts normally |
+| runtime-gated | exposed only with `--allow-runtime-tools` |
+| mutating | can change project/task/runtime state |
+| dry-run default | mutation requires explicit `dry_run=false` |
+
+## Safe Workspace Tools
+
+Default-on, read-oriented.
+
+| Tool | Mutates | Notes |
+| --- | --- | --- |
+| `read_file` | no | Read workspace file content |
+| `list_files` | no | List files/directories |
+| `find_file` | no | Find files by name/glob |
+| `grep_search` | no | Search workspace text |
+| `analyze_project` | no | AST/project analysis |
+
+## Project Management Tools
+
+Default-on.
+
+| Tool | Mutates | Notes |
+| --- | --- | --- |
+| `penguin_pm_list_projects` | no | List projects with optional status filter |
+| `penguin_pm_create_project` | yes | Create project |
+| `penguin_pm_get_project` | no | Get project by ID; can include tasks |
+| `penguin_pm_list_tasks` | no | List tasks by project/status/parent |
+| `penguin_pm_create_task` | yes | Create rich task; unsupported rich fields preserved as metadata where possible |
+| `penguin_pm_get_task` | no | Get task by ID |
+
+## Blueprint Tools
+
+Default-on.
+
+| Tool | Mutates | Dry-Run Default | Notes |
+| --- | --- | --- | --- |
+| `penguin_blueprint_lint` | no | n/a | Parse/lint Blueprint file or inline content |
+| `penguin_blueprint_graph` | no | n/a | Return nodes/edges and optional DOT |
+| `penguin_blueprint_status` | no | n/a | Report Blueprint-derived project/task DAG state |
+| `penguin_blueprint_sync` | yes | yes | Sync Blueprint into PM tasks; refuses lint errors |
+
+## RunMode Tools
+
+Runtime-gated with `--allow-runtime-tools`.
+
+| Tool | Mutates | Notes |
+| --- | --- | --- |
+| `penguin_runmode_capabilities` | no | Reports runtime support and caveats |
+| `penguin_runmode_list_jobs` | no | In-memory jobs today; durable records planned |
+| `penguin_runmode_get_job` | no | Inspect one in-memory job |
+| `penguin_runmode_start_task` | yes | Starts background RunMode task job |
+| `penguin_runmode_start_project` | yes | Starts background project-scoped execution |
+| `penguin_runmode_cancel_job` | yes | Cooperative cancellation; not hard thread kill |
+| `penguin_runmode_resume_clarification` | yes | Resume waiting clarification flow |
+
+## ITUV Tools
+
+Runtime-gated with `--allow-runtime-tools`.
+
+| Tool | Mutates | Dry-Run Default | Notes |
+| --- | --- | --- | --- |
+| `penguin_ituv_capabilities` | no | n/a | Statuses, phases, transitions, dependency policies |
+| `penguin_ituv_status` | no | n/a | Project/task ITUV status, readiness, artifact evidence |
+| `penguin_ituv_frontier` | no | n/a | Dependency-aware ready task frontier |
+| `penguin_ituv_signal` | yes | yes | `set_status`, `set_phase`, `block`, `unblock` with guards |
+| `penguin_ituv_mark_ready_for_review` | yes | yes | ProjectManager-owned bridge to `phase=done` + `status=pending_review` |
+| `penguin_ituv_record_artifact` | yes | yes | Attach `ArtifactEvidence`; ProjectManager helper still needed |
+
+## External MCP Host Tools
+
+When Penguin consumes external MCP servers, names use:
+
+```text
+mcp__<server>__<tool>
+```
+
+Examples:
+
+- `mcp__chrome_devtools__navigate`
+- `mcp__chrome_devtools__evaluate`
+- `mcp__everything__echo`
+
+These route through Penguin's ToolManager and permission semantics.
+
+## Known Documentation Gaps
+
+- Full JSON input/output examples should be added before public release.
+- Durable runtime job record tools are planned but not implemented yet.
+- Remote MCP transport/OAuth docs are future work.

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -58,7 +58,7 @@ Runtime-gated with `--allow-runtime-tools`.
 | --- | --- | --- |
 | `penguin_runmode_capabilities` | no | Reports runtime support and caveats |
 | `penguin_runmode_list_jobs` | no | Merges ProjectStorage-backed durable jobs with live in-process jobs |
-| `penguin_runmode_get_job` | no | Inspect one in-memory job |
+| `penguin_runmode_get_job` | no | Inspect merged durable + live job record |
 | `penguin_runmode_start_task` | yes | Starts background RunMode task job |
 | `penguin_runmode_start_project` | yes | Starts background project-scoped execution |
 | `penguin_runmode_cancel_job` | yes | Cooperative cancellation; not hard thread kill |

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -57,7 +57,7 @@ Runtime-gated with `--allow-runtime-tools`.
 | Tool | Mutates | Notes |
 | --- | --- | --- |
 | `penguin_runmode_capabilities` | no | Reports runtime support and caveats |
-| `penguin_runmode_list_jobs` | no | In-memory jobs today; durable records planned |
+| `penguin_runmode_list_jobs` | no | Merges ProjectStorage-backed durable jobs with live in-process jobs |
 | `penguin_runmode_get_job` | no | Inspect one in-memory job |
 | `penguin_runmode_start_task` | yes | Starts background RunMode task job |
 | `penguin_runmode_start_project` | yes | Starts background project-scoped execution |
@@ -96,5 +96,5 @@ These route through Penguin's ToolManager and permission semantics.
 ## Known Documentation Gaps
 
 - Full JSON input/output examples should be added before public release.
-- Durable runtime job record tools are planned but not implemented yet.
+- Runtime job records persist locally in ProjectStorage when a ProjectManager is available. Live records are merged with durable records; orphaned non-terminal records are visible but not controllable.
 - Remote MCP transport/OAuth docs are future work.

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -129,3 +129,14 @@ Prompts:
 - `penguin_task_brief`
 - `penguin_blueprint_outline`
 - `penguin_runmode_handoff`
+
+
+## Remote MCP Client Transport Support
+
+For Penguin-as-host/client, configured external MCP servers may use:
+
+- `stdio`
+- `streamable_http`
+- `sse`
+
+Remote servers require `url`. Secrets should use `bearer_token_env_var` or `env_http_headers` so token values are resolved from the environment at runtime. OAuth/client registration is not implemented yet.

--- a/docs/docs/api_reference/mcp-tools.md
+++ b/docs/docs/api_reference/mcp-tools.md
@@ -110,3 +110,22 @@ Default-on, read-only surfaces for handoff and audit.
 | `penguin_session_summary` | Return compact recent session message previews. | No | No |
 | `penguin_artifacts_list` | List task artifact evidence. | No | No |
 | `penguin_checkpoints_list` | List conversation checkpoints and stats. | No | No |
+
+
+## MCP Resources And Prompts
+
+Resources are read-only MCP resources, not tools:
+
+| URI | Purpose |
+|---|---|
+| `penguin://projects` | List projects. |
+| `penguin://project/{project_id}` | Return one project and tasks. |
+| `penguin://task/{task_id}` | Return one task lifecycle payload. |
+| `penguin://session/{session_id}/summary` | Return compact session handoff context. |
+| `penguin://docs-cache/{source}/{page}` | Read cached docs pages under `context/docs_cache`. |
+
+Prompts:
+
+- `penguin_task_brief`
+- `penguin_blueprint_outline`
+- `penguin_runmode_handoff`

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -184,7 +184,7 @@ Privacy/safety note: Chrome DevTools MCP can inspect browser state. Use an isola
 
 ## Current Limitations
 
-- STDIO host/client support is implemented; remote Streamable HTTP/OAuth support is future work.
+- STDIO, Streamable HTTP, and legacy SSE host/client transports are implemented. Full OAuth/client-registration remains future work.
 - Runtime job records persist locally in ProjectStorage when a ProjectManager is available; orphaned non-terminal records survive restarts but are not controllable.
 - ITUV artifact writes currently use task storage directly from the MCP tool layer; a ProjectManager helper should be added.
 - Phase transition policy for ITUV mutation tools is currently MCP-local and should move into ProjectManager if it becomes a broader API contract.
@@ -233,3 +233,26 @@ Prompts:
 - `penguin_runmode_handoff`
 
 Disable them with `--no-resources` or `--no-prompts` when running `scripts/penguin_mcp_server.py`.
+
+
+### Remote MCP Client Config
+
+Penguin can connect to remote MCP servers over Streamable HTTP or legacy SSE when the MCP SDK extra is installed. Secrets should be referenced through environment variables, not inline plaintext tokens.
+
+```yaml
+mcp:
+  enabled: true
+  servers:
+    sentry:
+      transport: streamable_http
+      url: https://mcp.sentry.dev/mcp
+      bearer_token_env_var: SENTRY_MCP_TOKEN
+      http_headers:
+        X-Client: Penguin
+      env_http_headers:
+        X-Team-Token: TEAM_MCP_TOKEN
+      startup_timeout_sec: 30
+      tool_timeout_sec: 120
+```
+
+Legacy SSE servers can use `transport: sse` with the same `url` and header fields. Full OAuth/client-registration flows are intentionally deferred.

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -185,7 +185,7 @@ Privacy/safety note: Chrome DevTools MCP can inspect browser state. Use an isola
 ## Current Limitations
 
 - STDIO host/client support is implemented; remote Streamable HTTP/OAuth support is future work.
-- Runtime job records are in-memory today; durable ProjectStorage-backed records are planned.
+- Runtime job records persist locally in ProjectStorage when a ProjectManager is available; orphaned non-terminal records survive restarts but are not controllable.
 - ITUV artifact writes currently use task storage directly from the MCP tool layer; a ProjectManager helper should be added.
 - Phase transition policy for ITUV mutation tools is currently MCP-local and should move into ProjectManager if it becomes a broader API contract.
 
@@ -195,3 +195,8 @@ Privacy/safety note: Chrome DevTools MCP can inspect browser state. Use an isola
 - `context/architecture/mcp-runtime-surface.md`
 - `context/architecture/mcp-runtime-job-records.md`
 - `context/architecture/runmode-project-ituv-system-map.md`
+
+
+## Runtime Job Durability
+
+RunMode MCP jobs are persisted locally in Penguin's project database (`projects.db`) when a `ProjectManager` is available. The live MCP server still owns cancellation handles, so a restarted server can recover job history but cannot force-control an orphaned non-terminal Python thread from a dead process. Orphaned records are returned as `live=false`, `controllable=false`, with metadata explaining the missing live handle.

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -1,0 +1,197 @@
+# Model Context Protocol (MCP)
+
+Penguin supports MCP in two directions:
+
+1. **Penguin as an MCP host/client** — Penguin connects to external MCP servers and uses their tools.
+2. **Penguin as an MCP server** — external MCP hosts connect to Penguin and use Penguin's tools/runtime surface.
+
+MCP support is optional. Install Penguin with MCP support when you want this functionality:
+
+```bash
+uv sync --extra mcp
+# or for package installs
+pip install "penguin-ai[mcp]"
+```
+
+## Penguin As MCP Host / Client
+
+Penguin can consume local STDIO MCP servers and expose their tools through Penguin's ToolManager.
+
+Example config shape:
+
+```yaml
+mcp:
+  enabled: true
+  servers:
+    chrome-devtools:
+      command: npx
+      args:
+        - -y
+        - chrome-devtools-mcp@latest
+        - --no-usage-statistics
+        - --no-update-checks
+        - --slim
+      startup_timeout_sec: 60
+      tool_timeout_sec: 120
+```
+
+Penguin also accepts common aliases:
+
+```yaml
+mcpServers:
+  everything:
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-everything"
+```
+
+Discovered tools use model-safe names:
+
+```text
+mcp__chrome_devtools__navigate
+mcp__chrome_devtools__evaluate
+mcp__everything__echo
+```
+
+### Host Smoke Script
+
+A control-plane smoke script exercises Penguin's MCP server over real MCP stdio:
+
+```bash
+uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py
+```
+
+## Penguin As MCP Server
+
+Run Penguin's MCP stdio server:
+
+```bash
+uv run --python 3.11 --extra mcp python scripts/penguin_mcp_server.py
+```
+
+Use MCP Inspector:
+
+```bash
+npx -y @modelcontextprotocol/inspector \
+  --cli \
+  uv -- run --python 3.11 --extra mcp python scripts/penguin_mcp_server.py \
+  --method tools/list
+```
+
+### Default-On Tools
+
+Default-on tools are exposed when a user intentionally starts Penguin's MCP server.
+
+Safe workspace/read tools:
+
+- `read_file`
+- `list_files`
+- `find_file`
+- `grep_search`
+- `analyze_project`
+
+Project Management tools:
+
+- `penguin_pm_list_projects`
+- `penguin_pm_create_project`
+- `penguin_pm_get_project`
+- `penguin_pm_list_tasks`
+- `penguin_pm_create_task`
+- `penguin_pm_get_task`
+
+Blueprint tools:
+
+- `penguin_blueprint_lint`
+- `penguin_blueprint_graph`
+- `penguin_blueprint_status`
+- `penguin_blueprint_sync`
+
+`penguin_blueprint_sync` defaults to dry-run.
+
+### Runtime-Gated Tools
+
+Runtime tools are exposed only with:
+
+```bash
+uv run --python 3.11 --extra mcp python scripts/penguin_mcp_server.py --allow-runtime-tools
+```
+
+RunMode tools:
+
+- `penguin_runmode_capabilities`
+- `penguin_runmode_list_jobs`
+- `penguin_runmode_get_job`
+- `penguin_runmode_start_task`
+- `penguin_runmode_start_project`
+- `penguin_runmode_cancel_job`
+- `penguin_runmode_resume_clarification`
+
+ITUV tools:
+
+- `penguin_ituv_capabilities`
+- `penguin_ituv_status`
+- `penguin_ituv_frontier`
+- `penguin_ituv_signal`
+- `penguin_ituv_mark_ready_for_review`
+- `penguin_ituv_record_artifact`
+
+Runtime mutation tools default to dry-run where applicable. Callers must explicitly pass `dry_run=false` to apply lifecycle or artifact changes.
+
+## Example: Blueprint Control Plane
+
+Create a project, dry-run sync a Blueprint, apply the sync, then inspect tasks:
+
+```text
+penguin_pm_create_project
+penguin_blueprint_sync { dry_run: true }
+penguin_blueprint_sync { dry_run: false }
+penguin_pm_list_tasks
+penguin_blueprint_status
+```
+
+This is the recommended first product-path test before starting autonomous RunMode execution.
+
+## Example: Chrome DevTools MCP
+
+Chrome DevTools MCP is a strong real-world test target for Penguin as host/client.
+
+Recommended first config uses slim mode:
+
+```yaml
+mcp:
+  enabled: true
+  servers:
+    chrome-devtools:
+      command: npx
+      args:
+        - -y
+        - chrome-devtools-mcp@latest
+        - --no-usage-statistics
+        - --no-update-checks
+        - --slim
+```
+
+Privacy/safety note: Chrome DevTools MCP can inspect browser state. Use an isolated test profile for serious testing.
+
+## Security Model
+
+- External MCP host tools route through Penguin's tool permission path.
+- Penguin-as-server denies dangerous low-level tools by default.
+- Shell execution, file writes, browser automation, sub-agent spawning, and delegation are not exposed unless explicitly allowlisted.
+- RunMode/ITUV tools require `--allow-runtime-tools`.
+- Local STDIO MCP servers are trusted enough to run as local subprocesses; configure them deliberately.
+
+## Current Limitations
+
+- STDIO host/client support is implemented; remote Streamable HTTP/OAuth support is future work.
+- Runtime job records are in-memory today; durable ProjectStorage-backed records are planned.
+- ITUV artifact writes currently use task storage directly from the MCP tool layer; a ProjectManager helper should be added.
+- Phase transition policy for ITUV mutation tools is currently MCP-local and should move into ProjectManager if it becomes a broader API contract.
+
+## Related Internal Docs
+
+- `context/tasks/mcp.md`
+- `context/architecture/mcp-runtime-surface.md`
+- `context/architecture/mcp-runtime-job-records.md`
+- `context/architecture/runmode-project-ituv-system-map.md`

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -62,6 +62,47 @@ A control-plane smoke script exercises Penguin's MCP server over real MCP stdio:
 uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py
 ```
 
+
+### Host CLI Diagnostics
+
+Penguin includes lightweight MCP host lifecycle commands. These operate on the
+configured external MCP servers and do not start or stop the Penguin web server.
+
+```bash
+uv run penguin-cli mcp status
+uv run penguin-cli mcp status --refresh
+uv run penguin-cli mcp refresh
+uv run penguin-cli mcp reconnect chrome-devtools
+uv run penguin-cli mcp close
+```
+
+Use `--json` on these commands for machine-readable diagnostics. Status payloads
+include server status, transport, tool count, last error, output cap, and whether
+a list-change notification has been observed.
+
+### Host Tool Policy And Output Caps
+
+Per-server tool selection supports exact names and shell-style globs:
+
+```yaml
+mcp:
+  enabled: true
+  servers:
+    github:
+      command: npx
+      args: [-y, "@modelcontextprotocol/server-github"]
+      enabled_tools:
+        - "list_*"
+        - "get_*"
+      disabled_tools:
+        - "delete_*"
+      output_token_limit: 12000
+```
+
+`output_token_limit` caps oversized MCP tool results before they enter Penguin's
+conversation/tool-result flow. This is intentionally conservative: noisy external
+servers should not be able to flood the model context for free.
+
 ## Penguin As MCP Server
 
 Run Penguin's MCP stdio server:

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -200,3 +200,15 @@ Privacy/safety note: Chrome DevTools MCP can inspect browser state. Use an isola
 ## Runtime Job Durability
 
 RunMode MCP jobs are persisted locally in Penguin's project database (`projects.db`) when a `ProjectManager` is available. The live MCP server still owns cancellation handles, so a restarted server can recover job history but cannot force-control an orphaned non-terminal Python thread from a dead process. Orphaned records are returned as `live=false`, `controllable=false`, with metadata explaining the missing live handle.
+
+
+### Session, Artifact, And Checkpoint Reads
+
+Penguin MCP also exposes default-on read-only handoff tools:
+
+- `penguin_session_list`
+- `penguin_session_summary`
+- `penguin_artifacts_list`
+- `penguin_checkpoints_list`
+
+These tools do not restore checkpoints or mutate sessions. Restore/rollback remains intentionally gated future work.

--- a/docs/docs/system/mcp.md
+++ b/docs/docs/system/mcp.md
@@ -212,3 +212,24 @@ Penguin MCP also exposes default-on read-only handoff tools:
 - `penguin_checkpoints_list`
 
 These tools do not restore checkpoints or mutate sessions. Restore/rollback remains intentionally gated future work.
+
+
+### MCP Resources And Prompts
+
+Penguin's MCP server exposes conservative resources and prompts by default:
+
+Resources:
+
+- `penguin://projects`
+- `penguin://project/{project_id}`
+- `penguin://task/{task_id}`
+- `penguin://session/{session_id}/summary`
+- `penguin://docs-cache/{source}/{page}`
+
+Prompts:
+
+- `penguin_task_brief`
+- `penguin_blueprint_outline`
+- `penguin_runmode_handoff`
+
+Disable them with `--no-resources` or `--no-prompts` when running `scripts/penguin_mcp_server.py`.

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -366,6 +366,10 @@ app.add_typer(config_app, name="config")
 skill_app = typer.Typer(help="Agent Skills discovery and activation commands")
 app.add_typer(skill_app, name="skill")
 
+# MCP host diagnostics and lifecycle controls
+mcp_app = typer.Typer(help="MCP server diagnostics and lifecycle commands")
+app.add_typer(mcp_app, name="mcp")
+
 T = TypeVar("T")
 
 # Global core components - initialized by _initialize_core_components_globally
@@ -793,6 +797,94 @@ def _manual_skill_install_message() -> str:
         "~/.penguin/skills/<skill-name>/ for user skills or "
         ".penguin/skills/<skill-name>/ for trusted project skills."
     )
+
+
+
+def _mcp_tool_manager() -> Any:
+    """Create a lightweight ToolManager for MCP host diagnostics."""
+    from penguin.config import load_config
+    from penguin.tools.tool_manager import ToolManager
+
+    loaded_config = load_config()
+    return ToolManager(loaded_config, lambda *_args, **_kwargs: None, fast_startup=True)
+
+
+def _print_mcp_status(status: dict[str, Any], json_output: bool) -> None:
+    """Print MCP host status in JSON or human-readable form."""
+    if json_output:
+        console.print(json.dumps(status, indent=2, sort_keys=True))
+        return
+
+    console.print(
+        f"MCP SDK available: {status.get('available')} | "
+        f"discovered: {status.get('discovered')} | "
+        f"servers: {status.get('server_count', 0)} | "
+        f"tools: {status.get('tool_count', 0)}"
+    )
+    for name, server in (status.get("servers") or {}).items():
+        console.print(
+            f"- {name}: {server.get('status')} "
+            f"transport={server.get('transport')} "
+            f"tools={server.get('tool_count', 0)}"
+        )
+        if server.get("error"):
+            console.print(f"  error: {server['error']}")
+        if server.get("list_changed"):
+            console.print("  list changed: refresh recommended")
+
+
+@mcp_app.command("status")
+def mcp_status(
+    refresh: bool = typer.Option(False, "--refresh", help="Refresh tools before status."),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Show configured MCP server status and tool counts."""
+    manager = _mcp_tool_manager()
+    try:
+        if refresh:
+            manager.refresh_mcp_tools()
+        _print_mcp_status(manager.get_mcp_status(), json_output)
+    finally:
+        manager.close_mcp()
+
+
+@mcp_app.command("refresh")
+def mcp_refresh(
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Refresh discovered MCP tools for configured servers."""
+    manager = _mcp_tool_manager()
+    try:
+        tools = manager.refresh_mcp_tools()
+        status = manager.get_mcp_status()
+        status["refreshed_tools"] = [tool.get("name") for tool in tools]
+        _print_mcp_status(status, json_output)
+    finally:
+        manager.close_mcp()
+
+
+@mcp_app.command("reconnect")
+def mcp_reconnect(
+    server: Optional[str] = typer.Argument(None, help="Optional MCP server name."),
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Reconnect one MCP server or all servers."""
+    manager = _mcp_tool_manager()
+    try:
+        status = manager.reconnect_mcp(server)
+        _print_mcp_status(status, json_output)
+    finally:
+        manager.close_mcp()
+
+
+@mcp_app.command("close")
+def mcp_close(
+    json_output: bool = typer.Option(False, "--json", help="Output JSON."),
+) -> None:
+    """Close active MCP client sessions."""
+    manager = _mcp_tool_manager()
+    status = manager.close_mcp()
+    _print_mcp_status(status, json_output)
 
 
 @skill_app.command("list")

--- a/penguin/integrations/integrations.md
+++ b/penguin/integrations/integrations.md
@@ -1,0 +1,248 @@
+# Penguin Integrations
+
+## Purpose
+
+`penguin/integrations/` is for boundary adapters between Penguin and external protocols, products, platforms, and ecosystems.
+
+An integration belongs here when this sentence is true:
+
+> If the external system or protocol disappeared, this module would mostly disappear too.
+
+This directory should not become a junk drawer for core runtime logic. Integrations adapt external systems into Penguin; they should not own Penguin's internal semantics.
+
+## Design Principles
+
+1. Keep core abstractions in core packages.
+   - Tool execution belongs in `penguin/tools/`.
+   - Conversation/session state belongs in `penguin/system/` or runtime services.
+   - Model-provider behavior belongs in `penguin/llm/`.
+   - Project/task state belongs in `penguin/project/`.
+
+2. Keep protocol/product glue in `penguin/integrations/`.
+   - Transport setup.
+   - Auth handshakes.
+   - External API request/response mapping.
+   - Protocol-specific schema conversion.
+   - External event/webhook parsing.
+   - Diagnostics for that external surface.
+
+3. Dependency direction should point inward only through stable facades.
+   - Good: `ToolManager -> tools provider -> integrations.mcp -> MCP SDK`.
+   - Bad: `integrations.mcp -> random PenguinCore internals -> ToolManager private state`.
+
+4. Prefer manager/provider boundaries.
+   - Integration manager: owns external lifecycle, clients, sessions, retries, auth state.
+   - Penguin provider/facade: adapts the integration into tools, resources, events, or UI commands.
+
+5. Make failure visible.
+   - Configured integrations should expose status, last error, and diagnostics.
+   - Silent optional imports are acceptable only when a feature is completely unconfigured.
+
+6. Treat permissions as a Penguin concern.
+   - Integrations may contribute metadata such as external identity, risk hints, scopes, and resource names.
+   - Final permission decisions should flow through Penguin's permission/tool/runtime systems.
+
+## Recommended Shape
+
+```text
+penguin/integrations/<name>/
+  __init__.py
+  config.py          # typed integration config
+  manager.py         # external lifecycle/client/session owner
+  client.py          # low-level API/protocol client if useful
+  schema.py          # schema conversion, if applicable
+  auth.py            # auth/OAuth/token handling, if applicable
+  diagnostics.py     # status snapshots and human-readable errors
+  errors.py          # explicit integration exceptions
+  webhooks.py        # inbound event parsing, if applicable
+```
+
+Optional companion code should live near the Penguin subsystem it adapts into:
+
+```text
+penguin/tools/providers/<name>.py     # external tools as Penguin tools
+penguin/web/routes/<name>.py          # web/API control/status surface
+penguin/cli/<name>.py                 # CLI commands, if substantial
+penguin/tui/...                       # TUI surface, if needed
+```
+
+## What Belongs Here
+
+### Protocol Integrations
+
+- **MCP**: Model Context Protocol host/client/server support.
+  - `integrations/mcp/` owns SDK sessions, transports, protocol schemas, server status, and MCP-specific diagnostics.
+  - Tool exposure should still route through `penguin/tools/` provider/facade code.
+
+- **LSP**: Language Server Protocol integration.
+  - Use for diagnostics, symbol search, definition/reference lookup, semantic workspace context, code actions, rename support.
+  - Keep editor-specific UI outside the protocol adapter.
+
+- **DAP**: Debug Adapter Protocol integration.
+  - Use for breakpoints, stack frames, variables, stepping, test/debug sessions.
+  - Treat execution/debug permissions as first-class; debugger attach is not a harmless read-only action.
+
+- **A2A / Agent Protocols**: Inter-agent communication with external agents or agent runtimes.
+  - Use for task delegation, capability discovery, status sync, result exchange.
+  - Must preserve Penguin's task lifecycle truth instead of flattening everything into generic chat messages.
+
+- **Webhooks**: Generic inbound event integration.
+  - Use for GitHub/GitLab events, CI events, deployment events, issue tracker updates, incident alerts.
+  - Should normalize payloads into typed Penguin events before touching project/task state.
+
+### Developer Platform Integrations
+
+- **GitHub**: issues, PRs, code review comments, checks, Actions status, repository metadata.
+- **GitLab**: merge requests, issues, pipelines, repository metadata.
+- **Sentry**: errors, traces, releases, issue triage, suspect commits, regression context.
+- **Linear/Jira**: issues, planning metadata, workflow state, requirements sync.
+- **Notion**: docs, specs, lightweight PM databases, knowledge base sync.
+
+### Communication And Collaboration
+
+- **Slack/Discord**: notifications, command entrypoints, human approval flows, incident rooms.
+- **Email/Calendar**: summaries, scheduling, release coordination, approval reminders.
+
+### Editor And IDE Integrations
+
+- **VS Code**: editor bridge, selected text/context, terminal/session attachment, diagnostics, inline actions.
+- **JetBrains / editor of choice**: same conceptual bridge with different transport/plugin implementation.
+- **Generic editor bridge**: a protocol-neutral layer for active file, selection, cursor, open buffers, diagnostics, and commands.
+
+Editor integration should distinguish:
+
+```text
+integrations/lsp/          # protocol-level language intelligence
+integrations/dap/          # protocol-level debugger intelligence
+integrations/editor_bridge/ # active-editor context and commands
+```
+
+Do not collapse those into one blob. LSP, DAP, and editor UI context are related but not the same beast.
+
+### Link Integration
+
+**Link** is expected to be deeper than a normal external integration.
+
+Working description:
+
+- OSS chat + project management + agent orchestration platform.
+- Intended to have deep Penguin integration.
+- Already has some support in `penguin/llm`, so the eventual boundary may cross `llm`, runtime events, project/task orchestration, and web surfaces.
+
+Likely responsibilities:
+
+- Chat/session sync.
+- Project/task sync.
+- Agent orchestration and delegation.
+- Human approval/clarification workflows.
+- Shared artifacts and references.
+- Runtime event streaming.
+- Possibly model/provider routing if Link acts as a gateway.
+
+Because Link may become a first-class Penguin surface, avoid forcing it into the same box as small API integrations. Start with `penguin/integrations/link/` for external protocol/client/auth glue, but expect companion code in:
+
+```text
+penguin/llm/               # existing/deeper model or gateway support
+penguin/project/           # task/project synchronization
+penguin/web/routes/        # Link API/event surfaces
+penguin/system/            # session/event bridging if needed
+penguin/multi/             # agent orchestration if needed
+```
+
+The rule still holds: `integrations/link/` should own Link boundary behavior, not all Penguin behavior related to Link.
+
+### Import/Export Bridges
+
+- Claude Desktop MCP config import.
+- Cursor/Windsurf/OpenCode config import.
+- Chat transcript import/export.
+- Project/task export.
+- Docs or knowledge-base import.
+
+### Secrets And Enterprise Connectors
+
+- 1Password.
+- HashiCorp Vault.
+- AWS/GCP/Azure secret managers.
+- SSO/OIDC/SAML helpers.
+
+These should provide credentials through typed interfaces. They should not scatter secret lookup code across integrations.
+
+## What Does Not Belong Here
+
+- Native Penguin tool implementations.
+- Permission decision engines.
+- Conversation persistence.
+- Context window management.
+- Prompt construction.
+- Core project/task database logic.
+- Model-provider adapters that are already first-class `penguin/llm` concerns.
+- Business logic that only happens to call an external API.
+
+If an integration starts deciding what Penguin means internally, it is in the wrong layer.
+
+## Integration Maturity Levels
+
+### Level 0: Config Stub
+
+- Typed config only.
+- No runtime behavior.
+- Useful for documenting intended shape.
+
+### Level 1: Client/Manager
+
+- Can authenticate/connect.
+- Can fetch status.
+- Has explicit diagnostics and errors.
+
+### Level 2: Penguin Surface
+
+- Exposes tools, resources, project events, or UI commands through stable Penguin facades.
+- Permission path is enforced.
+- Tests cover success and failure.
+
+### Level 3: Productized Integration
+
+- CLI/web/TUI status and controls.
+- Docs and example configs.
+- Retry/backoff/reconnect where appropriate.
+- Observability.
+- Compatibility tests or recorded fixtures.
+
+## Candidate Integration Backlog
+
+High leverage, near-term:
+
+1. MCP host/client support.
+2. GitHub/GitLab issue + PR context.
+3. Sentry issue/error context.
+4. VS Code/editor bridge for active file, selection, diagnostics, and commands.
+5. LSP symbol/diagnostics integration.
+
+Medium-term:
+
+1. DAP debugging workflows.
+2. Webhook event ingestion.
+3. Notion/docs synchronization.
+4. Linear/Jira planning synchronization.
+5. Slack/Discord notifications and approval flows.
+
+Strategic/deeper:
+
+1. Link platform integration.
+2. A2A / external agent runtime interoperability.
+3. Enterprise secrets/SSO connectors.
+4. Cross-agent/project orchestration bridges.
+
+## Architectural Smell Tests
+
+Ask these before adding code under `penguin/integrations/`:
+
+1. Is this mostly about an external system/protocol?
+2. Can it expose a small manager/client boundary?
+3. Does it avoid importing private core internals?
+4. Are permissions enforced outside the integration?
+5. Does it expose status and last-error diagnostics?
+6. Would the code mostly disappear if the external system disappeared?
+
+If the answer is no, do not put it here.

--- a/penguin/integrations/mcp/__init__.py
+++ b/penguin/integrations/mcp/__init__.py
@@ -1,10 +1,30 @@
-"""MCP integration package for Penguin.
+"""Model Context Protocol integration package for Penguin."""
 
-Contains server and client adapters for exposing Penguin tools via the
-Model Context Protocol and consuming remote MCP servers as virtual tools.
-"""
+from __future__ import annotations
 
-from .adapter import MCPAdapter, MCPToolImplementation
-from .echo import start_server
+from penguin.integrations.mcp.config import MCPServerConfig, load_mcp_server_configs
+from penguin.integrations.mcp.manager import (
+    HAS_MCP_SDK,
+    MCPClientManager,
+    MCPServerStatus,
+    MCPToolDefinition,
+)
+from penguin.integrations.mcp.names import (
+    MCP_TOOL_PREFIX,
+    is_mcp_tool_name,
+    make_tool_name,
+    sanitize_part,
+)
 
-__all__ = ["MCPAdapter", "MCPToolImplementation", "start_server"] 
+__all__ = [
+    "HAS_MCP_SDK",
+    "MCPClientManager",
+    "MCPServerConfig",
+    "MCPServerStatus",
+    "MCPToolDefinition",
+    "MCP_TOOL_PREFIX",
+    "is_mcp_tool_name",
+    "load_mcp_server_configs",
+    "make_tool_name",
+    "sanitize_part",
+]

--- a/penguin/integrations/mcp/config.py
+++ b/penguin/integrations/mcp/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+import fnmatch
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -29,6 +30,7 @@ class MCPServerConfig:
     tool_timeout_sec: float = 60.0
     enabled_tools: set[str] | None = None
     disabled_tools: set[str] = field(default_factory=set)
+    output_token_limit: int | None = None
 
     @classmethod
     def from_mapping(cls, name: str, data: Mapping[str, Any]) -> MCPServerConfig:
@@ -92,6 +94,12 @@ class MCPServerConfig:
             ),
             enabled_tools=enabled_tools,
             disabled_tools=disabled_tools,
+            output_token_limit=_parse_optional_int(
+                data.get("output_token_limit")
+                or data.get("outputTokenLimit")
+                or data.get("max_output_chars")
+                or data.get("maxOutputChars")
+            ),
         )
 
     @property
@@ -110,9 +118,12 @@ class MCPServerConfig:
 
     def allows_tool(self, tool_name: str) -> bool:
         """Return whether this config allows a raw MCP tool name."""
-        if self.enabled_tools is not None and tool_name not in self.enabled_tools:
+        if self.enabled_tools is not None and not _matches_any_tool_pattern(
+            tool_name,
+            self.enabled_tools,
+        ):
             return False
-        return tool_name not in self.disabled_tools
+        return not _matches_any_tool_pattern(tool_name, self.disabled_tools)
 
 
 def _parse_env(raw_env: Any) -> dict[str, str]:
@@ -131,6 +142,20 @@ def _parse_env_header_map(raw_env: Any) -> dict[str, str]:
     if not isinstance(raw_env, Mapping):
         return {}
     return {str(key): str(value) for key, value in raw_env.items()}
+
+
+def _matches_any_tool_pattern(tool_name: str, patterns: set[str]) -> bool:
+    return any(fnmatch.fnmatchcase(tool_name, pattern) for pattern in patterns)
+
+
+def _parse_optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _parse_tool_set(value: Any) -> set[str]:

--- a/penguin/integrations/mcp/config.py
+++ b/penguin/integrations/mcp/config.py
@@ -1,0 +1,112 @@
+"""Configuration parsing for Penguin MCP client integrations."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class MCPServerConfig:
+    """Configuration for one MCP server."""
+
+    name: str
+    command: str
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    cwd: Optional[str] = None
+    enabled: bool = True
+    startup_timeout_sec: float = 10.0
+    tool_timeout_sec: float = 60.0
+    enabled_tools: Optional[set[str]] = None
+    disabled_tools: set[str] = field(default_factory=set)
+
+    @classmethod
+    def from_mapping(cls, name: str, data: Mapping[str, Any]) -> "MCPServerConfig":
+        """Build server config from dict-style config."""
+        args = data.get("args") or []
+        if isinstance(args, str):
+            args = [args]
+
+        raw_env = data.get("env") or {}
+        env: dict[str, str] = {}
+        if isinstance(raw_env, Mapping):
+            for key, value in raw_env.items():
+                if isinstance(value, str) and value.startswith("$"):
+                    env[str(key)] = os.environ.get(value[1:], "")
+                else:
+                    env[str(key)] = str(value)
+
+        enabled_tools = data.get("enabled_tools")
+        if isinstance(enabled_tools, list):
+            enabled_tools_set: Optional[set[str]] = {str(item) for item in enabled_tools}
+        else:
+            enabled_tools_set = None
+
+        disabled_tools = data.get("disabled_tools") or []
+        disabled_tools_set = (
+            {str(item) for item in disabled_tools}
+            if isinstance(disabled_tools, list)
+            else set()
+        )
+
+        command = data.get("command")
+        if not command:
+            raise ValueError(f"MCP server '{name}' is missing required command")
+
+        cwd = data.get("cwd")
+        if isinstance(cwd, str) and cwd:
+            cwd = str(Path(cwd).expanduser())
+        else:
+            cwd = None
+
+        return cls(
+            name=str(data.get("name") or name),
+            command=str(command),
+            args=[str(arg) for arg in args],
+            env=env,
+            cwd=cwd,
+            enabled=bool(data.get("enabled", True)),
+            startup_timeout_sec=float(data.get("startup_timeout_sec", 10.0)),
+            tool_timeout_sec=float(data.get("tool_timeout_sec", 60.0)),
+            enabled_tools=enabled_tools_set,
+            disabled_tools=disabled_tools_set,
+        )
+
+    def allows_tool(self, tool_name: str) -> bool:
+        """Return whether this config allows a raw MCP tool name."""
+        if self.enabled_tools is not None and tool_name not in self.enabled_tools:
+            return False
+        return tool_name not in self.disabled_tools
+
+
+def load_mcp_server_configs(config: Optional[Mapping[str, Any]]) -> list[MCPServerConfig]:
+    """Load enabled MCP server configs from Penguin config data."""
+    root = config or {}
+    mcp_config = root.get("mcp", {}) if isinstance(root, Mapping) else {}
+    if not isinstance(mcp_config, Mapping) or not bool(mcp_config.get("enabled", False)):
+        return []
+
+    servers = mcp_config.get("servers") or {}
+    parsed: list[MCPServerConfig] = []
+    if isinstance(servers, Mapping):
+        for name, data in servers.items():
+            if not isinstance(data, Mapping):
+                continue
+            server = MCPServerConfig.from_mapping(str(name), data)
+            if server.enabled:
+                parsed.append(server)
+    elif isinstance(servers, list):
+        for index, data in enumerate(servers):
+            if not isinstance(data, Mapping):
+                continue
+            name = str(data.get("name") or f"server_{index + 1}")
+            server = MCPServerConfig.from_mapping(name, data)
+            if server.enabled:
+                parsed.append(server)
+    return parsed
+
+
+__all__ = ["MCPServerConfig", "load_mcp_server_configs"]

--- a/penguin/integrations/mcp/config.py
+++ b/penguin/integrations/mcp/config.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
 from dataclasses import dataclass, field
-import fnmatch
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -85,7 +85,7 @@ class MCPServerConfig:
             ),
             http_headers=http_headers,
             env_http_headers=env_http_headers,
-            enabled=bool(data.get("enabled", True)),
+            enabled=_parse_bool(data.get("enabled"), default=True),
             startup_timeout_sec=float(
                 data.get("startup_timeout_sec", data.get("startupTimeoutSec", 10.0))
             ),
@@ -144,6 +144,20 @@ def _parse_env_header_map(raw_env: Any) -> dict[str, str]:
     return {str(key): str(value) for key, value in raw_env.items()}
 
 
+def _parse_bool(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    return bool(value)
+
+
 def _matches_any_tool_pattern(tool_name: str, patterns: set[str]) -> bool:
     return any(fnmatch.fnmatchcase(tool_name, pattern) for pattern in patterns)
 
@@ -171,7 +185,7 @@ def _server_entries_from_root(root: Mapping[str, Any]) -> tuple[ServerEntries, b
     mcp_config = root.get("mcp", {}) if isinstance(root, Mapping) else {}
     if isinstance(mcp_config, Mapping):
         servers = mcp_config.get("servers") or mcp_config.get("mcpServers") or {}
-        enabled = bool(mcp_config.get("enabled", bool(servers)))
+        enabled = _parse_bool(mcp_config.get("enabled"), default=bool(servers))
         if servers:
             return servers, enabled
 

--- a/penguin/integrations/mcp/config.py
+++ b/penguin/integrations/mcp/config.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
+
+ServerEntries = Mapping[str, Any] | list[Any]
 
 
 @dataclass(frozen=True)
@@ -16,40 +18,38 @@ class MCPServerConfig:
     command: str
     args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
-    cwd: Optional[str] = None
+    cwd: str | None = None
+    transport: str = "stdio"
     enabled: bool = True
     startup_timeout_sec: float = 10.0
     tool_timeout_sec: float = 60.0
-    enabled_tools: Optional[set[str]] = None
+    enabled_tools: set[str] | None = None
     disabled_tools: set[str] = field(default_factory=set)
 
     @classmethod
-    def from_mapping(cls, name: str, data: Mapping[str, Any]) -> "MCPServerConfig":
+    def from_mapping(cls, name: str, data: Mapping[str, Any]) -> MCPServerConfig:
         """Build server config from dict-style config."""
+        transport = str(data.get("transport") or data.get("type") or "stdio")
+        if transport not in {"stdio", "streamable_http", "sse"}:
+            raise ValueError(
+                f"MCP server '{name}' has unsupported transport '{transport}'"
+            )
+        if transport != "stdio":
+            raise ValueError(
+                f"MCP server '{name}' uses transport '{transport}', "
+                "but Phase 1.5 only supports stdio"
+            )
+
         args = data.get("args") or []
         if isinstance(args, str):
             args = [args]
 
-        raw_env = data.get("env") or {}
-        env: dict[str, str] = {}
-        if isinstance(raw_env, Mapping):
-            for key, value in raw_env.items():
-                if isinstance(value, str) and value.startswith("$"):
-                    env[str(key)] = os.environ.get(value[1:], "")
-                else:
-                    env[str(key)] = str(value)
-
-        enabled_tools = data.get("enabled_tools")
-        if isinstance(enabled_tools, list):
-            enabled_tools_set: Optional[set[str]] = {str(item) for item in enabled_tools}
-        else:
-            enabled_tools_set = None
-
-        disabled_tools = data.get("disabled_tools") or []
-        disabled_tools_set = (
-            {str(item) for item in disabled_tools}
-            if isinstance(disabled_tools, list)
-            else set()
+        env = _parse_env(data.get("env") or {})
+        enabled_tools = _parse_optional_tool_set(
+            data.get("enabled_tools") or data.get("enabledTools")
+        )
+        disabled_tools = _parse_tool_set(
+            data.get("disabled_tools") or data.get("disabledTools") or []
         )
 
         command = data.get("command")
@@ -57,22 +57,28 @@ class MCPServerConfig:
             raise ValueError(f"MCP server '{name}' is missing required command")
 
         cwd = data.get("cwd")
-        if isinstance(cwd, str) and cwd:
-            cwd = str(Path(cwd).expanduser())
-        else:
-            cwd = None
+        cwd_value = (
+            str(Path(cwd).expanduser())
+            if isinstance(cwd, str) and cwd
+            else None
+        )
 
         return cls(
             name=str(data.get("name") or name),
             command=str(command),
             args=[str(arg) for arg in args],
             env=env,
-            cwd=cwd,
+            cwd=cwd_value,
+            transport=transport,
             enabled=bool(data.get("enabled", True)),
-            startup_timeout_sec=float(data.get("startup_timeout_sec", 10.0)),
-            tool_timeout_sec=float(data.get("tool_timeout_sec", 60.0)),
-            enabled_tools=enabled_tools_set,
-            disabled_tools=disabled_tools_set,
+            startup_timeout_sec=float(
+                data.get("startup_timeout_sec", data.get("startupTimeoutSec", 10.0))
+            ),
+            tool_timeout_sec=float(
+                data.get("tool_timeout_sec", data.get("toolTimeoutSec", 60.0))
+            ),
+            enabled_tools=enabled_tools,
+            disabled_tools=disabled_tools,
         )
 
     def allows_tool(self, tool_name: str) -> bool:
@@ -82,14 +88,53 @@ class MCPServerConfig:
         return tool_name not in self.disabled_tools
 
 
-def load_mcp_server_configs(config: Optional[Mapping[str, Any]]) -> list[MCPServerConfig]:
+def _parse_env(raw_env: Any) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if not isinstance(raw_env, Mapping):
+        return env
+    for key, value in raw_env.items():
+        if isinstance(value, str) and value.startswith("$"):
+            env[str(key)] = os.environ.get(value[1:], "")
+        else:
+            env[str(key)] = str(value)
+    return env
+
+
+def _parse_tool_set(value: Any) -> set[str]:
+    return {str(item) for item in value} if isinstance(value, list) else set()
+
+
+def _parse_optional_tool_set(value: Any) -> set[str] | None:
+    return _parse_tool_set(value) if isinstance(value, list) else None
+
+
+def _server_entries_from_root(root: Mapping[str, Any]) -> tuple[ServerEntries, bool]:
+    """Return MCP server entries and whether MCP is explicitly enabled."""
+    mcp_config = root.get("mcp", {}) if isinstance(root, Mapping) else {}
+    if isinstance(mcp_config, Mapping):
+        servers = mcp_config.get("servers") or mcp_config.get("mcpServers") or {}
+        enabled = bool(mcp_config.get("enabled", bool(servers)))
+        if servers:
+            return servers, enabled
+
+    # Compatibility with Claude/Codex-style top-level maps.
+    for key in ("mcpServers", "mcp_servers"):
+        servers = root.get(key)
+        if servers:
+            return servers, True
+    return {}, False
+
+
+def load_mcp_server_configs(config: Mapping[str, Any] | None) -> list[MCPServerConfig]:
     """Load enabled MCP server configs from Penguin config data."""
     root = config or {}
-    mcp_config = root.get("mcp", {}) if isinstance(root, Mapping) else {}
-    if not isinstance(mcp_config, Mapping) or not bool(mcp_config.get("enabled", False)):
+    if not isinstance(root, Mapping):
         return []
 
-    servers = mcp_config.get("servers") or {}
+    servers, enabled = _server_entries_from_root(root)
+    if not enabled:
+        return []
+
     parsed: list[MCPServerConfig] = []
     if isinstance(servers, Mapping):
         for name, data in servers.items():

--- a/penguin/integrations/mcp/config.py
+++ b/penguin/integrations/mcp/config.py
@@ -15,11 +15,15 @@ class MCPServerConfig:
     """Configuration for one MCP server."""
 
     name: str
-    command: str
+    command: str = ""
     args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
     cwd: str | None = None
     transport: str = "stdio"
+    url: str | None = None
+    bearer_token_env_var: str | None = None
+    http_headers: dict[str, str] = field(default_factory=dict)
+    env_http_headers: dict[str, str] = field(default_factory=dict)
     enabled: bool = True
     startup_timeout_sec: float = 10.0
     tool_timeout_sec: float = 60.0
@@ -34,17 +38,15 @@ class MCPServerConfig:
             raise ValueError(
                 f"MCP server '{name}' has unsupported transport '{transport}'"
             )
-        if transport != "stdio":
-            raise ValueError(
-                f"MCP server '{name}' uses transport '{transport}', "
-                "but Phase 1.5 only supports stdio"
-            )
-
         args = data.get("args") or []
         if isinstance(args, str):
             args = [args]
 
         env = _parse_env(data.get("env") or {})
+        http_headers = _parse_env(data.get("http_headers") or data.get("httpHeaders") or {})
+        env_http_headers = _parse_env_header_map(
+            data.get("env_http_headers") or data.get("envHttpHeaders") or {}
+        )
         enabled_tools = _parse_optional_tool_set(
             data.get("enabled_tools") or data.get("enabledTools")
         )
@@ -53,8 +55,11 @@ class MCPServerConfig:
         )
 
         command = data.get("command")
-        if not command:
+        url = data.get("url")
+        if transport == "stdio" and not command:
             raise ValueError(f"MCP server '{name}' is missing required command")
+        if transport != "stdio" and not url:
+            raise ValueError(f"MCP server '{name}' is missing required url")
 
         cwd = data.get("cwd")
         cwd_value = (
@@ -65,11 +70,19 @@ class MCPServerConfig:
 
         return cls(
             name=str(data.get("name") or name),
-            command=str(command),
+            command=str(command or ""),
             args=[str(arg) for arg in args],
             env=env,
             cwd=cwd_value,
             transport=transport,
+            url=str(url) if url else None,
+            bearer_token_env_var=(
+                str(data.get("bearer_token_env_var") or data.get("bearerTokenEnvVar"))
+                if data.get("bearer_token_env_var") or data.get("bearerTokenEnvVar")
+                else None
+            ),
+            http_headers=http_headers,
+            env_http_headers=env_http_headers,
             enabled=bool(data.get("enabled", True)),
             startup_timeout_sec=float(
                 data.get("startup_timeout_sec", data.get("startupTimeoutSec", 10.0))
@@ -80,6 +93,20 @@ class MCPServerConfig:
             enabled_tools=enabled_tools,
             disabled_tools=disabled_tools,
         )
+
+    @property
+    def resolved_http_headers(self) -> dict[str, str]:
+        """Return HTTP headers with env-backed secrets resolved at call time."""
+        headers = dict(self.http_headers)
+        for header_name, env_var in self.env_http_headers.items():
+            value = os.environ.get(env_var)
+            if value:
+                headers[header_name] = value
+        if self.bearer_token_env_var:
+            token = os.environ.get(self.bearer_token_env_var)
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+        return headers
 
     def allows_tool(self, tool_name: str) -> bool:
         """Return whether this config allows a raw MCP tool name."""
@@ -98,6 +125,12 @@ def _parse_env(raw_env: Any) -> dict[str, str]:
         else:
             env[str(key)] = str(value)
     return env
+
+
+def _parse_env_header_map(raw_env: Any) -> dict[str, str]:
+    if not isinstance(raw_env, Mapping):
+        return {}
+    return {str(key): str(value) for key, value in raw_env.items()}
 
 
 def _parse_tool_set(value: Any) -> set[str]:

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -20,13 +20,17 @@ logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - availability depends on optional extra
     from mcp import ClientSession, StdioServerParameters  # type: ignore
+    from mcp.client.sse import sse_client  # type: ignore
     from mcp.client.stdio import stdio_client  # type: ignore
+    from mcp.client.streamable_http import streamablehttp_client  # type: ignore
 
     HAS_MCP_SDK = True
 except Exception:  # pragma: no cover - exercised when extra is absent
     ClientSession = None  # type: ignore[assignment]
     StdioServerParameters = None  # type: ignore[assignment]
+    sse_client = None  # type: ignore[assignment]
     stdio_client = None  # type: ignore[assignment]
+    streamablehttp_client = None  # type: ignore[assignment]
     HAS_MCP_SDK = False
 
 
@@ -105,6 +109,7 @@ class MCPClientManager:
                     "status": state.status.value,
                     "transport": state.config.transport,
                     "command": state.config.command,
+                    "url": state.config.url,
                     "tool_count": len(state.tools),
                     "error": state.error,
                     "tools": sorted(state.tools),
@@ -285,15 +290,40 @@ class MCPClientManager:
             )
 
         stack = AsyncExitStack()
-        params = StdioServerParameters(  # type: ignore[misc]
-            command=state.config.command,
-            args=state.config.args,
-            env=state.config.env or None,
-            cwd=state.config.cwd,
-        )
-        read_stream, write_stream = await stack.enter_async_context(
-            stdio_client(params)
-        )
+        if state.config.transport == "stdio":
+            params = StdioServerParameters(  # type: ignore[misc]
+                command=state.config.command,
+                args=state.config.args,
+                env=state.config.env or None,
+                cwd=state.config.cwd,
+            )
+            read_stream, write_stream = await stack.enter_async_context(
+                stdio_client(params)
+            )
+        elif state.config.transport == "streamable_http":
+            if streamablehttp_client is None:
+                raise RuntimeError("MCP streamable HTTP client is unavailable")
+            read_stream, write_stream, _session_id = await stack.enter_async_context(
+                streamablehttp_client(
+                    state.config.url or "",
+                    headers=state.config.resolved_http_headers or None,
+                    timeout=state.config.startup_timeout_sec,
+                    sse_read_timeout=state.config.tool_timeout_sec,
+                )
+            )
+        elif state.config.transport == "sse":
+            if sse_client is None:
+                raise RuntimeError("MCP SSE client is unavailable")
+            read_stream, write_stream = await stack.enter_async_context(
+                sse_client(
+                    state.config.url or "",
+                    headers=state.config.resolved_http_headers or None,
+                    timeout=state.config.startup_timeout_sec,
+                    sse_read_timeout=state.config.tool_timeout_sec,
+                )
+            )
+        else:
+            raise ValueError(f"Unsupported MCP transport: {state.config.transport}")
         session = await stack.enter_async_context(
             ClientSession(read_stream, write_stream)
         )

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import threading
 from concurrent.futures import Future
 from contextlib import AsyncExitStack
@@ -77,6 +78,8 @@ class MCPServerState:
     error: str | None = None
     session: Any = None
     stack: AsyncExitStack | None = None
+    list_changed: bool = False
+    last_changed_at: float | None = None
 
 
 class MCPClientManager:
@@ -113,6 +116,9 @@ class MCPClientManager:
                     "tool_count": len(state.tools),
                     "error": state.error,
                     "tools": sorted(state.tools),
+                    "list_changed": state.list_changed,
+                    "last_changed_at": state.last_changed_at,
+                    "output_token_limit": state.config.output_token_limit,
                 }
                 for name, state in self._states.items()
             },
@@ -214,7 +220,7 @@ class MCPClientManager:
             state.session.call_tool(tool.raw_name, arguments or {}),
             timeout=timeout,
         )
-        return self._serialize_call_result(result)
+        return self._serialize_call_result(result, state.config.output_token_limit)
 
     async def close(self) -> None:
         """Close cached MCP session handles from the actor task that opened them."""
@@ -231,6 +237,7 @@ class MCPClientManager:
             state.stack = None
             state.session = None
             state.status = MCPServerStatus.DISCONNECTED
+            state.list_changed = False
 
     async def _connect_and_list_tools(
         self,
@@ -241,6 +248,7 @@ class MCPClientManager:
         state.error = None
         try:
             session = await self._ensure_session(state)
+            self._install_list_changed_handlers(state, session)
             response = await asyncio.wait_for(
                 session.list_tools(),
                 timeout=state.config.startup_timeout_sec,
@@ -279,6 +287,28 @@ class MCPClientManager:
                 state.config.name,
                 exc,
             )
+
+    def _install_list_changed_handlers(self, state: MCPServerState, session: Any) -> None:
+        """Install best-effort MCP list-change notification handlers."""
+
+        def mark_changed(*_args: Any, **_kwargs: Any) -> None:
+            state.list_changed = True
+            state.last_changed_at = time.time()
+
+        for attr_name in (
+            "on_tool_list_changed",
+            "on_tools_list_changed",
+            "tools_list_changed_callback",
+        ):
+            if hasattr(session, attr_name):
+                try:
+                    setattr(session, attr_name, mark_changed)
+                except Exception:  # pragma: no cover - SDK-version defensive
+                    logger.debug(
+                        "Unable to install MCP list-changed handler %s",
+                        attr_name,
+                        exc_info=True,
+                    )
 
     async def _ensure_session(self, state: MCPServerState) -> Any:
         """Open or return a persistent MCP stdio session."""
@@ -336,33 +366,52 @@ class MCPClientManager:
         return session
 
     @staticmethod
-    def _serialize_call_result(result: Any) -> Any:
-        """Convert MCP SDK result objects into JSON-ish data."""
+    def _cap_output(value: Any, output_limit: int | None) -> Any:
+        """Return value or a capped/truncated MCP tool result payload."""
+        if not output_limit:
+            return value
+        try:
+            serialized = json.dumps(value, ensure_ascii=False)
+        except TypeError:
+            serialized = str(value)
+        if len(serialized) <= output_limit:
+            return value
+        return {
+            "truncated": True,
+            "output_token_limit": output_limit,
+            "content": serialized[:output_limit],
+        }
+
+    @staticmethod
+    def _serialize_call_result(result: Any, output_limit: int | None = None) -> Any:
+        """Convert MCP SDK result objects into capped JSON-ish data."""
         if hasattr(result, "model_dump"):
-            return result.model_dump()
-        if hasattr(result, "dict"):
-            return result.dict()
-        if hasattr(result, "content"):
+            serialized = result.model_dump()
+        elif hasattr(result, "dict"):
+            serialized = result.dict()
+        elif hasattr(result, "content"):
             content = getattr(result, "content")
-            return [MCPClientManager._serialize_call_result(item) for item in content]
-        if isinstance(result, (str, int, float, bool)) or result is None:
-            return result
-        if isinstance(result, list):
-            return [MCPClientManager._serialize_call_result(item) for item in result]
-        if isinstance(result, dict):
-            return {
+            serialized = [MCPClientManager._serialize_call_result(item) for item in content]
+        elif isinstance(result, (str, int, float, bool)) or result is None:
+            serialized = result
+        elif isinstance(result, list):
+            serialized = [MCPClientManager._serialize_call_result(item) for item in result]
+        elif isinstance(result, dict):
+            serialized = {
                 key: MCPClientManager._serialize_call_result(value)
                 for key, value in result.items()
             }
-        try:
-            return json.loads(
-                json.dumps(
-                    result,
-                    default=lambda value: getattr(value, "__dict__", str(value)),
+        else:
+            try:
+                serialized = json.loads(
+                    json.dumps(
+                        result,
+                        default=lambda value: getattr(value, "__dict__", str(value)),
+                    )
                 )
-            )
-        except Exception:
-            return str(result)
+            except Exception:
+                serialized = str(result)
+        return MCPClientManager._cap_output(serialized, output_limit)
 
     def _run_async(self, coro: Any) -> Any:
         """Run manager coroutines on one actor task.

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -8,9 +8,10 @@ import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
-from penguin.integrations.mcp.config import MCPServerConfig
+if TYPE_CHECKING:
+    from penguin.integrations.mcp.config import MCPServerConfig
 from penguin.integrations.mcp.names import make_tool_name
 
 logger = logging.getLogger(__name__)
@@ -67,9 +68,9 @@ class MCPServerState:
     config: MCPServerConfig
     status: MCPServerStatus = MCPServerStatus.DISCONNECTED
     tools: dict[str, MCPToolDefinition] = field(default_factory=dict)
-    error: Optional[str] = None
+    error: str | None = None
     session: Any = None
-    stack: Optional[AsyncExitStack] = None
+    stack: AsyncExitStack | None = None
 
 
 class MCPClientManager:
@@ -92,9 +93,14 @@ class MCPClientManager:
         return {
             "available": self.available,
             "discovered": self._discovered,
+            "server_count": len(self._states),
+            "tool_count": len(self._tool_index),
             "servers": {
                 name: {
                     "status": state.status.value,
+                    "transport": state.config.transport,
+                    "command": state.config.command,
+                    "tool_count": len(state.tools),
                     "error": state.error,
                     "tools": sorted(state.tools),
                 }
@@ -112,11 +118,30 @@ class MCPClientManager:
         """Call an MCP tool synchronously for ToolManager integration."""
         return self._run_async(self.call_tool(public_name, arguments))
 
+    def refresh_sync(self) -> list[MCPToolDefinition]:
+        """Force rediscovery synchronously."""
+        return self._run_async(self.refresh())
+
+    def reconnect_sync(self, server_name: str | None = None) -> dict[str, Any]:
+        """Reconnect one or all MCP servers synchronously."""
+        self._run_async(self.reconnect(server_name))
+        return self.status()
+
+    def close_sync(self) -> dict[str, Any]:
+        """Close all MCP sessions synchronously."""
+        self._run_async(self.close())
+        return self.status()
+
     async def discover(self) -> list[MCPToolDefinition]:
         """Connect to configured servers and discover tools."""
         if self._discovered:
             return list(self._tool_index.values())
         if not HAS_MCP_SDK:
+            for state in self._states.values():
+                state.status = MCPServerStatus.FAILED
+                state.error = (
+                    "MCP SDK is not installed. Install with `penguin-ai[mcp]`."
+                )
             logger.info("MCP SDK is not installed; no MCP tools discovered")
             self._discovered = True
             return []
@@ -127,6 +152,37 @@ class MCPClientManager:
         self._discovered = True
         return list(self._tool_index.values())
 
+    async def refresh(self) -> list[MCPToolDefinition]:
+        """Close sessions and force a fresh tool discovery pass."""
+        await self.close()
+        self._tool_index.clear()
+        for state in self._states.values():
+            state.tools.clear()
+            state.error = None
+        self._discovered = False
+        return await self.discover()
+
+    async def reconnect(self, server_name: str | None = None) -> None:
+        """Reconnect one server or all servers and refresh their tool lists."""
+        if server_name is None:
+            await self.refresh()
+            return
+        state = self._states.get(server_name)
+        if state is None:
+            raise ValueError(f"Unknown MCP server: {server_name}")
+        if state.stack is not None:
+            await state.stack.aclose()
+        for public_name in list(state.tools):
+            self._tool_index.pop(public_name, None)
+        state.tools.clear()
+        state.stack = None
+        state.session = None
+        state.error = None
+        state.status = MCPServerStatus.DISCONNECTED
+        existing = set(self._tool_index)
+        await self._connect_and_list_tools(state, existing)
+        self._discovered = True
+
     async def call_tool(self, public_name: str, arguments: dict[str, Any]) -> Any:
         """Call a discovered MCP tool by Penguin public name."""
         if public_name not in self._tool_index:
@@ -136,26 +192,23 @@ class MCPClientManager:
             raise ValueError(f"Unknown MCP tool: {public_name}")
 
         state = self._states[tool.server_name]
-        if state.session is None or state.status != MCPServerStatus.CONNECTED:
-            await self._connect_and_list_tools(state, set(self._tool_index))
-        if state.session is None:
-            raise RuntimeError(f"MCP server '{tool.server_name}' is not connected")
-
         timeout = state.config.tool_timeout_sec
-        result = await asyncio.wait_for(
-            state.session.call_tool(tool.raw_name, arguments or {}),
-            timeout=timeout,
-        )
-        return self._serialize_call_result(result)
+        async with AsyncExitStack() as stack:
+            session = await self._open_session(state, stack)
+            result = await asyncio.wait_for(
+                session.call_tool(tool.raw_name, arguments or {}),
+                timeout=timeout,
+            )
+            return self._serialize_call_result(result)
 
     async def close(self) -> None:
-        """Close all open MCP sessions."""
+        """Close cached MCP session handles.
+
+        Phase 1.5 intentionally opens stdio sessions per discovery/call so AnyIO
+        cancel scopes close in the same task that created them. This method keeps
+        the lifecycle facade stable for future persistent-session support.
+        """
         for state in self._states.values():
-            if state.stack is not None:
-                try:
-                    await state.stack.aclose()
-                except Exception as exc:  # pragma: no cover - defensive cleanup
-                    logger.warning("Failed closing MCP server '%s': %s", state.config.name, exc)
             state.stack = None
             state.session = None
             state.status = MCPServerStatus.DISCONNECTED
@@ -168,58 +221,73 @@ class MCPClientManager:
         state.status = MCPServerStatus.CONNECTING
         state.error = None
         try:
-            session = await self._ensure_session(state)
-            response = await asyncio.wait_for(
-                session.list_tools(),
-                timeout=state.config.startup_timeout_sec,
-            )
-            for raw_tool in getattr(response, "tools", []) or []:
-                raw_name = str(getattr(raw_tool, "name", ""))
-                if not raw_name or not state.config.allows_tool(raw_name):
-                    continue
-                public_name = make_tool_name(state.config.name, raw_name, existing)
-                existing.add(public_name)
-                input_schema = getattr(raw_tool, "inputSchema", None) or getattr(
-                    raw_tool,
-                    "input_schema",
-                    None,
+            async with AsyncExitStack() as stack:
+                session = await self._open_session(state, stack)
+                response = await asyncio.wait_for(
+                    session.list_tools(),
+                    timeout=state.config.startup_timeout_sec,
                 )
-                if not isinstance(input_schema, dict):
-                    input_schema = {"type": "object", "properties": {}}
-                description = str(getattr(raw_tool, "description", "") or "")
-                definition = MCPToolDefinition(
-                    public_name=public_name,
-                    server_name=state.config.name,
-                    raw_name=raw_name,
-                    description=description or f"MCP tool {raw_name} from {state.config.name}",
-                    input_schema=input_schema,
-                )
-                state.tools[public_name] = definition
-                self._tool_index[public_name] = definition
+                for raw_tool in getattr(response, "tools", []) or []:
+                    raw_name = str(getattr(raw_tool, "name", ""))
+                    if not raw_name or not state.config.allows_tool(raw_name):
+                        continue
+                    public_name = make_tool_name(state.config.name, raw_name, existing)
+                    existing.add(public_name)
+                    input_schema = getattr(raw_tool, "inputSchema", None) or getattr(
+                        raw_tool,
+                        "input_schema",
+                        None,
+                    )
+                    if not isinstance(input_schema, dict):
+                        input_schema = {"type": "object", "properties": {}}
+                    description = str(getattr(raw_tool, "description", "") or "")
+                    definition = MCPToolDefinition(
+                        public_name=public_name,
+                        server_name=state.config.name,
+                        raw_name=raw_name,
+                        description=(
+                            description
+                            or f"MCP tool {raw_name} from {state.config.name}"
+                        ),
+                        input_schema=input_schema,
+                    )
+                    state.tools[public_name] = definition
+                    self._tool_index[public_name] = definition
+            state.session = None
+            state.stack = None
             state.status = MCPServerStatus.CONNECTED
         except Exception as exc:
             state.status = MCPServerStatus.FAILED
             state.error = str(exc)
-            logger.warning("MCP server '%s' discovery failed: %s", state.config.name, exc)
+            logger.warning(
+                "MCP server '%s' discovery failed: %s",
+                state.config.name,
+                exc,
+            )
 
-    async def _ensure_session(self, state: MCPServerState) -> Any:
-        if state.session is not None:
-            return state.session
+    async def _open_session(self, state: MCPServerState, stack: AsyncExitStack) -> Any:
+        """Open one MCP stdio session owned by the caller's async context."""
         if not HAS_MCP_SDK:
-            raise RuntimeError("MCP SDK is not installed. Install with `penguin-ai[mcp]`.")
+            raise RuntimeError(
+                "MCP SDK is not installed. Install with `penguin-ai[mcp]`."
+            )
 
-        stack = AsyncExitStack()
         params = StdioServerParameters(  # type: ignore[misc]
             command=state.config.command,
             args=state.config.args,
             env=state.config.env or None,
             cwd=state.config.cwd,
         )
-        read_stream, write_stream = await stack.enter_async_context(stdio_client(params))
-        session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
-        await asyncio.wait_for(session.initialize(), timeout=state.config.startup_timeout_sec)
-        state.stack = stack
-        state.session = session
+        read_stream, write_stream = await stack.enter_async_context(
+            stdio_client(params)
+        )
+        session = await stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+        await asyncio.wait_for(
+            session.initialize(),
+            timeout=state.config.startup_timeout_sec,
+        )
         return session
 
     @staticmethod
@@ -237,9 +305,17 @@ class MCPClientManager:
         if isinstance(result, list):
             return [MCPClientManager._serialize_call_result(item) for item in result]
         if isinstance(result, dict):
-            return {key: MCPClientManager._serialize_call_result(value) for key, value in result.items()}
+            return {
+                key: MCPClientManager._serialize_call_result(value)
+                for key, value in result.items()
+            }
         try:
-            return json.loads(json.dumps(result, default=lambda value: getattr(value, "__dict__", str(value))))
+            return json.loads(
+                json.dumps(
+                    result,
+                    default=lambda value: getattr(value, "__dict__", str(value)),
+                )
+            )
         except Exception:
             return str(result)
 
@@ -251,7 +327,7 @@ class MCPClientManager:
             return asyncio.run(coro)
 
         result: Any = None
-        error: Optional[BaseException] = None
+        error: BaseException | None = None
 
         def run() -> None:
             nonlocal result, error

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -26,7 +26,7 @@ try:  # pragma: no cover - availability depends on optional extra
     from mcp.client.streamable_http import streamablehttp_client  # type: ignore
 
     HAS_MCP_SDK = True
-except Exception:  # pragma: no cover - exercised when extra is absent
+except ImportError:  # pragma: no cover - exercised when extra is absent
     ClientSession = None  # type: ignore[assignment]
     StdioServerParameters = None  # type: ignore[assignment]
     sse_client = None  # type: ignore[assignment]
@@ -209,7 +209,11 @@ class MCPClientManager:
 
         state = self._states[tool.server_name]
         if state.session is None or state.status != MCPServerStatus.CONNECTED:
+            self._clear_server_tools(state)
             await self._connect_and_list_tools(state, set(self._tool_index))
+            tool = self._tool_index.get(public_name)
+            if tool is None:
+                raise ValueError(f"Unknown MCP tool after reconnect: {public_name}")
         if state.session is None:
             raise RuntimeError(f"MCP server '{tool.server_name}' is not connected")
 
@@ -238,7 +242,13 @@ class MCPClientManager:
             state.list_changed = False
 
     def _clear_server_tools(self, state: MCPServerState) -> None:
-        self._clear_server_tools(state)
+        """Remove cached tool definitions for one server."""
+        for public_name in list(state.tools):
+            self._tool_index.pop(public_name, None)
+        for public_name, tool in list(self._tool_index.items()):
+            if tool.server_name == state.config.name:
+                self._tool_index.pop(public_name, None)
+        state.tools.clear()
 
     async def _connect_and_list_tools(
         self,
@@ -321,47 +331,51 @@ class MCPClientManager:
             )
 
         stack = AsyncExitStack()
-        if state.config.transport == "stdio":
-            params = StdioServerParameters(  # type: ignore[misc]
-                command=state.config.command,
-                args=state.config.args,
-                env=state.config.env or None,
-                cwd=state.config.cwd,
-            )
-            read_stream, write_stream = await stack.enter_async_context(
-                stdio_client(params)
-            )
-        elif state.config.transport == "streamable_http":
-            if streamablehttp_client is None:
-                raise RuntimeError("MCP streamable HTTP client is unavailable")
-            read_stream, write_stream, _session_id = await stack.enter_async_context(
-                streamablehttp_client(
-                    state.config.url or "",
-                    headers=state.config.resolved_http_headers or None,
-                    timeout=state.config.startup_timeout_sec,
-                    sse_read_timeout=state.config.tool_timeout_sec,
+        try:
+            if state.config.transport == "stdio":
+                params = StdioServerParameters(  # type: ignore[misc]
+                    command=state.config.command,
+                    args=state.config.args,
+                    env=state.config.env or None,
+                    cwd=state.config.cwd,
                 )
-            )
-        elif state.config.transport == "sse":
-            if sse_client is None:
-                raise RuntimeError("MCP SSE client is unavailable")
-            read_stream, write_stream = await stack.enter_async_context(
-                sse_client(
-                    state.config.url or "",
-                    headers=state.config.resolved_http_headers or None,
-                    timeout=state.config.startup_timeout_sec,
-                    sse_read_timeout=state.config.tool_timeout_sec,
+                read_stream, write_stream = await stack.enter_async_context(
+                    stdio_client(params)
                 )
+            elif state.config.transport == "streamable_http":
+                if streamablehttp_client is None:
+                    raise RuntimeError("MCP streamable HTTP client is unavailable")
+                read_stream, write_stream, _session_id = await stack.enter_async_context(
+                    streamablehttp_client(
+                        state.config.url or "",
+                        headers=state.config.resolved_http_headers or None,
+                        timeout=state.config.startup_timeout_sec,
+                        sse_read_timeout=state.config.tool_timeout_sec,
+                    )
+                )
+            elif state.config.transport == "sse":
+                if sse_client is None:
+                    raise RuntimeError("MCP SSE client is unavailable")
+                read_stream, write_stream = await stack.enter_async_context(
+                    sse_client(
+                        state.config.url or "",
+                        headers=state.config.resolved_http_headers or None,
+                        timeout=state.config.startup_timeout_sec,
+                        sse_read_timeout=state.config.tool_timeout_sec,
+                    )
+                )
+            else:
+                raise ValueError(f"Unsupported MCP transport: {state.config.transport}")
+            session = await stack.enter_async_context(
+                ClientSession(read_stream, write_stream)
             )
-        else:
-            raise ValueError(f"Unsupported MCP transport: {state.config.transport}")
-        session = await stack.enter_async_context(
-            ClientSession(read_stream, write_stream)
-        )
-        await asyncio.wait_for(
-            session.initialize(),
-            timeout=state.config.startup_timeout_sec,
-        )
+            await asyncio.wait_for(
+                session.initialize(),
+                timeout=state.config.startup_timeout_sec,
+            )
+        except Exception:
+            await stack.aclose()
+            raise
         state.stack = stack
         state.session = session
         return session

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
+from concurrent.futures import Future
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from enum import Enum
@@ -82,6 +84,9 @@ class MCPClientManager:
         }
         self._tool_index: dict[str, MCPToolDefinition] = {}
         self._discovered = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
+        self._actor_queue: asyncio.Queue[tuple[Any, Future[Any]]] | None = None
 
     @property
     def available(self) -> bool:
@@ -130,7 +135,9 @@ class MCPClientManager:
     def close_sync(self) -> dict[str, Any]:
         """Close all MCP sessions synchronously."""
         self._run_async(self.close())
-        return self.status()
+        status = self.status()
+        self._stop_actor()
+        return status
 
     async def discover(self) -> list[MCPToolDefinition]:
         """Connect to configured servers and discover tools."""
@@ -192,23 +199,30 @@ class MCPClientManager:
             raise ValueError(f"Unknown MCP tool: {public_name}")
 
         state = self._states[tool.server_name]
+        if state.session is None or state.status != MCPServerStatus.CONNECTED:
+            await self._connect_and_list_tools(state, set(self._tool_index))
+        if state.session is None:
+            raise RuntimeError(f"MCP server '{tool.server_name}' is not connected")
+
         timeout = state.config.tool_timeout_sec
-        async with AsyncExitStack() as stack:
-            session = await self._open_session(state, stack)
-            result = await asyncio.wait_for(
-                session.call_tool(tool.raw_name, arguments or {}),
-                timeout=timeout,
-            )
-            return self._serialize_call_result(result)
+        result = await asyncio.wait_for(
+            state.session.call_tool(tool.raw_name, arguments or {}),
+            timeout=timeout,
+        )
+        return self._serialize_call_result(result)
 
     async def close(self) -> None:
-        """Close cached MCP session handles.
-
-        Phase 1.5 intentionally opens stdio sessions per discovery/call so AnyIO
-        cancel scopes close in the same task that created them. This method keeps
-        the lifecycle facade stable for future persistent-session support.
-        """
+        """Close cached MCP session handles from the actor task that opened them."""
         for state in self._states.values():
+            if state.stack is not None:
+                try:
+                    await state.stack.aclose()
+                except Exception as exc:  # pragma: no cover - defensive cleanup
+                    logger.warning(
+                        "Failed closing MCP server '%s': %s",
+                        state.config.name,
+                        exc,
+                    )
             state.stack = None
             state.session = None
             state.status = MCPServerStatus.DISCONNECTED
@@ -221,40 +235,36 @@ class MCPClientManager:
         state.status = MCPServerStatus.CONNECTING
         state.error = None
         try:
-            async with AsyncExitStack() as stack:
-                session = await self._open_session(state, stack)
-                response = await asyncio.wait_for(
-                    session.list_tools(),
-                    timeout=state.config.startup_timeout_sec,
+            session = await self._ensure_session(state)
+            response = await asyncio.wait_for(
+                session.list_tools(),
+                timeout=state.config.startup_timeout_sec,
+            )
+            for raw_tool in getattr(response, "tools", []) or []:
+                raw_name = str(getattr(raw_tool, "name", ""))
+                if not raw_name or not state.config.allows_tool(raw_name):
+                    continue
+                public_name = make_tool_name(state.config.name, raw_name, existing)
+                existing.add(public_name)
+                input_schema = getattr(raw_tool, "inputSchema", None) or getattr(
+                    raw_tool,
+                    "input_schema",
+                    None,
                 )
-                for raw_tool in getattr(response, "tools", []) or []:
-                    raw_name = str(getattr(raw_tool, "name", ""))
-                    if not raw_name or not state.config.allows_tool(raw_name):
-                        continue
-                    public_name = make_tool_name(state.config.name, raw_name, existing)
-                    existing.add(public_name)
-                    input_schema = getattr(raw_tool, "inputSchema", None) or getattr(
-                        raw_tool,
-                        "input_schema",
-                        None,
-                    )
-                    if not isinstance(input_schema, dict):
-                        input_schema = {"type": "object", "properties": {}}
-                    description = str(getattr(raw_tool, "description", "") or "")
-                    definition = MCPToolDefinition(
-                        public_name=public_name,
-                        server_name=state.config.name,
-                        raw_name=raw_name,
-                        description=(
-                            description
-                            or f"MCP tool {raw_name} from {state.config.name}"
-                        ),
-                        input_schema=input_schema,
-                    )
-                    state.tools[public_name] = definition
-                    self._tool_index[public_name] = definition
-            state.session = None
-            state.stack = None
+                if not isinstance(input_schema, dict):
+                    input_schema = {"type": "object", "properties": {}}
+                description = str(getattr(raw_tool, "description", "") or "")
+                definition = MCPToolDefinition(
+                    public_name=public_name,
+                    server_name=state.config.name,
+                    raw_name=raw_name,
+                    description=(
+                        description or f"MCP tool {raw_name} from {state.config.name}"
+                    ),
+                    input_schema=input_schema,
+                )
+                state.tools[public_name] = definition
+                self._tool_index[public_name] = definition
             state.status = MCPServerStatus.CONNECTED
         except Exception as exc:
             state.status = MCPServerStatus.FAILED
@@ -265,13 +275,16 @@ class MCPClientManager:
                 exc,
             )
 
-    async def _open_session(self, state: MCPServerState, stack: AsyncExitStack) -> Any:
-        """Open one MCP stdio session owned by the caller's async context."""
+    async def _ensure_session(self, state: MCPServerState) -> Any:
+        """Open or return a persistent MCP stdio session."""
+        if state.session is not None:
+            return state.session
         if not HAS_MCP_SDK:
             raise RuntimeError(
                 "MCP SDK is not installed. Install with `penguin-ai[mcp]`."
             )
 
+        stack = AsyncExitStack()
         params = StdioServerParameters(  # type: ignore[misc]
             command=state.config.command,
             args=state.config.args,
@@ -288,6 +301,8 @@ class MCPClientManager:
             session.initialize(),
             timeout=state.config.startup_timeout_sec,
         )
+        state.stack = stack
+        state.session = session
         return session
 
     @staticmethod
@@ -319,31 +334,79 @@ class MCPClientManager:
         except Exception:
             return str(result)
 
-    @staticmethod
-    def _run_async(coro: Any) -> Any:
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(coro)
+    def _run_async(self, coro: Any) -> Any:
+        """Run manager coroutines on one actor task.
 
-        result: Any = None
-        error: BaseException | None = None
+        The MCP SDK stdio transport uses AnyIO cancel scopes that must close in
+        the same task that opened them. A single actor task preserves session
+        state and closes transports cleanly.
+        """
+        loop, queue = self._ensure_actor()
+        future: Future[Any] = Future()
+        loop.call_soon_threadsafe(queue.put_nowait, (coro, future))
+        return future.result()
 
-        def run() -> None:
-            nonlocal result, error
-            try:
-                result = asyncio.run(coro)
-            except BaseException as exc:  # pragma: no cover - re-raised below
-                error = exc
+    def _ensure_actor(
+        self,
+    ) -> tuple[asyncio.AbstractEventLoop, asyncio.Queue[tuple[Any, Future[Any]]]]:
+        if (
+            self._loop is not None
+            and self._loop.is_running()
+            and self._actor_queue is not None
+        ):
+            return self._loop, self._actor_queue
 
-        import threading
+        ready = threading.Event()
+        loop = asyncio.new_event_loop()
 
-        thread = threading.Thread(target=run, daemon=True)
+        def run_loop() -> None:
+            asyncio.set_event_loop(loop)
+            self._actor_queue = asyncio.Queue()
+            ready.set()
+            loop.run_until_complete(self._actor_worker())
+            loop.close()
+
+        thread = threading.Thread(
+            target=run_loop,
+            name="penguin-mcp-client-loop",
+            daemon=True,
+        )
         thread.start()
-        thread.join()
-        if error is not None:
-            raise error
-        return result
+        ready.wait(timeout=5)
+        if self._actor_queue is None:
+            raise RuntimeError("MCP actor failed to start")
+        self._loop = loop
+        self._loop_thread = thread
+        return loop, self._actor_queue
+
+    async def _actor_worker(self) -> None:
+        assert self._actor_queue is not None
+        while True:
+            coro, future = await self._actor_queue.get()
+            if coro is None:
+                future.set_result(None)
+                return
+            try:
+                result = await coro
+            except BaseException as exc:  # pragma: no cover - re-raised by caller
+                future.set_exception(exc)
+            else:
+                future.set_result(result)
+
+    def _stop_actor(self) -> None:
+        if self._loop is None or self._actor_queue is None:
+            return
+        future: Future[Any] = Future()
+        self._loop.call_soon_threadsafe(
+            self._actor_queue.put_nowait,
+            (None, future),
+        )
+        future.result(timeout=5)
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=5)
+        self._loop = None
+        self._loop_thread = None
+        self._actor_queue = None
 
 
 __all__ = [

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -1,0 +1,278 @@
+"""MCP client manager for consuming external MCP servers as Penguin tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from penguin.integrations.mcp.config import MCPServerConfig
+from penguin.integrations.mcp.names import make_tool_name
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - availability depends on optional extra
+    from mcp import ClientSession, StdioServerParameters  # type: ignore
+    from mcp.client.stdio import stdio_client  # type: ignore
+
+    HAS_MCP_SDK = True
+except Exception:  # pragma: no cover - exercised when extra is absent
+    ClientSession = None  # type: ignore[assignment]
+    StdioServerParameters = None  # type: ignore[assignment]
+    stdio_client = None  # type: ignore[assignment]
+    HAS_MCP_SDK = False
+
+
+class MCPServerStatus(str, Enum):
+    """Lifecycle status for a configured MCP server."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    FAILED = "failed"
+
+
+@dataclass
+class MCPToolDefinition:
+    """A discovered MCP tool mapped onto Penguin's public tool surface."""
+
+    public_name: str
+    server_name: str
+    raw_name: str
+    description: str
+    input_schema: dict[str, Any]
+
+    def to_penguin_schema(self) -> dict[str, Any]:
+        """Return ToolManager-compatible schema."""
+        return {
+            "name": self.public_name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+            "metadata": {
+                "provider": "mcp",
+                "mcp_server": self.server_name,
+                "mcp_tool": self.raw_name,
+            },
+        }
+
+
+@dataclass
+class MCPServerState:
+    """Runtime state for one MCP server connection."""
+
+    config: MCPServerConfig
+    status: MCPServerStatus = MCPServerStatus.DISCONNECTED
+    tools: dict[str, MCPToolDefinition] = field(default_factory=dict)
+    error: Optional[str] = None
+    session: Any = None
+    stack: Optional[AsyncExitStack] = None
+
+
+class MCPClientManager:
+    """Manage MCP client sessions and tool discovery."""
+
+    def __init__(self, servers: list[MCPServerConfig]) -> None:
+        self._states = {
+            server.name: MCPServerState(config=server) for server in servers
+        }
+        self._tool_index: dict[str, MCPToolDefinition] = {}
+        self._discovered = False
+
+    @property
+    def available(self) -> bool:
+        """Return whether the optional MCP SDK is importable."""
+        return HAS_MCP_SDK
+
+    def status(self) -> dict[str, Any]:
+        """Return serializable MCP manager status."""
+        return {
+            "available": self.available,
+            "discovered": self._discovered,
+            "servers": {
+                name: {
+                    "status": state.status.value,
+                    "error": state.error,
+                    "tools": sorted(state.tools),
+                }
+                for name, state in self._states.items()
+            },
+        }
+
+    def list_tools_sync(self) -> list[MCPToolDefinition]:
+        """Discover MCP tools synchronously for ToolManager integration."""
+        if not self._discovered:
+            self._run_async(self.discover())
+        return list(self._tool_index.values())
+
+    def call_tool_sync(self, public_name: str, arguments: dict[str, Any]) -> Any:
+        """Call an MCP tool synchronously for ToolManager integration."""
+        return self._run_async(self.call_tool(public_name, arguments))
+
+    async def discover(self) -> list[MCPToolDefinition]:
+        """Connect to configured servers and discover tools."""
+        if self._discovered:
+            return list(self._tool_index.values())
+        if not HAS_MCP_SDK:
+            logger.info("MCP SDK is not installed; no MCP tools discovered")
+            self._discovered = True
+            return []
+
+        existing: set[str] = set()
+        for state in self._states.values():
+            await self._connect_and_list_tools(state, existing)
+        self._discovered = True
+        return list(self._tool_index.values())
+
+    async def call_tool(self, public_name: str, arguments: dict[str, Any]) -> Any:
+        """Call a discovered MCP tool by Penguin public name."""
+        if public_name not in self._tool_index:
+            await self.discover()
+        tool = self._tool_index.get(public_name)
+        if tool is None:
+            raise ValueError(f"Unknown MCP tool: {public_name}")
+
+        state = self._states[tool.server_name]
+        if state.session is None or state.status != MCPServerStatus.CONNECTED:
+            await self._connect_and_list_tools(state, set(self._tool_index))
+        if state.session is None:
+            raise RuntimeError(f"MCP server '{tool.server_name}' is not connected")
+
+        timeout = state.config.tool_timeout_sec
+        result = await asyncio.wait_for(
+            state.session.call_tool(tool.raw_name, arguments or {}),
+            timeout=timeout,
+        )
+        return self._serialize_call_result(result)
+
+    async def close(self) -> None:
+        """Close all open MCP sessions."""
+        for state in self._states.values():
+            if state.stack is not None:
+                try:
+                    await state.stack.aclose()
+                except Exception as exc:  # pragma: no cover - defensive cleanup
+                    logger.warning("Failed closing MCP server '%s': %s", state.config.name, exc)
+            state.stack = None
+            state.session = None
+            state.status = MCPServerStatus.DISCONNECTED
+
+    async def _connect_and_list_tools(
+        self,
+        state: MCPServerState,
+        existing: set[str],
+    ) -> None:
+        state.status = MCPServerStatus.CONNECTING
+        state.error = None
+        try:
+            session = await self._ensure_session(state)
+            response = await asyncio.wait_for(
+                session.list_tools(),
+                timeout=state.config.startup_timeout_sec,
+            )
+            for raw_tool in getattr(response, "tools", []) or []:
+                raw_name = str(getattr(raw_tool, "name", ""))
+                if not raw_name or not state.config.allows_tool(raw_name):
+                    continue
+                public_name = make_tool_name(state.config.name, raw_name, existing)
+                existing.add(public_name)
+                input_schema = getattr(raw_tool, "inputSchema", None) or getattr(
+                    raw_tool,
+                    "input_schema",
+                    None,
+                )
+                if not isinstance(input_schema, dict):
+                    input_schema = {"type": "object", "properties": {}}
+                description = str(getattr(raw_tool, "description", "") or "")
+                definition = MCPToolDefinition(
+                    public_name=public_name,
+                    server_name=state.config.name,
+                    raw_name=raw_name,
+                    description=description or f"MCP tool {raw_name} from {state.config.name}",
+                    input_schema=input_schema,
+                )
+                state.tools[public_name] = definition
+                self._tool_index[public_name] = definition
+            state.status = MCPServerStatus.CONNECTED
+        except Exception as exc:
+            state.status = MCPServerStatus.FAILED
+            state.error = str(exc)
+            logger.warning("MCP server '%s' discovery failed: %s", state.config.name, exc)
+
+    async def _ensure_session(self, state: MCPServerState) -> Any:
+        if state.session is not None:
+            return state.session
+        if not HAS_MCP_SDK:
+            raise RuntimeError("MCP SDK is not installed. Install with `penguin-ai[mcp]`.")
+
+        stack = AsyncExitStack()
+        params = StdioServerParameters(  # type: ignore[misc]
+            command=state.config.command,
+            args=state.config.args,
+            env=state.config.env or None,
+            cwd=state.config.cwd,
+        )
+        read_stream, write_stream = await stack.enter_async_context(stdio_client(params))
+        session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+        await asyncio.wait_for(session.initialize(), timeout=state.config.startup_timeout_sec)
+        state.stack = stack
+        state.session = session
+        return session
+
+    @staticmethod
+    def _serialize_call_result(result: Any) -> Any:
+        """Convert MCP SDK result objects into JSON-ish data."""
+        if hasattr(result, "model_dump"):
+            return result.model_dump()
+        if hasattr(result, "dict"):
+            return result.dict()
+        if hasattr(result, "content"):
+            content = getattr(result, "content")
+            return [MCPClientManager._serialize_call_result(item) for item in content]
+        if isinstance(result, (str, int, float, bool)) or result is None:
+            return result
+        if isinstance(result, list):
+            return [MCPClientManager._serialize_call_result(item) for item in result]
+        if isinstance(result, dict):
+            return {key: MCPClientManager._serialize_call_result(value) for key, value in result.items()}
+        try:
+            return json.loads(json.dumps(result, default=lambda value: getattr(value, "__dict__", str(value))))
+        except Exception:
+            return str(result)
+
+    @staticmethod
+    def _run_async(coro: Any) -> Any:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+
+        result: Any = None
+        error: Optional[BaseException] = None
+
+        def run() -> None:
+            nonlocal result, error
+            try:
+                result = asyncio.run(coro)
+            except BaseException as exc:  # pragma: no cover - re-raised below
+                error = exc
+
+        import threading
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join()
+        if error is not None:
+            raise error
+        return result
+
+
+__all__ = [
+    "HAS_MCP_SDK",
+    "MCPClientManager",
+    "MCPServerStatus",
+    "MCPToolDefinition",
+]

--- a/penguin/integrations/mcp/manager.py
+++ b/penguin/integrations/mcp/manager.py
@@ -190,9 +190,7 @@ class MCPClientManager:
             raise ValueError(f"Unknown MCP server: {server_name}")
         if state.stack is not None:
             await state.stack.aclose()
-        for public_name in list(state.tools):
-            self._tool_index.pop(public_name, None)
-        state.tools.clear()
+        self._clear_server_tools(state)
         state.stack = None
         state.session = None
         state.error = None
@@ -238,6 +236,9 @@ class MCPClientManager:
             state.session = None
             state.status = MCPServerStatus.DISCONNECTED
             state.list_changed = False
+
+    def _clear_server_tools(self, state: MCPServerState) -> None:
+        self._clear_server_tools(state)
 
     async def _connect_and_list_tools(
         self,

--- a/penguin/integrations/mcp/names.py
+++ b/penguin/integrations/mcp/names.py
@@ -1,0 +1,39 @@
+"""Name mapping helpers for MCP tools exposed through Penguin."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+MCP_TOOL_PREFIX = "mcp__"
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9_]+")
+
+
+def sanitize_part(value: str) -> str:
+    """Return a conservative function-name component."""
+    text = _SAFE_NAME_RE.sub("_", str(value or "").strip())
+    text = re.sub(r"_+", "_", text).strip("_").lower()
+    return text or "unnamed"
+
+
+def make_tool_name(server_name: str, tool_name: str, existing: Iterable[str] = ()) -> str:
+    """Build a collision-safe Penguin tool name for an MCP tool."""
+    base = f"{MCP_TOOL_PREFIX}{sanitize_part(server_name)}__{sanitize_part(tool_name)}"
+    seen = set(existing)
+    if base not in seen:
+        return base
+
+    index = 2
+    candidate = f"{base}_{index}"
+    while candidate in seen:
+        index += 1
+        candidate = f"{base}_{index}"
+    return candidate
+
+
+def is_mcp_tool_name(tool_name: str) -> bool:
+    """Return True when a public Penguin tool name belongs to MCP."""
+    return str(tool_name or "").startswith(MCP_TOOL_PREFIX)
+
+
+__all__ = ["MCP_TOOL_PREFIX", "is_mcp_tool_name", "make_tool_name", "sanitize_part"]

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -21,6 +21,7 @@ except Exception:  # pragma: no cover - exercised when optional extra missing
 from penguin.integrations.mcp.server_tools import (
     MCPServerTool,
     build_blueprint_tools,
+    build_ituv_tools,
     RunModeJobRegistry,
     build_pm_tools,
     build_runmode_tools,
@@ -38,6 +39,7 @@ DEFAULT_EXPOSED_TOOLS = (
     "penguin_pm_*",
     "penguin_blueprint_*",
     "penguin_runmode_*",
+    "penguin_ituv_*",
 )
 
 DEFAULT_DENIED_PATTERNS = (
@@ -203,6 +205,7 @@ class PenguinMCPServer:
             tools.extend(build_blueprint_tools(self.core))
         if self.config.expose_runtime_tools:
             tools.extend(build_runmode_tools(self.core, self._runmode_job_registry))
+            tools.extend(build_ituv_tools(self.core))
         return tools
 
     def _is_allowed(self, tool_name: str) -> bool:

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -18,7 +18,11 @@ except Exception:  # pragma: no cover - exercised when optional extra missing
     FastMCP = None  # type: ignore[assignment]
     HAS_MCP_SERVER_SDK = False
 
-from penguin.integrations.mcp.server_tools import MCPServerTool, build_pm_tools
+from penguin.integrations.mcp.server_tools import (
+    MCPServerTool,
+    build_blueprint_tools,
+    build_pm_tools,
+)
 from penguin.tools.tool_manager import ToolManager
 
 logger = logging.getLogger(__name__)
@@ -30,6 +34,7 @@ DEFAULT_EXPOSED_TOOLS = (
     "grep_search",
     "analyze_project",
     "penguin_pm_*",
+    "penguin_blueprint_*",
 )
 
 DEFAULT_DENIED_PATTERNS = (
@@ -71,6 +76,7 @@ class PenguinMCPServerConfig:
     transport: str = "stdio"
     enabled: bool = True
     expose_pm_tools: bool = True
+    expose_blueprint_tools: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -183,9 +189,14 @@ class PenguinMCPServer:
         return schemas
 
     def _build_runtime_tools(self) -> list[MCPServerTool]:
-        if not self.config.expose_pm_tools or self.core is None:
+        if self.core is None:
             return []
-        return build_pm_tools(self.core)
+        tools: list[MCPServerTool] = []
+        if self.config.expose_pm_tools:
+            tools.extend(build_pm_tools(self.core))
+        if self.config.expose_blueprint_tools:
+            tools.extend(build_blueprint_tools(self.core))
+        return tools
 
     def _is_allowed(self, tool_name: str) -> bool:
         if any(_glob_match(tool_name, pattern) for pattern in self.config.deny_patterns):
@@ -240,6 +251,7 @@ def build_penguin_mcp_server(
     name: str = "penguin",
     core: Any = None,
     expose_pm_tools: bool = True,
+    expose_blueprint_tools: bool = True,
 ) -> PenguinMCPServer:
     """Build a configured Penguin MCP server wrapper."""
     return PenguinMCPServer(
@@ -249,6 +261,7 @@ def build_penguin_mcp_server(
             allow_tools=tuple(allow_tools or DEFAULT_EXPOSED_TOOLS),
             deny_patterns=tuple(deny_patterns or DEFAULT_DENIED_PATTERNS),
             expose_pm_tools=expose_pm_tools,
+            expose_blueprint_tools=expose_blueprint_tools,
         ),
         core=core,
     )
@@ -284,7 +297,7 @@ def _safe_identifier(value: str) -> str:
 
 
 def _glob_match(value: str, pattern: str) -> bool:
-    regex = "^" + re.escape(pattern).replace("\*", ".*") + "$"
+    regex = "^" + re.escape(pattern).replace("\\*", ".*") + "$"
     return re.match(regex, value) is not None
 
 

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -1,124 +1,269 @@
+"""Expose selected Penguin tools through a real MCP server."""
+
 from __future__ import annotations
 
-import fnmatch
+import inspect
 import json
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, Optional
+
+try:  # pragma: no cover - import availability depends on optional extra
+    from mcp.server.fastmcp import FastMCP
+
+    HAS_MCP_SERVER_SDK = True
+except Exception:  # pragma: no cover - exercised when optional extra missing
+    FastMCP = None  # type: ignore[assignment]
+    HAS_MCP_SERVER_SDK = False
 
 from penguin.tools.tool_manager import ToolManager
 
+logger = logging.getLogger(__name__)
 
-class MCPServer:
-    """Thin adapter exposing a subset of ToolManager tools via MCP.
+DEFAULT_EXPOSED_TOOLS = (
+    "read_file",
+    "list_files",
+    "find_file",
+    "grep_search",
+    "analyze_project",
+)
 
-    - Filters tools using allow/deny patterns.
-    - Normalizes input/output to structured JSON objects.
-    - Provides discovery and invocation entrypoints.
-    """
+DEFAULT_DENIED_PATTERNS = (
+    "mcp__*",
+    "execute*",
+    "run_*",
+    "process_*",
+    "browser_*",
+    "pydoll_*",
+    "create_*",
+    "write_*",
+    "patch_*",
+    "delete_*",
+    "apply_*",
+    "edit_*",
+    "reindex_workspace",
+    "spawn_sub_agent",
+    "delegate*",
+    "send_message",
+)
+
+_JSON_TYPE_TO_PYTHON: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+@dataclass(frozen=True)
+class PenguinMCPServerConfig:
+    """Configuration for exposing Penguin as an MCP server."""
+
+    name: str = "penguin"
+    allow_tools: tuple[str, ...] = DEFAULT_EXPOSED_TOOLS
+    deny_patterns: tuple[str, ...] = DEFAULT_DENIED_PATTERNS
+    transport: str = "stdio"
+    enabled: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class MCPServerUnavailableError(RuntimeError):
+    """Raised when the optional MCP SDK server extra is unavailable."""
+
+
+class PenguinMCPServer:
+    """SDK-backed MCP server exposing selected Penguin ToolManager tools."""
 
     def __init__(
         self,
         tool_manager: ToolManager,
-        *,
-        allow: Optional[Iterable[str]] = None,
-        deny: Optional[Iterable[str]] = None,
-        confirm_required_write: bool = True,
+        config: Optional[PenguinMCPServerConfig] = None,
     ) -> None:
-        self.tm = tool_manager
-        self.allow = tuple(allow or ("*",))
-        # Default denylists: browser/pydoll and embedding/vector tools
-        self.deny = tuple(
-            deny
-            or (
-                "browser_*",
-                "pydoll_*",
-                "reindex_workspace",
-            )
-        )
-        self.confirm_required_write = confirm_required_write
+        self.tool_manager = tool_manager
+        self.config = config or PenguinMCPServerConfig()
+        self._tool_schemas = self._select_tool_schemas()
 
-    # -------------------------
-    # Discovery
-    # -------------------------
-    def list_tools(self) -> List[Dict[str, Any]]:
-        tools: List[Dict[str, Any]] = []
-        for spec in getattr(self.tm, "tools", []) or []:
-            name = spec.get("name")
-            if not name or not self._is_allowed(name):
+    def list_exposed_tools(self) -> list[dict[str, Any]]:
+        """Return the selected ToolManager schemas exposed over MCP."""
+        return list(self._tool_schemas)
+
+    def create_fastmcp(self) -> Any:
+        """Create and populate a FastMCP server instance."""
+        if not HAS_MCP_SERVER_SDK or FastMCP is None:
+            raise MCPServerUnavailableError(
+                "MCP server SDK is not installed. Install with `penguin-ai[mcp]` "
+                "on Python 3.10+."
+            )
+
+        mcp = FastMCP(self.config.name)
+        for schema in self._tool_schemas:
+            handler = self._build_tool_handler(schema)
+            mcp.add_tool(
+                handler,
+                name=schema["name"],
+                description=schema.get("description") or "Penguin tool",
+                structured_output=False,
+            )
+        return mcp
+
+    def run(self, transport: Optional[str] = None) -> None:
+        """Run the FastMCP server."""
+        selected_transport = transport or self.config.transport
+        if selected_transport != "stdio":
+            raise ValueError(
+                "Phase 2A only supports stdio transport for Penguin MCP server."
+            )
+        self.create_fastmcp().run(transport="stdio")
+
+    def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Route an MCP call through ToolManager.execute_tool()."""
+        if not self._is_allowed(tool_name):
+            return json.dumps(
+                {
+                    "error": "tool_not_exposed",
+                    "tool": tool_name,
+                    "message": "This Penguin tool is not exposed over MCP.",
+                },
+                indent=2,
+            )
+
+        result = self.tool_manager.execute_tool(tool_name, arguments or {})
+        if isinstance(result, str):
+            return result
+        return json.dumps(result, indent=2, default=str)
+
+    def _select_tool_schemas(self) -> list[dict[str, Any]]:
+        schemas: list[dict[str, Any]] = []
+        for schema in self.tool_manager.get_tools():
+            name = schema.get("name")
+            if not isinstance(name, str) or not self._is_allowed(name):
                 continue
-            tools.append(
+            schemas.append(
                 {
                     "name": name,
-                    "description": spec.get("description", ""),
-                    "input_schema": spec.get("input_schema") or {"type": "object", "properties": {}},
+                    "description": schema.get("description", ""),
+                    "input_schema": _object_schema(schema.get("input_schema")),
                 }
             )
-        return tools
+        return schemas
 
-    # -------------------------
-    # Invocation
-    # -------------------------
-    async def call_tool(self, name: str, params: Dict[str, Any], *, confirm: bool = False) -> Dict[str, Any]:
-        if not self._is_allowed(name):
-            return self._error("forbidden", f"Tool '{name}' is not allowed")
-
-        if self.confirm_required_write and self._is_write_tool(name) and not confirm:
-            return self._error("confirmation_required", f"Tool '{name}' requires confirmation")
-
-        # Resolve the callable using ToolManager's internal registry
-        func = self._resolve_tool_callable(name)
-        if func is None:
-            return self._error("not_found", f"Tool '{name}' not found")
-        try:
-            result = func(**(params or {}))  # supports sync; ToolManager tools are sync
-            # Some tools return coroutine (rare) – await if needed
-            if hasattr(result, "__await__"):
-                result = await result  # type: ignore[func-returns-value]
-            return self._ok(result)
-        except Exception as e:  # pragma: no cover - surface errors cleanly
-            return self._error("execution_error", str(e))
-
-    # -------------------------
-    # Helpers
-    # -------------------------
-    def _is_allowed(self, name: str) -> bool:
-        if any(fnmatch.fnmatch(name, pat) for pat in self.deny):
+    def _is_allowed(self, tool_name: str) -> bool:
+        if any(_glob_match(tool_name, pattern) for pattern in self.config.deny_patterns):
             return False
-        return any(fnmatch.fnmatch(name, pat) for pat in self.allow)
+        return any(_glob_match(tool_name, pattern) for pattern in self.config.allow_tools)
 
-    @staticmethod
-    def _is_write_tool(name: str) -> bool:
-        # Heuristic: known write/edit tools
-        return name in {"apply_diff", "edit_with_pattern", "create_file", "write_to_file"}
+    def _build_tool_handler(self, schema: dict[str, Any]) -> Callable[..., Any]:
+        tool_name = schema["name"]
+        input_schema = _object_schema(schema.get("input_schema"))
+        properties = input_schema.get("properties", {})
+        required = set(input_schema.get("required", []))
+        param_to_property: dict[str, str] = {}
 
-    def _resolve_tool_callable(self, name: str):
-        # ToolManager keeps a private registry mapping names to call paths
-        registry: Dict[str, str] = getattr(self.tm, "_tool_registry", {})
-        target = registry.get(name)
-        if not target:
-            return None
-        # Resolve 'self.xxx' members directly on ToolManager
-        if target.startswith("self."):
-            attr_path = target.split(".")
-            obj = self.tm
-            for part in attr_path[1:]:
-                obj = getattr(obj, part)
-            return obj
-        # Otherwise, import the function dynamically
-        try:
-            import importlib
+        async def handler(**kwargs: Any) -> str:
+            arguments = {
+                param_to_property.get(key, key): value for key, value in kwargs.items()
+            }
+            return self.call_tool(tool_name, arguments)
 
-            module_path, func_name = target.rsplit(".", 1)
-            mod = importlib.import_module(module_path)
-            return getattr(mod, func_name)
-        except Exception:
-            return None
+        handler.__name__ = _safe_identifier(tool_name)
+        handler.__doc__ = schema.get("description") or f"Run Penguin tool {tool_name}."
+        parameters: list[inspect.Parameter] = []
 
-    @staticmethod
-    def _ok(data: Any) -> Dict[str, Any]:
-        return {"status": "ok", "data": data}
+        for property_name, property_schema in properties.items():
+            param_name = _safe_identifier(property_name)
+            if param_name in param_to_property:
+                param_name = f"{param_name}_{len(param_to_property)}"
+            param_to_property[param_name] = property_name
+            default = inspect.Parameter.empty if property_name in required else None
+            annotation = _python_annotation_for_schema(property_schema)
+            parameters.append(
+                inspect.Parameter(
+                    param_name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=default,
+                    annotation=annotation,
+                )
+            )
 
-    @staticmethod
-    def _error(code: str, message: str) -> Dict[str, Any]:
-        return {"status": "error", "error": {"code": code, "message": message}}
+        handler.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+            parameters=parameters,
+            return_annotation=str,
+        )
+        return handler
 
 
+def build_penguin_mcp_server(
+    tool_manager: ToolManager,
+    *,
+    allow_tools: Optional[Iterable[str]] = None,
+    deny_patterns: Optional[Iterable[str]] = None,
+    name: str = "penguin",
+) -> PenguinMCPServer:
+    """Build a configured Penguin MCP server wrapper."""
+    return PenguinMCPServer(
+        tool_manager,
+        PenguinMCPServerConfig(
+            name=name,
+            allow_tools=tuple(allow_tools or DEFAULT_EXPOSED_TOOLS),
+            deny_patterns=tuple(deny_patterns or DEFAULT_DENIED_PATTERNS),
+        ),
+    )
+
+
+def _object_schema(schema: Any) -> dict[str, Any]:
+    if not isinstance(schema, dict):
+        return {"type": "object", "properties": {}}
+    result = dict(schema)
+    if result.get("type") != "object":
+        result["type"] = "object"
+    if not isinstance(result.get("properties"), dict):
+        result["properties"] = {}
+    return result
+
+
+def _python_annotation_for_schema(schema: Any) -> Any:
+    if not isinstance(schema, dict):
+        return Any
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    return _JSON_TYPE_TO_PYTHON.get(str(schema_type), Any)
+
+
+def _safe_identifier(value: str) -> str:
+    cleaned = re.sub(r"\W+", "_", value).strip("_") or "tool"
+    if cleaned[0].isdigit():
+        cleaned = f"_{cleaned}"
+    if not cleaned.isidentifier():
+        cleaned = "tool"
+    return cleaned
+
+
+def _glob_match(value: str, pattern: str) -> bool:
+    regex = "^" + re.escape(pattern).replace("\*", ".*") + "$"
+    return re.match(regex, value) is not None
+
+
+def configure_stdio_logging() -> None:
+    """Configure logging for stdio MCP mode without corrupting stdout."""
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+__all__ = [
+    "DEFAULT_DENIED_PATTERNS",
+    "DEFAULT_EXPOSED_TOOLS",
+    "HAS_MCP_SERVER_SDK",
+    "MCPServerUnavailableError",
+    "PenguinMCPServer",
+    "PenguinMCPServerConfig",
+    "build_penguin_mcp_server",
+    "configure_stdio_logging",
+]

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -286,8 +286,14 @@ def build_penguin_mcp_server(
         tool_manager,
         PenguinMCPServerConfig(
             name=name,
-            allow_tools=tuple(allow_tools or DEFAULT_EXPOSED_TOOLS),
-            deny_patterns=tuple(deny_patterns or DEFAULT_DENIED_PATTERNS),
+            allow_tools=(
+                tuple(allow_tools) if allow_tools is not None else DEFAULT_EXPOSED_TOOLS
+            ),
+            deny_patterns=(
+                tuple(deny_patterns)
+                if deny_patterns is not None
+                else DEFAULT_DENIED_PATTERNS
+            ),
             expose_pm_tools=expose_pm_tools,
             expose_blueprint_tools=expose_blueprint_tools,
             expose_runtime_tools=expose_runtime_tools,
@@ -339,6 +345,7 @@ def configure_stdio_logging() -> None:
         level=logging.INFO,
         stream=sys.stderr,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
     )
 
 

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -21,7 +21,9 @@ except Exception:  # pragma: no cover - exercised when optional extra missing
 from penguin.integrations.mcp.server_tools import (
     MCPServerTool,
     build_blueprint_tools,
+    RunModeJobRegistry,
     build_pm_tools,
+    build_runmode_tools,
 )
 from penguin.tools.tool_manager import ToolManager
 
@@ -35,6 +37,7 @@ DEFAULT_EXPOSED_TOOLS = (
     "analyze_project",
     "penguin_pm_*",
     "penguin_blueprint_*",
+    "penguin_runmode_*",
 )
 
 DEFAULT_DENIED_PATTERNS = (
@@ -77,6 +80,7 @@ class PenguinMCPServerConfig:
     enabled: bool = True
     expose_pm_tools: bool = True
     expose_blueprint_tools: bool = True
+    expose_runtime_tools: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -96,6 +100,7 @@ class PenguinMCPServer:
         self.tool_manager = tool_manager
         self.config = config or PenguinMCPServerConfig()
         self.core = core or getattr(tool_manager, "_core", None)
+        self._runmode_job_registry = RunModeJobRegistry()
         self._runtime_tools = self._build_runtime_tools()
         self._runtime_tool_map = {tool.name: tool for tool in self._runtime_tools}
         self._tool_schemas = self._select_tool_schemas()
@@ -196,6 +201,8 @@ class PenguinMCPServer:
             tools.extend(build_pm_tools(self.core))
         if self.config.expose_blueprint_tools:
             tools.extend(build_blueprint_tools(self.core))
+        if self.config.expose_runtime_tools:
+            tools.extend(build_runmode_tools(self.core, self._runmode_job_registry))
         return tools
 
     def _is_allowed(self, tool_name: str) -> bool:
@@ -252,6 +259,7 @@ def build_penguin_mcp_server(
     core: Any = None,
     expose_pm_tools: bool = True,
     expose_blueprint_tools: bool = True,
+    expose_runtime_tools: bool = False,
 ) -> PenguinMCPServer:
     """Build a configured Penguin MCP server wrapper."""
     return PenguinMCPServer(
@@ -262,6 +270,7 @@ def build_penguin_mcp_server(
             deny_patterns=tuple(deny_patterns or DEFAULT_DENIED_PATTERNS),
             expose_pm_tools=expose_pm_tools,
             expose_blueprint_tools=expose_blueprint_tools,
+            expose_runtime_tools=expose_runtime_tools,
         ),
         core=core,
     )

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - exercised when optional extra missing
     FastMCP = None  # type: ignore[assignment]
     HAS_MCP_SERVER_SDK = False
 
+from penguin.integrations.mcp.server_tools import MCPServerTool, build_pm_tools
 from penguin.tools.tool_manager import ToolManager
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ DEFAULT_EXPOSED_TOOLS = (
     "find_file",
     "grep_search",
     "analyze_project",
+    "penguin_pm_*",
 )
 
 DEFAULT_DENIED_PATTERNS = (
@@ -68,6 +70,7 @@ class PenguinMCPServerConfig:
     deny_patterns: tuple[str, ...] = DEFAULT_DENIED_PATTERNS
     transport: str = "stdio"
     enabled: bool = True
+    expose_pm_tools: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -82,9 +85,13 @@ class PenguinMCPServer:
         self,
         tool_manager: ToolManager,
         config: Optional[PenguinMCPServerConfig] = None,
+        core: Any = None,
     ) -> None:
         self.tool_manager = tool_manager
         self.config = config or PenguinMCPServerConfig()
+        self.core = core or getattr(tool_manager, "_core", None)
+        self._runtime_tools = self._build_runtime_tools()
+        self._runtime_tool_map = {tool.name: tool for tool in self._runtime_tools}
         self._tool_schemas = self._select_tool_schemas()
 
     def list_exposed_tools(self) -> list[dict[str, Any]]:
@@ -131,7 +138,22 @@ class PenguinMCPServer:
                 indent=2,
             )
 
-        result = self.tool_manager.execute_tool(tool_name, arguments or {})
+        runtime_tool = self._runtime_tool_map.get(tool_name)
+        if runtime_tool is not None:
+            try:
+                result = runtime_tool.handler(arguments or {})
+            except Exception as exc:
+                return json.dumps(
+                    {
+                        "error": "penguin_runtime_tool_failed",
+                        "tool": tool_name,
+                        "message": str(exc),
+                    },
+                    indent=2,
+                    default=str,
+                )
+        else:
+            result = self.tool_manager.execute_tool(tool_name, arguments or {})
         if isinstance(result, str):
             return result
         return json.dumps(result, indent=2, default=str)
@@ -149,7 +171,21 @@ class PenguinMCPServer:
                     "input_schema": _object_schema(schema.get("input_schema")),
                 }
             )
+        for tool in self._runtime_tools:
+            if self._is_allowed(tool.name):
+                schemas.append(
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": _object_schema(tool.input_schema),
+                    }
+                )
         return schemas
+
+    def _build_runtime_tools(self) -> list[MCPServerTool]:
+        if not self.config.expose_pm_tools or self.core is None:
+            return []
+        return build_pm_tools(self.core)
 
     def _is_allowed(self, tool_name: str) -> bool:
         if any(_glob_match(tool_name, pattern) for pattern in self.config.deny_patterns):
@@ -202,6 +238,8 @@ def build_penguin_mcp_server(
     allow_tools: Optional[Iterable[str]] = None,
     deny_patterns: Optional[Iterable[str]] = None,
     name: str = "penguin",
+    core: Any = None,
+    expose_pm_tools: bool = True,
 ) -> PenguinMCPServer:
     """Build a configured Penguin MCP server wrapper."""
     return PenguinMCPServer(
@@ -210,7 +248,9 @@ def build_penguin_mcp_server(
             name=name,
             allow_tools=tuple(allow_tools or DEFAULT_EXPOSED_TOOLS),
             deny_patterns=tuple(deny_patterns or DEFAULT_DENIED_PATTERNS),
+            expose_pm_tools=expose_pm_tools,
         ),
+        core=core,
     )
 
 

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -14,7 +14,7 @@ try:  # pragma: no cover - import availability depends on optional extra
     from mcp.server.fastmcp import FastMCP
 
     HAS_MCP_SERVER_SDK = True
-except Exception:  # pragma: no cover - exercised when optional extra missing
+except ImportError:  # pragma: no cover - exercised when optional extra missing
     FastMCP = None  # type: ignore[assignment]
     HAS_MCP_SERVER_SDK = False
 
@@ -112,7 +112,8 @@ class PenguinMCPServer:
         self.tool_manager = tool_manager
         self.config = config or PenguinMCPServerConfig()
         self.core = core or getattr(tool_manager, "_core", None)
-        self._runmode_job_registry = RunModeJobRegistry()
+        project_manager = getattr(self.core, "project_manager", None)
+        self._runmode_job_registry = RunModeJobRegistry(project_manager)
         self._runtime_tools = self._build_runtime_tools()
         self._runtime_tool_map = {tool.name: tool for tool in self._runtime_tools}
         self._tool_schemas = self._select_tool_schemas()

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -18,6 +18,9 @@ except Exception:  # pragma: no cover - exercised when optional extra missing
     FastMCP = None  # type: ignore[assignment]
     HAS_MCP_SERVER_SDK = False
 
+from penguin.integrations.mcp.server_resources import (
+    register_penguin_resources_and_prompts,
+)
 from penguin.integrations.mcp.server_tools import (
     MCPServerTool,
     build_blueprint_tools,
@@ -88,6 +91,8 @@ class PenguinMCPServerConfig:
     expose_blueprint_tools: bool = True
     expose_runtime_tools: bool = False
     expose_session_tools: bool = True
+    expose_resources: bool = True
+    expose_prompts: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -133,6 +138,8 @@ class PenguinMCPServer:
                 description=schema.get("description") or "Penguin tool",
                 structured_output=False,
             )
+        if self.config.expose_resources or self.config.expose_prompts:
+            register_penguin_resources_and_prompts(mcp, self)
         return mcp
 
     def run(self, transport: Optional[str] = None) -> None:
@@ -271,6 +278,8 @@ def build_penguin_mcp_server(
     expose_blueprint_tools: bool = True,
     expose_runtime_tools: bool = False,
     expose_session_tools: bool = True,
+    expose_resources: bool = True,
+    expose_prompts: bool = True,
 ) -> PenguinMCPServer:
     """Build a configured Penguin MCP server wrapper."""
     return PenguinMCPServer(
@@ -283,6 +292,8 @@ def build_penguin_mcp_server(
             expose_blueprint_tools=expose_blueprint_tools,
             expose_runtime_tools=expose_runtime_tools,
             expose_session_tools=expose_session_tools,
+            expose_resources=expose_resources,
+            expose_prompts=expose_prompts,
         ),
         core=core,
     )

--- a/penguin/integrations/mcp/server.py
+++ b/penguin/integrations/mcp/server.py
@@ -25,6 +25,7 @@ from penguin.integrations.mcp.server_tools import (
     RunModeJobRegistry,
     build_pm_tools,
     build_runmode_tools,
+    build_session_tools,
 )
 from penguin.tools.tool_manager import ToolManager
 
@@ -40,6 +41,9 @@ DEFAULT_EXPOSED_TOOLS = (
     "penguin_blueprint_*",
     "penguin_runmode_*",
     "penguin_ituv_*",
+    "penguin_session_*",
+    "penguin_artifacts_*",
+    "penguin_checkpoints_*",
 )
 
 DEFAULT_DENIED_PATTERNS = (
@@ -83,6 +87,7 @@ class PenguinMCPServerConfig:
     expose_pm_tools: bool = True
     expose_blueprint_tools: bool = True
     expose_runtime_tools: bool = False
+    expose_session_tools: bool = True
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -206,6 +211,8 @@ class PenguinMCPServer:
         if self.config.expose_runtime_tools:
             tools.extend(build_runmode_tools(self.core, self._runmode_job_registry))
             tools.extend(build_ituv_tools(self.core))
+        if self.config.expose_session_tools:
+            tools.extend(build_session_tools(self.core))
         return tools
 
     def _is_allowed(self, tool_name: str) -> bool:
@@ -263,6 +270,7 @@ def build_penguin_mcp_server(
     expose_pm_tools: bool = True,
     expose_blueprint_tools: bool = True,
     expose_runtime_tools: bool = False,
+    expose_session_tools: bool = True,
 ) -> PenguinMCPServer:
     """Build a configured Penguin MCP server wrapper."""
     return PenguinMCPServer(
@@ -274,6 +282,7 @@ def build_penguin_mcp_server(
             expose_pm_tools=expose_pm_tools,
             expose_blueprint_tools=expose_blueprint_tools,
             expose_runtime_tools=expose_runtime_tools,
+            expose_session_tools=expose_session_tools,
         ),
         core=core,
     )

--- a/penguin/integrations/mcp/server_resources.py
+++ b/penguin/integrations/mcp/server_resources.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 import json
 
 from penguin.web.services.project_payloads import (
@@ -100,7 +100,8 @@ def _register_resources(mcp: Any, core: Any) -> None:
         mime_type=_TEXT_MIME,
     )
     def docs_cache_resource(source: str, page: str) -> str:
-        root = Path("context/docs_cache").resolve()
+        workspace = _workspace_path(core)
+        root = (workspace / "context" / "docs_cache").resolve()
         safe_source = _safe_segment(source)
         safe_page = _safe_segment(page)
         candidates = [
@@ -160,11 +161,11 @@ def _register_prompts(mcp: Any) -> None:
         )
 
 
-def _preview_message(row: Dict[str, Any]) -> Dict[str, Any]:
+def _preview_message(row: dict[str, Any]) -> dict[str, Any]:
     info = row.get("info") if isinstance(row, dict) else {}
     info = info if isinstance(info, dict) else {}
     parts = row.get("parts") if isinstance(row, dict) else []
-    chunks: List[str] = []
+    chunks: list[str] = []
     if isinstance(parts, list):
         for part in parts:
             if isinstance(part, dict) and part.get("type") == "text":
@@ -179,8 +180,17 @@ def _preview_message(row: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _json(payload: Dict[str, Any]) -> str:
+def _json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, indent=2, default=str)
+
+
+def _workspace_path(core: Any) -> Path:
+    config = getattr(core, "config", None)
+    workspace = getattr(config, "workspace_path", None)
+    if workspace is None:
+        conversation_manager = getattr(core, "conversation_manager", None)
+        workspace = getattr(conversation_manager, "workspace_path", None)
+    return Path(workspace or Path.cwd()).expanduser().resolve()
 
 
 def _safe_segment(value: str) -> str:

--- a/penguin/integrations/mcp/server_resources.py
+++ b/penguin/integrations/mcp/server_resources.py
@@ -1,0 +1,198 @@
+"""MCP resources and prompts for Penguin's MCP server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+from penguin.web.services.project_payloads import (
+    serialize_project_payload,
+    serialize_task_payload,
+)
+from penguin.web.services.session_view import get_session_info, get_session_messages
+
+
+_TEXT_MIME = "text/plain"
+_JSON_MIME = "application/json"
+
+
+def register_penguin_resources_and_prompts(mcp: Any, server: Any) -> None:
+    """Register conservative MCP resources and prompts on a FastMCP instance."""
+    core = getattr(server, "core", None)
+    _register_resources(mcp, core)
+    _register_prompts(mcp)
+
+
+def _register_resources(mcp: Any, core: Any) -> None:
+    @mcp.resource(
+        "penguin://projects",
+        name="penguin_projects",
+        title="Penguin Projects",
+        description="List Penguin projects visible to this MCP server.",
+        mime_type=_JSON_MIME,
+    )
+    def projects_resource() -> str:
+        project_manager = getattr(core, "project_manager", None)
+        if project_manager is None:
+            return _json({"projects": [], "count": 0, "error": "project_manager_unavailable"})
+        projects = [serialize_project_payload(project) for project in project_manager.list_projects()]
+        return _json({"projects": projects, "count": len(projects)})
+
+    @mcp.resource(
+        "penguin://project/{project_id}",
+        name="penguin_project",
+        title="Penguin Project",
+        description="Return one Penguin project and its current tasks.",
+        mime_type=_JSON_MIME,
+    )
+    def project_resource(project_id: str) -> str:
+        project_manager = getattr(core, "project_manager", None)
+        if project_manager is None:
+            return _json({"error": "project_manager_unavailable"})
+        project = project_manager.get_project(project_id)
+        if project is None:
+            return _json({"error": "project_not_found", "project_id": project_id})
+        tasks = [serialize_task_payload(task) for task in project_manager.list_tasks(project_id=project.id)]
+        return _json({"project": serialize_project_payload(project), "tasks": tasks})
+
+    @mcp.resource(
+        "penguin://task/{task_id}",
+        name="penguin_task",
+        title="Penguin Task",
+        description="Return one Penguin task with lifecycle/dependency/artifact truth.",
+        mime_type=_JSON_MIME,
+    )
+    def task_resource(task_id: str) -> str:
+        project_manager = getattr(core, "project_manager", None)
+        if project_manager is None:
+            return _json({"error": "project_manager_unavailable"})
+        task = project_manager.get_task(task_id)
+        if task is None:
+            return _json({"error": "task_not_found", "task_id": task_id})
+        return _json({"task": serialize_task_payload(task)})
+
+    @mcp.resource(
+        "penguin://session/{session_id}/summary",
+        name="penguin_session_summary_resource",
+        title="Penguin Session Summary",
+        description="Return compact read-only session context suitable for handoff.",
+        mime_type=_JSON_MIME,
+    )
+    def session_summary_resource(session_id: str) -> str:
+        info = get_session_info(core, session_id) if core is not None else None
+        if info is None:
+            return _json({"error": "session_not_found", "session_id": session_id})
+        messages = get_session_messages(core, session_id, limit=20) or []
+        return _json(
+            {
+                "session": info,
+                "message_count_returned": len(messages),
+                "messages_preview": [_preview_message(row) for row in messages],
+            }
+        )
+
+    @mcp.resource(
+        "penguin://docs-cache/{source}/{page}",
+        name="penguin_docs_cache_page",
+        title="Penguin Docs Cache Page",
+        description="Read one markdown/json file from context/docs_cache by source/page.",
+        mime_type=_TEXT_MIME,
+    )
+    def docs_cache_resource(source: str, page: str) -> str:
+        root = Path("context/docs_cache").resolve()
+        safe_source = _safe_segment(source)
+        safe_page = _safe_segment(page)
+        candidates = [
+            root / safe_source / safe_page,
+            root / safe_source / f"{safe_page}.md",
+            root / safe_source / f"{safe_page}.json",
+        ]
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if not _is_relative_to(resolved, root) or not resolved.is_file():
+                continue
+            return resolved.read_text(encoding="utf-8")
+        return f"Docs cache page not found: {source}/{page}"
+
+
+def _register_prompts(mcp: Any) -> None:
+    @mcp.prompt(
+        name="penguin_task_brief",
+        title="Penguin Task Brief",
+        description="Create a concise Penguin task brief for PM/Blueprint work.",
+    )
+    def task_brief(title: str, goal: str, constraints: Optional[str] = None) -> str:
+        constraint_text = constraints or "None provided."
+        return (
+            "Create or update a Penguin project task with the following brief.\n\n"
+            f"Title: {title}\n"
+            f"Goal: {goal}\n"
+            f"Constraints: {constraint_text}\n\n"
+            "Include acceptance criteria, dependencies, and evidence expectations."
+        )
+
+    @mcp.prompt(
+        name="penguin_blueprint_outline",
+        title="Penguin Blueprint Outline",
+        description="Draft a dependency-aware Penguin Blueprint outline.",
+    )
+    def blueprint_outline(objective: str, scope: Optional[str] = None) -> str:
+        scope_text = scope or "Use the current project/repository context."
+        return (
+            "Draft a Penguin Blueprint for the objective below.\n\n"
+            f"Objective: {objective}\n"
+            f"Scope: {scope_text}\n\n"
+            "Return YAML with task IDs, dependencies, acceptance criteria, and ITUV expectations."
+        )
+
+    @mcp.prompt(
+        name="penguin_runmode_handoff",
+        title="Penguin RunMode Handoff",
+        description="Prepare a safe handoff for starting Penguin RunMode later.",
+    )
+    def runmode_handoff(project_id: str, task_id: Optional[str] = None) -> str:
+        target = f"task {task_id}" if task_id else f"project {project_id}"
+        return (
+            f"Prepare a RunMode handoff for Penguin {target}.\n\n"
+            "Summarize readiness, dependencies, risks, required clarifications, and expected artifacts. "
+            "Do not start execution unless runtime tools are explicitly enabled."
+        )
+
+
+def _preview_message(row: Dict[str, Any]) -> Dict[str, Any]:
+    info = row.get("info") if isinstance(row, dict) else {}
+    info = info if isinstance(info, dict) else {}
+    parts = row.get("parts") if isinstance(row, dict) else []
+    chunks: List[str] = []
+    if isinstance(parts, list):
+        for part in parts:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    chunks.append(" ".join(text.split()))
+    text = "\n".join(chunks)
+    return {
+        "id": info.get("id"),
+        "role": info.get("role"),
+        "text_preview": text[:500],
+    }
+
+
+def _json(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, default=str)
+
+
+def _safe_segment(value: str) -> str:
+    return "".join(ch for ch in str(value) if ch.isalnum() or ch in {"-", "_", "."}).strip(".")
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+__all__ = ["register_penguin_resources_and_prompts"]

--- a/penguin/integrations/mcp/server_tools/__init__.py
+++ b/penguin/integrations/mcp/server_tools/__init__.py
@@ -4,6 +4,7 @@ from penguin.integrations.mcp.server_tools.base import MCPServerTool
 from penguin.integrations.mcp.server_tools.blueprints import build_blueprint_tools
 from penguin.integrations.mcp.server_tools.ituv import build_ituv_tools
 from penguin.integrations.mcp.server_tools.pm import build_pm_tools
+from penguin.integrations.mcp.server_tools.sessions import build_session_tools
 from penguin.integrations.mcp.server_tools.runmode import (
     RunModeJobRegistry,
     build_runmode_tools,
@@ -16,4 +17,5 @@ __all__ = [
     "build_ituv_tools",
     "build_pm_tools",
     "build_runmode_tools",
+    "build_session_tools",
 ]

--- a/penguin/integrations/mcp/server_tools/__init__.py
+++ b/penguin/integrations/mcp/server_tools/__init__.py
@@ -1,0 +1,6 @@
+"""MCP server-side Penguin runtime tool groups."""
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.integrations.mcp.server_tools.pm import build_pm_tools
+
+__all__ = ["MCPServerTool", "build_pm_tools"]

--- a/penguin/integrations/mcp/server_tools/__init__.py
+++ b/penguin/integrations/mcp/server_tools/__init__.py
@@ -3,5 +3,15 @@
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
 from penguin.integrations.mcp.server_tools.blueprints import build_blueprint_tools
 from penguin.integrations.mcp.server_tools.pm import build_pm_tools
+from penguin.integrations.mcp.server_tools.runmode import (
+    RunModeJobRegistry,
+    build_runmode_tools,
+)
 
-__all__ = ["MCPServerTool", "build_blueprint_tools", "build_pm_tools"]
+__all__ = [
+    "MCPServerTool",
+    "RunModeJobRegistry",
+    "build_blueprint_tools",
+    "build_pm_tools",
+    "build_runmode_tools",
+]

--- a/penguin/integrations/mcp/server_tools/__init__.py
+++ b/penguin/integrations/mcp/server_tools/__init__.py
@@ -1,6 +1,7 @@
 """MCP server-side Penguin runtime tool groups."""
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.integrations.mcp.server_tools.blueprints import build_blueprint_tools
 from penguin.integrations.mcp.server_tools.pm import build_pm_tools
 
-__all__ = ["MCPServerTool", "build_pm_tools"]
+__all__ = ["MCPServerTool", "build_blueprint_tools", "build_pm_tools"]

--- a/penguin/integrations/mcp/server_tools/__init__.py
+++ b/penguin/integrations/mcp/server_tools/__init__.py
@@ -2,6 +2,7 @@
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
 from penguin.integrations.mcp.server_tools.blueprints import build_blueprint_tools
+from penguin.integrations.mcp.server_tools.ituv import build_ituv_tools
 from penguin.integrations.mcp.server_tools.pm import build_pm_tools
 from penguin.integrations.mcp.server_tools.runmode import (
     RunModeJobRegistry,
@@ -12,6 +13,7 @@ __all__ = [
     "MCPServerTool",
     "RunModeJobRegistry",
     "build_blueprint_tools",
+    "build_ituv_tools",
     "build_pm_tools",
     "build_runmode_tools",
 ]

--- a/penguin/integrations/mcp/server_tools/base.py
+++ b/penguin/integrations/mcp/server_tools/base.py
@@ -1,0 +1,19 @@
+"""Shared MCP server-tool descriptors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class MCPServerTool:
+    """A Penguin runtime capability exposed as an MCP server tool."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    handler: Callable[[dict[str, Any]], Any]
+
+
+__all__ = ["MCPServerTool"]

--- a/penguin/integrations/mcp/server_tools/base.py
+++ b/penguin/integrations/mcp/server_tools/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 
-@dataclass(frozen=True)
+@dataclass
 class MCPServerTool:
     """A Penguin runtime capability exposed as an MCP server tool."""
 

--- a/penguin/integrations/mcp/server_tools/blueprints.py
+++ b/penguin/integrations/mcp/server_tools/blueprints.py
@@ -13,7 +13,10 @@ from penguin.web.services.blueprint_payloads import (
     serialize_blueprint_graph,
     serialize_blueprint_summary,
 )
-from penguin.web.services.project_payloads import serialize_task_payload
+from penguin.web.services.project_payloads import (
+    serialize_project_payload,
+    serialize_task_payload,
+)
 
 
 def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
@@ -69,6 +72,89 @@ def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
             ]
         return payload
 
+    def sync_blueprint(arguments: dict[str, Any]) -> dict[str, Any]:
+        if project_manager is None:
+            return {"error": "project_manager_unavailable"}
+
+        blueprint, source = _parse_blueprint(arguments)
+        parser = BlueprintParser(base_path=_base_path_for_source(source))
+        report = parser.lint_blueprint(blueprint, source=source)
+        diagnostics = serialize_blueprint_diagnostics_report(report)
+        summary = serialize_blueprint_summary(blueprint)
+        if report.has_errors:
+            return {
+                "status": "rejected",
+                "reason": "lint_errors",
+                "source": source,
+                "blueprint": summary,
+                "diagnostics": diagnostics,
+            }
+        if not blueprint.items:
+            return {
+                "status": "rejected",
+                "reason": "empty_blueprint",
+                "source": source,
+                "blueprint": summary,
+                "diagnostics": diagnostics,
+            }
+
+        project_id = _optional_str(arguments.get("project_id"))
+        create_project = _optional_bool(arguments.get("create_project"), False)
+        dry_run = _optional_bool(arguments.get("dry_run"), True)
+        create_missing = _optional_bool(arguments.get("create_missing"), True)
+        update_existing = _optional_bool(arguments.get("update_existing"), False)
+        include_tasks = _optional_bool(arguments.get("include_tasks"), False)
+
+        if project_id is None and not create_project:
+            return {
+                "status": "rejected",
+                "reason": "project_id_required",
+                "message": "project_id is required unless create_project is true.",
+                "source": source,
+                "blueprint": summary,
+                "diagnostics": diagnostics,
+            }
+
+        if dry_run:
+            return _build_sync_dry_run_payload(
+                project_manager=project_manager,
+                blueprint=blueprint,
+                source=source,
+                diagnostics=diagnostics,
+                project_id=project_id,
+                create_project=create_project,
+                create_missing=create_missing,
+                update_existing=update_existing,
+            )
+
+        result = project_manager.sync_blueprint(
+            blueprint,
+            project_id=project_id,
+            create_missing=create_missing,
+            update_existing=update_existing,
+        )
+        synced_project = project_manager.get_project(result["project_id"])
+        payload: dict[str, Any] = {
+            "status": "synced",
+            "source": source,
+            "blueprint": summary,
+            "diagnostics": diagnostics,
+            "sync": result,
+            "options": {
+                "create_missing": create_missing,
+                "update_existing": update_existing,
+            },
+        }
+        if synced_project is not None:
+            payload["project"] = serialize_project_payload(synced_project)
+        if include_tasks:
+            payload["tasks"] = [
+                serialize_task_payload(task)
+                for task in project_manager.list_tasks(project_id=result["project_id"])
+            ]
+        return payload
+
+
     return [
         MCPServerTool(
             name="penguin_blueprint_lint",
@@ -110,7 +196,100 @@ def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
             ),
             handler=blueprint_status,
         ),
+        MCPServerTool(
+            name="penguin_blueprint_sync",
+            description=(
+                "Dry-run or sync a Penguin Blueprint into project tasks without "
+                "starting execution. Defaults to dry_run=true and update_existing=false."
+            ),
+            input_schema=_schema(
+                {
+                    "blueprint_path": {"type": "string"},
+                    "content": {"type": "string"},
+                    "format": {"type": "string"},
+                    "source": {"type": "string"},
+                    "project_id": {"type": "string"},
+                    "create_project": {"type": "boolean"},
+                    "dry_run": {"type": "boolean"},
+                    "create_missing": {"type": "boolean"},
+                    "update_existing": {"type": "boolean"},
+                    "include_tasks": {"type": "boolean"},
+                }
+            ),
+            handler=sync_blueprint,
+        ),
     ]
+
+
+def _build_sync_dry_run_payload(
+    *,
+    project_manager: Any,
+    blueprint: Any,
+    source: str,
+    diagnostics: dict[str, Any],
+    project_id: Optional[str],
+    create_project: bool,
+    create_missing: bool,
+    update_existing: bool,
+) -> dict[str, Any]:
+    project = None
+    existing_tasks = []
+    if project_id is not None:
+        project = project_manager.get_project(project_id)
+        if project is None:
+            return {
+                "status": "rejected",
+                "reason": "project_not_found",
+                "project_id": project_id,
+                "source": source,
+                "blueprint": serialize_blueprint_summary(blueprint),
+                "diagnostics": diagnostics,
+            }
+        existing_tasks = project_manager.list_tasks(project_id=project_id)
+
+    existing_by_blueprint = {
+        task.blueprint_id: task
+        for task in existing_tasks
+        if getattr(task, "blueprint_id", None)
+    }
+    created: list[str] = []
+    updated: list[str] = []
+    skipped: list[str] = []
+    for item in blueprint.items:
+        existing = existing_by_blueprint.get(item.id)
+        if existing is not None:
+            if update_existing:
+                updated.append(item.id)
+            else:
+                skipped.append(item.id)
+        elif create_missing:
+            created.append(item.id)
+        else:
+            skipped.append(item.id)
+
+    payload: dict[str, Any] = {
+        "status": "dry_run",
+        "source": source,
+        "blueprint": serialize_blueprint_summary(blueprint),
+        "diagnostics": diagnostics,
+        "would_create_project": project_id is None and create_project,
+        "project_id": project_id,
+        "options": {
+            "create_missing": create_missing,
+            "update_existing": update_existing,
+        },
+        "sync": {
+            "project_id": project_id,
+            "blueprint_title": blueprint.title,
+            "created": created,
+            "updated": updated,
+            "skipped": skipped,
+            "total_items": len(blueprint.items),
+        },
+    }
+    if project is not None:
+        payload["project"] = serialize_project_payload(project)
+    return payload
 
 
 def _parse_blueprint(arguments: dict[str, Any]):
@@ -176,6 +355,16 @@ def _optional_str(value: Any) -> Optional[str]:
         stripped = value.strip()
         return stripped or None
     return str(value)
+
+
+def _optional_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 __all__ = ["build_blueprint_tools"]

--- a/penguin/integrations/mcp/server_tools/blueprints.py
+++ b/penguin/integrations/mcp/server_tools/blueprints.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Any, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
-from penguin.project.blueprint_parser import BlueprintParseError, BlueprintParser
+from penguin.project.blueprint_parser import BlueprintParser
+from penguin.project.models import Blueprint
 from penguin.web.services.blueprint_payloads import (
     blueprint_graph_to_dot,
     serialize_blueprint_diagnostics_report,
@@ -165,6 +166,7 @@ def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
                     "content": {"type": "string"},
                     "format": {"type": "string"},
                     "source": {"type": "string"},
+                    "workspace_path": {"type": "string"},
                     "include_graph": {"type": "boolean"},
                 }
             ),
@@ -179,6 +181,7 @@ def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
                     "content": {"type": "string"},
                     "format": {"type": "string"},
                     "source": {"type": "string"},
+                    "workspace_path": {"type": "string"},
                     "output_format": {"type": "string"},
                 }
             ),
@@ -208,6 +211,7 @@ def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
                     "content": {"type": "string"},
                     "format": {"type": "string"},
                     "source": {"type": "string"},
+                    "workspace_path": {"type": "string"},
                     "project_id": {"type": "string"},
                     "create_project": {"type": "boolean"},
                     "dry_run": {"type": "boolean"},
@@ -292,7 +296,7 @@ def _build_sync_dry_run_payload(
     return payload
 
 
-def _parse_blueprint(arguments: dict[str, Any]):
+def _parse_blueprint(arguments: dict[str, Any]) -> tuple[Blueprint, str]:
     content = _optional_str(arguments.get("content"))
     fmt = (_optional_str(arguments.get("format")) or "markdown").lower()
     if content is not None:
@@ -303,7 +307,12 @@ def _parse_blueprint(arguments: dict[str, Any]):
     blueprint_path = _optional_str(arguments.get("blueprint_path"))
     if blueprint_path is None:
         raise ValueError("blueprint_path or content is required")
-    path = Path(blueprint_path).expanduser().resolve()
+    workspace_root = Path(
+        _optional_str(arguments.get("workspace_path")) or Path.cwd()
+    ).expanduser().resolve()
+    path = (workspace_root / blueprint_path).expanduser().resolve()
+    if not _is_relative_to(path, workspace_root):
+        raise PermissionError(f"Blueprint file is outside workspace: {path}")
     if not path.exists():
         raise FileNotFoundError(f"Blueprint file not found: {path}")
     parser = BlueprintParser(base_path=path.parent)
@@ -312,17 +321,22 @@ def _parse_blueprint(arguments: dict[str, Any]):
 
 def _parse_content(
     parser: BlueprintParser, content: str, fmt: str, source: str
-):
-    try:
-        if fmt == "yaml":
-            return parser.parse_yaml(content, source=source)
-        if fmt == "json":
-            return parser.parse_json(content, source=source)
-        if fmt == "markdown":
-            return parser.parse_markdown(content, source=source)
-    except BlueprintParseError:
-        raise
+) -> Blueprint:
+    if fmt == "yaml":
+        return parser.parse_yaml(content, source=source)
+    if fmt == "json":
+        return parser.parse_json(content, source=source)
+    if fmt == "markdown":
+        return parser.parse_markdown(content, source=source)
     raise ValueError("format must be one of markdown, yaml, or json")
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
 
 
 def _base_path_for_source(source: str) -> Optional[Path]:

--- a/penguin/integrations/mcp/server_tools/blueprints.py
+++ b/penguin/integrations/mcp/server_tools/blueprints.py
@@ -1,0 +1,181 @@
+"""Blueprint MCP server tools for Penguin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.project.blueprint_parser import BlueprintParseError, BlueprintParser
+from penguin.web.services.blueprint_payloads import (
+    blueprint_graph_to_dot,
+    serialize_blueprint_diagnostics_report,
+    serialize_blueprint_graph,
+    serialize_blueprint_summary,
+)
+from penguin.web.services.project_payloads import serialize_task_payload
+
+
+def build_blueprint_tools(core: Any) -> list[MCPServerTool]:
+    """Build default-on Blueprint introspection tools."""
+    project_manager = getattr(core, "project_manager", None)
+
+    def lint_blueprint(arguments: dict[str, Any]) -> dict[str, Any]:
+        blueprint, source = _parse_blueprint(arguments)
+        parser = BlueprintParser(base_path=_base_path_for_source(source))
+        report = parser.lint_blueprint(blueprint, source=source)
+        payload = {
+            "source": source,
+            "blueprint": serialize_blueprint_summary(blueprint),
+            "diagnostics": serialize_blueprint_diagnostics_report(report),
+        }
+        if bool(arguments.get("include_graph", False)):
+            payload["graph"] = serialize_blueprint_graph(blueprint)
+        return payload
+
+    def graph_blueprint(arguments: dict[str, Any]) -> dict[str, Any]:
+        blueprint, source = _parse_blueprint(arguments)
+        graph = serialize_blueprint_graph(blueprint)
+        output_format = _optional_str(arguments.get("output_format")) or "json"
+        payload: dict[str, Any] = {
+            "source": source,
+            "blueprint": serialize_blueprint_summary(blueprint),
+            "graph": graph,
+        }
+        if output_format.lower() == "dot":
+            payload["dot"] = blueprint_graph_to_dot(graph)
+        return payload
+
+    def blueprint_status(arguments: dict[str, Any]) -> dict[str, Any]:
+        if project_manager is None:
+            return {"error": "project_manager_unavailable"}
+        project_id = _required_str(arguments, "project_id")
+        project = project_manager.get_project(project_id)
+        if project is None:
+            return {"error": "project_not_found", "project_id": project_id}
+        tasks = project_manager.list_tasks(project_id=project_id)
+        blueprint_tasks = [task for task in tasks if getattr(task, "blueprint_id", None)]
+        stats = project_manager.get_dag_stats(project_id)
+        payload: dict[str, Any] = {
+            "project_id": project_id,
+            "project_name": project.name,
+            "stats": stats,
+            "blueprint_task_count": len(blueprint_tasks),
+            "blueprint_ids": [task.blueprint_id for task in blueprint_tasks],
+        }
+        if bool(arguments.get("include_tasks", False)):
+            payload["tasks"] = [
+                serialize_task_payload(task) for task in blueprint_tasks
+            ]
+        return payload
+
+    return [
+        MCPServerTool(
+            name="penguin_blueprint_lint",
+            description="Parse and lint a Penguin Blueprint file or content.",
+            input_schema=_schema(
+                {
+                    "blueprint_path": {"type": "string"},
+                    "content": {"type": "string"},
+                    "format": {"type": "string"},
+                    "source": {"type": "string"},
+                    "include_graph": {"type": "boolean"},
+                }
+            ),
+            handler=lint_blueprint,
+        ),
+        MCPServerTool(
+            name="penguin_blueprint_graph",
+            description="Return a Penguin Blueprint dependency graph as JSON and optionally DOT.",
+            input_schema=_schema(
+                {
+                    "blueprint_path": {"type": "string"},
+                    "content": {"type": "string"},
+                    "format": {"type": "string"},
+                    "source": {"type": "string"},
+                    "output_format": {"type": "string"},
+                }
+            ),
+            handler=graph_blueprint,
+        ),
+        MCPServerTool(
+            name="penguin_blueprint_status",
+            description="Report Blueprint-derived task/DAG status for a Penguin project.",
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "include_tasks": {"type": "boolean"},
+                },
+                required=["project_id"],
+            ),
+            handler=blueprint_status,
+        ),
+    ]
+
+
+def _parse_blueprint(arguments: dict[str, Any]):
+    content = _optional_str(arguments.get("content"))
+    fmt = (_optional_str(arguments.get("format")) or "markdown").lower()
+    if content is not None:
+        source = _optional_str(arguments.get("source")) or "inline-blueprint"
+        parser = BlueprintParser()
+        return _parse_content(parser, content, fmt, source), source
+
+    blueprint_path = _optional_str(arguments.get("blueprint_path"))
+    if blueprint_path is None:
+        raise ValueError("blueprint_path or content is required")
+    path = Path(blueprint_path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Blueprint file not found: {path}")
+    parser = BlueprintParser(base_path=path.parent)
+    return parser.parse_file(path), str(path)
+
+
+def _parse_content(
+    parser: BlueprintParser, content: str, fmt: str, source: str
+):
+    try:
+        if fmt == "yaml":
+            return parser.parse_yaml(content, source=source)
+        if fmt == "json":
+            return parser.parse_json(content, source=source)
+        if fmt == "markdown":
+            return parser.parse_markdown(content, source=source)
+    except BlueprintParseError:
+        raise
+    raise ValueError("format must be one of markdown, yaml, or json")
+
+
+def _base_path_for_source(source: str) -> Optional[Path]:
+    path = Path(source)
+    return path.parent if path.exists() else None
+
+
+def _schema(
+    properties: dict[str, dict[str, Any]], *, required: Optional[list[str]] = None
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+def _required_str(arguments: dict[str, Any], key: str) -> str:
+    value = _optional_str(arguments.get(key))
+    if value is None:
+        raise ValueError(f"{key} is required")
+    return value
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+__all__ = ["build_blueprint_tools"]

--- a/penguin/integrations/mcp/server_tools/ituv.py
+++ b/penguin/integrations/mcp/server_tools/ituv.py
@@ -155,13 +155,6 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
                     )
                 project_manager.update_task_phase(task_id, phase, reason=reason)
             elif action == "block":
-                if dry_run:
-                    return _dry_run_payload(
-                        task_id,
-                        action,
-                        before,
-                        {"phase": TaskPhase.BLOCKED.value},
-                    )
                 validation_error = _validate_phase_transition(task, TaskPhase.BLOCKED)
                 if validation_error:
                     return _mutation_rejected(
@@ -169,6 +162,13 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
                         action=action,
                         reason=validation_error,
                         before=before,
+                    )
+                if dry_run:
+                    return _dry_run_payload(
+                        task_id,
+                        action,
+                        before,
+                        {"phase": TaskPhase.BLOCKED.value},
                     )
                 project_manager.update_task_phase(
                     task_id,
@@ -297,6 +297,13 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
                 "before": before,
                 "artifact": artifact.to_dict(),
             }
+        normalized_artifacts = []
+        for item in task.artifact_evidence:
+            if isinstance(item, ArtifactEvidence):
+                normalized_artifacts.append(item)
+            elif isinstance(item, dict):
+                normalized_artifacts.append(ArtifactEvidence(**item))
+        task.artifact_evidence = normalized_artifacts
         task.artifact_evidence.append(artifact)
         task.updated_at = datetime.now(timezone.utc).isoformat()
         project_manager.storage.update_task(task)

--- a/penguin/integrations/mcp/server_tools/ituv.py
+++ b/penguin/integrations/mcp/server_tools/ituv.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
+import logging
 from typing import Any, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
@@ -12,22 +13,7 @@ from penguin.web.services.project_payloads import (
     serialize_task_payload,
 )
 
-
-PHASE_TRANSITIONS = {
-    TaskPhase.PENDING: {TaskPhase.IMPLEMENT, TaskPhase.BLOCKED},
-    TaskPhase.IMPLEMENT: {TaskPhase.TEST, TaskPhase.BLOCKED, TaskPhase.PENDING},
-    TaskPhase.TEST: {TaskPhase.USE, TaskPhase.VERIFY, TaskPhase.BLOCKED, TaskPhase.IMPLEMENT},
-    TaskPhase.USE: {TaskPhase.VERIFY, TaskPhase.BLOCKED, TaskPhase.TEST},
-    TaskPhase.VERIFY: {TaskPhase.TEST, TaskPhase.USE, TaskPhase.BLOCKED},
-    TaskPhase.BLOCKED: {
-        TaskPhase.PENDING,
-        TaskPhase.IMPLEMENT,
-        TaskPhase.TEST,
-        TaskPhase.USE,
-        TaskPhase.VERIFY,
-    },
-    TaskPhase.DONE: set(),
-}
+logger = logging.getLogger(__name__)
 
 
 def build_ituv_tools(core: Any) -> list[MCPServerTool]:
@@ -210,12 +196,25 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
                     "error": "unsupported_action",
                     "supported_actions": ["set_status", "set_phase", "block", "unblock"],
                 }
-        except Exception as exc:
+        except (ValueError, RuntimeError) as exc:
             return {
                 "status": "rejected",
                 "task_id": task_id,
                 "action": action,
                 "reason": str(exc),
+                "before": before,
+            }
+        except Exception:  # pragma: no cover - defensive server boundary
+            logger.exception(
+                "Unexpected ITUV signal failure for task %s action %s",
+                task_id,
+                action,
+            )
+            return {
+                "status": "rejected",
+                "task_id": task_id,
+                "action": action,
+                "reason": "internal error",
                 "before": before,
             }
         updated = project_manager.get_task(task_id)
@@ -284,7 +283,7 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
             path=_optional_str(arguments.get("path")),
             producer_task_id=_optional_str(arguments.get("producer_task_id")) or task_id,
             created_at=_optional_str(arguments.get("created_at"))
-            or datetime.utcnow().isoformat(),
+            or datetime.now(timezone.utc).isoformat(),
             valid=_optional_bool(arguments.get("valid"), False),
             metadata=_optional_dict(arguments.get("metadata")),
         )
@@ -299,7 +298,7 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
                 "artifact": artifact.to_dict(),
             }
         task.artifact_evidence.append(artifact)
-        task.updated_at = datetime.utcnow().isoformat()
+        task.updated_at = datetime.now(timezone.utc).isoformat()
         project_manager.storage.update_task(task)
         updated = project_manager.get_task(task_id)
         return {
@@ -439,8 +438,8 @@ def _capabilities_payload() -> dict[str, Any]:
         "statuses": [status.value for status in TaskStatus],
         "status_transitions": transitions,
         "phase_transitions": {
-            phase.value: [target.value for target in sorted(targets, key=lambda item: item.value)]
-            for phase, targets in PHASE_TRANSITIONS.items()
+            phase.value: [target.value for target in targets]
+            for phase, targets in TaskPhase.allowed_transitions().items()
         },
         "dependency_policies": [policy.value for policy in DependencyPolicy],
         "dependency_readiness_rules": {
@@ -474,7 +473,7 @@ def _task_readiness(project_manager: Any, task: Any) -> dict[str, Any]:
     try:
         tasks = project_manager.list_tasks(project_id=task.project_id)
         task_map = {item.id: item for item in tasks}
-        blockers = project_manager._get_unsatisfied_dependencies(task, task_map)
+        blockers = project_manager.get_unsatisfied_dependencies(task, task_map)
     except Exception as exc:  # pragma: no cover - defensive read-only boundary
         return {
             "ready_for_runmode": False,
@@ -528,7 +527,7 @@ def _validate_phase_transition(task: Any, phase: TaskPhase) -> Optional[str]:
             f"Cannot set phase {phase.value} while status is {task.status.value}. "
             "Use penguin_ituv_mark_ready_for_review for successful execution."
         )
-    if phase not in PHASE_TRANSITIONS.get(task.phase, set()):
+    if not task.phase.can_transition_to(phase):
         return f"Invalid phase transition from {task.phase.value} to {phase.value}."
     return None
 

--- a/penguin/integrations/mcp/server_tools/ituv.py
+++ b/penguin/integrations/mcp/server_tools/ituv.py
@@ -1,0 +1,252 @@
+"""Read-only ITUV orchestration tools for Penguin's MCP server surface."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.project.models import DependencyPolicy, TaskPhase, TaskStatus
+from penguin.web.services.project_payloads import (
+    serialize_project_payload,
+    serialize_task_payload,
+)
+
+
+def build_ituv_tools(core: Any) -> list[MCPServerTool]:
+    """Build read-only ITUV status/frontier tools for a Penguin core."""
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return []
+
+    def capabilities(_arguments: dict[str, Any]) -> dict[str, Any]:
+        return _capabilities_payload()
+
+    def status(arguments: dict[str, Any]) -> dict[str, Any]:
+        project_id = _optional_str(arguments.get("project_id"))
+        task_id = _optional_str(arguments.get("task_id"))
+        include_tasks = _optional_bool(arguments.get("include_tasks"), False)
+        include_ready = _optional_bool(arguments.get("include_ready"), True)
+        include_blocked = _optional_bool(arguments.get("include_blocked"), True)
+
+        if not project_id and not task_id:
+            return {
+                "error": "missing_scope",
+                "message": "project_id or task_id is required.",
+            }
+
+        project = None
+        task = None
+        if task_id:
+            task = project_manager.get_task(task_id)
+            if task is None:
+                return {"error": "task_not_found", "task_id": task_id}
+            project_id = project_id or getattr(task, "project_id", None)
+        if project_id:
+            project = project_manager.get_project(project_id)
+            if project is None:
+                return {"error": "project_not_found", "project_id": project_id}
+
+        payload: dict[str, Any] = {
+            "scope": {"project_id": project_id, "task_id": task_id},
+            "capabilities": _capabilities_payload(),
+        }
+        if project is not None:
+            project_tasks = project_manager.list_tasks(project_id=project.id)
+            payload["project"] = serialize_project_payload(
+                project,
+                tasks=project_tasks if include_tasks else None,
+            )
+            payload["dag"] = _safe_project_dag_stats(project_manager, project.id)
+            if include_ready:
+                payload["ready_tasks"] = [
+                    serialize_task_payload(item)
+                    for item in project_manager.get_ready_tasks(project.id)
+                ]
+            if include_blocked:
+                payload["blocked_ready_candidates"] = (
+                    project_manager.get_blocked_ready_candidates(project.id)
+                )
+        if task is not None:
+            payload["task"] = serialize_task_payload(task)
+            payload["task_readiness"] = _task_readiness(project_manager, task)
+        return payload
+
+    def frontier(arguments: dict[str, Any]) -> dict[str, Any]:
+        project_id = _required_str(arguments, "project_id")
+        project = project_manager.get_project(project_id)
+        if project is None:
+            return {"error": "project_not_found", "project_id": project_id}
+        limit = _optional_int(arguments.get("limit"), default=10) or 10
+        include_blocked = _optional_bool(arguments.get("include_blocked"), True)
+        ready_tasks = project_manager.get_ready_tasks(project_id)
+        next_task = project_manager.get_next_task_dag(project_id)
+        payload: dict[str, Any] = {
+            "project": serialize_project_payload(project),
+            "ready_count": len(ready_tasks),
+            "ready_tasks": [
+                serialize_task_payload(task) for task in ready_tasks[:limit]
+            ],
+            "next_task": serialize_task_payload(next_task) if next_task else None,
+            "dag": _safe_project_dag_stats(project_manager, project_id),
+        }
+        if include_blocked:
+            payload["blocked_ready_candidates"] = (
+                project_manager.get_blocked_ready_candidates(project_id)
+            )
+        return payload
+
+    return [
+        MCPServerTool(
+            name="penguin_ituv_capabilities",
+            description=(
+                "Report Penguin ITUV lifecycle/status semantics and read-only MCP "
+                "orchestration capabilities."
+            ),
+            input_schema=_schema({}),
+            handler=capabilities,
+        ),
+        MCPServerTool(
+            name="penguin_ituv_status",
+            description=(
+                "Return read-only ITUV/project/task lifecycle truth, including "
+                "status, phase, dependencies, artifact evidence, and DAG readiness."
+            ),
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "task_id": {"type": "string"},
+                    "include_tasks": {"type": "boolean"},
+                    "include_ready": {"type": "boolean"},
+                    "include_blocked": {"type": "boolean"},
+                }
+            ),
+            handler=status,
+        ),
+        MCPServerTool(
+            name="penguin_ituv_frontier",
+            description=(
+                "Return the current dependency-aware DAG frontier for a project "
+                "without starting or mutating execution."
+            ),
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "limit": {"type": "integer"},
+                    "include_blocked": {"type": "boolean"},
+                },
+                required=["project_id"],
+            ),
+            handler=frontier,
+        ),
+    ]
+
+
+def _capabilities_payload() -> dict[str, Any]:
+    transitions = {
+        status.value: [target.value for target in targets]
+        for status, targets in TaskStatus.valid_transitions().items()
+    }
+    return {
+        "slice": "4A",
+        "read_only": True,
+        "mutation_tools_exposed": False,
+        "tools": [
+            "penguin_ituv_capabilities",
+            "penguin_ituv_status",
+            "penguin_ituv_frontier",
+        ],
+        "phases": [phase.value for phase in TaskPhase],
+        "statuses": [status.value for status in TaskStatus],
+        "status_transitions": transitions,
+        "dependency_policies": [policy.value for policy in DependencyPolicy],
+        "dependency_readiness_rules": {
+            "completion_required": "Unlocks only when upstream status is completed.",
+            "review_ready_ok": (
+                "Unlocks when upstream phase is done and status is pending_review "
+                "or completed."
+            ),
+            "artifact_ready": (
+                "Unlocks when valid matching artifact evidence exists on the "
+                "upstream dependency task."
+            ),
+        },
+        "known_gaps": [
+            "ITUV mutation/signaling is not exposed in Slice 4A.",
+            "Task-specific readiness uses current ProjectManager dependency semantics.",
+            "Durable runtime job records are deferred to Slice 5.",
+        ],
+    }
+
+
+def _safe_project_dag_stats(project_manager: Any, project_id: str) -> dict[str, Any]:
+    try:
+        return project_manager.get_dag_stats(project_id)
+    except Exception as exc:
+        return {"error": "dag_stats_failed", "message": str(exc)}
+
+
+def _task_readiness(project_manager: Any, task: Any) -> dict[str, Any]:
+    blockers = []
+    try:
+        tasks = project_manager.list_tasks(project_id=task.project_id)
+        task_map = {item.id: item for item in tasks}
+        blockers = project_manager._get_unsatisfied_dependencies(task, task_map)
+    except Exception as exc:  # pragma: no cover - defensive read-only boundary
+        return {
+            "ready_for_runmode": False,
+            "error": "readiness_failed",
+            "message": str(exc),
+        }
+    return {
+        "ready_for_runmode": task.status == TaskStatus.ACTIVE and not blockers,
+        "blocked": bool(blockers),
+        "blockers": blockers,
+        "status": task.status.value,
+        "phase": task.phase.value,
+    }
+
+
+def _schema(
+    properties: dict[str, dict[str, Any]], *, required: Optional[list[str]] = None
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+def _required_str(arguments: dict[str, Any], key: str) -> str:
+    value = arguments.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    return value.strip()
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _optional_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _optional_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    if value is None:
+        return default
+    return int(value)
+
+
+__all__ = ["build_ituv_tools"]

--- a/penguin/integrations/mcp/server_tools/ituv.py
+++ b/penguin/integrations/mcp/server_tools/ituv.py
@@ -1,19 +1,37 @@
-"""Read-only ITUV orchestration tools for Penguin's MCP server surface."""
+"""ITUV orchestration tools for Penguin's MCP server surface."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
-from penguin.project.models import DependencyPolicy, TaskPhase, TaskStatus
+from penguin.project.models import ArtifactEvidence, DependencyPolicy, TaskPhase, TaskStatus
 from penguin.web.services.project_payloads import (
     serialize_project_payload,
     serialize_task_payload,
 )
 
 
+PHASE_TRANSITIONS = {
+    TaskPhase.PENDING: {TaskPhase.IMPLEMENT, TaskPhase.BLOCKED},
+    TaskPhase.IMPLEMENT: {TaskPhase.TEST, TaskPhase.BLOCKED, TaskPhase.PENDING},
+    TaskPhase.TEST: {TaskPhase.USE, TaskPhase.VERIFY, TaskPhase.BLOCKED, TaskPhase.IMPLEMENT},
+    TaskPhase.USE: {TaskPhase.VERIFY, TaskPhase.BLOCKED, TaskPhase.TEST},
+    TaskPhase.VERIFY: {TaskPhase.TEST, TaskPhase.USE, TaskPhase.BLOCKED},
+    TaskPhase.BLOCKED: {
+        TaskPhase.PENDING,
+        TaskPhase.IMPLEMENT,
+        TaskPhase.TEST,
+        TaskPhase.USE,
+        TaskPhase.VERIFY,
+    },
+    TaskPhase.DONE: set(),
+}
+
+
 def build_ituv_tools(core: Any) -> list[MCPServerTool]:
-    """Build read-only ITUV status/frontier tools for a Penguin core."""
+    """Build ITUV status/frontier/mutation tools for a Penguin core."""
     project_manager = getattr(core, "project_manager", None)
     if project_manager is None:
         return []
@@ -95,6 +113,204 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
             )
         return payload
 
+
+
+    def signal(arguments: dict[str, Any]) -> dict[str, Any]:
+        task_id = _required_str(arguments, "task_id")
+        action = (_optional_str(arguments.get("action")) or "").lower()
+        dry_run = _optional_bool(arguments.get("dry_run"), True)
+        reason = _optional_str(arguments.get("reason")) or "MCP ITUV signal"
+        user_id = _optional_str(arguments.get("user_id")) or "mcp"
+        task = project_manager.get_task(task_id)
+        if task is None:
+            return {"error": "task_not_found", "task_id": task_id}
+
+        before = serialize_task_payload(task)
+        try:
+            if action == "set_status":
+                status = _parse_status(_required_str(arguments, "status"))
+                validation_error = _validate_status_transition(task, status)
+                if validation_error:
+                    return _mutation_rejected(
+                        task_id=task_id,
+                        action=action,
+                        reason=validation_error,
+                        before=before,
+                    )
+                if dry_run:
+                    return _dry_run_payload(
+                        task_id,
+                        action,
+                        before,
+                        {"status": status.value},
+                    )
+                project_manager.update_task_status(
+                    task_id,
+                    status,
+                    reason=reason,
+                    user_id=user_id,
+                )
+            elif action == "set_phase":
+                phase = _parse_phase(_required_str(arguments, "phase"))
+                validation_error = _validate_phase_transition(task, phase)
+                if validation_error:
+                    return _mutation_rejected(
+                        task_id=task_id,
+                        action=action,
+                        reason=validation_error,
+                        before=before,
+                    )
+                if dry_run:
+                    return _dry_run_payload(
+                        task_id,
+                        action,
+                        before,
+                        {"phase": phase.value},
+                    )
+                project_manager.update_task_phase(task_id, phase, reason=reason)
+            elif action == "block":
+                if dry_run:
+                    return _dry_run_payload(
+                        task_id,
+                        action,
+                        before,
+                        {"phase": TaskPhase.BLOCKED.value},
+                    )
+                validation_error = _validate_phase_transition(task, TaskPhase.BLOCKED)
+                if validation_error:
+                    return _mutation_rejected(
+                        task_id=task_id,
+                        action=action,
+                        reason=validation_error,
+                        before=before,
+                    )
+                project_manager.update_task_phase(
+                    task_id,
+                    TaskPhase.BLOCKED,
+                    reason=reason,
+                )
+            elif action == "unblock":
+                if task.phase != TaskPhase.BLOCKED:
+                    return _mutation_rejected(
+                        task_id=task_id,
+                        action=action,
+                        reason="Task is not currently in blocked phase.",
+                        before=before,
+                    )
+                if dry_run:
+                    return _dry_run_payload(
+                        task_id,
+                        action,
+                        before,
+                        {"phase": TaskPhase.PENDING.value},
+                    )
+                project_manager.update_task_phase(task_id, TaskPhase.PENDING, reason=reason)
+            else:
+                return {
+                    "error": "unsupported_action",
+                    "supported_actions": ["set_status", "set_phase", "block", "unblock"],
+                }
+        except Exception as exc:
+            return {
+                "status": "rejected",
+                "task_id": task_id,
+                "action": action,
+                "reason": str(exc),
+                "before": before,
+            }
+        updated = project_manager.get_task(task_id)
+        return {
+            "status": "applied",
+            "task_id": task_id,
+            "action": action,
+            "dry_run": False,
+            "before": before,
+            "after": serialize_task_payload(updated) if updated else None,
+        }
+
+    def mark_ready_for_review(arguments: dict[str, Any]) -> dict[str, Any]:
+        task_id = _required_str(arguments, "task_id")
+        dry_run = _optional_bool(arguments.get("dry_run"), True)
+        task = project_manager.get_task(task_id)
+        if task is None:
+            return {"error": "task_not_found", "task_id": task_id}
+        before = serialize_task_payload(task)
+        validation_error = _validate_mark_ready(task)
+        if validation_error:
+            return _mutation_rejected(
+                task_id=task_id,
+                action="mark_ready_for_review",
+                reason=validation_error,
+                before=before,
+            )
+        if dry_run:
+            return _dry_run_payload(
+                task_id,
+                "mark_ready_for_review",
+                before,
+                {
+                    "status": TaskStatus.PENDING_REVIEW.value,
+                    "phase": TaskPhase.DONE.value,
+                },
+            )
+        updated = project_manager.mark_task_execution_ready_for_review(
+            task_id=task_id,
+            executor_id=_optional_str(arguments.get("executor_id")) or "mcp",
+            response=(
+                _optional_str(arguments.get("response"))
+                or "Marked ready by MCP ITUV tool."
+            ),
+            task_prompt=_optional_str(arguments.get("task_prompt")),
+            context=_optional_dict(arguments.get("context")),
+        )
+        return {
+            "status": "applied",
+            "task_id": task_id,
+            "action": "mark_ready_for_review",
+            "dry_run": False,
+            "before": before,
+            "after": serialize_task_payload(updated),
+        }
+
+    def record_artifact(arguments: dict[str, Any]) -> dict[str, Any]:
+        task_id = _required_str(arguments, "task_id")
+        dry_run = _optional_bool(arguments.get("dry_run"), True)
+        task = project_manager.get_task(task_id)
+        if task is None:
+            return {"error": "task_not_found", "task_id": task_id}
+        artifact = ArtifactEvidence(
+            key=_required_str(arguments, "key"),
+            kind=_required_str(arguments, "kind"),
+            path=_optional_str(arguments.get("path")),
+            producer_task_id=_optional_str(arguments.get("producer_task_id")) or task_id,
+            created_at=_optional_str(arguments.get("created_at"))
+            or datetime.utcnow().isoformat(),
+            valid=_optional_bool(arguments.get("valid"), False),
+            metadata=_optional_dict(arguments.get("metadata")),
+        )
+        before = serialize_task_payload(task)
+        if dry_run:
+            return {
+                "status": "dry_run",
+                "task_id": task_id,
+                "action": "record_artifact",
+                "dry_run": True,
+                "before": before,
+                "artifact": artifact.to_dict(),
+            }
+        task.artifact_evidence.append(artifact)
+        task.updated_at = datetime.utcnow().isoformat()
+        project_manager.storage.update_task(task)
+        updated = project_manager.get_task(task_id)
+        return {
+            "status": "applied",
+            "task_id": task_id,
+            "action": "record_artifact",
+            "dry_run": False,
+            "artifact": artifact.to_dict(),
+            "after": serialize_task_payload(updated) if updated else None,
+        }
+
     return [
         MCPServerTool(
             name="penguin_ituv_capabilities",
@@ -123,6 +339,67 @@ def build_ituv_tools(core: Any) -> list[MCPServerTool]:
             handler=status,
         ),
         MCPServerTool(
+            name="penguin_ituv_signal",
+            description=(
+                "Dry-run or apply validated ITUV task status/phase signals. "
+                "Defaults to dry_run=true."
+            ),
+            input_schema=_schema(
+                {
+                    "task_id": {"type": "string"},
+                    "action": {"type": "string"},
+                    "status": {"type": "string"},
+                    "phase": {"type": "string"},
+                    "reason": {"type": "string"},
+                    "user_id": {"type": "string"},
+                    "dry_run": {"type": "boolean"},
+                },
+                required=["task_id", "action"],
+            ),
+            handler=signal,
+        ),
+        MCPServerTool(
+            name="penguin_ituv_mark_ready_for_review",
+            description=(
+                "Dry-run or mark a successful task execution as phase=done and "
+                "status=pending_review through ProjectManager semantics."
+            ),
+            input_schema=_schema(
+                {
+                    "task_id": {"type": "string"},
+                    "executor_id": {"type": "string"},
+                    "response": {"type": "string"},
+                    "task_prompt": {"type": "string"},
+                    "context": {"type": "object"},
+                    "dry_run": {"type": "boolean"},
+                },
+                required=["task_id"],
+            ),
+            handler=mark_ready_for_review,
+        ),
+        MCPServerTool(
+            name="penguin_ituv_record_artifact",
+            description=(
+                "Dry-run or attach machine-checkable artifact evidence to a task. "
+                "Defaults to dry_run=true."
+            ),
+            input_schema=_schema(
+                {
+                    "task_id": {"type": "string"},
+                    "key": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "path": {"type": "string"},
+                    "producer_task_id": {"type": "string"},
+                    "created_at": {"type": "string"},
+                    "valid": {"type": "boolean"},
+                    "metadata": {"type": "object"},
+                    "dry_run": {"type": "boolean"},
+                },
+                required=["task_id", "key", "kind"],
+            ),
+            handler=record_artifact,
+        ),
+        MCPServerTool(
             name="penguin_ituv_frontier",
             description=(
                 "Return the current dependency-aware DAG frontier for a project "
@@ -147,17 +424,24 @@ def _capabilities_payload() -> dict[str, Any]:
         for status, targets in TaskStatus.valid_transitions().items()
     }
     return {
-        "slice": "4A",
-        "read_only": True,
-        "mutation_tools_exposed": False,
+        "slice": "4B",
+        "read_only": False,
+        "mutation_tools_exposed": True,
         "tools": [
             "penguin_ituv_capabilities",
             "penguin_ituv_status",
             "penguin_ituv_frontier",
+            "penguin_ituv_signal",
+            "penguin_ituv_mark_ready_for_review",
+            "penguin_ituv_record_artifact",
         ],
         "phases": [phase.value for phase in TaskPhase],
         "statuses": [status.value for status in TaskStatus],
         "status_transitions": transitions,
+        "phase_transitions": {
+            phase.value: [target.value for target in sorted(targets, key=lambda item: item.value)]
+            for phase, targets in PHASE_TRANSITIONS.items()
+        },
         "dependency_policies": [policy.value for policy in DependencyPolicy],
         "dependency_readiness_rules": {
             "completion_required": "Unlocks only when upstream status is completed.",
@@ -171,7 +455,7 @@ def _capabilities_payload() -> dict[str, Any]:
             ),
         },
         "known_gaps": [
-            "ITUV mutation/signaling is not exposed in Slice 4A.",
+            "Mutation tools default to dry_run=true and require explicit dry_run=false to apply.",
             "Task-specific readiness uses current ProjectManager dependency semantics.",
             "Durable runtime job records are deferred to Slice 5.",
         ],
@@ -204,6 +488,89 @@ def _task_readiness(project_manager: Any, task: Any) -> dict[str, Any]:
         "status": task.status.value,
         "phase": task.phase.value,
     }
+
+
+def _parse_status(value: str) -> TaskStatus:
+    try:
+        return TaskStatus(value)
+    except ValueError as exc:
+        valid = ", ".join(status.value for status in TaskStatus)
+        raise ValueError(f"Invalid status '{value}'. Valid statuses: {valid}") from exc
+
+
+def _parse_phase(value: str) -> TaskPhase:
+    try:
+        return TaskPhase(value)
+    except ValueError as exc:
+        valid = ", ".join(phase.value for phase in TaskPhase)
+        raise ValueError(f"Invalid phase '{value}'. Valid phases: {valid}") from exc
+
+
+def _validate_status_transition(task: Any, status: TaskStatus) -> Optional[str]:
+    if status in {TaskStatus.PENDING_REVIEW, TaskStatus.COMPLETED} and task.phase != TaskPhase.DONE:
+        return (
+            f"Cannot set status {status.value} while phase is {task.phase.value}. "
+            "Use penguin_ituv_mark_ready_for_review for the review bridge."
+        )
+    if not task.can_transition_to(status):
+        return f"Invalid status transition from {task.status.value} to {status.value}."
+    return None
+
+
+def _validate_phase_transition(task: Any, phase: TaskPhase) -> Optional[str]:
+    if phase == task.phase:
+        return None
+    if phase == TaskPhase.DONE and task.status not in {
+        TaskStatus.PENDING_REVIEW,
+        TaskStatus.COMPLETED,
+    }:
+        return (
+            f"Cannot set phase {phase.value} while status is {task.status.value}. "
+            "Use penguin_ituv_mark_ready_for_review for successful execution."
+        )
+    if phase not in PHASE_TRANSITIONS.get(task.phase, set()):
+        return f"Invalid phase transition from {task.phase.value} to {phase.value}."
+    return None
+
+
+def _validate_mark_ready(task: Any) -> Optional[str]:
+    if task.status in {TaskStatus.PENDING_REVIEW, TaskStatus.COMPLETED}:
+        return None
+    if task.status not in {TaskStatus.ACTIVE, TaskStatus.RUNNING}:
+        return (
+            "Only active/running tasks can be marked ready for review; "
+            f"current status is {task.status.value}."
+        )
+    return None
+
+
+def _mutation_rejected(
+    *, task_id: str, action: str, reason: str, before: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "status": "rejected",
+        "task_id": task_id,
+        "action": action,
+        "reason": reason,
+        "before": before,
+    }
+
+
+def _dry_run_payload(
+    task_id: str, action: str, before: dict[str, Any], would_apply: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "status": "dry_run",
+        "task_id": task_id,
+        "action": action,
+        "dry_run": True,
+        "before": before,
+        "would_apply": would_apply,
+    }
+
+
+def _optional_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
 
 
 def _schema(

--- a/penguin/integrations/mcp/server_tools/pm.py
+++ b/penguin/integrations/mcp/server_tools/pm.py
@@ -1,0 +1,280 @@
+"""Project-management MCP server tools for Penguin."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.project.models import TaskStatus
+from penguin.web.services.project_payloads import (
+    serialize_project_payload,
+    serialize_task_payload,
+)
+
+
+def build_pm_tools(core: Any) -> list[MCPServerTool]:
+    """Build default-on PM control-plane tools for a Penguin core-like object."""
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return []
+
+    def list_projects(arguments: dict[str, Any]) -> dict[str, Any]:
+        status = _optional_str(arguments.get("status"))
+        include_tasks = bool(arguments.get("include_tasks", False))
+        projects = project_manager.list_projects(status=status)
+        payloads = []
+        for project in projects:
+            tasks = (
+                project_manager.list_tasks(project_id=project.id)
+                if include_tasks
+                else None
+            )
+            payloads.append(serialize_project_payload(project, tasks=tasks))
+        return {"projects": payloads}
+
+    def create_project(arguments: dict[str, Any]) -> dict[str, Any]:
+        metadata = _metadata(arguments)
+        project = project_manager.create_project(
+            name=_required_str(arguments, "name"),
+            description=_optional_str(arguments.get("description"))
+            or f"Project: {_required_str(arguments, 'name')}",
+            tags=_optional_str_list(arguments.get("tags")),
+            budget_tokens=_optional_int(arguments.get("budget_tokens")),
+            budget_minutes=_optional_int(arguments.get("budget_minutes")),
+            workspace_path=_optional_path(arguments.get("workspace_path")),
+            **metadata,
+        )
+        changed = False
+        for attr in ("priority", "start_date", "due_date"):
+            if attr in arguments and arguments[attr] is not None:
+                setattr(project, attr, arguments[attr])
+                changed = True
+        if changed:
+            project.updated_at = datetime.utcnow().isoformat()
+            project_manager.storage.update_project(project)
+        return {"project": serialize_project_payload(project)}
+
+    def get_project(arguments: dict[str, Any]) -> dict[str, Any]:
+        project_id = _required_str(arguments, "project_id")
+        project = project_manager.get_project(project_id)
+        if project is None:
+            return {"error": "project_not_found", "project_id": project_id}
+        tasks = (
+            project_manager.list_tasks(project_id=project.id)
+            if bool(arguments.get("include_tasks", True))
+            else None
+        )
+        return {"project": serialize_project_payload(project, tasks=tasks)}
+
+    def list_tasks(arguments: dict[str, Any]) -> dict[str, Any]:
+        status = _parse_status(arguments.get("status"))
+        tasks = project_manager.list_tasks(
+            project_id=_optional_str(arguments.get("project_id")),
+            status=status,
+            parent_task_id=_optional_str(arguments.get("parent_task_id")),
+        )
+        return {"tasks": [serialize_task_payload(task) for task in tasks]}
+
+    def create_task(arguments: dict[str, Any]) -> dict[str, Any]:
+        metadata = _metadata(arguments)
+        task = project_manager.create_task(
+            project_id=_optional_str(arguments.get("project_id")),
+            title=_required_str(arguments, "title"),
+            description=_optional_str(arguments.get("description"))
+            or _required_str(arguments, "title"),
+            parent_task_id=_optional_str(arguments.get("parent_task_id")),
+            priority=_optional_int(arguments.get("priority"), default=1),
+            tags=_optional_str_list(arguments.get("tags")),
+            dependencies=_optional_str_list(arguments.get("dependencies")),
+            due_date=_optional_str(arguments.get("due_date")),
+            budget_tokens=_optional_int(arguments.get("budget_tokens")),
+            budget_minutes=_optional_int(arguments.get("budget_minutes")),
+            allowed_tools=_optional_str_list(arguments.get("allowed_tools")),
+            acceptance_criteria=_optional_str_list(
+                arguments.get("acceptance_criteria")
+            ),
+            **metadata,
+        )
+        changed = False
+        for attr in (
+            "definition_of_done",
+            "blueprint_id",
+            "blueprint_source",
+            "recipe",
+        ):
+            if attr in arguments and arguments[attr] is not None:
+                setattr(task, attr, arguments[attr])
+                changed = True
+        if changed:
+            task.updated_at = datetime.utcnow().isoformat()
+            project_manager.storage.update_task(task)
+        return {"task": serialize_task_payload(task)}
+
+    def get_task(arguments: dict[str, Any]) -> dict[str, Any]:
+        task_id = _required_str(arguments, "task_id")
+        task = project_manager.get_task(task_id)
+        if task is None:
+            return {"error": "task_not_found", "task_id": task_id}
+        return {"task": serialize_task_payload(task)}
+
+    return [
+        MCPServerTool(
+            name="penguin_pm_list_projects",
+            description="List Penguin projects, optionally including their tasks.",
+            input_schema=_schema(
+                {
+                    "status": {"type": "string"},
+                    "include_tasks": {"type": "boolean"},
+                }
+            ),
+            handler=list_projects,
+        ),
+        MCPServerTool(
+            name="penguin_pm_create_project",
+            description="Create a Penguin project with rich PM metadata.",
+            input_schema=_schema(
+                {
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "workspace_path": {"type": "string"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "priority": {"type": "integer"},
+                    "budget_tokens": {"type": "integer"},
+                    "budget_minutes": {"type": "integer"},
+                    "start_date": {"type": "string"},
+                    "due_date": {"type": "string"},
+                    "metadata": {"type": "object"},
+                },
+                required=["name"],
+            ),
+            handler=create_project,
+        ),
+        MCPServerTool(
+            name="penguin_pm_get_project",
+            description="Get one Penguin project by ID, including tasks by default.",
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "include_tasks": {"type": "boolean"},
+                },
+                required=["project_id"],
+            ),
+            handler=get_project,
+        ),
+        MCPServerTool(
+            name="penguin_pm_list_tasks",
+            description="List Penguin PM tasks by project, status, or parent task.",
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "status": {"type": "string"},
+                    "parent_task_id": {"type": "string"},
+                }
+            ),
+            handler=list_tasks,
+        ),
+        MCPServerTool(
+            name="penguin_pm_create_task",
+            description="Create a rich Penguin PM task without starting execution.",
+            input_schema=_schema(
+                {
+                    "project_id": {"type": "string"},
+                    "title": {"type": "string"},
+                    "description": {"type": "string"},
+                    "parent_task_id": {"type": "string"},
+                    "priority": {"type": "integer"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "dependencies": {"type": "array", "items": {"type": "string"}},
+                    "due_date": {"type": "string"},
+                    "budget_tokens": {"type": "integer"},
+                    "budget_minutes": {"type": "integer"},
+                    "allowed_tools": {"type": "array", "items": {"type": "string"}},
+                    "acceptance_criteria": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "definition_of_done": {"type": "string"},
+                    "blueprint_id": {"type": "string"},
+                    "blueprint_source": {"type": "string"},
+                    "recipe": {"type": "string"},
+                    "metadata": {"type": "object"},
+                },
+                required=["title"],
+            ),
+            handler=create_task,
+        ),
+        MCPServerTool(
+            name="penguin_pm_get_task",
+            description="Get one Penguin PM task by ID with lifecycle truth.",
+            input_schema=_schema(
+                {"task_id": {"type": "string"}},
+                required=["task_id"],
+            ),
+            handler=get_task,
+        ),
+    ]
+
+
+def _schema(
+    properties: dict[str, dict[str, Any]], *, required: Optional[list[str]] = None
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required or [],
+        "additionalProperties": False,
+    }
+
+
+def _metadata(arguments: dict[str, Any]) -> dict[str, Any]:
+    value = arguments.get("metadata")
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _required_str(arguments: dict[str, Any], key: str) -> str:
+    value = arguments.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} is required")
+    return value.strip()
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _optional_path(value: Any) -> Optional[Path]:
+    text = _optional_str(value)
+    return Path(text).expanduser().resolve() if text else None
+
+
+def _optional_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    if value is None:
+        return default
+    return int(value)
+
+
+def _optional_str_list(value: Any) -> Optional[list[str]]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return None
+
+
+def _parse_status(value: Any) -> Optional[TaskStatus]:
+    text = _optional_str(value)
+    if text is None:
+        return None
+    return TaskStatus(text.lower())
+
+
+__all__ = ["build_pm_tools"]

--- a/penguin/integrations/mcp/server_tools/pm.py
+++ b/penguin/integrations/mcp/server_tools/pm.py
@@ -43,7 +43,10 @@ def build_pm_tools(core: Any) -> list[MCPServerTool]:
             tags=_optional_str_list(arguments.get("tags")),
             budget_tokens=_optional_int(arguments.get("budget_tokens")),
             budget_minutes=_optional_int(arguments.get("budget_minutes")),
-            workspace_path=_optional_path(arguments.get("workspace_path")),
+            workspace_path=_bounded_workspace_path(
+                project_manager,
+                arguments.get("workspace_path"),
+            ),
             **metadata,
         )
         changed = False
@@ -247,6 +250,22 @@ def _optional_str(value: Any) -> Optional[str]:
         stripped = value.strip()
         return stripped or None
     return str(value)
+
+
+def _bounded_workspace_path(project_manager: Any, value: Any) -> Optional[Path]:
+    """Return a workspace path bounded to ProjectManager.workspace_path."""
+    if value in (None, ""):
+        return None
+    root = Path(project_manager.workspace_path).expanduser().resolve()
+    path = Path(str(value)).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    path = path.resolve()
+    if path != root and root not in path.parents:
+        raise PermissionError(
+            f"workspace_path must be inside Penguin workspace: {root}"
+        )
+    return path
 
 
 def _optional_path(value: Any) -> Optional[Path]:

--- a/penguin/integrations/mcp/server_tools/pm.py
+++ b/penguin/integrations/mcp/server_tools/pm.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -52,7 +52,7 @@ def build_pm_tools(core: Any) -> list[MCPServerTool]:
                 setattr(project, attr, arguments[attr])
                 changed = True
         if changed:
-            project.updated_at = datetime.utcnow().isoformat()
+            project.updated_at = datetime.now(timezone.utc).isoformat()
             project_manager.storage.update_project(project)
         return {"project": serialize_project_payload(project)}
 
@@ -108,7 +108,7 @@ def build_pm_tools(core: Any) -> list[MCPServerTool]:
                 setattr(task, attr, arguments[attr])
                 changed = True
         if changed:
-            task.updated_at = datetime.utcnow().isoformat()
+            task.updated_at = datetime.now(timezone.utc).isoformat()
             project_manager.storage.update_task(task)
         return {"task": serialize_task_payload(task)}
 
@@ -274,7 +274,13 @@ def _parse_status(value: Any) -> Optional[TaskStatus]:
     text = _optional_str(value)
     if text is None:
         return None
-    return TaskStatus(text.lower())
+    try:
+        return TaskStatus(text.lower())
+    except ValueError as exc:
+        valid = ", ".join(status.value for status in TaskStatus)
+        raise ValueError(
+            f"invalid status {text!r}, valid statuses are: {valid}"
+        ) from exc
 
 
 __all__ = ["build_pm_tools"]

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -1,0 +1,222 @@
+"""RunMode readiness tools for Penguin's MCP server surface."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+
+
+@dataclass
+class RunModeJobRecord:
+    """In-process runtime job record for future RunMode start/cancel tools."""
+
+    job_id: str
+    kind: str
+    status: str = "pending"
+    project_id: Optional[str] = None
+    task_id: Optional[str] = None
+    started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    finished_at: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable job record."""
+        return asdict(self)
+
+
+class RunModeJobRegistry:
+    """Small in-process registry for runtime MCP jobs.
+
+    Slice 3A only exposes read/capability methods. Start/cancel tools can use this
+    registry in later slices instead of inventing a second status model.
+    """
+
+    def __init__(self) -> None:
+        self._jobs: Dict[str, RunModeJobRecord] = {}
+
+    def list_jobs(
+        self,
+        *,
+        status: Optional[str] = None,
+        project_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List job records with optional filters."""
+        jobs: Iterable[RunModeJobRecord] = self._jobs.values()
+        if status:
+            jobs = [job for job in jobs if job.status == status]
+        if project_id:
+            jobs = [job for job in jobs if job.project_id == project_id]
+        if task_id:
+            jobs = [job for job in jobs if job.task_id == task_id]
+        return [job.to_dict() for job in jobs]
+
+    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Return one job record if known."""
+        job = self._jobs.get(job_id)
+        return job.to_dict() if job else None
+
+    def summary(self) -> Dict[str, Any]:
+        """Return registry metadata."""
+        return {
+            "type": "in_process",
+            "job_count": len(self._jobs),
+            "supports_start": False,
+            "supports_cancel": False,
+            "durable": False,
+        }
+
+
+def _core_capabilities(core: Any) -> Dict[str, Any]:
+    """Return runtime-related capability facts from the current core."""
+    run_mode = getattr(core, "run_mode", None)
+    return {
+        "has_core": core is not None,
+        "has_project_manager": bool(getattr(core, "project_manager", None)),
+        "has_engine": bool(getattr(core, "engine", None)),
+        "has_start_run_mode": hasattr(core, "start_run_mode"),
+        "has_active_run_mode_instance": run_mode is not None,
+        "runmode_active": bool(getattr(core, "_runmode_active", False)),
+        "continuous_mode": bool(getattr(core, "_continuous_mode", False)),
+        "current_status_summary": getattr(
+            core, "current_runmode_status_summary", None
+        ),
+        "run_mode_current_task": getattr(run_mode, "current_task_name", None),
+    }
+
+
+def _capabilities_payload(
+    core: Any,
+    registry: RunModeJobRegistry,
+) -> Dict[str, Any]:
+    """Build the Slice 3A capabilities payload."""
+    core_info = _core_capabilities(core)
+    return {
+        "runtime_tools_enabled": True,
+        "slice": "3A",
+        "tools": {
+            "available": [
+                "penguin_runmode_capabilities",
+                "penguin_runmode_list_jobs",
+                "penguin_runmode_get_job",
+            ],
+            "not_yet_exposed": [
+                "penguin_runmode_start_task",
+                "penguin_runmode_start_project",
+                "penguin_runmode_cancel_job",
+                "penguin_runmode_resume_clarification",
+            ],
+        },
+        "start_supported": False,
+        "cancel_supported": False,
+        "resume_clarification_supported": False,
+        "registry": registry.summary(),
+        "core": core_info,
+        "gaps": [
+            "No MCP background job start tool is exposed in Slice 3A.",
+            "No durable job registry exists yet; current registry is in-process only.",
+            "Cancellation semantics are not exposed until Slice 3C.",
+            "RunMode execution remains model-dependent and explicitly gated.",
+        ],
+    }
+
+
+def build_runmode_tools(
+    core: Any,
+    registry: Optional[RunModeJobRegistry] = None,
+) -> List[MCPServerTool]:
+    """Build runtime readiness tools for Penguin's MCP server."""
+    job_registry = registry or RunModeJobRegistry()
+
+    def capabilities(_arguments: Dict[str, Any]) -> Dict[str, Any]:
+        return _capabilities_payload(core, job_registry)
+
+    def list_jobs(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        jobs = job_registry.list_jobs(
+            status=arguments.get("status"),
+            project_id=arguments.get("project_id"),
+            task_id=arguments.get("task_id"),
+        )
+        return {
+            "jobs": jobs,
+            "count": len(jobs),
+            "registry": job_registry.summary(),
+        }
+
+    def get_job(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        job_id = arguments.get("job_id")
+        if not job_id:
+            return {
+                "error": "missing_job_id",
+                "message": "job_id is required.",
+            }
+        job = job_registry.get_job(str(job_id))
+        if job is None:
+            return {
+                "error": "job_not_found",
+                "job_id": job_id,
+                "message": "No runtime MCP job exists with this ID.",
+                "registry": job_registry.summary(),
+            }
+        return {"job": job, "registry": job_registry.summary()}
+
+    return [
+        MCPServerTool(
+            name="penguin_runmode_capabilities",
+            description=(
+                "Report current Penguin RunMode MCP readiness and known gaps. "
+                "This does not start execution."
+            ),
+            input_schema={"type": "object", "properties": {}, "required": []},
+            handler=capabilities,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_list_jobs",
+            description=(
+                "List in-process RunMode MCP jobs. Slice 3A exposes an empty "
+                "read-only registry until start tools are implemented."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Optional job status filter.",
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Optional project ID filter.",
+                    },
+                    "task_id": {
+                        "type": "string",
+                        "description": "Optional task ID filter.",
+                    },
+                },
+                "required": [],
+            },
+            handler=list_jobs,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_get_job",
+            description="Return one in-process RunMode MCP job by ID if it exists.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "description": "Runtime MCP job ID.",
+                    }
+                },
+                "required": ["job_id"],
+            },
+            handler=get_job,
+        ),
+    ]
+
+
+__all__ = ["RunModeJobRecord", "RunModeJobRegistry", "build_runmode_tools"]

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -10,12 +10,16 @@ from datetime import datetime
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.project.runtime_jobs import (
+    TERMINAL_RUNTIME_JOB_STATUSES,
+    build_runtime_job_record,
+)
 from penguin.web.services.project_payloads import serialize_task_payload
 
 
 @dataclass
 class RunModeJobRecord:
-    """In-process runtime job record for MCP-triggered RunMode work."""
+    """Live runtime job record for MCP-triggered RunMode work."""
 
     job_id: str
     kind: str
@@ -23,6 +27,7 @@ class RunModeJobRecord:
     project_id: Optional[str] = None
     task_id: Optional[str] = None
     started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     finished_at: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
@@ -44,7 +49,9 @@ class RunModeJobRecord:
             "status": self.status,
             "project_id": self.project_id,
             "task_id": self.task_id,
+            "session_id": self.metadata.get("session_id"),
             "started_at": self.started_at,
+            "updated_at": self.updated_at,
             "finished_at": self.finished_at,
             "result": self.result,
             "error": self.error,
@@ -52,18 +59,23 @@ class RunModeJobRecord:
             "cancel_requested": self.cancel_requested,
             "cancel_requested_at": self.cancel_requested_at,
             "cancel_signal_sent": self.cancel_signal_sent,
+            "durable": bool(self.metadata.get("durable")),
+            "live": True,
+            "controllable": self.status not in TERMINAL_RUNTIME_JOB_STATUSES,
         }
 
 
 class RunModeJobRegistry:
-    """Small in-process registry for runtime MCP jobs.
+    """Registry for runtime MCP jobs.
 
-    The registry intentionally starts jobs in daemon threads and records final
-    results/errors. This is not durable across process restarts; it is an MVP
-    control-plane handle so MCP clients do not block on model-dependent runs.
+    The registry starts jobs in daemon threads, records final results/errors,
+    and persists records through ProjectManager when available. Live handles are
+    still process-local, so restarted servers can recover history but cannot
+    force-control orphaned non-terminal jobs.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, project_manager: Optional[Any] = None) -> None:
+        self.project_manager = project_manager
         self._jobs: Dict[str, RunModeJobRecord] = {}
         self._threads: Dict[str, threading.Thread] = {}
         self._lock = threading.RLock()
@@ -85,8 +97,10 @@ class RunModeJobRegistry:
             task_id=task_id,
             metadata=dict(metadata or {}),
         )
+        record.metadata["durable"] = self._durable_enabled
         with self._lock:
             self._jobs[record.job_id] = record
+        self._persist(record)
 
         thread = threading.Thread(
             target=self._run_job_thread,
@@ -108,38 +122,71 @@ class RunModeJobRegistry:
     ) -> List[Dict[str, Any]]:
         """List job records with optional filters."""
         with self._lock:
-            jobs: Iterable[RunModeJobRecord] = list(self._jobs.values())
+            live_jobs: Iterable[RunModeJobRecord] = list(self._jobs.values())
+        live_payloads = [job.to_dict() for job in live_jobs]
+        durable_payloads = self._list_durable_jobs(
+            status=status,
+            project_id=project_id,
+            task_id=task_id,
+        )
+        merged: Dict[str, Dict[str, Any]] = {}
+        for payload in durable_payloads:
+            merged[payload["job_id"]] = payload
+        for payload in live_payloads:
+            merged[payload["job_id"]] = {**merged.get(payload["job_id"], {}), **payload}
+        jobs = list(merged.values())
         if status:
-            jobs = [job for job in jobs if job.status == status]
+            jobs = [job for job in jobs if job.get("status") == status]
         if project_id:
-            jobs = [job for job in jobs if job.project_id == project_id]
+            jobs = [job for job in jobs if job.get("project_id") == project_id]
         if task_id:
-            jobs = [job for job in jobs if job.task_id == task_id]
-        return [job.to_dict() for job in jobs]
+            jobs = [job for job in jobs if job.get("task_id") == task_id]
+        return jobs
 
     def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
         """Return one job record if known."""
         with self._lock:
             job = self._jobs.get(job_id)
-            return job.to_dict() if job else None
+            if job:
+                durable = self._get_durable_job(job_id) or {}
+                return {**durable, **job.to_dict()}
+        return self._get_durable_job(job_id)
 
     def cancel_job(self, job_id: str, reason: Optional[str] = None) -> Dict[str, Any]:
         """Request cooperative cancellation for one in-process job."""
         with self._lock:
             record = self._jobs.get(job_id)
             if record is None:
+                durable = self._get_durable_job(job_id)
+                if durable is None:
+                    return {
+                        "error": "job_not_found",
+                        "job_id": job_id,
+                        "message": "No runtime MCP job exists with this ID.",
+                        "registry": self.summary(),
+                    }
+                if durable.get("status") in TERMINAL_RUNTIME_JOB_STATUSES:
+                    return {
+                        "job": durable,
+                        "cancel_requested": False,
+                        "message": "Job is already terminal.",
+                        "registry": self.summary(),
+                    }
+                self._persist_cancel_intent(job_id, reason)
+                durable = self._get_durable_job(job_id) or durable
                 return {
-                    "error": "job_not_found",
-                    "job_id": job_id,
-                    "message": "No runtime MCP job exists with this ID.",
+                    "job": durable,
+                    "cancel_requested": True,
+                    "cancel_signal_sent": False,
+                    "hard_cancel_supported": False,
+                    "controllable": False,
+                    "message": (
+                        "Cancellation intent persisted, but this job has no live "
+                        "in-process handle in the current MCP server."
+                    ),
                     "registry": self.summary(),
                 }
-            if record.status in {
-                "completed",
-                "failed",
-                "cancelled",
-                "completed_after_cancel_requested",
-            }:
+            if record.status in TERMINAL_RUNTIME_JOB_STATUSES:
                 return {
                     "job": record.to_dict(),
                     "cancel_requested": False,
@@ -148,8 +195,9 @@ class RunModeJobRegistry:
                 }
             record.cancel_requested = True
             record.cancel_requested_at = datetime.utcnow().isoformat()
+            record.updated_at = record.cancel_requested_at
             record.metadata["cancel_reason"] = reason
-            record.status = "cancelling"
+            record.status = "cancel_requested"
             callback = record.cancel_callback
 
         signal_sent = False
@@ -161,6 +209,7 @@ class RunModeJobRegistry:
                     record.error = f"Cancel callback failed: {exc}"
         with self._lock:
             record.cancel_signal_sent = signal_sent
+            self._persist(record)
             return {
                 "job": record.to_dict(),
                 "cancel_requested": True,
@@ -180,14 +229,23 @@ class RunModeJobRegistry:
             running_count = sum(
                 1 for job in self._jobs.values() if job.status == "running"
             )
+        durable_jobs = self._list_durable_jobs()
+        orphaned_count = sum(
+            1
+            for job in durable_jobs
+            if not job.get("live") and job.get("metadata", {}).get("orphaned")
+        )
         return {
-            "type": "in_process",
-            "job_count": job_count,
+            "type": "project_storage_backed" if self._durable_enabled else "in_process",
+            "job_count": len({job["job_id"] for job in durable_jobs} | set(self._jobs)),
+            "live_job_count": job_count,
             "running_count": running_count,
+            "durable_job_count": len(durable_jobs),
+            "orphaned_job_count": orphaned_count,
             "supports_start": True,
             "supports_cancel": True,
             "hard_cancel_supported": False,
-            "durable": False,
+            "durable": self._durable_enabled,
         }
 
     def _run_job_thread(
@@ -199,23 +257,132 @@ class RunModeJobRegistry:
         with self._lock:
             record = self._jobs[job_id]
             record.status = "running"
+            record.updated_at = datetime.utcnow().isoformat()
+        self._persist(record)
         try:
             result = asyncio.run(runner(record))
             with self._lock:
                 record.result = result
                 mapped_status = _job_status_from_result(result)
                 if record.cancel_requested and mapped_status == "completed":
-                    record.status = "completed_after_cancel_requested"
-                else:
-                    record.status = mapped_status
+                    record.metadata["completed_after_cancel_requested"] = True
+                record.status = mapped_status
                 record.finished_at = datetime.utcnow().isoformat()
+                record.updated_at = record.finished_at
                 record.cancel_callback = None
+            self._persist(record)
         except Exception as exc:  # pragma: no cover - defensive job boundary
             with self._lock:
                 record.status = "failed"
                 record.error = str(exc)
                 record.finished_at = datetime.utcnow().isoformat()
+                record.updated_at = record.finished_at
                 record.cancel_callback = None
+            self._persist(record)
+
+    @property
+    def _durable_enabled(self) -> bool:
+        """Return whether ProjectManager-backed durable jobs are available."""
+        return all(
+            hasattr(self.project_manager, method)
+            for method in (
+                "upsert_runtime_job",
+                "get_runtime_job",
+                "list_runtime_jobs",
+            )
+        )
+
+    def _persist(self, record: RunModeJobRecord) -> None:
+        """Persist one live job record when ProjectManager supports it."""
+        if not self._durable_enabled:
+            return
+        durable = build_runtime_job_record(
+            job_id=record.job_id,
+            kind=record.kind,
+            status=record.status,
+            project_id=record.project_id,
+            task_id=record.task_id,
+            session_id=record.metadata.get("session_id"),
+            started_at=record.started_at,
+            updated_at=record.updated_at,
+            finished_at=record.finished_at,
+            cancel_requested=record.cancel_requested,
+            cancel_reason=record.metadata.get("cancel_reason"),
+            result=record.result,
+            error=record.error,
+            metadata=record.metadata,
+        )
+        self.project_manager.upsert_runtime_job(durable)
+
+    def _get_durable_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Return one durable job payload if present."""
+        if not self._durable_enabled:
+            return None
+        record = self.project_manager.get_runtime_job(job_id)
+        if record is None:
+            return None
+        payload = record.to_dict()
+        live = job_id in self._jobs
+        payload["live"] = live
+        payload["controllable"] = (
+            live and payload.get("status") not in TERMINAL_RUNTIME_JOB_STATUSES
+        )
+        if not live and payload.get("status") not in TERMINAL_RUNTIME_JOB_STATUSES:
+            metadata = dict(payload.get("metadata") or {})
+            metadata["orphaned"] = True
+            metadata["orphaned_reason"] = (
+                "No live in-process job handle exists in this MCP server."
+            )
+            payload["metadata"] = metadata
+        return payload
+
+    def _list_durable_jobs(
+        self,
+        *,
+        status: Optional[str] = None,
+        project_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List durable job payloads if ProjectManager supports them."""
+        if not self._durable_enabled:
+            return []
+        records = self.project_manager.list_runtime_jobs(
+            status=status,
+            project_id=project_id,
+            task_id=task_id,
+            limit=100,
+        )
+        payloads = []
+        for record in records:
+            payload = record.to_dict()
+            live = payload["job_id"] in self._jobs
+            payload["live"] = live
+            payload["controllable"] = (
+                live and payload.get("status") not in TERMINAL_RUNTIME_JOB_STATUSES
+            )
+            if not live and payload.get("status") not in TERMINAL_RUNTIME_JOB_STATUSES:
+                metadata = dict(payload.get("metadata") or {})
+                metadata["orphaned"] = True
+                metadata["orphaned_reason"] = (
+                    "No live in-process job handle exists in this MCP server."
+                )
+                payload["metadata"] = metadata
+            payloads.append(payload)
+        return payloads
+
+    def _persist_cancel_intent(self, job_id: str, reason: Optional[str]) -> None:
+        """Persist cancellation intent for a durable non-live job."""
+        if not self._durable_enabled:
+            return
+        record = self.project_manager.get_runtime_job(job_id)
+        if record is None:
+            return
+        record.cancel_requested = True
+        record.cancel_reason = reason
+        record.status = "cancel_requested"
+        record.updated_at = datetime.utcnow().isoformat()
+        record.metadata["cancel_request_without_live_handle"] = True
+        self.project_manager.upsert_runtime_job(record)
 
 
 def _job_status_from_result(result: Dict[str, Any]) -> str:
@@ -252,10 +419,10 @@ def _capabilities_payload(
     core: Any,
     registry: RunModeJobRegistry,
 ) -> Dict[str, Any]:
-    """Build the Slice 3C capabilities payload."""
+    """Build the Slice 5B capabilities payload."""
     return {
         "runtime_tools_enabled": True,
-        "slice": "3C",
+        "slice": "5B",
         "tools": {
             "available": [
                 "penguin_runmode_capabilities",
@@ -276,7 +443,7 @@ def _capabilities_payload(
         "core": _core_capabilities(core),
         "gaps": [
             "Cancellation is cooperative/best-effort; Python threads are not force-killed.",
-            "Job registry is in-process only and is lost on server restart.",
+            "Durable job records persist in ProjectStorage when ProjectManager is available.",
             "RunMode execution is model-dependent and remains explicitly gated.",
         ],
     }
@@ -469,7 +636,8 @@ def build_runmode_tools(
     registry: Optional[RunModeJobRegistry] = None,
 ) -> List[MCPServerTool]:
     """Build runtime tools for Penguin's MCP server."""
-    job_registry = registry or RunModeJobRegistry()
+    project_manager = getattr(core, "project_manager", None)
+    job_registry = registry or RunModeJobRegistry(project_manager=project_manager)
 
     def capabilities(_arguments: Dict[str, Any]) -> Dict[str, Any]:
         return _capabilities_payload(core, job_registry)
@@ -577,7 +745,7 @@ def build_runmode_tools(
         ),
         MCPServerTool(
             name="penguin_runmode_list_jobs",
-            description="List in-process RunMode MCP jobs with optional filters.",
+            description="List durable and live RunMode MCP jobs with optional filters.",
             input_schema={
                 "type": "object",
                 "properties": {
@@ -600,7 +768,7 @@ def build_runmode_tools(
         ),
         MCPServerTool(
             name="penguin_runmode_get_job",
-            description="Return one in-process RunMode MCP job by ID if it exists.",
+            description="Return one durable/live RunMode MCP job by ID if it exists.",
             input_schema={
                 "type": "object",
                 "properties": {

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import uuid
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
@@ -27,10 +27,32 @@ class RunModeJobRecord:
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    cancel_requested: bool = False
+    cancel_requested_at: Optional[str] = None
+    cancel_signal_sent: bool = False
+    cancel_callback: Optional[Callable[[], bool]] = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         """Return a JSON-serializable job record."""
-        return asdict(self)
+        return {
+            "job_id": self.job_id,
+            "kind": self.kind,
+            "status": self.status,
+            "project_id": self.project_id,
+            "task_id": self.task_id,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "result": self.result,
+            "error": self.error,
+            "metadata": self.metadata,
+            "cancel_requested": self.cancel_requested,
+            "cancel_requested_at": self.cancel_requested_at,
+            "cancel_signal_sent": self.cancel_signal_sent,
+        }
 
 
 class RunModeJobRegistry:
@@ -101,6 +123,56 @@ class RunModeJobRegistry:
             job = self._jobs.get(job_id)
             return job.to_dict() if job else None
 
+    def cancel_job(self, job_id: str, reason: Optional[str] = None) -> Dict[str, Any]:
+        """Request cooperative cancellation for one in-process job."""
+        with self._lock:
+            record = self._jobs.get(job_id)
+            if record is None:
+                return {
+                    "error": "job_not_found",
+                    "job_id": job_id,
+                    "message": "No runtime MCP job exists with this ID.",
+                    "registry": self.summary(),
+                }
+            if record.status in {
+                "completed",
+                "failed",
+                "cancelled",
+                "completed_after_cancel_requested",
+            }:
+                return {
+                    "job": record.to_dict(),
+                    "cancel_requested": False,
+                    "message": "Job is already terminal.",
+                    "registry": self.summary(),
+                }
+            record.cancel_requested = True
+            record.cancel_requested_at = datetime.utcnow().isoformat()
+            record.metadata["cancel_reason"] = reason
+            record.status = "cancelling"
+            callback = record.cancel_callback
+
+        signal_sent = False
+        if callback:
+            try:
+                signal_sent = bool(callback())
+            except Exception as exc:  # pragma: no cover - defensive boundary
+                with self._lock:
+                    record.error = f"Cancel callback failed: {exc}"
+        with self._lock:
+            record.cancel_signal_sent = signal_sent
+            return {
+                "job": record.to_dict(),
+                "cancel_requested": True,
+                "cancel_signal_sent": signal_sent,
+                "hard_cancel_supported": False,
+                "message": (
+                    "Cooperative cancellation requested. The job may still finish "
+                    "if the underlying RunMode path does not observe the signal."
+                ),
+                "registry": self.summary(),
+            }
+
     def summary(self) -> Dict[str, Any]:
         """Return registry metadata."""
         with self._lock:
@@ -113,7 +185,8 @@ class RunModeJobRegistry:
             "job_count": job_count,
             "running_count": running_count,
             "supports_start": True,
-            "supports_cancel": False,
+            "supports_cancel": True,
+            "hard_cancel_supported": False,
             "durable": False,
         }
 
@@ -130,13 +203,19 @@ class RunModeJobRegistry:
             result = asyncio.run(runner(record))
             with self._lock:
                 record.result = result
-                record.status = _job_status_from_result(result)
+                mapped_status = _job_status_from_result(result)
+                if record.cancel_requested and mapped_status == "completed":
+                    record.status = "completed_after_cancel_requested"
+                else:
+                    record.status = mapped_status
                 record.finished_at = datetime.utcnow().isoformat()
+                record.cancel_callback = None
         except Exception as exc:  # pragma: no cover - defensive job boundary
             with self._lock:
                 record.status = "failed"
                 record.error = str(exc)
                 record.finished_at = datetime.utcnow().isoformat()
+                record.cancel_callback = None
 
 
 def _job_status_from_result(result: Dict[str, Any]) -> str:
@@ -173,10 +252,10 @@ def _capabilities_payload(
     core: Any,
     registry: RunModeJobRegistry,
 ) -> Dict[str, Any]:
-    """Build the Slice 3B capabilities payload."""
+    """Build the Slice 3C capabilities payload."""
     return {
         "runtime_tools_enabled": True,
-        "slice": "3B",
+        "slice": "3C",
         "tools": {
             "available": [
                 "penguin_runmode_capabilities",
@@ -184,26 +263,30 @@ def _capabilities_payload(
                 "penguin_runmode_get_job",
                 "penguin_runmode_start_task",
                 "penguin_runmode_start_project",
-            ],
-            "not_yet_exposed": [
                 "penguin_runmode_cancel_job",
                 "penguin_runmode_resume_clarification",
             ],
+            "not_yet_exposed": [],
         },
         "start_supported": True,
-        "cancel_supported": False,
-        "resume_clarification_supported": False,
+        "cancel_supported": True,
+        "hard_cancel_supported": False,
+        "resume_clarification_supported": True,
         "registry": registry.summary(),
         "core": _core_capabilities(core),
         "gaps": [
+            "Cancellation is cooperative/best-effort; Python threads are not force-killed.",
             "Job registry is in-process only and is lost on server restart.",
-            "Cancellation semantics are not exposed until Slice 3C.",
             "RunMode execution is model-dependent and remains explicitly gated.",
         ],
     }
 
 
-async def _execute_task_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+async def _execute_task_job(
+    core: Any,
+    arguments: Dict[str, Any],
+    record: Optional[RunModeJobRecord] = None,
+) -> Dict[str, Any]:
     """Execute one project task through the same RunMode path as the web route."""
     from penguin.run_mode import RunMode
     from penguin.system.execution_context import (
@@ -227,11 +310,14 @@ async def _execute_task_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, A
         return {"status": "error", "message": f"Task {task_id} not found"}
 
     project = None
-    if getattr(task, "project_id", None) and hasattr(project_manager, "get_project_async"):
+    if getattr(task, "project_id", None) and hasattr(
+        project_manager,
+        "get_project_async",
+    ):
         project = await project_manager.get_project_async(task.project_id)
-    resolved_directory = normalize_directory(arguments.get("directory")) or normalize_directory(
-        getattr(project, "workspace_path", None)
-    )
+    resolved_directory = normalize_directory(
+        arguments.get("directory")
+    ) or normalize_directory(getattr(project, "workspace_path", None))
     session_id = arguments.get("session_id")
     execution_context = ExecutionContext(
         session_id=session_id,
@@ -243,6 +329,8 @@ async def _execute_task_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, A
     )
 
     run_mode = RunMode(core=core)
+    if record is not None:
+        record.cancel_callback = lambda: _request_runmode_shutdown(run_mode)
     with execution_context_scope(execution_context):
         result = await run_mode.start(
             name=task.title,
@@ -266,7 +354,11 @@ async def _execute_task_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, A
     }
 
 
-async def _execute_project_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+async def _execute_project_job(
+    core: Any,
+    arguments: Dict[str, Any],
+    record: Optional[RunModeJobRecord] = None,
+) -> Dict[str, Any]:
     """Execute project-scoped RunMode through the web service path."""
     from penguin.web.services.projects import start_project_execution
 
@@ -281,6 +373,13 @@ async def _execute_project_job(core: Any, arguments: Dict[str, Any]) -> Dict[str
             "message": "project_id, project_identifier, or project_name is required",
         }
 
+    if record is not None:
+        record.metadata["cancel_signal_note"] = (
+            "Project execution uses the web service path; cancellation can be "
+            "recorded but may not stop the underlying run until RunMode exposes "
+            "a shared cancellation handle."
+        )
+
     result = await start_project_execution(
         core=core,
         project_identifier=str(project_identifier),
@@ -290,6 +389,79 @@ async def _execute_project_job(core: Any, arguments: Dict[str, Any]) -> Dict[str
         directory=arguments.get("directory"),
     )
     return {"status": "completed", "execution": result}
+
+
+def _request_runmode_shutdown(run_mode: Any) -> bool:
+    """Request cooperative shutdown on a RunMode instance."""
+    setattr(run_mode, "_shutdown_requested", True)
+    setattr(run_mode, "_interrupted", True)
+    return True
+
+
+async def _resume_clarification_job(
+    core: Any,
+    arguments: Dict[str, Any],
+    record: Optional[RunModeJobRecord] = None,
+) -> Dict[str, Any]:
+    """Answer the latest clarification request and resume task execution."""
+    from penguin.run_mode import RunMode
+    from penguin.system.execution_context import (
+        ExecutionContext,
+        execution_context_scope,
+        normalize_directory,
+    )
+
+    task_id = arguments.get("task_id")
+    answer = arguments.get("answer")
+    if not task_id:
+        return {"status": "error", "message": "task_id is required"}
+    if not answer:
+        return {"status": "error", "message": "answer is required"}
+
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return {"status": "error", "message": "Project manager not available"}
+
+    task = await project_manager.get_task_async(str(task_id))
+    if not task:
+        return {"status": "error", "message": f"Task {task_id} not found"}
+
+    project = None
+    if getattr(task, "project_id", None) and hasattr(
+        project_manager,
+        "get_project_async",
+    ):
+        project = await project_manager.get_project_async(task.project_id)
+    resolved_directory = normalize_directory(
+        arguments.get("directory")
+    ) or normalize_directory(getattr(project, "workspace_path", None))
+    session_id = arguments.get("session_id")
+    execution_context = ExecutionContext(
+        session_id=session_id,
+        conversation_id=session_id,
+        directory=resolved_directory,
+        project_root=resolved_directory,
+        workspace_root=resolved_directory,
+        request_id=f"mcp-task-resume:{task_id}",
+    )
+
+    run_mode = RunMode(core=core)
+    if record is not None:
+        record.cancel_callback = lambda: _request_runmode_shutdown(run_mode)
+    with execution_context_scope(execution_context):
+        result = await run_mode.resume_with_clarification(
+            task_id=str(task_id),
+            answer=str(answer),
+            answered_by=arguments.get("answered_by"),
+        )
+
+    updated_task = await project_manager.get_task_async(str(task_id))
+    return {
+        "status": _job_status_from_result(result if isinstance(result, dict) else {}),
+        "task_id": str(task_id),
+        "result": result,
+        "task": serialize_task_payload(updated_task or task),
+    }
 
 
 def build_runmode_tools(
@@ -337,10 +509,34 @@ def build_runmode_tools(
             return {"error": "missing_task_id", "message": "task_id is required."}
         return job_registry.start_job(
             kind="task",
-            runner=lambda _job: _execute_task_job(core, arguments),
+            runner=lambda job: _execute_task_job(core, arguments, job),
             task_id=str(task_id),
             project_id=arguments.get("project_id"),
             metadata={
+                "session_id": arguments.get("session_id"),
+                "directory": arguments.get("directory"),
+            },
+        )
+
+    def cancel_job(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        job_id = arguments.get("job_id")
+        if not job_id:
+            return {"error": "missing_job_id", "message": "job_id is required."}
+        return job_registry.cancel_job(str(job_id), reason=arguments.get("reason"))
+
+    def resume_clarification(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        task_id = arguments.get("task_id")
+        if not task_id:
+            return {"error": "missing_task_id", "message": "task_id is required."}
+        if not arguments.get("answer"):
+            return {"error": "missing_answer", "message": "answer is required."}
+        return job_registry.start_job(
+            kind="clarification_resume",
+            runner=lambda job: _resume_clarification_job(core, arguments, job),
+            task_id=str(task_id),
+            project_id=arguments.get("project_id"),
+            metadata={
+                "answered_by": arguments.get("answered_by"),
                 "session_id": arguments.get("session_id"),
                 "directory": arguments.get("directory"),
             },
@@ -359,7 +555,7 @@ def build_runmode_tools(
             }
         return job_registry.start_job(
             kind="project",
-            runner=lambda _job: _execute_project_job(core, arguments),
+            runner=lambda job: _execute_project_job(core, arguments, job),
             project_id=str(project_identifier),
             metadata={
                 "continuous": bool(arguments.get("continuous", False)),
@@ -385,7 +581,10 @@ def build_runmode_tools(
             input_schema={
                 "type": "object",
                 "properties": {
-                    "status": {"type": "string", "description": "Optional status filter."},
+                    "status": {
+                        "type": "string",
+                        "description": "Optional status filter.",
+                    },
                     "project_id": {
                         "type": "string",
                         "description": "Optional project ID filter.",
@@ -405,7 +604,10 @@ def build_runmode_tools(
             input_schema={
                 "type": "object",
                 "properties": {
-                    "job_id": {"type": "string", "description": "Runtime MCP job ID."}
+                    "job_id": {
+                        "type": "string",
+                        "description": "Runtime MCP job ID.",
+                    }
                 },
                 "required": ["job_id"],
             },
@@ -479,6 +681,63 @@ def build_runmode_tools(
                 "required": [],
             },
             handler=start_project,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_cancel_job",
+            description=(
+                "Request cooperative cancellation for a runtime MCP job. This is "
+                "best-effort and cannot force-kill Python threads."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "job_id": {
+                        "type": "string",
+                        "description": "Runtime MCP job ID.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Optional cancellation reason.",
+                    },
+                },
+                "required": ["job_id"],
+            },
+            handler=cancel_job,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_resume_clarification",
+            description=(
+                "Answer a task's latest open clarification request and resume "
+                "execution in a background job."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "task_id": {"type": "string", "description": "Project task ID."},
+                    "answer": {
+                        "type": "string",
+                        "description": "Answer to the latest open clarification request.",
+                    },
+                    "answered_by": {
+                        "type": "string",
+                        "description": "Optional actor/user answering the clarification.",
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Optional project ID for metadata/filtering.",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional Penguin session/conversation ID.",
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": "Optional execution directory override.",
+                    },
+                },
+                "required": ["task_id", "answer"],
+            },
+            handler=resume_clarification,
         ),
     ]
 

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -6,7 +6,7 @@ import asyncio
 import threading
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
@@ -26,8 +26,8 @@ class RunModeJobRecord:
     status: str = "pending"
     project_id: Optional[str] = None
     task_id: Optional[str] = None
-    started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
-    updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     finished_at: Optional[str] = None
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
@@ -194,7 +194,7 @@ class RunModeJobRegistry:
                     "registry": self.summary(),
                 }
             record.cancel_requested = True
-            record.cancel_requested_at = datetime.utcnow().isoformat()
+            record.cancel_requested_at = datetime.now(timezone.utc).isoformat()
             record.updated_at = record.cancel_requested_at
             record.metadata["cancel_reason"] = reason
             record.status = "cancel_requested"
@@ -257,7 +257,7 @@ class RunModeJobRegistry:
         with self._lock:
             record = self._jobs[job_id]
             record.status = "running"
-            record.updated_at = datetime.utcnow().isoformat()
+            record.updated_at = datetime.now(timezone.utc).isoformat()
         self._persist(record)
         try:
             result = asyncio.run(runner(record))
@@ -267,7 +267,7 @@ class RunModeJobRegistry:
                 if record.cancel_requested and mapped_status == "completed":
                     record.metadata["completed_after_cancel_requested"] = True
                 record.status = mapped_status
-                record.finished_at = datetime.utcnow().isoformat()
+                record.finished_at = datetime.now(timezone.utc).isoformat()
                 record.updated_at = record.finished_at
                 record.cancel_callback = None
             self._persist(record)
@@ -275,7 +275,7 @@ class RunModeJobRegistry:
             with self._lock:
                 record.status = "failed"
                 record.error = str(exc)
-                record.finished_at = datetime.utcnow().isoformat()
+                record.finished_at = datetime.now(timezone.utc).isoformat()
                 record.updated_at = record.finished_at
                 record.cancel_callback = None
             self._persist(record)
@@ -350,7 +350,7 @@ class RunModeJobRegistry:
             status=status,
             project_id=project_id,
             task_id=task_id,
-            limit=100,
+            limit=None,
         )
         payloads = []
         for record in records:
@@ -380,7 +380,7 @@ class RunModeJobRegistry:
         record.cancel_requested = True
         record.cancel_reason = reason
         record.status = "cancel_requested"
-        record.updated_at = datetime.utcnow().isoformat()
+        record.updated_at = datetime.now(timezone.utc).isoformat()
         record.metadata["cancel_request_without_live_handle"] = True
         self.project_manager.upsert_runtime_job(record)
 
@@ -555,7 +555,40 @@ async def _execute_project_job(
         session_id=arguments.get("session_id"),
         directory=arguments.get("directory"),
     )
-    return {"status": "completed", "execution": result}
+    payload = result if isinstance(result, dict) else {"result": result}
+    status = _job_status_from_result(payload)
+    if status == "completed":
+        raw_status = str(payload.get("status") or "").lower()
+        if raw_status in {"error", "failed", "failure"}:
+            status = "failed"
+    return {"status": status, "execution": payload}
+
+
+def _resolve_project_id(core: Any, project_identifier: str) -> Optional[str]:
+    """Resolve a project identifier/name to a canonical project ID when possible."""
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return None
+    get_project = getattr(project_manager, "get_project", None)
+    project = get_project(project_identifier) if callable(get_project) else None
+    if project is not None:
+        return project.id
+    get_by_name = getattr(project_manager, "get_project_by_name", None)
+    if callable(get_by_name):
+        project = get_by_name(project_identifier)
+        if project is not None:
+            return project.id
+    return None
+
+
+def _resolve_task_project_id(core: Any, task_id: str) -> Optional[str]:
+    """Resolve the project ID for a task when ProjectManager is available."""
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return None
+    get_task = getattr(project_manager, "get_task", None)
+    task = get_task(task_id) if callable(get_task) else None
+    return getattr(task, "project_id", None) if task is not None else None
 
 
 def _request_runmode_shutdown(run_mode: Any) -> bool:
@@ -675,12 +708,14 @@ def build_runmode_tools(
         task_id = arguments.get("task_id")
         if not task_id:
             return {"error": "missing_task_id", "message": "task_id is required."}
+        canonical_project_id = _resolve_task_project_id(core, str(task_id)) or arguments.get("project_id")
         return job_registry.start_job(
             kind="task",
             runner=lambda job: _execute_task_job(core, arguments, job),
             task_id=str(task_id),
-            project_id=arguments.get("project_id"),
+            project_id=canonical_project_id,
             metadata={
+                "project_lookup": arguments.get("project_id"),
                 "session_id": arguments.get("session_id"),
                 "directory": arguments.get("directory"),
             },
@@ -698,12 +733,14 @@ def build_runmode_tools(
             return {"error": "missing_task_id", "message": "task_id is required."}
         if not arguments.get("answer"):
             return {"error": "missing_answer", "message": "answer is required."}
+        canonical_project_id = _resolve_task_project_id(core, str(task_id)) or arguments.get("project_id")
         return job_registry.start_job(
             kind="clarification_resume",
             runner=lambda job: _resume_clarification_job(core, arguments, job),
             task_id=str(task_id),
-            project_id=arguments.get("project_id"),
+            project_id=canonical_project_id,
             metadata={
+                "project_lookup": arguments.get("project_id"),
                 "answered_by": arguments.get("answered_by"),
                 "session_id": arguments.get("session_id"),
                 "directory": arguments.get("directory"),
@@ -721,11 +758,13 @@ def build_runmode_tools(
                 "error": "missing_project_identifier",
                 "message": "project_id, project_identifier, or project_name is required.",
             }
+        canonical_project_id = _resolve_project_id(core, str(project_identifier)) or str(project_identifier)
         return job_registry.start_job(
             kind="project",
             runner=lambda job: _execute_project_job(core, arguments, job),
-            project_id=str(project_identifier),
+            project_id=canonical_project_id,
             metadata={
+                "project_lookup": str(project_identifier),
                 "continuous": bool(arguments.get("continuous", False)),
                 "time_limit": arguments.get("time_limit"),
                 "session_id": arguments.get("session_id"),

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -1,17 +1,21 @@
-"""RunMode readiness tools for Penguin's MCP server surface."""
+"""RunMode tools for Penguin's MCP server surface."""
 
 from __future__ import annotations
 
+import asyncio
+import threading
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
 
 from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.web.services.project_payloads import serialize_task_payload
 
 
 @dataclass
 class RunModeJobRecord:
-    """In-process runtime job record for future RunMode start/cancel tools."""
+    """In-process runtime job record for MCP-triggered RunMode work."""
 
     job_id: str
     kind: str
@@ -32,12 +36,46 @@ class RunModeJobRecord:
 class RunModeJobRegistry:
     """Small in-process registry for runtime MCP jobs.
 
-    Slice 3A only exposes read/capability methods. Start/cancel tools can use this
-    registry in later slices instead of inventing a second status model.
+    The registry intentionally starts jobs in daemon threads and records final
+    results/errors. This is not durable across process restarts; it is an MVP
+    control-plane handle so MCP clients do not block on model-dependent runs.
     """
 
     def __init__(self) -> None:
         self._jobs: Dict[str, RunModeJobRecord] = {}
+        self._threads: Dict[str, threading.Thread] = {}
+        self._lock = threading.RLock()
+
+    def start_job(
+        self,
+        *,
+        kind: str,
+        runner: Callable[[RunModeJobRecord], Awaitable[Dict[str, Any]]],
+        project_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Start a background job and return its initial record."""
+        record = RunModeJobRecord(
+            job_id=str(uuid.uuid4()),
+            kind=kind,
+            project_id=project_id,
+            task_id=task_id,
+            metadata=dict(metadata or {}),
+        )
+        with self._lock:
+            self._jobs[record.job_id] = record
+
+        thread = threading.Thread(
+            target=self._run_job_thread,
+            args=(record.job_id, runner),
+            name=f"penguin-mcp-runmode-{record.job_id[:8]}",
+            daemon=True,
+        )
+        with self._lock:
+            self._threads[record.job_id] = thread
+        thread.start()
+        return {"job": record.to_dict(), "registry": self.summary()}
 
     def list_jobs(
         self,
@@ -47,7 +85,8 @@ class RunModeJobRegistry:
         task_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """List job records with optional filters."""
-        jobs: Iterable[RunModeJobRecord] = self._jobs.values()
+        with self._lock:
+            jobs: Iterable[RunModeJobRecord] = list(self._jobs.values())
         if status:
             jobs = [job for job in jobs if job.status == status]
         if project_id:
@@ -58,18 +97,58 @@ class RunModeJobRegistry:
 
     def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
         """Return one job record if known."""
-        job = self._jobs.get(job_id)
-        return job.to_dict() if job else None
+        with self._lock:
+            job = self._jobs.get(job_id)
+            return job.to_dict() if job else None
 
     def summary(self) -> Dict[str, Any]:
         """Return registry metadata."""
+        with self._lock:
+            job_count = len(self._jobs)
+            running_count = sum(
+                1 for job in self._jobs.values() if job.status == "running"
+            )
         return {
             "type": "in_process",
-            "job_count": len(self._jobs),
-            "supports_start": False,
+            "job_count": job_count,
+            "running_count": running_count,
+            "supports_start": True,
             "supports_cancel": False,
             "durable": False,
         }
+
+    def _run_job_thread(
+        self,
+        job_id: str,
+        runner: Callable[[RunModeJobRecord], Awaitable[Dict[str, Any]]],
+    ) -> None:
+        """Run one async job in a dedicated thread."""
+        with self._lock:
+            record = self._jobs[job_id]
+            record.status = "running"
+        try:
+            result = asyncio.run(runner(record))
+            with self._lock:
+                record.result = result
+                record.status = _job_status_from_result(result)
+                record.finished_at = datetime.utcnow().isoformat()
+        except Exception as exc:  # pragma: no cover - defensive job boundary
+            with self._lock:
+                record.status = "failed"
+                record.error = str(exc)
+                record.finished_at = datetime.utcnow().isoformat()
+
+
+def _job_status_from_result(result: Dict[str, Any]) -> str:
+    """Map a runtime result payload to job status."""
+    status = str(result.get("status") or result.get("completion_type") or "").lower()
+    if status in {"error", "failed", "failure"}:
+        return "failed"
+    if status in {"cancelled", "canceled"}:
+        return "cancelled"
+    if status in {"waiting_input", "clarification_needed", "needs_input"}:
+        return "waiting_input"
+    return "completed"
 
 
 def _core_capabilities(core: Any) -> Dict[str, Any]:
@@ -94,43 +173,130 @@ def _capabilities_payload(
     core: Any,
     registry: RunModeJobRegistry,
 ) -> Dict[str, Any]:
-    """Build the Slice 3A capabilities payload."""
-    core_info = _core_capabilities(core)
+    """Build the Slice 3B capabilities payload."""
     return {
         "runtime_tools_enabled": True,
-        "slice": "3A",
+        "slice": "3B",
         "tools": {
             "available": [
                 "penguin_runmode_capabilities",
                 "penguin_runmode_list_jobs",
                 "penguin_runmode_get_job",
-            ],
-            "not_yet_exposed": [
                 "penguin_runmode_start_task",
                 "penguin_runmode_start_project",
+            ],
+            "not_yet_exposed": [
                 "penguin_runmode_cancel_job",
                 "penguin_runmode_resume_clarification",
             ],
         },
-        "start_supported": False,
+        "start_supported": True,
         "cancel_supported": False,
         "resume_clarification_supported": False,
         "registry": registry.summary(),
-        "core": core_info,
+        "core": _core_capabilities(core),
         "gaps": [
-            "No MCP background job start tool is exposed in Slice 3A.",
-            "No durable job registry exists yet; current registry is in-process only.",
+            "Job registry is in-process only and is lost on server restart.",
             "Cancellation semantics are not exposed until Slice 3C.",
-            "RunMode execution remains model-dependent and explicitly gated.",
+            "RunMode execution is model-dependent and remains explicitly gated.",
         ],
     }
+
+
+async def _execute_task_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute one project task through the same RunMode path as the web route."""
+    from penguin.run_mode import RunMode
+    from penguin.system.execution_context import (
+        ExecutionContext,
+        execution_context_scope,
+        normalize_directory,
+    )
+
+    task_id = arguments.get("task_id")
+    if not task_id:
+        return {"status": "error", "message": "task_id is required"}
+
+    project_manager = getattr(core, "project_manager", None)
+    if project_manager is None:
+        return {"status": "error", "message": "Project manager not available"}
+    if not getattr(core, "engine", None):
+        return {"status": "error", "message": "Engine layer not available"}
+
+    task = await project_manager.get_task_async(str(task_id))
+    if not task:
+        return {"status": "error", "message": f"Task {task_id} not found"}
+
+    project = None
+    if getattr(task, "project_id", None) and hasattr(project_manager, "get_project_async"):
+        project = await project_manager.get_project_async(task.project_id)
+    resolved_directory = normalize_directory(arguments.get("directory")) or normalize_directory(
+        getattr(project, "workspace_path", None)
+    )
+    session_id = arguments.get("session_id")
+    execution_context = ExecutionContext(
+        session_id=session_id,
+        conversation_id=session_id,
+        directory=resolved_directory,
+        project_root=resolved_directory,
+        workspace_root=resolved_directory,
+        request_id=f"mcp-task-execute:{task_id}",
+    )
+
+    run_mode = RunMode(core=core)
+    with execution_context_scope(execution_context):
+        result = await run_mode.start(
+            name=task.title,
+            description=task.description,
+            context={
+                "task_id": task.id,
+                "project_id": task.project_id,
+                "priority": task.priority,
+                "session_id": session_id,
+                "conversation_id": session_id,
+                "directory": resolved_directory,
+            },
+        )
+
+    updated_task = await project_manager.get_task_async(task.id)
+    return {
+        "status": _job_status_from_result(result if isinstance(result, dict) else {}),
+        "task_id": task.id,
+        "result": result,
+        "task": serialize_task_payload(updated_task or task),
+    }
+
+
+async def _execute_project_job(core: Any, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute project-scoped RunMode through the web service path."""
+    from penguin.web.services.projects import start_project_execution
+
+    project_identifier = (
+        arguments.get("project_id")
+        or arguments.get("project_identifier")
+        or arguments.get("project_name")
+    )
+    if not project_identifier:
+        return {
+            "status": "error",
+            "message": "project_id, project_identifier, or project_name is required",
+        }
+
+    result = await start_project_execution(
+        core=core,
+        project_identifier=str(project_identifier),
+        continuous=bool(arguments.get("continuous", False)),
+        time_limit=arguments.get("time_limit"),
+        session_id=arguments.get("session_id"),
+        directory=arguments.get("directory"),
+    )
+    return {"status": "completed", "execution": result}
 
 
 def build_runmode_tools(
     core: Any,
     registry: Optional[RunModeJobRegistry] = None,
 ) -> List[MCPServerTool]:
-    """Build runtime readiness tools for Penguin's MCP server."""
+    """Build runtime tools for Penguin's MCP server."""
     job_registry = registry or RunModeJobRegistry()
 
     def capabilities(_arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -165,29 +331,61 @@ def build_runmode_tools(
             }
         return {"job": job, "registry": job_registry.summary()}
 
+    def start_task(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        task_id = arguments.get("task_id")
+        if not task_id:
+            return {"error": "missing_task_id", "message": "task_id is required."}
+        return job_registry.start_job(
+            kind="task",
+            runner=lambda _job: _execute_task_job(core, arguments),
+            task_id=str(task_id),
+            project_id=arguments.get("project_id"),
+            metadata={
+                "session_id": arguments.get("session_id"),
+                "directory": arguments.get("directory"),
+            },
+        )
+
+    def start_project(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        project_identifier = (
+            arguments.get("project_id")
+            or arguments.get("project_identifier")
+            or arguments.get("project_name")
+        )
+        if not project_identifier:
+            return {
+                "error": "missing_project_identifier",
+                "message": "project_id, project_identifier, or project_name is required.",
+            }
+        return job_registry.start_job(
+            kind="project",
+            runner=lambda _job: _execute_project_job(core, arguments),
+            project_id=str(project_identifier),
+            metadata={
+                "continuous": bool(arguments.get("continuous", False)),
+                "time_limit": arguments.get("time_limit"),
+                "session_id": arguments.get("session_id"),
+                "directory": arguments.get("directory"),
+            },
+        )
+
     return [
         MCPServerTool(
             name="penguin_runmode_capabilities",
             description=(
-                "Report current Penguin RunMode MCP readiness and known gaps. "
-                "This does not start execution."
+                "Report current Penguin RunMode MCP readiness, job registry, "
+                "and known gaps. This does not start execution."
             ),
             input_schema={"type": "object", "properties": {}, "required": []},
             handler=capabilities,
         ),
         MCPServerTool(
             name="penguin_runmode_list_jobs",
-            description=(
-                "List in-process RunMode MCP jobs. Slice 3A exposes an empty "
-                "read-only registry until start tools are implemented."
-            ),
+            description="List in-process RunMode MCP jobs with optional filters.",
             input_schema={
                 "type": "object",
                 "properties": {
-                    "status": {
-                        "type": "string",
-                        "description": "Optional job status filter.",
-                    },
+                    "status": {"type": "string", "description": "Optional status filter."},
                     "project_id": {
                         "type": "string",
                         "description": "Optional project ID filter.",
@@ -207,14 +405,80 @@ def build_runmode_tools(
             input_schema={
                 "type": "object",
                 "properties": {
-                    "job_id": {
-                        "type": "string",
-                        "description": "Runtime MCP job ID.",
-                    }
+                    "job_id": {"type": "string", "description": "Runtime MCP job ID."}
                 },
                 "required": ["job_id"],
             },
             handler=get_job,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_start_task",
+            description=(
+                "Start one project task in background RunMode. Requires runtime "
+                "tools opt-in and returns a job_id immediately."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "task_id": {"type": "string", "description": "Project task ID."},
+                    "project_id": {
+                        "type": "string",
+                        "description": "Optional project ID for filtering/metadata.",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional Penguin session/conversation ID.",
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": "Optional execution directory override.",
+                    },
+                },
+                "required": ["task_id"],
+            },
+            handler=start_task,
+        ),
+        MCPServerTool(
+            name="penguin_runmode_start_project",
+            description=(
+                "Start project-scoped RunMode execution in a background job. "
+                "Requires runtime tools opt-in and returns a job_id immediately."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "project_id": {
+                        "type": "string",
+                        "description": "Project ID to execute.",
+                    },
+                    "project_identifier": {
+                        "type": "string",
+                        "description": "Project ID or exact project name.",
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "description": "Exact project name fallback.",
+                    },
+                    "continuous": {
+                        "type": "boolean",
+                        "description": "Whether to run project execution continuously.",
+                    },
+                    "time_limit": {
+                        "type": "integer",
+                        "description": "Optional time limit in minutes.",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional Penguin session/conversation ID.",
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": "Optional execution directory override.",
+                    },
+                },
+                "required": [],
+            },
+            handler=start_project,
         ),
     ]
 

--- a/penguin/integrations/mcp/server_tools/runmode.py
+++ b/penguin/integrations/mcp/server_tools/runmode.py
@@ -394,7 +394,9 @@ def _job_status_from_result(result: Dict[str, Any]) -> str:
         return "cancelled"
     if status in {"waiting_input", "clarification_needed", "needs_input"}:
         return "waiting_input"
-    return "completed"
+    if status in {"completed", "complete", "success", "succeeded", "done"}:
+        return "completed"
+    return status or "unknown"
 
 
 def _core_capabilities(core: Any) -> Dict[str, Any]:

--- a/penguin/integrations/mcp/server_tools/sessions.py
+++ b/penguin/integrations/mcp/server_tools/sessions.py
@@ -1,0 +1,312 @@
+"""Session, artifact, and checkpoint read tools for Penguin's MCP server."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from penguin.integrations.mcp.server_tools.base import MCPServerTool
+from penguin.web.services.session_view import (
+    get_session_info,
+    get_session_messages,
+    list_session_infos,
+)
+
+
+_TEXT_PREVIEW_LIMIT = 500
+_DEFAULT_MESSAGE_LIMIT = 20
+_DEFAULT_LIST_LIMIT = 50
+
+
+def build_session_tools(core: Any) -> List[MCPServerTool]:
+    """Build default-on session/context/evidence read tools."""
+    if core is None:
+        return []
+
+    def list_sessions(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        limit = _positive_int(arguments.get("limit"), default=_DEFAULT_LIST_LIMIT)
+        sessions = list_session_infos(
+            core,
+            limit=limit,
+            search=_optional_str(arguments.get("search")),
+            directory=_optional_str(arguments.get("directory")),
+            roots=bool(arguments.get("roots", False)),
+        )
+        return {"sessions": sessions, "count": len(sessions)}
+
+    def session_summary(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        session_id = _optional_str(arguments.get("session_id"))
+        if not session_id:
+            return {"error": "missing_session_id", "message": "session_id is required."}
+
+        info = get_session_info(core, session_id)
+        if info is None:
+            return {
+                "error": "session_not_found",
+                "session_id": session_id,
+                "message": "No Penguin session exists with this ID.",
+            }
+
+        message_limit = _positive_int(
+            arguments.get("message_limit"),
+            default=_DEFAULT_MESSAGE_LIMIT,
+        )
+        messages = get_session_messages(core, session_id, limit=message_limit) or []
+        preview = [_message_preview(row) for row in messages]
+        return {
+            "session": info,
+            "message_count_returned": len(preview),
+            "message_limit": message_limit,
+            "messages_preview": preview,
+            "summary": _compact_session_summary(info, preview),
+        }
+
+    def artifacts_list(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        project_manager = getattr(core, "project_manager", None)
+        if project_manager is None:
+            return {
+                "error": "project_manager_unavailable",
+                "message": "Project manager is not available.",
+            }
+
+        task_id = _optional_str(arguments.get("task_id"))
+        project_id = _optional_str(arguments.get("project_id"))
+        artifact_key = _optional_str(arguments.get("artifact_key"))
+        valid_only = bool(arguments.get("valid_only", False))
+        limit = _positive_int(arguments.get("limit"), default=_DEFAULT_LIST_LIMIT)
+
+        if task_id:
+            task = project_manager.get_task(task_id)
+            tasks = [task] if task is not None else []
+        else:
+            tasks = project_manager.list_tasks(project_id=project_id)
+
+        artifacts: List[Dict[str, Any]] = []
+        for task in tasks:
+            if task is None:
+                continue
+            for artifact in getattr(task, "artifact_evidence", []) or []:
+                payload = _artifact_to_dict(artifact)
+                payload_key = payload.get("artifact_key") or payload.get("key")
+                if artifact_key and payload_key != artifact_key:
+                    continue
+                if valid_only and not bool(payload.get("valid")):
+                    continue
+                if "artifact_key" not in payload and payload_key is not None:
+                    payload["artifact_key"] = payload_key
+                payload["task_id"] = getattr(task, "id", None)
+                payload["task_title"] = getattr(task, "title", None)
+                payload["project_id"] = getattr(task, "project_id", None)
+                artifacts.append(payload)
+                if len(artifacts) >= limit:
+                    return {"artifacts": artifacts, "count": len(artifacts)}
+
+        return {"artifacts": artifacts, "count": len(artifacts)}
+
+    def checkpoints_list(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        session_id = _optional_str(arguments.get("session_id"))
+        checkpoint_type = _optional_str(arguments.get("checkpoint_type"))
+        limit = _positive_int(arguments.get("limit"), default=_DEFAULT_LIST_LIMIT)
+
+        if not hasattr(core, "list_checkpoints"):
+            return {
+                "error": "checkpoints_unavailable",
+                "message": "Checkpoint listing is not available on this core.",
+            }
+
+        checkpoints = core.list_checkpoints(session_id=session_id, limit=limit)
+        if checkpoint_type:
+            checkpoints = [
+                item for item in checkpoints if str(item.get("type")) == checkpoint_type
+            ]
+        stats = core.get_checkpoint_stats() if hasattr(core, "get_checkpoint_stats") else {}
+        return {
+            "checkpoints": checkpoints,
+            "count": len(checkpoints),
+            "stats": stats,
+        }
+
+    return [
+        MCPServerTool(
+            name="penguin_session_list",
+            description="List Penguin sessions in a compact OpenCode-compatible shape.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum sessions to return. Defaults to 50.",
+                    },
+                    "search": {
+                        "type": "string",
+                        "description": "Optional case-insensitive title search.",
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": "Optional directory filter.",
+                    },
+                    "roots": {
+                        "type": "boolean",
+                        "description": "When true, only return root sessions.",
+                    },
+                },
+                "required": [],
+            },
+            handler=list_sessions,
+        ),
+        MCPServerTool(
+            name="penguin_session_summary",
+            description=(
+                "Return one Penguin session with compact recent message previews. "
+                "This is read-only and does not call a model."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string", "description": "Session ID."},
+                    "message_limit": {
+                        "type": "integer",
+                        "description": "Recent messages to include. Defaults to 20.",
+                    },
+                },
+                "required": ["session_id"],
+            },
+            handler=session_summary,
+        ),
+        MCPServerTool(
+            name="penguin_artifacts_list",
+            description="List task artifact evidence from Penguin project storage.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "project_id": {
+                        "type": "string",
+                        "description": "Optional project ID filter.",
+                    },
+                    "task_id": {
+                        "type": "string",
+                        "description": "Optional task ID filter.",
+                    },
+                    "artifact_key": {
+                        "type": "string",
+                        "description": "Optional artifact key filter.",
+                    },
+                    "valid_only": {
+                        "type": "boolean",
+                        "description": "Only include valid artifact evidence.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum artifacts to return. Defaults to 50.",
+                    },
+                },
+                "required": [],
+            },
+            handler=artifacts_list,
+        ),
+        MCPServerTool(
+            name="penguin_checkpoints_list",
+            description="List Penguin conversation checkpoints and checkpoint stats.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional session ID filter.",
+                    },
+                    "checkpoint_type": {
+                        "type": "string",
+                        "description": "Optional checkpoint type filter.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum checkpoints to return. Defaults to 50.",
+                    },
+                },
+                "required": [],
+            },
+            handler=checkpoints_list,
+        ),
+    ]
+
+
+def _message_preview(row: Dict[str, Any]) -> Dict[str, Any]:
+    info = row.get("info") if isinstance(row, dict) else {}
+    info = info if isinstance(info, dict) else {}
+    role = str(info.get("role") or "unknown")
+    message_id = str(info.get("id") or "")
+    text = _extract_text(row.get("parts") if isinstance(row, dict) else [])
+    return {
+        "id": message_id,
+        "role": role,
+        "text_preview": _truncate(text, _TEXT_PREVIEW_LIMIT),
+    }
+
+
+def _compact_session_summary(
+    info: Dict[str, Any],
+    preview: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    last_user = next(
+        (
+            item.get("text_preview")
+            for item in reversed(preview)
+            if item.get("role") == "user" and item.get("text_preview")
+        ),
+        None,
+    )
+    return {
+        "session_id": info.get("id"),
+        "title": info.get("title"),
+        "directory": info.get("directory"),
+        "updated": (info.get("time") or {}).get("updated")
+        if isinstance(info.get("time"), dict)
+        else None,
+        "last_user_message_preview": last_user,
+    }
+
+
+def _extract_text(parts: Any) -> str:
+    if not isinstance(parts, list):
+        return ""
+    chunks: List[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if str(part.get("type", "")).lower() != "text":
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text.strip():
+            chunks.append(" ".join(text.split()))
+    return "\n".join(chunks)
+
+
+def _artifact_to_dict(artifact: Any) -> Dict[str, Any]:
+    if hasattr(artifact, "to_dict"):
+        return artifact.to_dict()
+    if isinstance(artifact, dict):
+        return dict(artifact)
+    return {"raw": str(artifact)}
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit].rstrip() + "…"
+
+
+__all__ = ["build_session_tools"]

--- a/penguin/project/__init__.py
+++ b/penguin/project/__init__.py
@@ -35,6 +35,7 @@ Example Usage:
 
 from .manager import ProjectManager
 from .models import Project, Task, TaskStatus, TaskEvent, ExecutionRecord
+from .runtime_jobs import RuntimeJobRecord
 from .storage import ProjectStorage
 from .exceptions import ProjectError, TaskError, ValidationError
 
@@ -48,6 +49,7 @@ __all__ = [
     "TaskStatus",
     "TaskEvent", 
     "ExecutionRecord",
+    "RuntimeJobRecord",
     
     # Storage
     "ProjectStorage",

--- a/penguin/project/manager.py
+++ b/penguin/project/manager.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
 
@@ -20,10 +20,8 @@ from .models import (
     Blueprint,
     BlueprintItem,
     DependencyPolicy,
-    ExecutionRecord,
     ExecutionResult,
     Project,
-    StateTransition,
     Task,
     TaskDependency,
     TaskPhase,
@@ -32,7 +30,7 @@ from .models import (
 from .storage import ProjectStorage
 from .runtime_jobs import RuntimeJobRecord
 from .exceptions import (
-    ProjectError, TaskError, ValidationError, ProjectNotFoundError, 
+    ProjectError, ValidationError, ProjectNotFoundError, 
     TaskNotFoundError, StateTransitionError, DependencyError
 )
 
@@ -991,7 +989,7 @@ class ProjectManager:
         Returns:
             List of ready tasks, sorted by tie-breakers.
         """
-        dag = self.build_dag(project_id)
+        self.build_dag(project_id)
         tasks = self.list_tasks(project_id)
         task_map = {t.id: t for t in tasks}
         

--- a/penguin/project/manager.py
+++ b/penguin/project/manager.py
@@ -30,6 +30,7 @@ from .models import (
     TaskStatus,
 )
 from .storage import ProjectStorage
+from .runtime_jobs import RuntimeJobRecord
 from .exceptions import (
     ProjectError, TaskError, ValidationError, ProjectNotFoundError, 
     TaskNotFoundError, StateTransitionError, DependencyError
@@ -89,6 +90,32 @@ class ProjectManager:
         
         logger.info(f"ProjectManager initialized with workspace: {workspace_path}")
     
+    # ==================== Runtime Job Operations ====================
+
+    def upsert_runtime_job(self, record: RuntimeJobRecord) -> None:
+        """Create or update a durable runtime job record."""
+        self.storage.upsert_runtime_job(record)
+
+    def get_runtime_job(self, job_id: str) -> Optional[RuntimeJobRecord]:
+        """Return a durable runtime job record by ID."""
+        return self.storage.get_runtime_job(job_id)
+
+    def list_runtime_jobs(
+        self,
+        *,
+        status: Optional[str] = None,
+        project_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[RuntimeJobRecord]:
+        """List durable runtime job records with optional filters."""
+        return self.storage.list_runtime_jobs(
+            status=status,
+            project_id=project_id,
+            task_id=task_id,
+            limit=limit,
+        )
+
     # ==================== Project Operations ====================
     
     def create_project(

--- a/penguin/project/manager.py
+++ b/penguin/project/manager.py
@@ -104,7 +104,7 @@ class ProjectManager:
         status: Optional[str] = None,
         project_id: Optional[str] = None,
         task_id: Optional[str] = None,
-        limit: int = 50,
+        limit: Optional[int] = 50,
     ) -> List[RuntimeJobRecord]:
         """List durable runtime job records with optional filters."""
         return self.storage.list_runtime_jobs(
@@ -871,6 +871,14 @@ class ProjectManager:
             return False
 
         return False
+
+    def get_unsatisfied_dependencies(
+        self,
+        task: Task,
+        task_map: Optional[Dict[str, Task]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return dependency details that currently block a task."""
+        return self._get_unsatisfied_dependencies(task, task_map)
 
     def _get_unsatisfied_dependencies(
         self,

--- a/penguin/project/models.py
+++ b/penguin/project/models.py
@@ -30,6 +30,32 @@ class TaskPhase(Enum):
     BLOCKED = "blocked"      # Waiting on dependencies or clarification
 
 
+    @classmethod
+    def allowed_transitions(cls) -> Dict["TaskPhase", List["TaskPhase"]]:
+        """Return valid ITUV phase transitions."""
+        return {
+            cls.PENDING: [cls.IMPLEMENT, cls.BLOCKED],
+            cls.IMPLEMENT: [cls.TEST, cls.BLOCKED, cls.PENDING],
+            cls.TEST: [cls.USE, cls.VERIFY, cls.BLOCKED, cls.IMPLEMENT],
+            cls.USE: [cls.VERIFY, cls.BLOCKED, cls.TEST],
+            cls.VERIFY: [cls.TEST, cls.USE, cls.BLOCKED],
+            cls.BLOCKED: [
+                cls.PENDING,
+                cls.IMPLEMENT,
+                cls.TEST,
+                cls.USE,
+                cls.VERIFY,
+            ],
+            cls.DONE: [],
+        }
+
+    def can_transition_to(self, phase: "TaskPhase") -> bool:
+        """Return whether this phase may transition to the target phase."""
+        if phase == self:
+            return True
+        return phase in self.allowed_transitions().get(self, [])
+
+
 class TaskStatus(Enum):
     """Task status enumeration with clear state transitions."""
     ACTIVE = "active"

--- a/penguin/project/models.py
+++ b/penguin/project/models.py
@@ -38,7 +38,7 @@ class TaskPhase(Enum):
             cls.IMPLEMENT: [cls.TEST, cls.BLOCKED, cls.PENDING],
             cls.TEST: [cls.USE, cls.VERIFY, cls.BLOCKED, cls.IMPLEMENT],
             cls.USE: [cls.VERIFY, cls.BLOCKED, cls.TEST],
-            cls.VERIFY: [cls.TEST, cls.USE, cls.BLOCKED],
+            cls.VERIFY: [cls.TEST, cls.USE, cls.DONE, cls.BLOCKED],
             cls.BLOCKED: [
                 cls.PENDING,
                 cls.IMPLEMENT,

--- a/penguin/project/runtime_jobs.py
+++ b/penguin/project/runtime_jobs.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Optional
 
 
 RUNTIME_JOB_RESULT_JSON_LIMIT = 64 * 1024
@@ -23,7 +23,7 @@ class RuntimeJobRecord:
     kind: str
     status: str
     started_at: str
-    updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     project_id: Optional[str] = None
     task_id: Optional[str] = None
     session_id: Optional[str] = None
@@ -33,14 +33,14 @@ class RuntimeJobRecord:
     result_summary: Optional[str] = None
     result_json: Optional[str] = None
     error: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
     def terminal(self) -> bool:
         """Return whether the record is terminal."""
         return self.status in TERMINAL_RUNTIME_JOB_STATUSES
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable dictionary."""
         result = _decode_json(self.result_json)
         return {
@@ -79,10 +79,10 @@ def build_runtime_job_record(
     result: Optional[Any] = None,
     result_summary: Optional[str] = None,
     error: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: Optional[dict[str, Any]] = None,
 ) -> RuntimeJobRecord:
     """Build a durable runtime job record with capped result/error fields."""
-    now = datetime.utcnow().isoformat()
+    now = datetime.now(timezone.utc).isoformat()
     encoded_result = encode_result_json(result)
     return RuntimeJobRecord(
         job_id=job_id,
@@ -128,15 +128,22 @@ def encode_result_json(result: Optional[Any]) -> Optional[str]:
         encoded = json.dumps(result, default=str)
     except (TypeError, ValueError):
         encoded = json.dumps({"repr": str(result)})
-    if len(encoded) > RUNTIME_JOB_RESULT_JSON_LIMIT:
-        return json.dumps(
-            {
-                "truncated": True,
-                "limit": RUNTIME_JOB_RESULT_JSON_LIMIT,
-                "preview": encoded[:RUNTIME_JOB_RESULT_JSON_LIMIT],
-            }
-        )
-    return encoded
+    if len(encoded) <= RUNTIME_JOB_RESULT_JSON_LIMIT:
+        return encoded
+
+    wrapper = {"truncated": True, "limit": RUNTIME_JOB_RESULT_JSON_LIMIT, "preview": ""}
+    wrapper_overhead = len(json.dumps(wrapper))
+    preview_budget = max(0, RUNTIME_JOB_RESULT_JSON_LIMIT - wrapper_overhead)
+    wrapper["preview"] = _truncate(encoded, preview_budget) or ""
+    wrapped = json.dumps(wrapper)
+    if len(wrapped) <= RUNTIME_JOB_RESULT_JSON_LIMIT:
+        return wrapped
+    # JSON escaping can add a few bytes after preview truncation. Recompute with
+    # a smaller preview until the complete serialized payload is within cap.
+    while wrapper["preview"] and len(wrapped) > RUNTIME_JOB_RESULT_JSON_LIMIT:
+        wrapper["preview"] = wrapper["preview"][:-1]
+        wrapped = json.dumps(wrapper)
+    return wrapped[:RUNTIME_JOB_RESULT_JSON_LIMIT]
 
 
 def _decode_json(value: Optional[str]) -> Optional[Any]:
@@ -151,9 +158,13 @@ def _decode_json(value: Optional[str]) -> Optional[Any]:
 def _truncate(value: Optional[str], limit: int) -> Optional[str]:
     if value is None:
         return None
+    if limit <= 0:
+        return ""
     if len(value) <= limit:
         return value
-    return value[:limit] + "…"
+    if limit == 1:
+        return "…"
+    return value[: limit - 1] + "…"
 
 
 __all__ = [

--- a/penguin/project/runtime_jobs.py
+++ b/penguin/project/runtime_jobs.py
@@ -1,0 +1,165 @@
+"""Runtime job records for project-scoped execution attempts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+RUNTIME_JOB_RESULT_JSON_LIMIT = 64 * 1024
+RUNTIME_JOB_RESULT_SUMMARY_LIMIT = 4 * 1024
+RUNTIME_JOB_ERROR_LIMIT = 16 * 1024
+
+TERMINAL_RUNTIME_JOB_STATUSES = {"completed", "failed", "cancelled"}
+
+
+@dataclass
+class RuntimeJobRecord:
+    """Durable runtime job record stored with project/task state."""
+
+    job_id: str
+    kind: str
+    status: str
+    started_at: str
+    updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    project_id: Optional[str] = None
+    task_id: Optional[str] = None
+    session_id: Optional[str] = None
+    finished_at: Optional[str] = None
+    cancel_requested: bool = False
+    cancel_reason: Optional[str] = None
+    result_summary: Optional[str] = None
+    result_json: Optional[str] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def terminal(self) -> bool:
+        """Return whether the record is terminal."""
+        return self.status in TERMINAL_RUNTIME_JOB_STATUSES
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dictionary."""
+        result = _decode_json(self.result_json)
+        return {
+            "job_id": self.job_id,
+            "kind": self.kind,
+            "status": self.status,
+            "project_id": self.project_id,
+            "task_id": self.task_id,
+            "session_id": self.session_id,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at,
+            "finished_at": self.finished_at,
+            "cancel_requested": self.cancel_requested,
+            "cancel_reason": self.cancel_reason,
+            "result_summary": self.result_summary,
+            "result": result,
+            "error": self.error,
+            "metadata": dict(self.metadata or {}),
+            "durable": True,
+        }
+
+
+def build_runtime_job_record(
+    *,
+    job_id: str,
+    kind: str,
+    status: str,
+    project_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    started_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+    finished_at: Optional[str] = None,
+    cancel_requested: bool = False,
+    cancel_reason: Optional[str] = None,
+    result: Optional[Any] = None,
+    result_summary: Optional[str] = None,
+    error: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> RuntimeJobRecord:
+    """Build a durable runtime job record with capped result/error fields."""
+    now = datetime.utcnow().isoformat()
+    encoded_result = encode_result_json(result)
+    return RuntimeJobRecord(
+        job_id=job_id,
+        kind=kind,
+        status=status,
+        project_id=project_id,
+        task_id=task_id,
+        session_id=session_id,
+        started_at=started_at or now,
+        updated_at=updated_at or now,
+        finished_at=finished_at,
+        cancel_requested=cancel_requested,
+        cancel_reason=_truncate(cancel_reason, RUNTIME_JOB_ERROR_LIMIT),
+        result_summary=_truncate(
+            result_summary if result_summary is not None else summarize_result(result),
+            RUNTIME_JOB_RESULT_SUMMARY_LIMIT,
+        ),
+        result_json=encoded_result,
+        error=_truncate(error, RUNTIME_JOB_ERROR_LIMIT),
+        metadata=dict(metadata or {}),
+    )
+
+
+def summarize_result(result: Optional[Any]) -> Optional[str]:
+    """Return a compact summary for a runtime result payload."""
+    if result is None:
+        return None
+    if isinstance(result, dict):
+        for key in ("message", "summary", "status", "completion_type"):
+            value = result.get(key)
+            if value:
+                return _truncate(str(value), RUNTIME_JOB_RESULT_SUMMARY_LIMIT)
+        if "result" in result:
+            return _truncate(str(result["result"]), RUNTIME_JOB_RESULT_SUMMARY_LIMIT)
+    return _truncate(str(result), RUNTIME_JOB_RESULT_SUMMARY_LIMIT)
+
+
+def encode_result_json(result: Optional[Any]) -> Optional[str]:
+    """Encode a JSON result payload with a conservative size cap."""
+    if result is None:
+        return None
+    try:
+        encoded = json.dumps(result, default=str)
+    except (TypeError, ValueError):
+        encoded = json.dumps({"repr": str(result)})
+    if len(encoded) > RUNTIME_JOB_RESULT_JSON_LIMIT:
+        return json.dumps(
+            {
+                "truncated": True,
+                "limit": RUNTIME_JOB_RESULT_JSON_LIMIT,
+                "preview": encoded[:RUNTIME_JOB_RESULT_JSON_LIMIT],
+            }
+        )
+    return encoded
+
+
+def _decode_json(value: Optional[str]) -> Optional[Any]:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return {"raw": value}
+
+
+def _truncate(value: Optional[str], limit: int) -> Optional[str]:
+    if value is None:
+        return None
+    if len(value) <= limit:
+        return value
+    return value[:limit] + "…"
+
+
+__all__ = [
+    "RuntimeJobRecord",
+    "TERMINAL_RUNTIME_JOB_STATUSES",
+    "build_runtime_job_record",
+    "encode_result_json",
+    "summarize_result",
+]

--- a/penguin/project/storage.py
+++ b/penguin/project/storage.py
@@ -18,6 +18,10 @@ from .exceptions import StorageError
 logger = logging.getLogger(__name__)
 
 
+def _json_dumps_safe(value: Any) -> str:
+    return json.dumps(value, default=str)
+
+
 class ProjectStorage:
     """SQLite-backed storage for projects and tasks."""
     
@@ -511,7 +515,7 @@ class ProjectStorage:
                 record.result_summary,
                 record.result_json,
                 record.error,
-                json.dumps(record.metadata) if record.metadata else None,
+                _json_dumps_safe(record.metadata) if record.metadata else None,
             ))
             conn.commit()
 
@@ -530,7 +534,7 @@ class ProjectStorage:
         status: Optional[str] = None,
         project_id: Optional[str] = None,
         task_id: Optional[str] = None,
-        limit: int = 50,
+        limit: Optional[int] = 50,
     ) -> List[RuntimeJobRecord]:
         """List durable runtime job records with optional filters."""
         query = "SELECT * FROM runtime_jobs WHERE 1=1"
@@ -544,8 +548,10 @@ class ProjectStorage:
         if task_id:
             query += " AND task_id = ?"
             params.append(task_id)
-        query += " ORDER BY started_at DESC LIMIT ?"
-        params.append(max(1, int(limit)))
+        query += " ORDER BY started_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(max(1, int(limit)))
         with self._get_connection() as conn:
             rows = conn.execute(query, params).fetchall()
             return [self._row_to_runtime_job(row) for row in rows]

--- a/penguin/project/storage.py
+++ b/penguin/project/storage.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 from contextlib import contextmanager
 
 from .models import Project, Task, TaskPhase, TaskStatus, ExecutionRecord, StateTransition
+from .runtime_jobs import RuntimeJobRecord
 from .exceptions import StorageError, ProjectNotFoundError, TaskNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -136,6 +137,26 @@ class ProjectStorage:
                     FOREIGN KEY (task_id) REFERENCES tasks (id) ON DELETE CASCADE
                 )
             """)
+            # Runtime job records table
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS runtime_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    project_id TEXT,
+                    task_id TEXT,
+                    session_id TEXT,
+                    started_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    finished_at TEXT,
+                    cancel_requested INTEGER DEFAULT 0,
+                    cancel_reason TEXT,
+                    result_summary TEXT,
+                    result_json TEXT,
+                    error TEXT,
+                    metadata_json TEXT
+                )
+            """)
             
             # Indexes for better query performance
             conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_project_id ON tasks (project_id)")
@@ -143,6 +164,9 @@ class ProjectStorage:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON tasks (parent_task_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_execution_records_task_id ON execution_records (task_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_state_transitions_task_id ON state_transitions (task_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_runtime_jobs_project_id ON runtime_jobs (project_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_runtime_jobs_task_id ON runtime_jobs (task_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_runtime_jobs_status ON runtime_jobs (status)")
             
             conn.commit()
     
@@ -447,6 +471,86 @@ class ProjectStorage:
             rows = conn.execute(query, task.dependencies).fetchall()
             return [self._row_to_task(row) for row in rows]
 
+    # Runtime job operations
+
+    def upsert_runtime_job(self, record: RuntimeJobRecord) -> None:
+        """Create or update a durable runtime job record."""
+        with self._get_connection() as conn:
+            conn.execute("""
+                INSERT INTO runtime_jobs (
+                    job_id, kind, status, project_id, task_id, session_id,
+                    started_at, updated_at, finished_at, cancel_requested,
+                    cancel_reason, result_summary, result_json, error, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(job_id) DO UPDATE SET
+                    kind = excluded.kind,
+                    status = excluded.status,
+                    project_id = excluded.project_id,
+                    task_id = excluded.task_id,
+                    session_id = excluded.session_id,
+                    started_at = excluded.started_at,
+                    updated_at = excluded.updated_at,
+                    finished_at = excluded.finished_at,
+                    cancel_requested = excluded.cancel_requested,
+                    cancel_reason = excluded.cancel_reason,
+                    result_summary = excluded.result_summary,
+                    result_json = excluded.result_json,
+                    error = excluded.error,
+                    metadata_json = excluded.metadata_json
+            """, (
+                record.job_id,
+                record.kind,
+                record.status,
+                record.project_id,
+                record.task_id,
+                record.session_id,
+                record.started_at,
+                record.updated_at,
+                record.finished_at,
+                1 if record.cancel_requested else 0,
+                record.cancel_reason,
+                record.result_summary,
+                record.result_json,
+                record.error,
+                json.dumps(record.metadata) if record.metadata else None,
+            ))
+            conn.commit()
+
+    def get_runtime_job(self, job_id: str) -> Optional[RuntimeJobRecord]:
+        """Return a durable runtime job record by ID."""
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM runtime_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            return self._row_to_runtime_job(row) if row else None
+
+    def list_runtime_jobs(
+        self,
+        *,
+        status: Optional[str] = None,
+        project_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[RuntimeJobRecord]:
+        """List durable runtime job records with optional filters."""
+        query = "SELECT * FROM runtime_jobs WHERE 1=1"
+        params: List[Any] = []
+        if status:
+            query += " AND status = ?"
+            params.append(status)
+        if project_id:
+            query += " AND project_id = ?"
+            params.append(project_id)
+        if task_id:
+            query += " AND task_id = ?"
+            params.append(task_id)
+        query += " ORDER BY started_at DESC LIMIT ?"
+        params.append(max(1, int(limit)))
+        with self._get_connection() as conn:
+            rows = conn.execute(query, params).fetchall()
+            return [self._row_to_runtime_job(row) for row in rows]
+
     # Helper methods
 
     def _insert_execution_record(self, conn: sqlite3.Connection, record: ExecutionRecord) -> None:
@@ -545,6 +649,26 @@ class ProjectStorage:
             task.transition_history = [self._row_to_state_transition(r) for r in transition_rows]
 
         return task
+
+    def _row_to_runtime_job(self, row: sqlite3.Row) -> RuntimeJobRecord:
+        """Convert a database row to a RuntimeJobRecord object."""
+        return RuntimeJobRecord(
+            job_id=row["job_id"],
+            kind=row["kind"],
+            status=row["status"],
+            project_id=row["project_id"],
+            task_id=row["task_id"],
+            session_id=row["session_id"],
+            started_at=row["started_at"],
+            updated_at=row["updated_at"],
+            finished_at=row["finished_at"],
+            cancel_requested=bool(row["cancel_requested"]),
+            cancel_reason=row["cancel_reason"],
+            result_summary=row["result_summary"],
+            result_json=row["result_json"],
+            error=row["error"],
+            metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
+        )
 
     def _row_to_execution_record(self, row: sqlite3.Row) -> ExecutionRecord:
         """Convert a database row to an ExecutionRecord object."""

--- a/penguin/project/storage.py
+++ b/penguin/project/storage.py
@@ -7,14 +7,13 @@ SQLite with ACID transactions, supporting both sync and async operations.
 import sqlite3
 import json
 import logging
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 from contextlib import contextmanager
 
 from .models import Project, Task, TaskPhase, TaskStatus, ExecutionRecord, StateTransition
 from .runtime_jobs import RuntimeJobRecord
-from .exceptions import StorageError, ProjectNotFoundError, TaskNotFoundError
+from .exceptions import StorageError
 
 logger = logging.getLogger(__name__)
 

--- a/penguin/prompt_actions.py
+++ b/penguin/prompt_actions.py
@@ -18,6 +18,24 @@ from penguin.tools.editing.registry import (
 )
 
 
+__all__ = [
+    "AGENT_TOOLS",
+    "BROWSER_TOOLS",
+    "COMPLETION_TOOLS",
+    "EXECUTION_TOOLS",
+    "FILE_EDITING_TOOLS",
+    "FILE_OPERATION_TOOLS",
+    "MCP_TOOL_GUIDANCE",
+    "MEMORY_TOOLS",
+    "QUESTION_TOOLS",
+    "SEARCH_TOOLS",
+    "SKILL_TOOLS",
+    "TODO_TOOLS",
+    "TOOL_INVOCATION_PROTOCOL",
+    "get_tool_guide",
+]
+
+
 @dataclass(frozen=True)
 class ToolPromptExample:
     title: str

--- a/penguin/prompt_actions.py
+++ b/penguin/prompt_actions.py
@@ -159,6 +159,47 @@ compatibility fallback.
 """
 
 
+MCP_TOOL_GUIDANCE = """
+## MCP-Hosted Tools
+
+Penguin may expose external Model Context Protocol (MCP) server tools as normal
+runtime tools. MCP-hosted tools use model-safe names like
+`mcp__server_name__tool_name`, for example `mcp__chrome_devtools__navigate` or
+`mcp__github__list_issues`.
+
+**How to use MCP tools:**
+- Use MCP tools when the external server has the best capability for the task:
+  browser/page inspection, GitHub/Sentry/Linear data, databases, local
+  filesystem sandboxes, documentation servers, or other configured services.
+- Treat every `mcp__*` tool as an external third-party capability. Prefer
+  read-only inspection first, and ask/confirm before destructive, expensive, or
+  privacy-sensitive actions.
+- Do not invent MCP tool names. Use only names that are actually present in the
+  active tool schema/listing, and follow each tool's schema exactly.
+- Keep MCP calls narrowly scoped. Avoid broad queries or dumping huge external
+  datasets into context; request specific fields, pages, issues, traces, or
+  screenshots when possible.
+- If an MCP call returns a file path, image path, or artifact reference, summarize
+  it and read/load it only when needed for the user goal.
+- If an MCP tool fails because a server is disconnected, stale, or missing a
+  tool, report that clearly. When appropriate for debugging, use MCP status or
+  refresh/reconnect surfaces instead of repeatedly retrying the same failed call.
+
+**Browser MCP pattern:**
+- Navigate first, then verify with title/URL/evaluate, then capture screenshots
+  or inspect the DOM/network as needed.
+- Use isolated or non-sensitive browser profiles for browser MCP tasks. Browser
+  MCP servers can inspect and modify page/browser state.
+- Screenshots may return image data or a local file path depending on the MCP
+  server; handle either shape without assuming one fixed format.
+
+**Security posture:** MCP is powerful glue, not magic safety dust. Server-level
+allow/deny policy, output caps, and normal Penguin permission checks still
+matter. When in doubt, be explicit about the external system being accessed and
+what action will be taken.
+"""
+
+
 READ_FILE_HINT = ToolPromptHint(
     when_to_use="Reading source files, configs, or documentation.",
     strategy_notes=[
@@ -1010,6 +1051,7 @@ def get_tool_guide() -> str:
     return "\n\n".join(
         [
             TOOL_INVOCATION_PROTOCOL,
+            MCP_TOOL_GUIDANCE,
             _build_file_editing_tools(),
             _build_file_operation_tools(),
             EXECUTION_TOOLS,

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -84,6 +84,9 @@ def get_tool_operations(tool_name: str) -> List[Operation]:
         List of Operation enums required by the tool.
         Returns empty list if tool is unknown (allows by default).
     """
+    if str(tool_name or "").startswith("mcp__"):
+        return [Operation.NETWORK_POST]
+
     return TOOL_OPERATION_MAP.get(tool_name, [])
 
 
@@ -119,6 +122,9 @@ def extract_resource_from_input(
 
     if tool_name in ("memory_search", "perplexity_search"):
         return tool_input.get("query")
+
+    if str(tool_name or "").startswith("mcp__"):
+        return tool_name
 
     # For operations without a clear resource, return None
     return None

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from penguin.security.permission_engine import PermissionEnforcer
 
 from penguin.security.permission_engine import Operation, PermissionResult
 
@@ -124,7 +127,7 @@ def extract_resource_from_input(
         return tool_input.get("query")
 
     if str(tool_name or "").startswith("mcp__"):
-        return tool_name
+        return None
 
     # For operations without a clear resource, return None
     return None

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from penguin.security.permission_engine import PermissionEnforcer
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 # Map tool names to their required operations
 # Tools can require multiple operations (e.g., apply_diff needs read + write)
-TOOL_OPERATION_MAP: Dict[str, List[Operation]] = {
+TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     # File read operations
     "read_file": [Operation.FILESYSTEM_READ],
     "list_files": [Operation.FILESYSTEM_LIST],
@@ -77,7 +77,7 @@ TOOL_OPERATION_MAP: Dict[str, List[Operation]] = {
 }
 
 
-def get_tool_operations(tool_name: str) -> List[Operation]:
+def get_tool_operations(tool_name: str) -> list[Operation]:
     """Get the operations required by a tool.
 
     Args:
@@ -94,7 +94,7 @@ def get_tool_operations(tool_name: str) -> List[Operation]:
 
 
 def extract_resource_from_input(
-    tool_name: str, tool_input: Dict[str, Any]
+    tool_name: str, tool_input: dict[str, Any]
 ) -> Optional[str]:
     """Extract the primary resource (usually file path) from tool input.
 
@@ -126,14 +126,11 @@ def extract_resource_from_input(
     if tool_name in ("memory_search", "perplexity_search"):
         return tool_input.get("query")
 
-    if str(tool_name or "").startswith("mcp__"):
-        return None
-
     # For operations without a clear resource, return None
     return None
 
 
-def _resolve_resource_path(resource: str, context: Optional[Dict[str, Any]]) -> str:
+def _resolve_resource_path(resource: str, context: Optional[dict[str, Any]]) -> str:
     """Resolve relative resource paths against request-scoped directory hints."""
     text = str(resource or "").strip()
     if not text:
@@ -154,13 +151,13 @@ def _resolve_resource_path(resource: str, context: Optional[Dict[str, Any]]) -> 
     return text
 
 
-def _extract_patch_files_content_paths(content: str) -> List[str]:
+def _extract_patch_files_content_paths(content: str) -> list[str]:
     """Extract candidate file paths from legacy patch_files content payloads."""
     text = str(content or "")
     if not text.strip():
         return []
 
-    paths: List[str] = []
+    paths: list[str] = []
 
     for match in re.finditer(r"^\+\+\+\s+(?:b/)?(.+)$", text, re.MULTILINE):
         value = match.group(1).strip()
@@ -180,11 +177,11 @@ def _extract_patch_files_content_paths(content: str) -> List[str]:
 
 def extract_resources_from_input(
     tool_name: str,
-    tool_input: Dict[str, Any],
-    context: Optional[Dict[str, Any]] = None,
-) -> List[str]:
+    tool_input: dict[str, Any],
+    context: Optional[dict[str, Any]] = None,
+) -> list[str]:
     """Extract all primary resources from tool input, normalized for permission checks."""
-    resources: List[str] = []
+    resources: list[str] = []
 
     if tool_name == "patch_files":
         operations = tool_input.get("operations")
@@ -207,7 +204,7 @@ def extract_resources_from_input(
     if single:
         resources.append(_resolve_resource_path(single, context))
 
-    deduped: List[str] = []
+    deduped: list[str] = []
     seen: set[str] = set()
     for resource in resources:
         text = str(resource or "").strip()
@@ -285,10 +282,10 @@ def get_highest_risk_operation(tool_name: str) -> Optional[Operation]:
 
 def check_tool_permission(
     tool_name: str,
-    tool_input: Dict[str, Any],
+    tool_input: dict[str, Any],
     enforcer: "PermissionEnforcer",
-    context: Optional[Dict[str, Any]] = None,
-) -> Tuple[PermissionResult, str]:
+    context: Optional[dict[str, Any]] = None,
+) -> tuple[PermissionResult, str]:
     """Check if a tool execution is allowed.
 
     This is the main entry point for ToolManager integration.
@@ -361,10 +358,10 @@ def check_tool_permission(
 
 def _check_agent_permission(
     agent_id: str,
-    operations: List[Operation],
+    operations: list[Operation],
     resource: str,
-    context: Dict[str, Any],
-) -> Tuple[PermissionResult, str]:
+    context: dict[str, Any],
+) -> tuple[PermissionResult, str]:
     """Check agent-specific permission policy.
 
     Args:

--- a/penguin/tools/providers/__init__.py
+++ b/penguin/tools/providers/__init__.py
@@ -1,0 +1,13 @@
+"""Tool provider adapters for dynamic external tool surfaces."""
+
+from __future__ import annotations
+
+__all__ = ["MCPToolProvider"]
+
+
+def __getattr__(name: str):
+    if name == "MCPToolProvider":
+        from penguin.tools.providers.mcp import MCPToolProvider
+
+        return MCPToolProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/penguin/tools/providers/__init__.py
+++ b/penguin/tools/providers/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any, Type
+
 __all__ = ["MCPToolProvider"]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Type[Any]:
     if name == "MCPToolProvider":
         from penguin.tools.providers.mcp import MCPToolProvider
 

--- a/penguin/tools/providers/mcp.py
+++ b/penguin/tools/providers/mcp.py
@@ -1,0 +1,92 @@
+"""ToolManager provider for MCP-hosted tools."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from penguin.integrations.mcp.config import load_mcp_server_configs
+from penguin.integrations.mcp.manager import MCPClientManager
+from penguin.integrations.mcp.names import is_mcp_tool_name
+
+logger = logging.getLogger(__name__)
+
+
+class MCPToolProvider:
+    """Expose external MCP server tools through Penguin's ToolManager."""
+
+    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+        self.config = config or {}
+        self._manager: Optional[MCPClientManager] = None
+        self._schemas: Optional[list[dict[str, Any]]] = None
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether MCP has enabled server config."""
+        return bool(load_mcp_server_configs(self.config))
+
+    @property
+    def manager(self) -> MCPClientManager:
+        """Create the client manager lazily."""
+        if self._manager is None:
+            self._manager = MCPClientManager(load_mcp_server_configs(self.config))
+        return self._manager
+
+    def is_mcp_tool(self, tool_name: str) -> bool:
+        """Return whether a public tool name belongs to this provider."""
+        return is_mcp_tool_name(tool_name)
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        """Return ToolManager-compatible schemas for discovered MCP tools."""
+        if not self.enabled:
+            return []
+        if self._schemas is None:
+            self._schemas = [
+                definition.to_penguin_schema()
+                for definition in self.manager.list_tools_sync()
+            ]
+        return list(self._schemas)
+
+    def execute_tool(
+        self, tool_name: str, tool_input: Optional[dict[str, Any]] = None
+    ) -> str:
+        """Execute an MCP tool and return a JSON string payload."""
+        if not self.enabled:
+            return json.dumps(
+                {
+                    "error": "mcp_disabled",
+                    "tool": tool_name,
+                    "message": "MCP is not enabled in Penguin config.",
+                }
+            )
+        try:
+            result = self.manager.call_tool_sync(tool_name, tool_input or {})
+            return json.dumps({"status": "ok", "result": result}, indent=2)
+        except Exception as exc:
+            logger.warning("MCP tool '%s' failed: %s", tool_name, exc)
+            return json.dumps(
+                {
+                    "error": "mcp_tool_error",
+                    "tool": tool_name,
+                    "message": str(exc),
+                },
+                indent=2,
+            )
+
+    def status(self) -> dict[str, Any]:
+        """Return serializable provider diagnostics."""
+        if self._manager is None:
+            return {
+                "enabled": self.enabled,
+                "initialized": False,
+                "servers": {},
+            }
+        return {
+            "enabled": self.enabled,
+            "initialized": True,
+            **self._manager.status(),
+        }
+
+
+__all__ = ["MCPToolProvider"]

--- a/penguin/tools/providers/mcp.py
+++ b/penguin/tools/providers/mcp.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 
 from penguin.integrations.mcp.config import load_mcp_server_configs
-from penguin.integrations.mcp.manager import MCPClientManager
+from penguin.integrations.mcp.manager import HAS_MCP_SDK, MCPClientManager
 from penguin.integrations.mcp.names import is_mcp_tool_name
 
 logger = logging.getLogger(__name__)
@@ -63,13 +63,23 @@ class MCPToolProvider:
         try:
             result = self.manager.call_tool_sync(tool_name, tool_input or {})
             return json.dumps({"status": "ok", "result": result}, indent=2)
-        except Exception as exc:
-            logger.warning("MCP tool '%s' failed: %s", tool_name, exc)
+        except (ValueError, RuntimeError) as exc:
+            logger.debug("MCP tool '%s' expected failure: %s", tool_name, exc)
             return json.dumps(
                 {
                     "error": "mcp_tool_error",
                     "tool": tool_name,
-                    "message": str(exc),
+                    "message": "MCP tool invocation failed.",
+                },
+                indent=2,
+            )
+        except Exception:
+            logger.exception("MCP tool '%s' unexpected failure", tool_name)
+            return json.dumps(
+                {
+                    "error": "internal_mcp_error",
+                    "tool": tool_name,
+                    "message": "internal error",
                 },
                 indent=2,
             )
@@ -109,7 +119,7 @@ class MCPToolProvider:
             return {
                 "enabled": self.enabled,
                 "initialized": False,
-                "available": None,
+                "available": bool(HAS_MCP_SDK),
                 "discovered": False,
                 "server_count": len(load_mcp_server_configs(self.config)),
                 "tool_count": 0,

--- a/penguin/tools/providers/mcp.py
+++ b/penguin/tools/providers/mcp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from penguin.integrations.mcp.config import load_mcp_server_configs
 from penguin.integrations.mcp.manager import MCPClientManager
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 class MCPToolProvider:
     """Expose external MCP server tools through Penguin's ToolManager."""
 
-    def __init__(self, config: Optional[dict[str, Any]] = None) -> None:
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
         self.config = config or {}
-        self._manager: Optional[MCPClientManager] = None
-        self._schemas: Optional[list[dict[str, Any]]] = None
+        self._manager: MCPClientManager | None = None
+        self._schemas: list[dict[str, Any]] | None = None
 
     @property
     def enabled(self) -> bool:
@@ -49,7 +49,7 @@ class MCPToolProvider:
         return list(self._schemas)
 
     def execute_tool(
-        self, tool_name: str, tool_input: Optional[dict[str, Any]] = None
+        self, tool_name: str, tool_input: dict[str, Any] | None = None
     ) -> str:
         """Execute an MCP tool and return a JSON string payload."""
         if not self.enabled:
@@ -74,12 +74,45 @@ class MCPToolProvider:
                 indent=2,
             )
 
+    def refresh(self) -> list[dict[str, Any]]:
+        """Force rediscovery and return fresh ToolManager-compatible schemas."""
+        self._schemas = None
+        if not self.enabled:
+            return []
+        definitions = self.manager.refresh_sync()
+        self._schemas = [definition.to_penguin_schema() for definition in definitions]
+        return list(self._schemas)
+
+    def reconnect(self, server_name: str | None = None) -> dict[str, Any]:
+        """Reconnect one or all MCP servers and invalidate cached schemas."""
+        self._schemas = None
+        if not self.enabled:
+            return self.status()
+        result = self.manager.reconnect_sync(server_name)
+        self._schemas = [
+            definition.to_penguin_schema()
+            for definition in self.manager.list_tools_sync()
+        ]
+        return {"enabled": self.enabled, "initialized": True, **result}
+
+    def close(self) -> dict[str, Any]:
+        """Close MCP sessions and return diagnostics."""
+        self._schemas = None
+        if self._manager is None:
+            return self.status()
+        result = self._manager.close_sync()
+        return {"enabled": self.enabled, "initialized": True, **result}
+
     def status(self) -> dict[str, Any]:
         """Return serializable provider diagnostics."""
         if self._manager is None:
             return {
                 "enabled": self.enabled,
                 "initialized": False,
+                "available": None,
+                "discovered": False,
+                "server_count": len(load_mcp_server_configs(self.config)),
+                "tool_count": 0,
                 "servers": {},
             }
         return {

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -44,6 +44,7 @@ from penguin.tools.editing.registry import (
     get_edit_tool_public_names,
     get_edit_tool_schemas,
 )
+from penguin.tools.providers.mcp import MCPToolProvider
 
 # Lazy import for PyDoll to avoid breaking if pydoll-python is not installed
 _pydoll_tools_imported = False
@@ -256,6 +257,9 @@ class ToolManager:
             self._memory_provider = None
             self._indexing_task = None
             self._indexing_completed = False
+
+            # Dynamic external tool providers
+            self._mcp_provider = MCPToolProvider(self.config)
 
             # Browser tools placeholders
             self._browser_navigation_tool = None
@@ -1961,7 +1965,9 @@ class ToolManager:
 
     def get_tools(self):
         """Get available tool schemas."""
-        return self.tools
+        tools = list(self.tools)
+        tools.extend(self._mcp_provider.get_tool_schemas())
+        return tools
 
     def get_tool_aliases(self) -> Dict[str, str]:
         """Return centralized legacy-to-canonical tool aliases."""
@@ -2009,7 +2015,7 @@ class ToolManager:
             for name in (allowed_names or default_allowed)
         }
         responses_tools: List[Dict[str, Any]] = []
-        for t in self.tools:
+        for t in self.get_tools():
             name = t.get("name")
             if not name or name not in allowed:
                 continue
@@ -2037,6 +2043,9 @@ class ToolManager:
     def get_tool(self, tool_name: str):
         """Get a tool instance on-demand with caching."""
         tool_name = self._canonical_tool_name(tool_name)
+        if self._mcp_provider.is_mcp_tool(tool_name):
+            return lambda **kwargs: self._mcp_provider.execute_tool(tool_name, kwargs)
+
         if tool_name in self._tool_instances:
             return self._tool_instances[tool_name]
 
@@ -3001,6 +3010,21 @@ class ToolManager:
             effective_context.setdefault("directory", file_root)
             effective_context.setdefault("project_root", file_root)
             effective_context.setdefault("workspace_root", file_root)
+            tool_input = tool_input if isinstance(tool_input, dict) else {}
+
+            if self._mcp_provider.is_mcp_tool(tool_name):
+                if self._permission_enabled:
+                    result, reason = self.check_tool_permission(
+                        tool_name, tool_input, effective_context
+                    )
+                    if result is not None:
+                        _ensure_permission_imports()
+                        if result == _PermissionResult.DENY:
+                            return {"error": f"Permission denied: {reason}"}
+                        if result == _PermissionResult.ASK:
+                            return {"error": f"Permission required: {reason}"}
+                return self._mcp_provider.execute_tool(tool_name, tool_input)
+
             tool_input = self._normalize_tool_input_paths(tool_input, file_root)
 
             # Check permission before executing
@@ -4614,6 +4638,8 @@ class ToolManager:
             self._skill_tools.conversation_manager = getattr(
                 core, "conversation_manager", None
             )
+        if hasattr(self._mcp_provider, "core"):
+            self._mcp_provider.core = core
 
     def _resolve_subagent_tool_call_id(
         self, tool_input: Optional[Dict[str, Any]]

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -1969,6 +1969,22 @@ class ToolManager:
         tools.extend(self._mcp_provider.get_tool_schemas())
         return tools
 
+    def get_mcp_status(self) -> Dict[str, Any]:
+        """Return MCP provider diagnostics."""
+        return self._mcp_provider.status()
+
+    def refresh_mcp_tools(self) -> List[Dict[str, Any]]:
+        """Force MCP tool rediscovery and return fresh schemas."""
+        return self._mcp_provider.refresh()
+
+    def reconnect_mcp(self, server_name: Optional[str] = None) -> Dict[str, Any]:
+        """Reconnect one or all MCP servers."""
+        return self._mcp_provider.reconnect(server_name)
+
+    def close_mcp(self) -> Dict[str, Any]:
+        """Close MCP sessions."""
+        return self._mcp_provider.close()
+
     def get_tool_aliases(self) -> Dict[str, str]:
         """Return centralized legacy-to-canonical tool aliases."""
         return dict(self._tool_aliases)

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -241,16 +241,6 @@ def create_app() -> "FastAPI":
         http_conf: Dict[str, Any] = (
             srv_conf.get("http", {}) if isinstance(srv_conf, dict) else {}
         )
-        # Register remote MCP servers as virtual tools (client bridge)
-        servers_conf = mcp_conf.get("servers") if isinstance(mcp_conf, dict) else None
-        if isinstance(servers_conf, list) and servers_conf:
-            try:
-                from penguin.integrations.mcp.client import MCPClientBridge  # type: ignore
-
-                MCPClientBridge(servers_conf).register_remote_tools(core.tool_manager)
-            except Exception:
-                pass
-
         if bool(http_conf.get("enabled", False)):
             allow_patterns = srv_conf.get("allow_tools") or ["*"]
             deny_patterns = srv_conf.get("deny_tools") or [

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -112,6 +112,11 @@ from penguin.web.services.opencode_provider import (
     remove_provider_auth_record,
     set_provider_auth_record,
 )
+from penguin.web.services.mcp import (
+    close_mcp as close_mcp_service,
+    get_mcp_status as get_mcp_status_service,
+    reconnect_mcp as reconnect_mcp_service,
+)
 from penguin.system.execution_context import (
     ExecutionContext,
     execution_context_scope,
@@ -2176,6 +2181,32 @@ async def list_skills(
         )
 
     return payload
+
+
+@router.get("/api/v1/mcp")
+async def get_mcp_status(
+    refresh: bool = False,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Return MCP server diagnostics for web/TUI clients."""
+    return get_mcp_status_service(core, refresh=refresh)
+
+
+@router.post("/api/v1/mcp/reconnect")
+async def reconnect_mcp(
+    server_name: Optional[str] = None,
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Reconnect one or all configured MCP servers."""
+    return reconnect_mcp_service(core, server_name=server_name)
+
+
+@router.post("/api/v1/mcp/close")
+async def close_mcp(
+    core: PenguinCore = Depends(get_core),
+) -> Dict[str, Any]:
+    """Close all MCP sessions."""
+    return close_mcp_service(core)
 
 
 @router.get("/api/v1/skills/{name}")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -94,6 +94,7 @@ from penguin.web.services.system_status import (
     get_path_info,
     get_vcs_info,
 )
+from penguin.web.services.project_payloads import serialize_task_payload
 from penguin.web.services.projects import (
     delete_project_with_tasks,
     initialize_project_from_blueprint,
@@ -149,42 +150,8 @@ def _format_error_response(error: Exception, status_code: int = 500) -> HTTPExce
 def _serialize_task_payload(
     task: Any, *, include_metadata: bool = True
 ) -> Dict[str, Any]:
-    """Serialize a task for web responses without flattening new runtime state away."""
-    # Keep this centralized so task payload fixes land in one place instead of drifting across routes.
-    # The web surface should expose current lifecycle truth, including phase and clarification state, not just legacy status fields.
-    dependency_specs = [
-        spec.to_dict() if hasattr(spec, "to_dict") else dict(spec)
-        for spec in getattr(task, "dependency_specs", []) or []
-    ]
-    artifact_evidence = [
-        artifact.to_dict() if hasattr(artifact, "to_dict") else dict(artifact)
-        for artifact in getattr(task, "artifact_evidence", []) or []
-    ]
-    metadata = dict(getattr(task, "metadata", {}) or {})
-    clarification_requests = list(metadata.get("clarification_requests", []))
-
-    payload = {
-        "id": task.id,
-        "project_id": getattr(task, "project_id", None),
-        "title": task.title,
-        "description": task.description,
-        "status": task.status.value if hasattr(task.status, "value") else task.status,
-        "phase": task.phase.value
-        if hasattr(task.phase, "value")
-        else getattr(task, "phase", None),
-        "priority": getattr(task, "priority", None),
-        "parent_task_id": getattr(task, "parent_task_id", None),
-        "dependencies": list(getattr(task, "dependencies", []) or []),
-        "dependency_specs": dependency_specs,
-        "artifact_evidence": artifact_evidence,
-        "recipe": getattr(task, "recipe", None),
-        "clarification_requests": clarification_requests,
-        "created_at": task.created_at if getattr(task, "created_at", None) else None,
-        "updated_at": task.updated_at if getattr(task, "updated_at", None) else None,
-    }
-    if include_metadata:
-        payload["metadata"] = metadata
-    return payload
+    """Serialize a task for web responses using the shared PM payload shape."""
+    return serialize_task_payload(task, include_metadata=include_metadata)
 
 
 MAX_IMAGES_PER_REQUEST = 10

--- a/penguin/web/services/blueprint_payloads.py
+++ b/penguin/web/services/blueprint_payloads.py
@@ -1,0 +1,127 @@
+"""Shared Blueprint payload serializers for web and MCP surfaces."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def serialize_blueprint_diagnostic(diagnostic: Any) -> Dict[str, Any]:
+    """Return a JSON-safe Blueprint diagnostic payload."""
+    if hasattr(diagnostic, "to_dict"):
+        return diagnostic.to_dict()
+    return {
+        "code": getattr(diagnostic, "code", None),
+        "severity": getattr(diagnostic, "severity", None),
+        "message": getattr(diagnostic, "message", None),
+        "source": getattr(diagnostic, "source", None),
+        "line": getattr(diagnostic, "line", None),
+        "task_id": getattr(diagnostic, "task_id", None),
+        "suggestion": getattr(diagnostic, "suggestion", None),
+    }
+
+
+def serialize_blueprint_diagnostics_report(report: Any) -> Dict[str, Any]:
+    """Serialize a Blueprint diagnostics report."""
+    diagnostics = [
+        serialize_blueprint_diagnostic(diagnostic)
+        for diagnostic in getattr(report, "diagnostics", [])
+    ]
+    return {
+        "has_errors": bool(getattr(report, "has_errors", False)),
+        "has_warnings": bool(getattr(report, "has_warnings", False)),
+        "diagnostics": diagnostics,
+        "error_count": sum(
+            1 for item in diagnostics if item.get("severity") == "error"
+        ),
+        "warning_count": sum(
+            1 for item in diagnostics if item.get("severity") == "warning"
+        ),
+    }
+
+
+def serialize_blueprint_summary(blueprint: Any) -> Dict[str, Any]:
+    """Serialize high-signal Blueprint metadata without dumping full content."""
+    items = list(getattr(blueprint, "items", []) or [])
+    return {
+        "title": getattr(blueprint, "title", None),
+        "project_key": getattr(blueprint, "project_key", None),
+        "version": getattr(blueprint, "version", None),
+        "status": getattr(blueprint, "status", None),
+        "item_count": len(items),
+        "labels": list(getattr(blueprint, "labels", []) or []),
+        "owners": list(getattr(blueprint, "owners", []) or []),
+        "ituv_enabled": getattr(blueprint, "ituv_enabled", None),
+        "default_agent_role": getattr(blueprint, "default_agent_role", None),
+        "default_required_tools": list(
+            getattr(blueprint, "default_required_tools", []) or []
+        ),
+        "default_skills": list(getattr(blueprint, "default_skills", []) or []),
+        "recipes": list(getattr(blueprint, "recipes", []) or []),
+        "validation": list(getattr(blueprint, "validation", []) or []),
+    }
+
+
+def serialize_blueprint_graph(blueprint: Any) -> Dict[str, Any]:
+    """Serialize Blueprint task dependency graph as nodes and edges."""
+    nodes = []
+    edges = []
+    for item in getattr(blueprint, "items", []) or []:
+        nodes.append(
+            {
+                "id": item.id,
+                "title": item.title,
+                "priority": getattr(item, "priority", None),
+                "acceptance_criteria_count": len(
+                    getattr(item, "acceptance_criteria", []) or []
+                ),
+                "parallelizable": bool(getattr(item, "parallelizable", False)),
+                "batch": getattr(item, "batch", None),
+                "recipe": getattr(item, "recipe", None),
+            }
+        )
+        dependency_specs = list(getattr(item, "dependency_specs", []) or [])
+        if dependency_specs:
+            for spec in dependency_specs:
+                edges.append(
+                    {
+                        "from": spec.task_id,
+                        "to": item.id,
+                        "policy": getattr(spec.policy, "value", spec.policy),
+                        "artifact_key": getattr(spec, "artifact_key", None),
+                    }
+                )
+        else:
+            for dependency_id in getattr(item, "depends_on", []) or []:
+                edges.append(
+                    {
+                        "from": dependency_id,
+                        "to": item.id,
+                        "policy": "completion_required",
+                        "artifact_key": None,
+                    }
+                )
+    return {"nodes": nodes, "edges": edges}
+
+
+def blueprint_graph_to_dot(graph: Dict[str, Any]) -> str:
+    """Render a serialized Blueprint graph as DOT."""
+    lines = ["digraph BlueprintDAG {", "  rankdir=LR;", "  node [shape=box];"]
+    for node in graph.get("nodes", []):
+        label = str(node.get("title") or node.get("id") or "")[:40]
+        lines.append(f'  "{node.get("id")}" [label="{label}"];')
+    for edge in graph.get("edges", []):
+        label = edge.get("policy") or ""
+        lines.append(
+            f'  "{edge.get("from")}" -> "{edge.get("to")}" [label="{label}"];'
+        )
+    lines.append("}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "blueprint_graph_to_dot",
+    "serialize_blueprint_diagnostic",
+    "serialize_blueprint_diagnostics_report",
+    "serialize_blueprint_graph",
+    "serialize_blueprint_summary",
+]

--- a/penguin/web/services/blueprint_payloads.py
+++ b/penguin/web/services/blueprint_payloads.py
@@ -103,6 +103,17 @@ def serialize_blueprint_graph(blueprint: Any) -> Dict[str, Any]:
     return {"nodes": nodes, "edges": edges}
 
 
+def _escape_dot(value: object) -> str:
+    """Escape a value for safe insertion into quoted DOT strings."""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\n")
+        .replace("\n", "\\n")
+    )
+
+
 def blueprint_graph_to_dot(graph: Dict[str, Any]) -> str:
     """Render a serialized Blueprint graph as DOT."""
     lines = ["digraph BlueprintDAG {", "  rankdir=LR;", "  node [shape=box];"]

--- a/penguin/web/services/blueprint_payloads.py
+++ b/penguin/web/services/blueprint_payloads.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 
-def serialize_blueprint_diagnostic(diagnostic: Any) -> Dict[str, Any]:
+def serialize_blueprint_diagnostic(diagnostic: Any) -> dict[str, Any]:
     """Return a JSON-safe Blueprint diagnostic payload."""
     if hasattr(diagnostic, "to_dict"):
         return diagnostic.to_dict()
@@ -20,7 +20,7 @@ def serialize_blueprint_diagnostic(diagnostic: Any) -> Dict[str, Any]:
     }
 
 
-def serialize_blueprint_diagnostics_report(report: Any) -> Dict[str, Any]:
+def serialize_blueprint_diagnostics_report(report: Any) -> dict[str, Any]:
     """Serialize a Blueprint diagnostics report."""
     diagnostics = [
         serialize_blueprint_diagnostic(diagnostic)
@@ -39,7 +39,7 @@ def serialize_blueprint_diagnostics_report(report: Any) -> Dict[str, Any]:
     }
 
 
-def serialize_blueprint_summary(blueprint: Any) -> Dict[str, Any]:
+def serialize_blueprint_summary(blueprint: Any) -> dict[str, Any]:
     """Serialize high-signal Blueprint metadata without dumping full content."""
     items = list(getattr(blueprint, "items", []) or [])
     return {
@@ -61,7 +61,7 @@ def serialize_blueprint_summary(blueprint: Any) -> Dict[str, Any]:
     }
 
 
-def serialize_blueprint_graph(blueprint: Any) -> Dict[str, Any]:
+def serialize_blueprint_graph(blueprint: Any) -> dict[str, Any]:
     """Serialize Blueprint task dependency graph as nodes and edges."""
     nodes = []
     edges = []
@@ -114,17 +114,18 @@ def _escape_dot(value: object) -> str:
     )
 
 
-def blueprint_graph_to_dot(graph: Dict[str, Any]) -> str:
+def blueprint_graph_to_dot(graph: dict[str, Any]) -> str:
     """Render a serialized Blueprint graph as DOT."""
     lines = ["digraph BlueprintDAG {", "  rankdir=LR;", "  node [shape=box];"]
     for node in graph.get("nodes", []):
-        label = str(node.get("title") or node.get("id") or "")[:40]
-        lines.append(f'  "{node.get("id")}" [label="{label}"];')
+        node_id = _escape_dot(node.get("id") or "")
+        label = _escape_dot(str(node.get("title") or node.get("id") or "")[:40])
+        lines.append(f'  "{node_id}" [label="{label}"];')
     for edge in graph.get("edges", []):
-        label = edge.get("policy") or ""
-        lines.append(
-            f'  "{edge.get("from")}" -> "{edge.get("to")}" [label="{label}"];'
-        )
+        source = _escape_dot(edge.get("from") or "")
+        target = _escape_dot(edge.get("to") or "")
+        label = _escape_dot(edge.get("policy") or "")
+        lines.append(f'  "{source}" -> "{target}" [label="{label}"];')
     lines.append("}")
     return "\n".join(lines)
 

--- a/penguin/web/services/mcp.py
+++ b/penguin/web/services/mcp.py
@@ -1,0 +1,42 @@
+"""MCP diagnostics service helpers for the web/API layer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from penguin.core import PenguinCore
+
+
+def get_mcp_status(core: PenguinCore, refresh: bool = False) -> dict[str, Any]:
+    """Return MCP provider status, optionally refreshing tool discovery first."""
+    tool_manager = getattr(core, "tool_manager", None)
+    if tool_manager is None:
+        return {"enabled": False, "initialized": False, "servers": {}}
+    if refresh and hasattr(tool_manager, "refresh_mcp_tools"):
+        tool_manager.refresh_mcp_tools()
+    if hasattr(tool_manager, "get_mcp_status"):
+        return tool_manager.get_mcp_status()
+    return {"enabled": False, "initialized": False, "servers": {}}
+
+
+def reconnect_mcp(
+    core: PenguinCore,
+    server_name: str | None = None,
+) -> dict[str, Any]:
+    """Reconnect one or all configured MCP servers."""
+    tool_manager = getattr(core, "tool_manager", None)
+    if tool_manager is None or not hasattr(tool_manager, "reconnect_mcp"):
+        return {"enabled": False, "initialized": False, "servers": {}}
+    return tool_manager.reconnect_mcp(server_name)
+
+
+def close_mcp(core: PenguinCore) -> dict[str, Any]:
+    """Close all MCP sessions."""
+    tool_manager = getattr(core, "tool_manager", None)
+    if tool_manager is None or not hasattr(tool_manager, "close_mcp"):
+        return {"enabled": False, "initialized": False, "servers": {}}
+    return tool_manager.close_mcp()
+
+
+__all__ = ["close_mcp", "get_mcp_status", "reconnect_mcp"]

--- a/penguin/web/services/project_payloads.py
+++ b/penguin/web/services/project_payloads.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Optional
 
 
 def _enum_value(value: Any) -> Any:
@@ -21,10 +22,10 @@ def _dict_list(values: Any) -> list[dict[str, Any]]:
 
 def serialize_task_payload(
     task: Any, *, include_metadata: bool = True
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Serialize a task without flattening current lifecycle/runtime truth."""
     metadata = dict(getattr(task, "metadata", {}) or {})
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "id": task.id,
         "project_id": getattr(task, "project_id", None),
         "title": task.title,
@@ -61,9 +62,9 @@ def serialize_project_payload(
     *,
     tasks: Optional[Sequence[Any]] = None,
     include_metadata: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Serialize a project with richer PM fields than the legacy route subset."""
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "id": project.id,
         "name": project.name,
         "description": project.description,

--- a/penguin/web/services/project_payloads.py
+++ b/penguin/web/services/project_payloads.py
@@ -1,0 +1,89 @@
+"""Shared project/task payload serializers for web and MCP surfaces."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+
+def _enum_value(value: Any) -> Any:
+    return value.value if hasattr(value, "value") else value
+
+
+def _dict_list(values: Any) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for item in values or []:
+        if hasattr(item, "to_dict"):
+            result.append(item.to_dict())
+        elif isinstance(item, dict):
+            result.append(dict(item))
+    return result
+
+
+def serialize_task_payload(
+    task: Any, *, include_metadata: bool = True
+) -> Dict[str, Any]:
+    """Serialize a task without flattening current lifecycle/runtime truth."""
+    metadata = dict(getattr(task, "metadata", {}) or {})
+    payload: Dict[str, Any] = {
+        "id": task.id,
+        "project_id": getattr(task, "project_id", None),
+        "title": task.title,
+        "description": task.description,
+        "status": _enum_value(getattr(task, "status", None)),
+        "phase": _enum_value(getattr(task, "phase", None)),
+        "priority": getattr(task, "priority", None),
+        "parent_task_id": getattr(task, "parent_task_id", None),
+        "dependencies": list(getattr(task, "dependencies", []) or []),
+        "dependency_specs": _dict_list(getattr(task, "dependency_specs", []) or []),
+        "artifact_evidence": _dict_list(getattr(task, "artifact_evidence", []) or []),
+        "recipe": getattr(task, "recipe", None),
+        "clarification_requests": list(metadata.get("clarification_requests", [])),
+        "tags": list(getattr(task, "tags", []) or []),
+        "due_date": getattr(task, "due_date", None),
+        "progress": getattr(task, "progress", None),
+        "budget_tokens": getattr(task, "budget_tokens", None),
+        "budget_minutes": getattr(task, "budget_minutes", None),
+        "allowed_tools": getattr(task, "allowed_tools", None),
+        "acceptance_criteria": list(getattr(task, "acceptance_criteria", []) or []),
+        "definition_of_done": getattr(task, "definition_of_done", None),
+        "blueprint_id": getattr(task, "blueprint_id", None),
+        "blueprint_source": getattr(task, "blueprint_source", None),
+        "created_at": getattr(task, "created_at", None),
+        "updated_at": getattr(task, "updated_at", None),
+    }
+    if include_metadata:
+        payload["metadata"] = metadata
+    return payload
+
+
+def serialize_project_payload(
+    project: Any,
+    *,
+    tasks: Optional[Sequence[Any]] = None,
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
+    """Serialize a project with richer PM fields than the legacy route subset."""
+    payload: Dict[str, Any] = {
+        "id": project.id,
+        "name": project.name,
+        "description": project.description,
+        "status": getattr(project, "status", None),
+        "workspace_path": str(getattr(project, "workspace_path", "") or "") or None,
+        "context_path": str(getattr(project, "context_path", "") or "") or None,
+        "tags": list(getattr(project, "tags", []) or []),
+        "priority": getattr(project, "priority", None),
+        "budget_tokens": getattr(project, "budget_tokens", None),
+        "budget_minutes": getattr(project, "budget_minutes", None),
+        "start_date": getattr(project, "start_date", None),
+        "due_date": getattr(project, "due_date", None),
+        "created_at": getattr(project, "created_at", None),
+        "updated_at": getattr(project, "updated_at", None),
+    }
+    if include_metadata:
+        payload["metadata"] = dict(getattr(project, "metadata", {}) or {})
+    if tasks is not None:
+        payload["tasks"] = [serialize_task_payload(task) for task in tasks]
+    return payload
+
+
+__all__ = ["serialize_project_payload", "serialize_task_payload"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,9 @@ legacy_tui = [
 
 # MCP client/server (install when using MCP features)
 mcp = [
+    "mcp>=1.2.0; python_version>='3.10'",
     "pyjwt[crypto]>=2.8.0",
-    "requests-oauthlib>=1.3.1"
+    "requests-oauthlib>=1.3.1",
 ]
 
 # Minimal install for library/embedding usage (overrides default dependencies)
@@ -169,6 +170,7 @@ test = [
 # Full installation (everything)
 all = [
     "pyjwt[crypto]>=2.8.0",
+    "mcp>=1.2.0; python_version>='3.10'",
     "requests-oauthlib>=1.3.1",
     "lancedb>=0.5.4",
     "pyarrow>=15.0.0",

--- a/scripts/mcp_chrome_smoke.py
+++ b/scripts/mcp_chrome_smoke.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Smoke test Penguin's MCP host path with Chrome DevTools MCP.
+
+This script exercises Penguin consuming an external MCP server, not Penguin's own
+MCP server surface. It starts `chrome-devtools-mcp` over stdio, navigates to a
+Wikipedia page, verifies title/URL with JavaScript evaluation, and stores a
+screenshot under /tmp by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from penguin.tools.providers.mcp import MCPToolProvider
+
+
+def _build_config(args: argparse.Namespace) -> dict[str, Any]:
+    chrome_args = [
+        "-y",
+        args.package,
+        "--no-usage-statistics",
+        "--no-update-checks",
+        "--slim",
+        "--isolated",
+        "--viewport",
+        args.viewport,
+    ]
+    if args.headless:
+        chrome_args.append("--headless")
+    return {
+        "mcp": {
+            "enabled": True,
+            "servers": {
+                "chrome-devtools": {
+                    "command": "npx",
+                    "args": chrome_args,
+                    "startup_timeout_sec": args.startup_timeout,
+                    "tool_timeout_sec": args.tool_timeout,
+                    "output_token_limit": args.output_token_limit,
+                }
+            },
+        }
+    }
+
+
+def _call(provider: MCPToolProvider, tool_name: str, arguments: dict[str, Any]) -> Any:
+    payload = json.loads(provider.execute_tool(tool_name, arguments))
+    if payload.get("error"):
+        raise RuntimeError(payload)
+    return payload["result"]
+
+
+def _flatten(value: Any) -> Iterable[Any]:
+    queue = [value]
+    while queue:
+        item = queue.pop(0)
+        yield item
+        if isinstance(item, dict):
+            queue.extend(item.values())
+        elif isinstance(item, list):
+            queue.extend(item)
+
+
+def _copy_screenshot(result: Any, destination: Path) -> Path:
+    for item in _flatten(result):
+        if isinstance(item, dict):
+            data = item.get("data")
+            mime = item.get("mimeType") or item.get("mime_type")
+            if isinstance(data, str) and (mime or item.get("type") == "image"):
+                destination.write_bytes(base64.b64decode(data))
+                return destination
+            text = item.get("text")
+            if isinstance(text, str):
+                source = Path(text)
+                if source.exists() and source.suffix.lower() == ".png":
+                    destination.write_bytes(source.read_bytes())
+                    return destination
+        elif isinstance(item, str):
+            source = Path(item)
+            if source.exists() and source.suffix.lower() == ".png":
+                destination.write_bytes(source.read_bytes())
+                return destination
+    raise RuntimeError("Chrome MCP screenshot result did not include image data or a PNG path.")
+
+
+def _text_content(result: Any) -> Optional[str]:
+    for item in _flatten(result):
+        if isinstance(item, dict) and isinstance(item.get("text"), str):
+            return item["text"]
+    return None
+
+
+def _visit_and_capture(
+    provider: MCPToolProvider,
+    url: str,
+    output_path: Path,
+) -> dict[str, Any]:
+    navigation = _call(provider, "mcp__chrome_devtools__navigate", {"url": url})
+    title = _call(provider, "mcp__chrome_devtools__evaluate", {"script": "document.title"})
+    href = _call(provider, "mcp__chrome_devtools__evaluate", {"script": "location.href"})
+    screenshot = _call(provider, "mcp__chrome_devtools__screenshot", {})
+    saved = _copy_screenshot(screenshot, output_path)
+    return {
+        "requested_url": url,
+        "resolved_url": _text_content(href),
+        "title": _text_content(title),
+        "navigation": _text_content(navigation),
+        "screenshot": str(saved),
+        "bytes": saved.stat().st_size,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="/tmp/penguin-mcp-chrome-smoke")
+    parser.add_argument("--package", default="chrome-devtools-mcp@latest")
+    parser.add_argument("--viewport", default="1280x900")
+    parser.add_argument("--startup-timeout", type=int, default=120)
+    parser.add_argument("--tool-timeout", type=int, default=180)
+    parser.add_argument("--output-token-limit", type=int, default=20_000_000)
+    parser.add_argument("--no-headless", action="store_false", dest="headless")
+    parser.add_argument("--include-random", action="store_true")
+    parser.set_defaults(headless=True)
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    provider = MCPToolProvider(_build_config(args))
+    try:
+        schemas = provider.get_tool_schemas()
+        names = {schema.get("name") for schema in schemas}
+        required = {
+            "mcp__chrome_devtools__navigate",
+            "mcp__chrome_devtools__evaluate",
+            "mcp__chrome_devtools__screenshot",
+        }
+        missing = sorted(required - names)
+        if missing:
+            raise RuntimeError(f"Missing Chrome MCP tools: {missing}")
+
+        results = [
+            _visit_and_capture(
+                provider,
+                "https://en.wikipedia.org/wiki/Penguin",
+                output_dir / "wikipedia-penguin.png",
+            )
+        ]
+        if args.include_random:
+            results.append(
+                _visit_and_capture(
+                    provider,
+                    "https://en.wikipedia.org/wiki/Special:Random",
+                    output_dir / "wikipedia-random.png",
+                )
+            )
+        print(json.dumps({"status": "ok", "results": results}, indent=2))
+        return 0
+    finally:
+        provider.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mcp_chrome_smoke.py
+++ b/scripts/mcp_chrome_smoke.py
@@ -13,6 +13,7 @@ import argparse
 import base64
 import json
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -117,7 +118,7 @@ def _visit_and_capture(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--output-dir", default="/tmp/penguin-mcp-chrome-smoke")
+    parser.add_argument("--output-dir", default=None)
     parser.add_argument("--package", default="chrome-devtools-mcp@latest")
     parser.add_argument("--viewport", default="1280x900")
     parser.add_argument("--startup-timeout", type=int, default=120)
@@ -128,7 +129,11 @@ def main() -> int:
     parser.set_defaults(headless=True)
     args = parser.parse_args()
 
-    output_dir = Path(args.output_dir)
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else Path(tempfile.mkdtemp(prefix="penguin-mcp-chrome-smoke-"))
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
 
     provider = MCPToolProvider(_build_config(args))

--- a/scripts/mcp_control_plane_smoke.py
+++ b/scripts/mcp_control_plane_smoke.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Smoke test Penguin's MCP control-plane tools over STDIO.
+
+This script validates the MCP server path, not just internal Python calls. It
+starts `scripts/penguin_mcp_server.py` in an isolated temporary workspace, then
+uses the official MCP Python SDK to:
+
+1. list tools,
+2. create a project,
+3. dry-run Blueprint sync,
+4. apply Blueprint sync,
+5. list tasks,
+6. query Blueprint status.
+
+Run with a Python environment that has Penguin's MCP extra installed, e.g.:
+
+    uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+except ImportError as exc:  # pragma: no cover - developer environment guard
+    raise SystemExit(
+        "MCP SDK is not installed. Run with: "
+        "uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py"
+    ) from exc
+
+
+BLUEPRINT_CONTENT = """version: 1
+name: MCP Control Plane Smoke
+summary: Validate Penguin MCP PM and Blueprint tools.
+tasks:
+  - id: setup
+    title: Prepare smoke fixture
+    description: Create a deterministic project/task fixture.
+    acceptance_criteria:
+      - Fixture task exists.
+  - id: verify
+    title: Verify smoke fixture
+    description: Confirm Blueprint status sees the synced DAG.
+    depends_on:
+      - setup
+    acceptance_criteria:
+      - Blueprint status reports synced tasks.
+"""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _default_server_command() -> List[str]:
+    return [
+        sys.executable,
+        str(_repo_root() / "scripts" / "penguin_mcp_server.py"),
+    ]
+
+
+def _json_from_result(result: Any) -> Dict[str, Any]:
+    """Extract a JSON object from an MCP tool result."""
+    content = getattr(result, "content", None) or []
+    texts: List[str] = []
+    for item in content:
+        text = getattr(item, "text", None)
+        if isinstance(text, str):
+            texts.append(text)
+    if not texts:
+        return {"raw_result": repr(result)}
+    combined = "\n".join(texts).strip()
+    try:
+        parsed = json.loads(combined)
+    except json.JSONDecodeError:
+        return {"text": combined}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"value": parsed}
+
+
+def _tool_names(tools: Iterable[Any]) -> List[str]:
+    return sorted(str(getattr(tool, "name", "")) for tool in tools)
+
+
+def _require_tools(names: Sequence[str], required: Sequence[str]) -> None:
+    missing = [name for name in required if name not in names]
+    if missing:
+        raise RuntimeError(
+            "Penguin MCP server did not expose required tools: "
+            f"{missing}; available={names}"
+        )
+
+
+async def _run_smoke(server_command: Sequence[str], keep_workspace: bool) -> Dict[str, Any]:
+    if not server_command:
+        raise ValueError("server_command must not be empty")
+
+    with tempfile.TemporaryDirectory(prefix="penguin-mcp-smoke-") as tmp:
+        workspace = Path(tmp) / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        project_root = Path(tmp) / "project"
+        project_root.mkdir(parents=True, exist_ok=True)
+        blueprint_path = project_root / "blueprint.yml"
+        blueprint_path.write_text(BLUEPRINT_CONTENT, encoding="utf-8")
+
+        env = dict(os.environ)
+        env["PENGUIN_WORKSPACE"] = str(workspace)
+
+        params = StdioServerParameters(
+            command=server_command[0],
+            args=list(server_command[1:]),
+            env=env,
+        )
+
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                names = _tool_names(listed.tools)
+                _require_tools(
+                    names,
+                    [
+                        "penguin_pm_create_project",
+                        "penguin_blueprint_sync",
+                        "penguin_pm_list_tasks",
+                        "penguin_blueprint_status",
+                    ],
+                )
+
+                project_result = _json_from_result(
+                    await session.call_tool(
+                        "penguin_pm_create_project",
+                        {
+                            "name": "MCP Control Plane Smoke",
+                            "description": "Created by MCP control-plane smoke.",
+                            "workspace_path": str(project_root),
+                        },
+                    )
+                )
+                project_id = project_result.get("project", {}).get("id") or project_result.get("id")
+                if not project_id:
+                    raise RuntimeError(f"Project creation did not return project_id: {project_result}")
+
+                dry_run = _json_from_result(
+                    await session.call_tool(
+                        "penguin_blueprint_sync",
+                        {
+                            "blueprint_path": str(blueprint_path),
+                            "project_id": project_id,
+                            "dry_run": True,
+                        },
+                    )
+                )
+                if dry_run.get("status") != "dry_run":
+                    raise RuntimeError(f"Expected dry_run status, got: {dry_run}")
+
+                sync = _json_from_result(
+                    await session.call_tool(
+                        "penguin_blueprint_sync",
+                        {
+                            "blueprint_path": str(blueprint_path),
+                            "project_id": project_id,
+                            "dry_run": False,
+                            "create_missing": True,
+                            "update_existing": False,
+                        },
+                    )
+                )
+                if sync.get("status") not in {"synced", "success"}:
+                    raise RuntimeError(f"Expected sync success, got: {sync}")
+
+                tasks = _json_from_result(
+                    await session.call_tool(
+                        "penguin_pm_list_tasks",
+                        {"project_id": project_id},
+                    )
+                )
+                task_items = tasks.get("tasks", [])
+                if len(task_items) < 2:
+                    raise RuntimeError(f"Expected at least 2 synced tasks, got: {tasks}")
+
+                status = _json_from_result(
+                    await session.call_tool(
+                        "penguin_blueprint_status",
+                        {"project_id": project_id},
+                    )
+                )
+                status_project_id = (
+                    status.get("project_id")
+                    or status.get("project", {}).get("id")
+                    or status.get("stats", {}).get("project_id")
+                )
+                if status_project_id != project_id:
+                    raise RuntimeError(f"Blueprint status returned wrong project: {status}")
+
+                summary = {
+                    "status": "passed",
+                    "workspace": str(workspace),
+                    "project_root": str(project_root),
+                    "project_id": project_id,
+                    "tool_count": len(names),
+                    "synced_task_count": len(task_items),
+                    "dry_run": dry_run,
+                    "sync": sync,
+                    "blueprint_status": status,
+                }
+
+        if keep_workspace:
+            # TemporaryDirectory deletes on context exit; copy-out would be needed for full preservation.
+            summary["note"] = "--keep-workspace is informational; temp cleanup still occurs."
+        return summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-workspace",
+        action="store_true",
+        help="Include workspace paths in output for debugging.",
+    )
+    parser.add_argument(
+        "server_command",
+        nargs=argparse.REMAINDER,
+        help="Optional server command after '--'. Defaults to current Python running scripts/penguin_mcp_server.py.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    server_command = list(args.server_command)
+    if server_command and server_command[0] == "--":
+        server_command = server_command[1:]
+    if not server_command:
+        server_command = _default_server_command()
+
+    summary = asyncio.run(_run_smoke(server_command, keep_workspace=args.keep_workspace))
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp_control_plane_smoke.py
+++ b/scripts/mcp_control_plane_smoke.py
@@ -20,6 +20,7 @@ Run with a Python environment that has Penguin's MCP extra installed, e.g.:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import asyncio
 import json
 import os
@@ -105,10 +106,17 @@ async def _run_smoke(server_command: Sequence[str], keep_workspace: bool) -> Dic
     if not server_command:
         raise ValueError("server_command must not be empty")
 
-    with tempfile.TemporaryDirectory(prefix="penguin-mcp-smoke-") as tmp:
+    if keep_workspace:
+        temp_context = contextlib.nullcontext(
+            tempfile.mkdtemp(prefix="penguin-mcp-smoke-")
+        )
+    else:
+        temp_context = tempfile.TemporaryDirectory(prefix="penguin-mcp-smoke-")
+
+    with temp_context as tmp:
         workspace = Path(tmp) / "workspace"
         workspace.mkdir(parents=True, exist_ok=True)
-        project_root = Path(tmp) / "project"
+        project_root = workspace / "project"
         project_root.mkdir(parents=True, exist_ok=True)
         blueprint_path = project_root / "blueprint.yml"
         blueprint_path.write_text(BLUEPRINT_CONTENT, encoding="utf-8")
@@ -156,6 +164,7 @@ async def _run_smoke(server_command: Sequence[str], keep_workspace: bool) -> Dic
                         "penguin_blueprint_sync",
                         {
                             "blueprint_path": str(blueprint_path),
+                            "workspace_path": str(workspace),
                             "project_id": project_id,
                             "dry_run": True,
                         },
@@ -169,6 +178,7 @@ async def _run_smoke(server_command: Sequence[str], keep_workspace: bool) -> Dic
                         "penguin_blueprint_sync",
                         {
                             "blueprint_path": str(blueprint_path),
+                            "workspace_path": str(workspace),
                             "project_id": project_id,
                             "dry_run": False,
                             "create_missing": True,

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -57,23 +57,24 @@ def main() -> None:
         tool_timeout_sec=args.tool_timeout,
     )
     manager = MCPClientManager([server])
-    tools = manager.list_tools_sync()
-    print(json.dumps(manager.status(), indent=2, sort_keys=True))
-    if not args.no_schemas:
-        print(
-            json.dumps(
-                [tool.to_penguin_schema() for tool in tools],
-                indent=2,
-                sort_keys=True,
+    try:
+        tools = manager.list_tools_sync()
+        print(json.dumps(manager.status(), indent=2, sort_keys=True))
+        if not args.no_schemas:
+            print(
+                json.dumps(
+                    [tool.to_penguin_schema() for tool in tools],
+                    indent=2,
+                    sort_keys=True,
+                )
             )
-        )
 
-    if args.call:
-        arguments: dict[str, Any] = json.loads(args.arguments)
-        result = manager.call_tool_sync(args.call, arguments)
-        print(json.dumps(result, indent=2, sort_keys=True))
-
-    manager.close_sync()
+        if args.call:
+            arguments: dict[str, Any] = json.loads(args.arguments)
+            result = manager.call_tool_sync(args.call, arguments)
+            print(json.dumps(result, indent=2, sort_keys=True))
+    finally:
+        manager.close_sync()
 
 
 if __name__ == "__main__":

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Smoke-test Penguin's MCP host path against one stdio MCP server.
+
+Example:
+  uv run --extra mcp python scripts/mcp_smoke.py \
+    --name everything \
+    --command npx \
+    --startup-timeout 60 \
+    --args -y @modelcontextprotocol/server-everything stdio
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from penguin.integrations.mcp.config import MCPServerConfig
+from penguin.integrations.mcp.manager import MCPClientManager
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Smoke-test one stdio MCP server.")
+    parser.add_argument("--name", default="smoke", help="MCP server name")
+    parser.add_argument("--command", required=True, help="Server command, e.g. npx")
+    parser.add_argument(
+        "--arg",
+        action="append",
+        default=[],
+        help="Server arg; repeatable; use --arg=-y for dash-prefixed values",
+    )
+    parser.add_argument(
+        "--args",
+        nargs=argparse.REMAINDER,
+        default=None,
+        help="All remaining values are server args; keep this last",
+    )
+    parser.add_argument("--call", help="Optional discovered public tool name to call")
+    parser.add_argument("--arguments", default="{}", help="JSON arguments for --call")
+    parser.add_argument("--startup-timeout", type=float, default=30.0)
+    parser.add_argument("--tool-timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--no-schemas",
+        action="store_true",
+        help="Only print status and optional call result",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    server = MCPServerConfig(
+        name=args.name,
+        command=args.command,
+        args=list(args.args if args.args is not None else args.arg),
+        startup_timeout_sec=args.startup_timeout,
+        tool_timeout_sec=args.tool_timeout,
+    )
+    manager = MCPClientManager([server])
+    tools = manager.list_tools_sync()
+    print(json.dumps(manager.status(), indent=2, sort_keys=True))
+    if not args.no_schemas:
+        print(
+            json.dumps(
+                [tool.to_penguin_schema() for tool in tools],
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
+    if args.call:
+        arguments: dict[str, Any] = json.loads(args.arguments)
+        result = manager.call_tool_sync(args.call, arguments)
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+    manager.close_sync()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--allow-runtime-tools",
         action="store_true",
-        help="Expose opt-in RunMode readiness tools. Start/cancel remain unavailable in Slice 3A.",
+        help="Expose opt-in RunMode and ITUV runtime/orchestration MCP tools.",
     )
     parser.add_argument(
         "--minimal-core",

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -43,6 +43,16 @@ def parse_args() -> argparse.Namespace:
         help="Disable default Penguin Blueprint MCP tools.",
     )
     parser.add_argument(
+        "--no-resources",
+        action="store_true",
+        help="Disable MCP resources. Prompts remain controlled separately.",
+    )
+    parser.add_argument(
+        "--no-prompts",
+        action="store_true",
+        help="Disable MCP prompts.",
+    )
+    parser.add_argument(
         "--no-session-tools",
         action="store_true",
         help="Disable default-on session/artifact/checkpoint read tools.",
@@ -86,6 +96,8 @@ def main() -> None:
         expose_blueprint_tools=not args.no_blueprint_tools,
         expose_runtime_tools=args.allow_runtime_tools,
         expose_session_tools=not args.no_session_tools,
+        expose_resources=not args.no_resources,
+        expose_prompts=not args.no_prompts,
     )
     try:
         server.run("stdio")

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -38,6 +38,11 @@ def parse_args() -> argparse.Namespace:
         help="Disable default Penguin PM MCP tools.",
     )
     parser.add_argument(
+        "--no-blueprint-tools",
+        action="store_true",
+        help="Disable default Penguin Blueprint MCP tools.",
+    )
+    parser.add_argument(
         "--minimal-core",
         action="store_true",
         help="Use a bare ToolManager only; PM tools require full PenguinCore.",
@@ -68,6 +73,7 @@ def main() -> None:
         deny_patterns=args.deny_pattern,
         core=core,
         expose_pm_tools=not args.no_pm_tools,
+        expose_blueprint_tools=not args.no_blueprint_tools,
     )
     try:
         server.run("stdio")

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -43,6 +43,11 @@ def parse_args() -> argparse.Namespace:
         help="Disable default Penguin Blueprint MCP tools.",
     )
     parser.add_argument(
+        "--allow-runtime-tools",
+        action="store_true",
+        help="Expose opt-in RunMode readiness tools. Start/cancel remain unavailable in Slice 3A.",
+    )
+    parser.add_argument(
         "--minimal-core",
         action="store_true",
         help="Use a bare ToolManager only; PM tools require full PenguinCore.",
@@ -74,6 +79,7 @@ def main() -> None:
         core=core,
         expose_pm_tools=not args.no_pm_tools,
         expose_blueprint_tools=not args.no_blueprint_tools,
+        expose_runtime_tools=args.allow_runtime_tools,
     )
     try:
         server.run("stdio")

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -43,6 +43,11 @@ def parse_args() -> argparse.Namespace:
         help="Disable default Penguin Blueprint MCP tools.",
     )
     parser.add_argument(
+        "--no-session-tools",
+        action="store_true",
+        help="Disable default-on session/artifact/checkpoint read tools.",
+    )
+    parser.add_argument(
         "--allow-runtime-tools",
         action="store_true",
         help="Expose opt-in RunMode and ITUV runtime/orchestration MCP tools.",
@@ -80,6 +85,7 @@ def main() -> None:
         expose_pm_tools=not args.no_pm_tools,
         expose_blueprint_tools=not args.no_blueprint_tools,
         expose_runtime_tools=args.allow_runtime_tools,
+        expose_session_tools=not args.no_session_tools,
     )
     try:
         server.run("stdio")

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+import asyncio
+
 from penguin.config import config
 from penguin.integrations.mcp.server import (
     MCPServerUnavailableError,
@@ -30,18 +32,42 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Tool/pattern to deny; repeatable. Defaults deny dangerous tools.",
     )
+    parser.add_argument(
+        "--no-pm-tools",
+        action="store_true",
+        help="Disable default Penguin PM MCP tools.",
+    )
+    parser.add_argument(
+        "--minimal-core",
+        action="store_true",
+        help="Use a bare ToolManager only; PM tools require full PenguinCore.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     configure_stdio_logging()
-    tool_manager = ToolManager(config, lambda *_args, **_kwargs: None, fast_startup=True)
+    core = None
+    if args.minimal_core:
+        tool_manager = ToolManager(
+            config, lambda *_args, **_kwargs: None, fast_startup=True
+        )
+    else:
+        from penguin.core import PenguinCore
+
+        core = asyncio.run(
+            PenguinCore.create(show_progress=False, fast_startup=True)
+        )
+        tool_manager = core.tool_manager
+
     server = build_penguin_mcp_server(
         tool_manager,
         name=args.name,
         allow_tools=args.allow_tool,
         deny_patterns=args.deny_pattern,
+        core=core,
+        expose_pm_tools=not args.no_pm_tools,
     )
     try:
         server.run("stdio")

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -86,13 +86,15 @@ def main() -> None:
         )
         tool_manager = core.tool_manager
 
+    expose_pm_tools = not args.no_pm_tools and not args.minimal_core
+
     server = build_penguin_mcp_server(
         tool_manager,
         name=args.name,
         allow_tools=args.allow_tool,
         deny_patterns=args.deny_pattern,
         core=core,
-        expose_pm_tools=not args.no_pm_tools,
+        expose_pm_tools=expose_pm_tools,
         expose_blueprint_tools=not args.no_blueprint_tools,
         expose_runtime_tools=args.allow_runtime_tools,
         expose_session_tools=not args.no_session_tools,

--- a/scripts/penguin_mcp_server.py
+++ b/scripts/penguin_mcp_server.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run Penguin as an MCP stdio server exposing safe read-only tools."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from penguin.config import config
+from penguin.integrations.mcp.server import (
+    MCPServerUnavailableError,
+    build_penguin_mcp_server,
+    configure_stdio_logging,
+)
+from penguin.tools.tool_manager import ToolManager
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Penguin's MCP stdio server.")
+    parser.add_argument("--name", default="penguin", help="MCP server name")
+    parser.add_argument(
+        "--allow-tool",
+        action="append",
+        default=None,
+        help="Tool/pattern to expose; repeatable. Defaults to safe read-only tools.",
+    )
+    parser.add_argument(
+        "--deny-pattern",
+        action="append",
+        default=None,
+        help="Tool/pattern to deny; repeatable. Defaults deny dangerous tools.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    configure_stdio_logging()
+    tool_manager = ToolManager(config, lambda *_args, **_kwargs: None, fast_startup=True)
+    server = build_penguin_mcp_server(
+        tool_manager,
+        name=args.name,
+        allow_tools=args.allow_tool,
+        deny_patterns=args.deny_pattern,
+    )
+    try:
+        server.run("stdio")
+    except MCPServerUnavailableError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -972,7 +972,7 @@ def test_penguin_mcp_runmode_cancel_job_marks_running_job() -> None:
     cancelled = registry.cancel_job(job_id, reason="test requested")
 
     assert cancelled["cancel_requested"] is True
-    assert cancelled["job"]["status"] == "cancelling"
+    assert cancelled["job"]["status"] == "cancel_requested"
     assert cancelled["job"]["metadata"]["cancel_reason"] == "test requested"
     assert cancelled["registry"]["supports_cancel"] is True
 
@@ -1068,6 +1068,102 @@ def test_penguin_mcp_runmode_resume_clarification_registers_job(monkeypatch) -> 
     assert latest["status"] == "completed"
     assert latest["result"]["answer"] == "Use SQLite"
     assert latest["result"]["record_seen"] is True
+
+
+
+def test_runtime_job_records_persist_in_project_storage(tmp_path) -> None:
+    from penguin.project.manager import ProjectManager
+    from penguin.project.runtime_jobs import build_runtime_job_record
+
+    manager = ProjectManager(tmp_path)
+    record = build_runtime_job_record(
+        job_id="job-1",
+        kind="task",
+        status="running",
+        project_id="project-1",
+        task_id="task-1",
+        session_id="session-1",
+        result={"status": "running"},
+        metadata={"source": "test"},
+    )
+    manager.upsert_runtime_job(record)
+
+    reloaded = ProjectManager(tmp_path).get_runtime_job("job-1")
+
+    assert reloaded is not None
+    assert reloaded.job_id == "job-1"
+    assert reloaded.project_id == "project-1"
+    assert reloaded.task_id == "task-1"
+    assert reloaded.session_id == "session-1"
+    assert reloaded.to_dict()["result"] == {"status": "running"}
+    assert reloaded.metadata == {"source": "test"}
+
+
+def test_runmode_job_registry_persists_lifecycle(tmp_path) -> None:
+    import time
+
+    from penguin.integrations.mcp.server_tools.runmode import RunModeJobRegistry
+    from penguin.project.manager import ProjectManager
+
+    async def runner(_record):
+        return {"status": "completed", "message": "done"}
+
+    manager = ProjectManager(tmp_path)
+    registry = RunModeJobRegistry(project_manager=manager)
+    started = registry.start_job(
+        kind="task",
+        runner=runner,
+        project_id="project-1",
+        task_id="task-1",
+        metadata={"session_id": "session-1"},
+    )
+    job_id = started["job"]["job_id"]
+
+    for _ in range(50):
+        job = registry.get_job(job_id)
+        if job and job["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    reloaded_registry = RunModeJobRegistry(project_manager=ProjectManager(tmp_path))
+    durable = reloaded_registry.get_job(job_id)
+
+    assert durable is not None
+    assert durable["status"] == "completed"
+    assert durable["durable"] is True
+    assert durable["live"] is False
+    assert durable["controllable"] is False
+    assert durable["result_summary"] == "done"
+    assert durable["result"] == {"status": "completed", "message": "done"}
+
+
+def test_runmode_cancel_persists_intent_for_non_live_durable_job(tmp_path) -> None:
+    from penguin.integrations.mcp.server_tools.runmode import RunModeJobRegistry
+    from penguin.project.manager import ProjectManager
+    from penguin.project.runtime_jobs import build_runtime_job_record
+
+    manager = ProjectManager(tmp_path)
+    manager.upsert_runtime_job(
+        build_runtime_job_record(
+            job_id="job-orphan",
+            kind="task",
+            status="running",
+            project_id="project-1",
+            task_id="task-1",
+        )
+    )
+    registry = RunModeJobRegistry(project_manager=ProjectManager(tmp_path))
+
+    cancelled = registry.cancel_job("job-orphan", reason="operator request")
+    durable = registry.get_job("job-orphan")
+
+    assert cancelled["cancel_requested"] is True
+    assert cancelled["cancel_signal_sent"] is False
+    assert cancelled["controllable"] is False
+    assert durable["status"] == "cancel_requested"
+    assert durable["cancel_requested"] is True
+    assert durable["cancel_reason"] == "operator request"
+    assert durable["metadata"]["cancel_request_without_live_handle"] is True
 
 
 def test_penguin_mcp_ituv_tools_are_runtime_gated(tmp_path) -> None:

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -1069,3 +1069,109 @@ def test_penguin_mcp_runmode_resume_clarification_registers_job(monkeypatch) -> 
     assert latest["result"]["answer"] == "Use SQLite"
     assert latest["result"]["record_seen"] is True
 
+
+def test_penguin_mcp_ituv_tools_are_runtime_gated(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("ITUV tools should not route through ToolManager")
+
+    core = FakeCore()
+    default_server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    assert "penguin_ituv_capabilities" not in {
+        tool["name"] for tool in default_server.list_exposed_tools()
+    }
+
+    runtime_server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+    names = {tool["name"] for tool in runtime_server.list_exposed_tools()}
+    assert "penguin_ituv_capabilities" in names
+    assert "penguin_ituv_status" in names
+    assert "penguin_ituv_frontier" in names
+
+    capabilities = json.loads(runtime_server.call_tool("penguin_ituv_capabilities", {}))
+    assert capabilities["slice"] == "4A"
+    assert capabilities["read_only"] is True
+    assert "implement" in capabilities["phases"]
+    assert "pending_review" in capabilities["statuses"]
+    assert capabilities["dependency_readiness_rules"]["artifact_ready"]
+
+
+def test_penguin_mcp_ituv_status_and_frontier_report_ready_tasks(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("ITUV tools should not route through ToolManager")
+
+    core = FakeCore()
+    project = core.project_manager.create_project(
+        name="ITUV Test",
+        description="ITUV Test",
+        workspace_path=tmp_path,
+    )
+    ready_task = core.project_manager.create_task(
+        project_id=project.id,
+        title="Ready task",
+        description="Ready task",
+    )
+    blocked_task = core.project_manager.create_task(
+        project_id=project.id,
+        title="Blocked task",
+        description="Blocked task",
+        dependencies=[ready_task.id],
+    )
+
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    status = json.loads(
+        server.call_tool(
+            "penguin_ituv_status",
+            {"project_id": project.id, "task_id": blocked_task.id},
+        )
+    )
+    assert status["task"]["id"] == blocked_task.id
+    assert status["task_readiness"]["blocked"] is True
+    assert status["task_readiness"]["blockers"][0]["task_id"] == ready_task.id
+    assert status["dag"]["ready_count"] == 1
+
+    frontier = json.loads(
+        server.call_tool("penguin_ituv_frontier", {"project_id": project.id})
+    )
+    assert frontier["ready_count"] == 1
+    assert frontier["ready_tasks"][0]["id"] == ready_task.id
+    assert frontier["next_task"]["id"] == ready_task.id
+    assert frontier["blocked_ready_candidates"][0]["task_id"] == blocked_task.id
+

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -790,7 +790,7 @@ def test_penguin_mcp_runmode_tools_are_opt_in(tmp_path) -> None:
     )
     assert capabilities["runtime_tools_enabled"] is True
     assert capabilities["start_supported"] is True
-    assert capabilities["cancel_supported"] is False
+    assert capabilities["cancel_supported"] is True
     assert capabilities["core"]["has_project_manager"] is True
     assert capabilities["core"]["has_engine"] is True
 
@@ -827,6 +827,7 @@ def test_penguin_mcp_runmode_job_read_tools(tmp_path) -> None:
     jobs = json.loads(server.call_tool("penguin_runmode_list_jobs", {}))
     assert jobs["jobs"] == []
     assert jobs["registry"]["supports_start"] is True
+    assert jobs["registry"]["supports_cancel"] is True
 
     missing = json.loads(
         server.call_tool("penguin_runmode_get_job", {"job_id": "missing"})
@@ -839,8 +840,12 @@ def test_penguin_mcp_runmode_start_task_registers_background_job(monkeypatch) ->
     import penguin.integrations.mcp.server_tools.runmode as runmode_tools
     from penguin.integrations.mcp.server import build_penguin_mcp_server
 
-    async def fake_execute_task(core, arguments):
-        return {"status": "completed", "task_id": arguments["task_id"]}
+    async def fake_execute_task(core, arguments, record=None):
+        return {
+            "status": "completed",
+            "task_id": arguments["task_id"],
+            "record_seen": record is not None,
+        }
 
     monkeypatch.setattr(runmode_tools, "_execute_task_job", fake_execute_task)
 
@@ -884,7 +889,11 @@ def test_penguin_mcp_runmode_start_task_registers_background_job(monkeypatch) ->
 
     assert latest is not None
     assert latest["status"] == "completed"
-    assert latest["result"] == {"status": "completed", "task_id": "task-1"}
+    assert latest["result"] == {
+        "status": "completed",
+        "task_id": "task-1",
+        "record_seen": True,
+    }
 
 
 def test_penguin_mcp_runmode_start_project_registers_background_job(monkeypatch) -> None:
@@ -892,10 +901,11 @@ def test_penguin_mcp_runmode_start_project_registers_background_job(monkeypatch)
     import penguin.integrations.mcp.server_tools.runmode as runmode_tools
     from penguin.integrations.mcp.server import build_penguin_mcp_server
 
-    async def fake_execute_project(core, arguments):
+    async def fake_execute_project(core, arguments, record=None):
         return {
             "status": "completed",
             "execution": {"project_id": arguments["project_id"]},
+            "record_seen": record is not None,
         }
 
     monkeypatch.setattr(runmode_tools, "_execute_project_job", fake_execute_project)
@@ -940,4 +950,122 @@ def test_penguin_mcp_runmode_start_project_registers_background_job(monkeypatch)
     assert latest is not None
     assert latest["status"] == "completed"
     assert latest["result"]["execution"] == {"project_id": "proj-1"}
+    assert latest["result"]["record_seen"] is True
+
+
+def test_penguin_mcp_runmode_cancel_job_marks_running_job() -> None:
+    from penguin.integrations.mcp.server_tools.runmode import RunModeJobRegistry
+
+    async def never_finishes(job):
+        import asyncio
+
+        for _ in range(50):
+            if job.cancel_requested:
+                return {"status": "cancelled"}
+            await asyncio.sleep(0.01)
+        return {"status": "completed"}
+
+    registry = RunModeJobRegistry()
+    started = registry.start_job(kind="task", runner=never_finishes, task_id="task-1")
+    job_id = started["job"]["job_id"]
+
+    cancelled = registry.cancel_job(job_id, reason="test requested")
+
+    assert cancelled["cancel_requested"] is True
+    assert cancelled["job"]["status"] == "cancelling"
+    assert cancelled["job"]["metadata"]["cancel_reason"] == "test requested"
+    assert cancelled["registry"]["supports_cancel"] is True
+
+
+def test_penguin_mcp_runmode_cancel_tool_handles_unknown_job(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    payload = json.loads(
+        server.call_tool("penguin_runmode_cancel_job", {"job_id": "missing"})
+    )
+    assert payload["error"] == "job_not_found"
+
+
+def test_penguin_mcp_runmode_resume_clarification_registers_job(monkeypatch) -> None:
+    import time
+    import penguin.integrations.mcp.server_tools.runmode as runmode_tools
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    async def fake_resume(core, arguments, record=None):
+        return {
+            "status": "completed",
+            "task_id": arguments["task_id"],
+            "answer": arguments["answer"],
+            "record_seen": record is not None,
+        }
+
+    monkeypatch.setattr(runmode_tools, "_resume_clarification_job", fake_resume)
+
+    class FakeCore:
+        project_manager = object()
+        engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    start_payload = json.loads(
+        server.call_tool(
+            "penguin_runmode_resume_clarification",
+            {"task_id": "task-1", "answer": "Use SQLite", "answered_by": "test"},
+        )
+    )
+    job = start_payload["job"]
+    assert job["kind"] == "clarification_resume"
+    assert job["task_id"] == "task-1"
+
+    latest = None
+    for _ in range(50):
+        latest = json.loads(
+            server.call_tool("penguin_runmode_get_job", {"job_id": job["job_id"]})
+        )["job"]
+        if latest["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    assert latest is not None
+    assert latest["status"] == "completed"
+    assert latest["result"]["answer"] == "Use SQLite"
+    assert latest["result"]["record_seen"] is True
 

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -141,6 +141,50 @@ def test_mcp_config_requires_url_for_remote_transport() -> None:
     else:  # pragma: no cover - defensive
         raise AssertionError("remote MCP config without url should fail")
 
+
+def test_mcp_tool_allow_deny_supports_globs() -> None:
+    configs = load_mcp_server_configs(
+        {
+            "mcpServers": {
+                "mixed": {
+                    "command": "fake",
+                    "enabled_tools": ["read_*"],
+                    "disabled_tools": ["read_secret*"],
+                }
+            }
+        }
+    )
+
+    server = configs[0]
+    assert server.allows_tool("read_file") is True
+    assert server.allows_tool("read_secret_file") is False
+    assert server.allows_tool("write_file") is False
+
+
+def test_mcp_config_parses_output_limit() -> None:
+    configs = load_mcp_server_configs(
+        {
+            "mcpServers": {
+                "capped": {
+                    "command": "fake",
+                    "output_token_limit": 25,
+                }
+            }
+        }
+    )
+
+    assert configs[0].output_token_limit == 25
+
+
+def test_mcp_output_cap_truncates_large_results() -> None:
+    from penguin.integrations.mcp.manager import MCPClientManager
+
+    result = MCPClientManager._cap_output({"text": "x" * 100}, 20)
+
+    assert result["truncated"] is True
+    assert result["output_token_limit"] == 20
+    assert len(result["content"]) == 20
+
 def test_mcp_tool_name_sanitization_and_collision() -> None:
     first = make_tool_name("Local FS", "read-file")
     second = make_tool_name("Local FS", "read-file", existing=[first])

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -582,3 +582,162 @@ items:
     assert payload["stats"]["total_edges"] == 1
     assert payload["blueprint_task_count"] == 2
     assert {task["blueprint_id"] for task in payload["tasks"]} == {"ROOT", "LEAF"}
+
+
+def test_penguin_mcp_blueprint_sync_dry_run_defaults_to_safe_no_mutation(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    project_payload = json.loads(
+        server.call_tool("penguin_pm_create_project", {"name": "Sync Dry Run"})
+    )
+    project_id = project_payload["project"]["id"]
+    blueprint = """
+title: Dry Blueprint
+project_key: DRY
+items:
+  - id: ROOT
+    title: Root
+    description: Root
+    acceptance_criteria:
+      - root works
+  - id: LEAF
+    title: Leaf
+    description: Leaf
+    depends_on:
+      - ROOT
+""".strip()
+
+    payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_sync",
+            {"project_id": project_id, "content": blueprint, "format": "yaml"},
+        )
+    )
+
+    assert payload["status"] == "dry_run"
+    assert payload["sync"]["created"] == ["ROOT", "LEAF"]
+    assert payload["sync"]["updated"] == []
+    assert payload["sync"]["total_items"] == 2
+    assert core.project_manager.list_tasks(project_id=project_id) == []
+
+
+def test_penguin_mcp_blueprint_sync_mutates_when_dry_run_false(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    blueprint = """
+title: Apply Blueprint
+project_key: APPLY
+items:
+  - id: ROOT
+    title: Root
+    description: Root
+    acceptance_criteria:
+      - root works
+  - id: LEAF
+    title: Leaf
+    description: Leaf
+    depends_on:
+      - ROOT
+""".strip()
+
+    payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_sync",
+            {
+                "content": blueprint,
+                "format": "yaml",
+                "create_project": True,
+                "dry_run": False,
+                "include_tasks": True,
+            },
+        )
+    )
+
+    assert payload["status"] == "synced"
+    assert payload["sync"]["created"] == ["ROOT", "LEAF"]
+    assert payload["sync"]["updated"] == []
+    assert len(payload["tasks"]) == 2
+    assert {task["blueprint_id"] for task in payload["tasks"]} == {"ROOT", "LEAF"}
+
+
+def test_penguin_mcp_blueprint_sync_rejects_errors(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    blueprint = """
+title: Broken Blueprint
+project_key: BROKEN
+items:
+  - id: CHILD
+    title: Child
+    description: Child
+    depends_on:
+      - MISSING
+""".strip()
+
+    payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_sync",
+            {
+                "content": blueprint,
+                "format": "yaml",
+                "create_project": True,
+                "dry_run": False,
+            },
+        )
+    )
+
+    assert payload["status"] == "rejected"
+    assert payload["reason"] == "lint_errors"
+    assert payload["diagnostics"]["has_errors"] is True
+    assert core.project_manager.list_projects() == []

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -433,3 +433,152 @@ def test_penguin_mcp_pm_project_and_task_lifecycle(tmp_path) -> None:
         server.call_tool("penguin_pm_get_project", {"project_id": project["id"]})
     )
     assert fetched["project"]["tasks"][0]["id"] == task["id"]
+
+
+def test_penguin_mcp_server_exposes_blueprint_tools_with_core(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    exposed = {tool["name"] for tool in server.list_exposed_tools()}
+
+    assert {
+        "penguin_blueprint_lint",
+        "penguin_blueprint_graph",
+        "penguin_blueprint_status",
+    } <= exposed
+
+
+def test_penguin_mcp_blueprint_lint_and_graph_from_yaml(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    blueprint = """
+title: MCP Blueprint
+project_key: MCP
+items:
+  - id: BASE
+    title: Base task
+    description: Base task
+    acceptance_criteria:
+      - base works
+  - id: CHILD
+    title: Child task
+    description: Child task
+    depends_on:
+      - BASE
+""".strip()
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+
+    lint_payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_lint",
+            {"content": blueprint, "format": "yaml", "source": "inline.yaml"},
+        )
+    )
+    assert lint_payload["blueprint"]["title"] == "MCP Blueprint"
+    assert lint_payload["diagnostics"]["has_errors"] is False
+
+    graph_payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_graph",
+            {
+                "content": blueprint,
+                "format": "yaml",
+                "source": "inline.yaml",
+                "output_format": "dot",
+            },
+        )
+    )
+    assert {node["id"] for node in graph_payload["graph"]["nodes"]} == {
+        "BASE",
+        "CHILD",
+    }
+    assert graph_payload["graph"]["edges"] == [
+        {"from": "BASE", "to": "CHILD", "policy": "completion_required", "artifact_key": None}
+    ]
+    assert "digraph BlueprintDAG" in graph_payload["dot"]
+
+
+def test_penguin_mcp_blueprint_status_reports_project_dag(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+    from penguin.project.blueprint_parser import BlueprintParser
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("Blueprint tools should not route through ToolManager")
+
+    blueprint = BlueprintParser().parse_yaml(
+        """
+title: Status Blueprint
+project_key: STAT
+items:
+  - id: ROOT
+    title: Root
+    description: Root
+    acceptance_criteria:
+      - root works
+  - id: LEAF
+    title: Leaf
+    description: Leaf
+    depends_on:
+      - ROOT
+""".strip(),
+        source="status.yaml",
+    )
+    core = FakeCore()
+    sync_result = core.project_manager.sync_blueprint(blueprint)
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+
+    payload = json.loads(
+        server.call_tool(
+            "penguin_blueprint_status",
+            {"project_id": sync_result["project_id"], "include_tasks": True},
+        )
+    )
+
+    assert payload["stats"]["total_tasks"] == 2
+    assert payload["stats"]["total_edges"] == 1
+    assert payload["blueprint_task_count"] == 2
+    assert {task["blueprint_id"] for task in payload["tasks"]} == {"ROOT", "LEAF"}

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -1106,8 +1106,9 @@ def test_penguin_mcp_ituv_tools_are_runtime_gated(tmp_path) -> None:
     assert "penguin_ituv_frontier" in names
 
     capabilities = json.loads(runtime_server.call_tool("penguin_ituv_capabilities", {}))
-    assert capabilities["slice"] == "4A"
-    assert capabilities["read_only"] is True
+    assert capabilities["slice"] == "4B"
+    assert capabilities["read_only"] is False
+    assert capabilities["mutation_tools_exposed"] is True
     assert "implement" in capabilities["phases"]
     assert "pending_review" in capabilities["statuses"]
     assert capabilities["dependency_readiness_rules"]["artifact_ready"]
@@ -1175,3 +1176,145 @@ def test_penguin_mcp_ituv_status_and_frontier_report_ready_tasks(tmp_path) -> No
     assert frontier["next_task"]["id"] == ready_task.id
     assert frontier["blocked_ready_candidates"][0]["task_id"] == blocked_task.id
 
+
+
+
+def test_penguin_mcp_ituv_mutations_default_to_dry_run(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+    from penguin.project.models import TaskPhase
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("ITUV tools should not route through ToolManager")
+
+    core = FakeCore()
+    project = core.project_manager.create_project(
+        name="ITUV Mutations",
+        description="ITUV Mutations",
+        workspace_path=tmp_path,
+    )
+    task = core.project_manager.create_task(
+        project_id=project.id,
+        title="Mutable task",
+        description="Mutable task",
+    )
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    dry_run = json.loads(
+        server.call_tool(
+            "penguin_ituv_signal",
+            {"task_id": task.id, "action": "set_phase", "phase": "implement"},
+        )
+    )
+    assert dry_run["status"] == "dry_run"
+    assert core.project_manager.get_task(task.id).phase == TaskPhase.PENDING
+
+    applied = json.loads(
+        server.call_tool(
+            "penguin_ituv_signal",
+            {
+                "task_id": task.id,
+                "action": "set_phase",
+                "phase": "implement",
+                "dry_run": False,
+            },
+        )
+    )
+    assert applied["status"] == "applied"
+    assert applied["after"]["phase"] == "implement"
+    assert core.project_manager.get_task(task.id).phase == TaskPhase.IMPLEMENT
+
+    rejected = json.loads(
+        server.call_tool(
+            "penguin_ituv_signal",
+            {
+                "task_id": task.id,
+                "action": "set_phase",
+                "phase": "done",
+                "dry_run": False,
+            },
+        )
+    )
+    assert rejected["status"] == "rejected"
+    assert "mark_ready_for_review" in rejected["reason"]
+
+
+def test_penguin_mcp_ituv_artifact_and_review_bridge(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+    from penguin.project.models import TaskPhase, TaskStatus
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("ITUV tools should not route through ToolManager")
+
+    core = FakeCore()
+    project = core.project_manager.create_project(
+        name="ITUV Evidence",
+        description="ITUV Evidence",
+        workspace_path=tmp_path,
+    )
+    task = core.project_manager.create_task(
+        project_id=project.id,
+        title="Evidence task",
+        description="Evidence task",
+    )
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    artifact = json.loads(
+        server.call_tool(
+            "penguin_ituv_record_artifact",
+            {
+                "task_id": task.id,
+                "key": "build-log",
+                "kind": "file",
+                "path": "build.log",
+                "valid": True,
+                "dry_run": False,
+            },
+        )
+    )
+    assert artifact["status"] == "applied"
+    assert artifact["after"]["artifact_evidence"][0]["key"] == "build-log"
+
+    review = json.loads(
+        server.call_tool(
+            "penguin_ituv_mark_ready_for_review",
+            {"task_id": task.id, "dry_run": False, "response": "done"},
+        )
+    )
+    assert review["status"] == "applied"
+    updated = core.project_manager.get_task(task.id)
+    assert updated.status == TaskStatus.PENDING_REVIEW
+    assert updated.phase == TaskPhase.DONE

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -4,7 +4,11 @@ import json
 
 from penguin.integrations.mcp.config import load_mcp_server_configs
 from penguin.integrations.mcp.manager import MCPToolDefinition
-from penguin.integrations.mcp.names import is_mcp_tool_name, make_tool_name, sanitize_part
+from penguin.integrations.mcp.names import (
+    is_mcp_tool_name,
+    make_tool_name,
+    sanitize_part,
+)
 from penguin.tools.providers.mcp import MCPToolProvider
 from penguin.tools.tool_manager import ToolManager
 
@@ -32,8 +36,31 @@ class FakeManager:
         self.called_with = (public_name, arguments)
         return {"public_name": public_name, "arguments": arguments}
 
+    def refresh_sync(self):
+        return self.list_tools_sync()
+
+    def reconnect_sync(self, server_name=None) -> dict:
+        return {
+            "available": True,
+            "discovered": True,
+            "servers": {"local-fs": {"status": "connected"}},
+        }
+
+    def close_sync(self) -> dict:
+        return {
+            "available": True,
+            "discovered": True,
+            "servers": {"local-fs": {"status": "disconnected"}},
+        }
+
     def status(self) -> dict:
-        return {"available": True, "discovered": True, "servers": {}}
+        return {
+            "available": True,
+            "discovered": True,
+            "server_count": 1,
+            "tool_count": 1,
+            "servers": {},
+        }
 
 
 def test_mcp_config_parses_mapping_servers_and_env(monkeypatch) -> None:
@@ -157,3 +184,70 @@ def test_mcp_provider_gracefully_noops_when_disabled() -> None:
     assert provider.get_tool_schemas() == []
     payload = json.loads(provider.execute_tool("mcp__missing__tool", {}))
     assert payload["error"] == "mcp_disabled"
+
+
+
+def test_mcp_config_accepts_claude_style_mcp_servers() -> None:
+    configs = load_mcp_server_configs(
+        {
+            "mcpServers": {
+                "everything": {
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-everything"],
+                    "startupTimeoutSec": 30,
+                    "toolTimeoutSec": 120,
+                }
+            }
+        }
+    )
+
+    assert len(configs) == 1
+    server = configs[0]
+    assert server.name == "everything"
+    assert server.command == "npx"
+    assert server.startup_timeout_sec == 30
+    assert server.tool_timeout_sec == 120
+
+
+def test_mcp_provider_status_refresh_reconnect_and_close() -> None:
+    provider = MCPToolProvider(
+        {
+            "mcp": {
+                "enabled": True,
+                "servers": {"local-fs": {"command": "fake"}},
+            }
+        }
+    )
+    fake_manager = FakeManager()
+    provider._manager = fake_manager
+
+    assert provider.status()["initialized"] is True
+    assert provider.refresh()[0]["name"] == "mcp__local_fs__read_file"
+    assert (
+        provider.reconnect("local-fs")["servers"]["local-fs"]["status"]
+        == "connected"
+    )
+    assert provider.close()["servers"]["local-fs"]["status"] == "disconnected"
+
+
+def test_tool_manager_mcp_diagnostic_facade() -> None:
+    manager = ToolManager(
+        {
+            "mcp": {
+                "enabled": True,
+                "servers": {"local-fs": {"command": "fake"}},
+            }
+        },
+        lambda *_args, **_kwargs: None,
+        fast_startup=True,
+    )
+    fake_manager = FakeManager()
+    manager._mcp_provider._manager = fake_manager
+
+    assert manager.get_mcp_status()["initialized"] is True
+    assert manager.refresh_mcp_tools()[0]["name"] == "mcp__local_fs__read_file"
+    assert (
+        manager.reconnect_mcp("local-fs")["servers"]["local-fs"]["status"]
+        == "connected"
+    )
+    assert manager.close_mcp()["servers"]["local-fs"]["status"] == "disconnected"

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -355,7 +355,11 @@ def test_penguin_mcp_server_exposes_pm_tools_with_core(tmp_path) -> None:
             raise AssertionError("PM tools should not route through ToolManager")
 
     core = FakeCore()
-    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
     exposed = {tool["name"] for tool in server.list_exposed_tools()}
 
     assert {
@@ -1414,3 +1418,106 @@ def test_penguin_mcp_ituv_artifact_and_review_bridge(tmp_path) -> None:
     updated = core.project_manager.get_task(task.id)
     assert updated.status == TaskStatus.PENDING_REVIEW
     assert updated.phase == TaskPhase.DONE
+
+
+
+def test_penguin_mcp_session_tools_are_default_on(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+    from penguin.system.conversation_manager import ConversationManager
+    from penguin.system.state import MessageCategory, create_message
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.conversation_manager = ConversationManager(workspace_path=tmp_path)
+            self.model_config = type("Model", (), {"provider": "test", "model": "fake"})()
+
+        def list_checkpoints(self, session_id=None, limit=50):
+            return []
+
+        def get_checkpoint_stats(self):
+            return {"enabled": True, "total_checkpoints": 0}
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("session tools should not route through ToolManager")
+
+    core = FakeCore()
+    session_id = core.conversation_manager.create_new_conversation()
+    session = core.conversation_manager.get_current_session()
+    session.add_message(
+        create_message(
+            "user",
+            "Summarize the MCP session surface",
+            MessageCategory.DIALOG,
+        )
+    )
+    core.conversation_manager.save()
+
+    project = core.project_manager.create_project(
+        name="Artifact Project",
+        description="Artifact Project",
+        workspace_path=tmp_path,
+    )
+    task = core.project_manager.create_task(
+        project_id=project.id,
+        title="Evidence task",
+        description="Evidence task",
+    )
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+    tool_names = {tool["name"] for tool in server.list_exposed_tools()}
+    assert "penguin_session_list" in tool_names
+    assert "penguin_artifacts_list" in tool_names
+    assert "penguin_checkpoints_list" in tool_names
+
+    listed = json.loads(server.call_tool("penguin_session_list", {"limit": 10}))
+    assert any(item["id"] == session_id for item in listed["sessions"])
+
+    summary = json.loads(
+        server.call_tool(
+            "penguin_session_summary",
+            {"session_id": session_id, "message_limit": 5},
+        )
+    )
+    assert summary["session"]["id"] == session_id
+    assert summary["messages_preview"]
+    assert "MCP session surface" in summary["messages_preview"][-1]["text_preview"]
+
+    artifact = json.loads(
+        server.call_tool(
+            "penguin_ituv_record_artifact",
+            {
+                "task_id": task.id,
+                "key": "report",
+                "kind": "file",
+                "path": "report.md",
+                "valid": True,
+                "dry_run": False,
+            },
+        )
+    )
+    assert artifact["status"] == "applied"
+
+    artifacts = json.loads(
+        server.call_tool(
+            "penguin_artifacts_list",
+            {"project_id": project.id, "valid_only": True},
+        )
+    )
+    assert artifacts["count"] == 1
+    assert artifacts["artifacts"][0]["artifact_key"] == "report"
+
+    checkpoints = json.loads(server.call_tool("penguin_checkpoints_list", {}))
+    assert checkpoints["count"] == 0
+    assert checkpoints["stats"]["enabled"] is True

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -741,3 +741,95 @@ items:
     assert payload["reason"] == "lint_errors"
     assert payload["diagnostics"]["has_errors"] is True
     assert core.project_manager.list_projects() == []
+
+
+def test_penguin_mcp_runmode_tools_are_opt_in(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+            self._runmode_active = False
+            self._continuous_mode = False
+            self.current_runmode_status_summary = None
+
+        async def start_run_mode(self, *args, **kwargs):
+            raise AssertionError("Slice 3A must not start RunMode")
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    default_server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    default_exposed = {tool["name"] for tool in default_server.list_exposed_tools()}
+    assert "penguin_runmode_capabilities" not in default_exposed
+
+    runtime_server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+    exposed = {tool["name"] for tool in runtime_server.list_exposed_tools()}
+    assert {
+        "penguin_runmode_capabilities",
+        "penguin_runmode_list_jobs",
+        "penguin_runmode_get_job",
+    } <= exposed
+
+    capabilities = json.loads(
+        runtime_server.call_tool("penguin_runmode_capabilities", {})
+    )
+    assert capabilities["runtime_tools_enabled"] is True
+    assert capabilities["start_supported"] is False
+    assert capabilities["cancel_supported"] is False
+    assert capabilities["core"]["has_project_manager"] is True
+    assert capabilities["core"]["has_engine"] is True
+
+
+def test_penguin_mcp_runmode_job_read_tools(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+            self.engine = object()
+
+        async def start_run_mode(self, *args, **kwargs):
+            raise AssertionError("Slice 3A must not start RunMode")
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    jobs = json.loads(server.call_tool("penguin_runmode_list_jobs", {}))
+    assert jobs["jobs"] == []
+    assert jobs["registry"]["supports_start"] is False
+
+    missing = json.loads(
+        server.call_tool("penguin_runmode_get_job", {"job_id": "missing"})
+    )
+    assert missing["error"] == "job_not_found"
+

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -251,3 +251,86 @@ def test_tool_manager_mcp_diagnostic_facade() -> None:
         == "connected"
     )
     assert manager.close_mcp()["servers"]["local-fs"]["status"] == "disconnected"
+
+def test_penguin_mcp_server_exposes_safe_tools_only() -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    manager = ToolManager({}, lambda *_args, **_kwargs: None, fast_startup=True)
+    server = build_penguin_mcp_server(manager)
+    exposed = {tool["name"] for tool in server.list_exposed_tools()}
+
+    assert {"read_file", "list_files", "find_file", "grep_search", "analyze_project"} <= exposed
+    assert "execute" not in exposed
+    assert "write_file" not in exposed
+    assert all(not name.startswith("mcp__") for name in exposed)
+
+
+def test_penguin_mcp_server_routes_calls_through_tool_manager() -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    class FakeToolManager:
+        def __init__(self) -> None:
+            self.called_with = None
+
+        def get_tools(self):
+            return [
+                {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    },
+                },
+                {
+                    "name": "execute",
+                    "description": "Run a command",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+            ]
+
+        def execute_tool(self, tool_name, arguments):
+            self.called_with = (tool_name, arguments)
+            return {"ok": True, "tool": tool_name, "arguments": arguments}
+
+    fake = FakeToolManager()
+    server = build_penguin_mcp_server(fake)
+    result = json.loads(server.call_tool("read_file", {"path": "README.md"}))
+
+    assert result["ok"] is True
+    assert fake.called_with == ("read_file", {"path": "README.md"})
+    assert json.loads(server.call_tool("execute", {}))["error"] == "tool_not_exposed"
+
+
+def test_penguin_mcp_server_dynamic_handler_signature() -> None:
+    import inspect
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    class FakeToolManager:
+        def get_tools(self):
+            return [
+                {
+                    "name": "find_file",
+                    "description": "Find a file",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "filename": {"type": "string"},
+                            "search_path": {"type": "string"},
+                        },
+                        "required": ["filename"],
+                    },
+                }
+            ]
+
+        def execute_tool(self, tool_name, arguments):
+            return arguments
+
+    server = build_penguin_mcp_server(FakeToolManager(), allow_tools=["find_file"])
+    handler = server._build_tool_handler(server.list_exposed_tools()[0])
+    signature = inspect.signature(handler)
+
+    assert "filename" in signature.parameters
+    assert signature.parameters["filename"].default is inspect.Parameter.empty
+    assert signature.parameters["search_path"].default is None

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -334,3 +334,102 @@ def test_penguin_mcp_server_dynamic_handler_signature() -> None:
     assert "filename" in signature.parameters
     assert signature.parameters["filename"].default is inspect.Parameter.empty
     assert signature.parameters["search_path"].default is None
+
+
+def test_penguin_mcp_server_exposes_pm_tools_with_core(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("PM tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+    exposed = {tool["name"] for tool in server.list_exposed_tools()}
+
+    assert {
+        "penguin_pm_list_projects",
+        "penguin_pm_create_project",
+        "penguin_pm_get_project",
+        "penguin_pm_list_tasks",
+        "penguin_pm_create_task",
+        "penguin_pm_get_task",
+    } <= exposed
+
+
+def test_penguin_mcp_pm_project_and_task_lifecycle(tmp_path) -> None:
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+    from penguin.project.manager import ProjectManager
+
+    class FakeCore:
+        def __init__(self) -> None:
+            self.project_manager = ProjectManager(tmp_path)
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("PM tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
+
+    project_payload = json.loads(
+        server.call_tool(
+            "penguin_pm_create_project",
+            {
+                "name": "MCP Slice 1",
+                "description": "PM control plane",
+                "tags": ["mcp"],
+                "metadata": {"source": "test"},
+            },
+        )
+    )
+    project = project_payload["project"]
+    assert project["name"] == "MCP Slice 1"
+    assert project["metadata"] == {"source": "test"}
+
+    task_payload = json.loads(
+        server.call_tool(
+            "penguin_pm_create_task",
+            {
+                "project_id": project["id"],
+                "title": "Implement PM tools",
+                "description": "Expose PM over MCP",
+                "acceptance_criteria": ["tools/list includes PM tools"],
+                "definition_of_done": "verified",
+                "metadata": {"risk": "low"},
+            },
+        )
+    )
+    task = task_payload["task"]
+    assert task["project_id"] == project["id"]
+    assert task["title"] == "Implement PM tools"
+    assert task["acceptance_criteria"] == ["tools/list includes PM tools"]
+    assert task["definition_of_done"] == "verified"
+    assert task["metadata"] == {"risk": "low"}
+
+    list_payload = json.loads(
+        server.call_tool("penguin_pm_list_tasks", {"project_id": project["id"]})
+    )
+    assert [item["id"] for item in list_payload["tasks"]] == [task["id"]]
+
+    fetched = json.loads(
+        server.call_tool("penguin_pm_get_project", {"project_id": project["id"]})
+    )
+    assert fetched["project"]["tasks"][0]["id"] == task["id"]

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+
+from penguin.integrations.mcp.config import load_mcp_server_configs
+from penguin.integrations.mcp.manager import MCPToolDefinition
+from penguin.integrations.mcp.names import is_mcp_tool_name, make_tool_name, sanitize_part
+from penguin.tools.providers.mcp import MCPToolProvider
+from penguin.tools.tool_manager import ToolManager
+
+
+class FakeManager:
+    def __init__(self) -> None:
+        self.called_with = None
+
+    def list_tools_sync(self) -> list[MCPToolDefinition]:
+        return [
+            MCPToolDefinition(
+                public_name="mcp__local_fs__read_file",
+                server_name="local-fs",
+                raw_name="read-file",
+                description="Read a file through MCP",
+                input_schema={
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            )
+        ]
+
+    def call_tool_sync(self, public_name: str, arguments: dict) -> dict:
+        self.called_with = (public_name, arguments)
+        return {"public_name": public_name, "arguments": arguments}
+
+    def status(self) -> dict:
+        return {"available": True, "discovered": True, "servers": {}}
+
+
+def test_mcp_config_parses_mapping_servers_and_env(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_TOKEN", "secret-value")
+    configs = load_mcp_server_configs(
+        {
+            "mcp": {
+                "enabled": True,
+                "servers": {
+                    "filesystem": {
+                        "command": "uvx",
+                        "args": ["mcp-server-filesystem"],
+                        "env": {"TOKEN": "$MCP_TOKEN"},
+                        "disabled_tools": ["write_file"],
+                    }
+                },
+            }
+        }
+    )
+
+    assert len(configs) == 1
+    server = configs[0]
+    assert server.name == "filesystem"
+    assert server.command == "uvx"
+    assert server.args == ["mcp-server-filesystem"]
+    assert server.env == {"TOKEN": "secret-value"}
+    assert server.allows_tool("read_file") is True
+    assert server.allows_tool("write_file") is False
+
+
+def test_mcp_config_is_disabled_by_default() -> None:
+    assert load_mcp_server_configs({}) == []
+    assert load_mcp_server_configs({"mcp": {"enabled": False}}) == []
+
+
+def test_mcp_tool_name_sanitization_and_collision() -> None:
+    first = make_tool_name("Local FS", "read-file")
+    second = make_tool_name("Local FS", "read-file", existing=[first])
+
+    assert first == "mcp__local_fs__read_file"
+    assert second == "mcp__local_fs__read_file_2"
+    assert sanitize_part("../Bad Name!!") == "bad_name"
+    assert is_mcp_tool_name(first) is True
+    assert is_mcp_tool_name("read_file") is False
+
+
+def test_mcp_provider_exposes_schemas_and_dispatches() -> None:
+    provider = MCPToolProvider(
+        {
+            "mcp": {
+                "enabled": True,
+                "servers": {"local-fs": {"command": "fake"}},
+            }
+        }
+    )
+    fake_manager = FakeManager()
+    provider._manager = fake_manager
+
+    schemas = provider.get_tool_schemas()
+    assert schemas == [
+        {
+            "name": "mcp__local_fs__read_file",
+            "description": "Read a file through MCP",
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            "metadata": {
+                "provider": "mcp",
+                "mcp_server": "local-fs",
+                "mcp_tool": "read-file",
+            },
+        }
+    ]
+
+    payload = json.loads(
+        provider.execute_tool("mcp__local_fs__read_file", {"path": "README.md"})
+    )
+    assert payload["status"] == "ok"
+    assert payload["result"] == {
+        "public_name": "mcp__local_fs__read_file",
+        "arguments": {"path": "README.md"},
+    }
+    assert fake_manager.called_with == (
+        "mcp__local_fs__read_file",
+        {"path": "README.md"},
+    )
+
+
+def test_tool_manager_exposes_and_dispatches_mcp_tools() -> None:
+    manager = ToolManager(
+        {
+            "mcp": {
+                "enabled": True,
+                "servers": {"local-fs": {"command": "fake"}},
+            }
+        },
+        lambda *_args, **_kwargs: None,
+        fast_startup=True,
+    )
+    fake_manager = FakeManager()
+    manager._mcp_provider._manager = fake_manager
+
+    tool_names = {tool["name"] for tool in manager.get_tools()}
+    assert "mcp__local_fs__read_file" in tool_names
+
+    payload = json.loads(
+        manager.execute_tool("mcp__local_fs__read_file", {"path": "README.md"})
+    )
+    assert payload["status"] == "ok"
+    assert fake_manager.called_with == (
+        "mcp__local_fs__read_file",
+        {"path": "README.md"},
+    )
+
+
+def test_mcp_provider_gracefully_noops_when_disabled() -> None:
+    provider = MCPToolProvider({})
+
+    assert provider.get_tool_schemas() == []
+    payload = json.loads(provider.execute_tool("mcp__missing__tool", {}))
+    assert payload["error"] == "mcp_disabled"

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -789,7 +789,7 @@ def test_penguin_mcp_runmode_tools_are_opt_in(tmp_path) -> None:
         runtime_server.call_tool("penguin_runmode_capabilities", {})
     )
     assert capabilities["runtime_tools_enabled"] is True
-    assert capabilities["start_supported"] is False
+    assert capabilities["start_supported"] is True
     assert capabilities["cancel_supported"] is False
     assert capabilities["core"]["has_project_manager"] is True
     assert capabilities["core"]["has_engine"] is True
@@ -826,10 +826,118 @@ def test_penguin_mcp_runmode_job_read_tools(tmp_path) -> None:
 
     jobs = json.loads(server.call_tool("penguin_runmode_list_jobs", {}))
     assert jobs["jobs"] == []
-    assert jobs["registry"]["supports_start"] is False
+    assert jobs["registry"]["supports_start"] is True
 
     missing = json.loads(
         server.call_tool("penguin_runmode_get_job", {"job_id": "missing"})
     )
     assert missing["error"] == "job_not_found"
+
+
+def test_penguin_mcp_runmode_start_task_registers_background_job(monkeypatch) -> None:
+    import time
+    import penguin.integrations.mcp.server_tools.runmode as runmode_tools
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    async def fake_execute_task(core, arguments):
+        return {"status": "completed", "task_id": arguments["task_id"]}
+
+    monkeypatch.setattr(runmode_tools, "_execute_task_job", fake_execute_task)
+
+    class FakeCore:
+        project_manager = object()
+        engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    start_payload = json.loads(
+        server.call_tool("penguin_runmode_start_task", {"task_id": "task-1"})
+    )
+    job = start_payload["job"]
+    assert job["kind"] == "task"
+    assert job["task_id"] == "task-1"
+    assert start_payload["registry"]["supports_start"] is True
+
+    latest = None
+    for _ in range(50):
+        latest = json.loads(
+            server.call_tool("penguin_runmode_get_job", {"job_id": job["job_id"]})
+        )["job"]
+        if latest["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    assert latest is not None
+    assert latest["status"] == "completed"
+    assert latest["result"] == {"status": "completed", "task_id": "task-1"}
+
+
+def test_penguin_mcp_runmode_start_project_registers_background_job(monkeypatch) -> None:
+    import time
+    import penguin.integrations.mcp.server_tools.runmode as runmode_tools
+    from penguin.integrations.mcp.server import build_penguin_mcp_server
+
+    async def fake_execute_project(core, arguments):
+        return {
+            "status": "completed",
+            "execution": {"project_id": arguments["project_id"]},
+        }
+
+    monkeypatch.setattr(runmode_tools, "_execute_project_job", fake_execute_project)
+
+    class FakeCore:
+        project_manager = object()
+        engine = object()
+
+    class FakeToolManager:
+        def __init__(self, core) -> None:
+            self._core = core
+
+        def get_tools(self):
+            return []
+
+        def execute_tool(self, tool_name, arguments):
+            raise AssertionError("RunMode tools should not route through ToolManager")
+
+    core = FakeCore()
+    server = build_penguin_mcp_server(
+        FakeToolManager(core),
+        core=core,
+        expose_runtime_tools=True,
+    )
+
+    start_payload = json.loads(
+        server.call_tool("penguin_runmode_start_project", {"project_id": "proj-1"})
+    )
+    job = start_payload["job"]
+    assert job["kind"] == "project"
+    assert job["project_id"] == "proj-1"
+
+    latest = None
+    for _ in range(50):
+        latest = json.loads(
+            server.call_tool("penguin_runmode_get_job", {"job_id": job["job_id"]})
+        )["job"]
+        if latest["status"] == "completed":
+            break
+        time.sleep(0.02)
+
+    assert latest is not None
+    assert latest["status"] == "completed"
+    assert latest["result"]["execution"] == {"project_id": "proj-1"}
 

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -355,11 +355,7 @@ def test_penguin_mcp_server_exposes_pm_tools_with_core(tmp_path) -> None:
             raise AssertionError("PM tools should not route through ToolManager")
 
     core = FakeCore()
-    server = build_penguin_mcp_server(
-        FakeToolManager(core),
-        core=core,
-        expose_runtime_tools=True,
-    )
+    server = build_penguin_mcp_server(FakeToolManager(core), core=core)
     exposed = {tool["name"] for tool in server.list_exposed_tools()}
 
     assert {

--- a/tests/test_mcp_phase1.py
+++ b/tests/test_mcp_phase1.py
@@ -96,6 +96,51 @@ def test_mcp_config_is_disabled_by_default() -> None:
     assert load_mcp_server_configs({"mcp": {"enabled": False}}) == []
 
 
+
+def test_mcp_config_accepts_streamable_http_and_env_headers(monkeypatch) -> None:
+    monkeypatch.setenv("REMOTE_MCP_TOKEN", "token-value")
+    configs = load_mcp_server_configs(
+        {
+            "mcp_servers": {
+                "remote": {
+                    "transport": "streamable_http",
+                    "url": "https://example.test/mcp",
+                    "bearer_token_env_var": "REMOTE_MCP_TOKEN",
+                    "http_headers": {"X-Client": "Penguin"},
+                    "env_http_headers": {"X-Env": "REMOTE_MCP_TOKEN"},
+                }
+            }
+        }
+    )
+
+    assert len(configs) == 1
+    server = configs[0]
+    assert server.name == "remote"
+    assert server.transport == "streamable_http"
+    assert server.url == "https://example.test/mcp"
+    assert server.command == ""
+    assert server.resolved_http_headers == {
+        "Authorization": "Bearer token-value",
+        "X-Client": "Penguin",
+        "X-Env": "token-value",
+    }
+
+
+def test_mcp_config_requires_url_for_remote_transport() -> None:
+    try:
+        load_mcp_server_configs(
+            {
+                "mcp": {
+                    "enabled": True,
+                    "servers": {"remote": {"transport": "sse"}},
+                }
+            }
+        )
+    except ValueError as exc:
+        assert "missing required url" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("remote MCP config without url should fail")
+
 def test_mcp_tool_name_sanitization_and_collision() -> None:
     first = make_tool_name("Local FS", "read-file")
     second = make_tool_name("Local FS", "read-file", existing=[first])


### PR DESCRIPTION
## Summary

This PR rewrites Penguin's MCP integration into a real MCP system, with the primary product value focused on **Penguin as an MCP host** consuming external MCP servers.

Highlights:
- Add optional `penguin-ai[mcp]` support for the official Python MCP SDK.
- Add MCP host/client support for STDIO, Streamable HTTP, and SSE servers.
- Expose external MCP tools through Penguin's ToolManager as `mcp__server__tool` tools.
- Add persistent STDIO sessions, diagnostics, refresh/reconnect/close controls, wildcard allow/deny filtering, and output caps.
- Validate host usage against Chrome DevTools MCP and OpenAI Docs MCP.
- Add a real Penguin MCP server surface for safe tools, PM, Blueprint, RunMode, ITUV, sessions, resources, and prompts.
- Add docs, architecture notes, smoke scripts, and prompt guidance for MCP-hosted tools.

## Why

The previous MCP integration was custom HTTP/JSON-lines scaffolding, not real MCP protocol support. This PR replaces that path with SDK-backed MCP host/server behavior and keeps ToolManager as the policy/schema/execution boundary.

## Host / Client Support

Penguin can now consume configured MCP servers and expose their tools as normal Penguin tools:

- `stdio`
- `streamable_http`
- `sse`
- env-backed bearer/header auth
- model-safe names like `mcp__chrome_devtools__navigate`
- raw MCP tool identity preserved internally
- wildcard `enabled_tools` / `disabled_tools`
- `output_token_limit` / `max_output_chars`
- status/refresh/reconnect/close APIs and CLI commands

CLI diagnostics:

```bash
penguin-cli mcp status --json
penguin-cli mcp refresh --json
penguin-cli mcp reconnect chrome-devtools --json
penguin-cli mcp close --json
```

## Penguin MCP Server Surface

This PR also adds a real SDK-backed MCP server wrapper:

```bash
uv run --extra mcp python scripts/penguin_mcp_server.py
uv run --extra mcp python scripts/penguin_mcp_server.py --allow-runtime-tools
```

Default-on server surfaces:
- safe read tools
- project/task management
- Blueprint lint/graph/status/sync
- session/artifact/checkpoint read tools
- resources and prompts

Runtime-gated surfaces behind `--allow-runtime-tools`:
- RunMode capabilities/start/cancel/resume
- ITUV status/frontier/signaling/artifact recording

## Validation

Ran:

```bash
pytest -q tests/test_mcp_phase1.py tests/test_permission_engine.py
uv run --python 3.11 --extra mcp python scripts/mcp_control_plane_smoke.py
uv run --python 3.11 --extra mcp python scripts/mcp_chrome_smoke.py --include-random
uv run python -m py_compile <touched MCP/CLI/script files>
uv run ruff check --isolated scripts/mcp_chrome_smoke.py penguin/prompt_actions.py penguin/integrations/mcp/config.py penguin/integrations/mcp/manager.py tests/test_mcp_phase1.py
uv run penguin-cli mcp status --json
```

Results:
- `79 passed`
- control-plane smoke passed via real MCP protocol
- Chrome DevTools MCP smoke passed, screenshots captured at `1280x900`
- OpenAI Docs MCP Streamable HTTP live validation passed:
  - discovered 5 tools
  - successfully called `mcp__openai_docs__search_openai_docs`

## Security / Safety

- MCP tools are treated as external capability surfaces.
- `mcp__*` maps to conservative permission behavior.
- Wildcard allow/deny filters are supported and tested.
- Output caps truncate large MCP responses before model-facing payloads.
- Runtime execution tools are opt-in via `--allow-runtime-tools`.
- Prompt guidance now instructs Penguin to treat MCP tools as third-party external capabilities.

## Deferred / Follow-Up

Not included in this PR:
- Full OAuth / dynamic client registration.
- Full dynamic `tools/list_changed` parity.
- TUI MCP UX polish.
- Link/cloud-grade distributed runtime job orchestration.
- More vendor smoke tests for GitHub/Sentry/Linear.

## Notes

The PR intentionally leads with Penguin consuming MCP servers. The Penguin-as-MCP-server control-plane work is included, but the highest near-term value is host-side use of tools like Chrome DevTools MCP, OpenAI Docs MCP, GitHub, Sentry, and similar external capability servers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full MCP integration: host/server tooling, discovery, lifecycle, CLI and web endpoints, MCP-backed tools (PM, Blueprints, RunMode, ITUV, sessions) and runtime job tracking with streaming task updates.

* **Documentation**
  * Comprehensive MCP system docs, architecture guides, tool catalog, audits, and bug notes.

* **Chores**
  * Added optional MCP SDK dependency and smoke-test scripts.

* **Bug Fixes**
  * Documented read-tool empty-loop scenario and small install/test workflow guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->