### PR TITLE
Stabilize LLM provider contract and replay handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Style and Conventions
 - Errors: raise specific exceptions, no bare except; add context; never swallow; log via logging with appropriate level.
 - Logging: use logging.getLogger(__name__); avoid printing in library code.
 - Tests: pytest, aim for high coverage; add async tests with pytest-asyncio where needed; keep unit tests deterministic. Tests go in tests/, NEVER in penguin/ source dirs.
+- Provider/tool/runtime reliability changes must follow `context/tasks/testing-pyramid.md`: prefer deterministic fake-provider, contract, state-machine, and fault-injection tests before live-provider checks. Cover incomplete streams, provider errors, retry/release behavior, native tool replay adjacency, and CWM category-priority truncation where relevant. Live provider tests are opt-in smoke tests, not the proof of correctness.
+- Penguin's context window manager trims message categories by priority and recency; it does not summarize or compact conversation content. Do not describe current CWM behavior as compaction unless you are explicitly discussing a future or external compaction feature.
 - Files to avoid committing: see .gitignore; add .crush/ local artifacts.
 - Docs: keep README and docs/ in sync when changing public API.
 

--- a/context/tasks/codex-integration-parity.md
+++ b/context/tasks/codex-integration-parity.md
@@ -45,6 +45,8 @@ behavior.
 - Penguin model catalog merge path:
   `penguin/web/services/provider_catalog.py`
   `penguin/web/services/opencode_provider.py`
+- Penguin testing strategy:
+  `context/tasks/testing-pyramid.md`
 
 ## Parity Gaps
 
@@ -316,6 +318,31 @@ Phase 5 implementation note:
   all provider fixtures and adapters consistently emit provider completion
   events.
 
+### Phase 5.5: Codex Reliability Test Harness
+
+1. Build a deterministic fake Codex Responses/SSE fixture layer inspired by
+   Codex's Rust `core/tests/common/responses.rs` helpers.
+2. Add captured-request assertions for input items, instructions, native tool
+   calls, function-call outputs, reasoning includes, service tier, and
+   `previous_response_id` safety.
+3. Add fault injection for incomplete streams, early close after text, early
+   close after tool call, provider error mid-stream, timeout/stall, malformed
+   event, duplicate event, and partial function-call arguments.
+4. Convert representative `context/bugs/*` and `misc/web-server-logs-*` cases
+   into minimized deterministic fixtures.
+5. Keep live OpenAI/Codex checks opt-in and cheap; they prove credentials and
+   transport, not correctness of the lifecycle contract.
+
+Acceptance criteria:
+
+- Phase 6 replay work starts only after fake-provider fixtures can express the
+  failure modes being enforced.
+- No incomplete stream is treated as completed merely because it emitted some
+  text or tool bytes.
+- Provider errors and incomplete streams always release the current turn.
+- CWM category-priority truncation does not create malformed OpenAI Responses
+  tool-call adjacency.
+
 ### Phase 6: OpenAI/Codex Tool Replay Stability
 
 1. Persist native tool calls as canonical runtime records before executing the
@@ -328,7 +355,7 @@ Phase 5 implementation note:
    calls during replay.
 5. Apply universal model-visible tool-output truncation before replay, with
    full output stored locally.
-6. Retry empty non-tool continuations after tool-heavy turns once with compacted
+6. Retry empty non-tool continuations after tool-heavy turns once with bounded
    recent tool output before returning a structured diagnostic.
 
 ### Phase 7: Optional OpenAI Background Recovery

--- a/context/tasks/codex-integration-parity.md
+++ b/context/tasks/codex-integration-parity.md
@@ -28,8 +28,18 @@ behavior.
 
 - Upstream Codex request construction:
   `reference/codex/codex-rs/core/src/client.rs`
+- Upstream Codex turn-scoped client/session state:
+  `reference/codex/codex-rs/core/src/client.rs`
+  `reference/codex/codex-rs/core/src/client_common.rs`
 - Upstream Codex model metadata:
   `reference/codex/codex-rs/protocol/src/openai_models.rs`
+- Upstream Codex stream recovery tests:
+  `reference/codex/codex-rs/core/tests/suite/stream_no_completed.rs`
+  `reference/codex/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs`
+- Upstream Codex tool replay/truncation references:
+  `reference/codex/codex-rs/core/src/tools/parallel.rs`
+  `reference/codex/codex-rs/core/src/tools/handlers/shell.rs`
+  `reference/codex/codex-rs/core/tests/suite/shell_serialization.rs`
 - Penguin Codex OAuth request construction:
   `penguin/llm/adapters/openai.py`
 - Penguin model catalog merge path:
@@ -177,6 +187,70 @@ Expected Penguin behavior:
 - tune thresholds by mode when needed
 - surface continuation affordances when the guard stops a run
 
+### 9. Provider Request Lifecycle / Abrupt Stop Recovery
+
+The recurring abrupt-stop reports look more like provider transport lifecycle
+problems than context-window-management truncation. The observed logs show
+large request histories, `store=False`, fixed HTTP client timeouts, and
+timeout-style failures. Penguin's CWM can still affect stability indirectly by
+changing tool replay pressure, but it is unlikely to be the direct cause of
+network `ReadTimeout` failures.
+
+Codex's reference client is useful here because it treats a model turn as a
+tracked provider request, not just a synchronous HTTP call. It keeps per-turn
+state, records incomplete streams, releases the turn after stream errors, and
+only reuses incremental `previous_response_id`-style state when the request is
+known to be a safe prefix extension.
+
+Expected Penguin behavior:
+
+- create a provider request record before sending OpenAI/Codex traffic
+- track lifecycle states such as pending, running, streaming, disconnected,
+  retrying, completed, failed, and cancelled
+- record request payload hash, provider/model, session/turn id, attempt count,
+  provider response id when available, and last received stream event
+- distinguish no-completion stream drops from completed responses with no text
+- retry or recover incomplete streams without leaving the engine/session stuck
+- emit a structured failure and turn-complete signal when recovery is not
+  possible, so the next user turn can proceed normally
+- gate `previous_response_id` reuse on a payload-prefix/hash contract; fall
+  back to a full request after errors, shape changes, or non-prefix history
+  changes
+
+### 10. OpenAI Background / Stored Response Capability
+
+OpenAI background mode and `store=true` are provider-specific recovery tools,
+not the provider-agnostic foundation. They are useful when Penguin wants
+OpenAI to keep a long-running response alive server-side so Penguin can poll or
+reconnect after a client/network interruption.
+
+Expected Penguin behavior:
+
+- implement provider request lifecycle tracking before relying on background
+  mode
+- keep background mode opt-in per provider/model/task until costs and UX are
+  clear
+- use `store=true` only when Penguin intentionally needs provider-side
+  resumability or response retrieval
+- keep stateless encrypted reasoning handling intact for non-stored requests
+- fall back to canonical conversation/tool replay for providers that do not
+  offer stored response recovery
+
+Pros:
+
+- better recovery from long-running requests and local network interruptions
+- clearer polling/reconnect semantics for OpenAI Responses requests
+- less need to repeat expensive long-running model work after a disconnect
+
+Cons:
+
+- provider-specific behavior that should not leak into the general contract
+- potential persistence/privacy implications because the provider stores the
+  response
+- more lifecycle states to expose and test
+- not a replacement for timeout policy, stream completion checks, or tool
+  replay correctness
+
 ## Suggested Implementation Order
 
 ### Phase 1: Low-Risk Request Parity
@@ -207,6 +281,67 @@ Expected Penguin behavior:
 3. Consider WebSocket/incremental transport only if SSE latency remains a real
    bottleneck.
 
+### Phase 5: OpenAI/Codex Request Lifecycle Stability
+
+1. Add a provider request record around Codex OAuth Responses calls.
+2. Replace fixed read timeouts with an explicit streaming timeout/stall policy:
+   bounded connect/write/pool timeouts, long or disabled read timeout for active
+   streams, and a Penguin-owned cancellation/stall watchdog.
+3. Add incomplete-stream detection for streams that end without
+   `response.completed`.
+4. Retry safe incomplete streams or return a structured recoverable failure
+   without leaving the current turn locked.
+5. Add regression tests mirroring Codex's stream closes before completion and
+   stream error allows next turn cases.
+6. Gate `previous_response_id` reuse on payload-prefix/hash safety.
+
+Phase 5 implementation note:
+
+- `penguin.llm.contracts` now exposes `ProviderRequestStatus`,
+  `LLMRequestLifecycle`, and `RequestLifecycleRuntime` as the shared lifecycle
+  contract.
+- OpenAI/Codex OAuth SSE requests now record pending, running, streaming,
+  completed, disconnected, and failed states with request id, payload hash,
+  provider/model, stream transport, last event, provider response id when
+  available, finish reason, and canonical error metadata.
+- Codex OAuth HTTP clients now use bounded connect/write/pool timeouts without
+  a fixed active-stream read timeout.
+- Empty Codex streams that end before `response.completed` without text or a
+  tool call now raise a retryable provider error and record a disconnected
+  lifecycle instead of returning a silent empty response.
+- Regression coverage verifies incomplete empty streams and confirms a later
+  turn can still succeed after the disconnected request.
+- Compatibility note: streams that produce text/tool calls but omit
+  `response.completed` still return successfully for now. Tighten that after
+  all provider fixtures and adapters consistently emit provider completion
+  events.
+
+### Phase 6: OpenAI/Codex Tool Replay Stability
+
+1. Persist native tool calls as canonical runtime records before executing the
+   tools.
+2. Persist completed, failed, denied, cancelled, and interrupted tool results
+   with provider call ids.
+3. Reconstruct OpenAI Responses `function_call` / `function_call_output`
+   adjacency from persisted records instead of loose message text.
+4. Synthesize explicit failed/cancelled tool outputs for dangling historical
+   calls during replay.
+5. Apply universal model-visible tool-output truncation before replay, with
+   full output stored locally.
+6. Retry empty non-tool continuations after tool-heavy turns once with compacted
+   recent tool output before returning a structured diagnostic.
+
+### Phase 7: Optional OpenAI Background Recovery
+
+1. Add capability-gated `background=true` / `store=true` support for
+   OpenAI/Codex only after request lifecycle tracking exists.
+2. Record provider response ids and polling/reconnect state in the request
+   record.
+3. Prefer background mode for long-running Codex tasks where replay would be
+   expensive or unsafe.
+4. Keep foreground stateless mode as the default until the UX and privacy trade
+   offs are settled.
+
 ## Non-Goals
 
 - Do not make Penguin depend on Codex internals directly.
@@ -215,6 +350,10 @@ Expected Penguin behavior:
 - Do not mirror upstream client metadata unless it has a clear benefit.
 - Do not hardcode latest model names where authenticated catalog metadata can
   answer the question.
+- Do not treat OpenAI background mode as the general solution for provider
+  reliability.
+- Do not reuse `previous_response_id` after ambiguous failures unless the next
+  request is provably a safe prefix extension.
 
 ## Open Questions
 
@@ -226,3 +365,6 @@ Expected Penguin behavior:
   provide speed-oriented UI grouping?
 - Which Penguin tools are safe candidates for eventual parallel tool calls?
 - Should the repeated empty tool-only guard be configurable per mode?
+- Which request lifecycle fields should be persisted in conversation/session
+  storage versus transient diagnostics?
+- What tasks should opt into OpenAI background recovery by default, if any?

--- a/context/tasks/codex-integration-parity.md
+++ b/context/tasks/codex-integration-parity.md
@@ -311,12 +311,13 @@ Phase 5 implementation note:
 - Empty Codex streams that end before `response.completed` without text or a
   tool call now raise a retryable provider error and record a disconnected
   lifecycle instead of returning a silent empty response.
-- Regression coverage verifies incomplete empty streams and confirms a later
-  turn can still succeed after the disconnected request.
-- Compatibility note: streams that produce text/tool calls but omit
-  `response.completed` still return successfully for now. Tighten that after
-  all provider fixtures and adapters consistently emit provider completion
-  events.
+- Streams that produce text or native tool-call bytes but end before
+  `response.completed` now fail as disconnected incomplete streams rather than
+  being treated as successful partial responses.
+- Regression coverage verifies incomplete empty streams, incomplete partial
+  text streams, incomplete partial native tool-call streams, mid-stream
+  provider error events, and a later turn succeeding after a disconnected
+  request.
 
 ### Phase 5.5: Codex Reliability Test Harness
 
@@ -342,6 +343,27 @@ Acceptance criteria:
 - Provider errors and incomplete streams always release the current turn.
 - CWM category-priority truncation does not create malformed OpenAI Responses
   tool-call adjacency.
+
+Phase 5.5 implementation note:
+
+- `tests/llm/test_openai_oauth_subscription_flow.py` now has reusable fake
+  Codex SSE helpers and request-capturing transport fixtures factored through
+  `tests/llm/codex_oauth_fixtures.py` for deterministic OpenAI/Codex OAuth
+  tests.
+- Successful Codex OAuth fixtures now emit explicit `response.completed`
+  events instead of relying on text plus `[DONE]`.
+- Incomplete streams after partial text or partial native tool calls now record
+  disconnected lifecycle failures instead of being treated as completed
+  responses.
+- Partial native tool calls from incomplete streams are cleared so they cannot
+  be executed as replay-safe pending tools.
+- Completed native tool-call streams still preserve pending tool calls for the
+  runtime to execute.
+- Mid-stream provider error events now produce failed lifecycle records.
+- Request-shape coverage now verifies CWM-truncated tool history does not send
+  unresolved Codex `function_call` items, complete tool pairs replay in order,
+  and tool-result-only records with enough metadata can synthesize a valid
+  replay pair.
 
 ### Phase 6: OpenAI/Codex Tool Replay Stability
 

--- a/context/tasks/llm-provider-contract.md
+++ b/context/tasks/llm-provider-contract.md
@@ -213,6 +213,21 @@ The contract suite should use real log/bug cases as minimized fixtures where
 possible, especially `context/bugs/*` and `misc/web-server-logs-*`. Do not use
 live provider requests as the proof that a contract path is correct.
 
+Current implementation note:
+
+- OpenAI/Codex OAuth is the first adapter with deterministic lifecycle
+  fault-injection coverage for empty incomplete streams, partial text streams,
+  partial native tool-call streams, completed native tool-call streams,
+  mid-stream provider error events, and next-turn release after a disconnected
+  request.
+- OpenAI/Codex OAuth now also has deterministic request-shape coverage for
+  CWM-truncated native tool history: unresolved function calls are dropped,
+  complete call/output pairs are replayed in order, and metadata-rich
+  tool-result-only records synthesize valid replay pairs.
+- Broader provider matrix coverage should extend these same cases to
+  OpenRouter/OpenAI-compatible and Anthropic before enabling provider-specific
+  replay enforcement outside Codex.
+
 ## Phase 2 Notes
 
 - Added canonical types in `penguin/llm/contracts.py` for request/result/event/error/usage/tool-call modeling.

--- a/context/tasks/llm-provider-contract.md
+++ b/context/tasks/llm-provider-contract.md
@@ -49,10 +49,33 @@ Key architectural lessons to adopt from OpenCode:
 - one canonical stream/result grammar
 - one centralized usage/error/retry model
 
+Tool-runtime lessons from Codex/OpenCode are tracked in
+`context/tasks/tool-call-runtime-architecture.md`. This provider-contract plan
+should own wire-format normalization, provider-specific request shaping, stream
+events, finish reasons, usage, and error semantics. It should not duplicate the
+scheduler, permission, truncation, or process-runtime plan.
+
+Provider reliability lessons from Codex/OpenCode should be adopted at the
+contract level where they are provider-agnostic:
+
+- a model turn should have a request lifecycle record, not just an awaited HTTP
+  call
+- stream completion must be explicit; a socket close without a provider
+  completion event is an incomplete response, not a successful empty response
+- provider errors must release the current turn so the next user turn can
+  proceed
+- retry/recovery decisions should use provider capability metadata and request
+  identity, not ad hoc string matching
+- provider-specific resumability, such as OpenAI background responses, should
+  be a capability behind the common lifecycle record
+
 Important constraint:
 
 - adopt the architecture, not the dependency; Penguin should remain provider-agnostic and local-inference-friendly rather than coupling itself to Vercel's AI SDK
 - provider-specific behavior must live in `penguin/llm` provider modules and shared LLM runtime layers, not in `engine.py`, `core.py`, `web/routes.py`, or tool implementations
+- provider adapters may translate provider-native tool-call wire formats into
+  canonical calls/results, but tool risk, permissions, scheduling, truncation,
+  and process execution belong to the tool runtime
 
 ## Progress Snapshot
 
@@ -89,6 +112,59 @@ Important constraint:
 - [x] Add explicit fixtures for streaming + tool-call edge cases
 - [x] Add reasoning-token cases where relevant
 - [x] Verify the same contract against native, gateway, and local-inference-compatible adapters
+- [ ] Add incomplete-stream and turn-release contract cases for provider
+      transports that stream
+
+## Provider Request Lifecycle Contract
+
+The provider contract should expose one lifecycle model for all model calls,
+even when a specific provider has extra recovery features.
+
+Canonical states:
+
+- `pending`: Penguin has created the request record but has not sent traffic yet.
+- `running`: the provider request has been sent.
+- `streaming`: Penguin has received at least one stream event.
+- `disconnected`: transport ended before the provider emitted a completion
+  event or equivalent terminal signal.
+- `retrying`: Penguin is retrying or reconnecting under the provider policy.
+- `completed`: the provider emitted a terminal completion and Penguin recorded
+  final content/tool calls/usage.
+- `failed`: the provider request ended with a normalized failure.
+- `cancelled`: Penguin or the user cancelled the request.
+
+Minimum request-record fields:
+
+- Penguin session/conversation id and turn id
+- provider, adapter, model, and endpoint/transport family
+- request payload hash and request-shape version
+- attempt count, start time, last event time, and terminal time
+- provider response id or equivalent continuation id when available
+- last stream event type and provider finish reason when available
+- canonical error category plus provider-native error metadata
+
+Contract expectations:
+
+- providers that stream must distinguish completed streams from incomplete
+  streams
+- incomplete streams must either retry/recover or surface a structured
+  recoverable failure
+- failures must emit a terminal lifecycle event so the engine/session is not
+  left busy
+- provider adapters should expose whether a request can be resumed, polled, or
+  safely retried from canonical history
+- incremental identifiers such as `previous_response_id` should only be reused
+  when the adapter can prove the next request is a safe prefix extension of the
+  prior request
+
+OpenAI-specific notes:
+
+- `background=true` and `store=true` are capabilities for server-side
+  continuation/retrieval, not the general lifecycle model.
+- Foreground stateless requests still need long-stream timeout/stall handling
+  and explicit incomplete-stream detection.
+- Stateless reasoning continuity still depends on the encrypted reasoning
+  content path when Penguin is not using stored provider state.
 
 ## Verification Targets
 
@@ -132,6 +208,11 @@ Important constraint:
 ## Post-Phase 3 Implementation Notes
 
 - Canonical error metadata now flows through `LLMError` / `LLMProviderError` plus handler `get_last_error()` hooks.
+- Canonical provider request lifecycle metadata now lives in
+  `ProviderRequestStatus`, `LLMRequestLifecycle`, and
+  `RequestLifecycleRuntime`.
+- OpenAI/Codex OAuth SSE is the first lifecycle adopter, including disconnected
+  incomplete-stream handling and long-stream timeout policy.
 - `APIClient` now prefers canonical handler error metadata over provider-specific placeholder strings when formatting user-visible failures.
 - Retry, timeout, rate-limit, and upstream-unavailable cases now normalize onto canonical categories for active handler paths.
 - `Retry-After` / retry timing is normalized where handlers expose it.
@@ -219,6 +300,16 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Standardize retry, timeout, and rate-limit handling semantics behind canonical error categories
 - [x] Normalize `Retry-After` and retryability metadata where providers expose them
 - [x] Stop relying on provider-specific returned error strings as the main failure contract
+- [ ] Add provider request lifecycle records for model calls so retries,
+      disconnects, completions, cancellations, and failures share one
+      observable state machine
+- [ ] Replace fixed streaming read-timeout behavior with provider-aware
+      timeout/stall policy: bounded connect/write/pool timeouts, long or
+      disabled read timeout for active streams, and Penguin-owned cancellation
+      watchdogs
+- [ ] Normalize incomplete stream handling so a transport close without a
+      provider completion event is retryable/disconnected rather than a
+      successful empty response
 
 ### 2. Finish tool-call and reasoning normalization
 
@@ -234,6 +325,12 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Stop using `penguin/core.py` to compensate for provider/runtime-specific tool event naming or metadata gaps
 - [ ] Move provider-specific request shaping and response quirks out of shared call sites where possible
 - [ ] Keep `Engine` and higher-level runtime code ignorant of provider-specific branching
+- [ ] Keep provider-specific native tool replay at the adapter edge while
+  consuming canonical `ToolCall` / `ToolResult` records from the tool runtime
+- [ ] Add provider-contract coverage for completed, failed, cancelled, and
+  interrupted tool-call replay, including provider-specific id normalization
+- [ ] Add provider-contract coverage for incomplete stream recovery and
+  stream-error turn release
 - [ ] Finish the unchecked Phase 2 item: keep provider-specific quirks at the adapter edge
 
 ### 4. Expand or consciously narrow coverage

--- a/context/tasks/llm-provider-contract.md
+++ b/context/tasks/llm-provider-contract.md
@@ -40,6 +40,8 @@
 
 - `context/rationale/llm_provider_contract_design_patterns.md`
 - `context/rationale/llm_provider_contract_audit.md`
+- OpenCode `packages/llm` on `dev`:
+  `https://github.com/anomalyco/opencode/tree/dev/packages/llm`
 
 Key architectural lessons to adopt from OpenCode:
 
@@ -49,15 +51,55 @@ Key architectural lessons to adopt from OpenCode:
 - one canonical stream/result grammar
 - one centralized usage/error/retry model
 
+Additional OpenCode `packages/llm` patterns worth borrowing:
+
+- Split provider integration into clearer layers:
+  - `Protocol`: semantic API contract, provider-native body construction,
+    provider event decoding, and stream state machine
+  - `Route`: protocol plus endpoint, auth, framing, headers, defaults, and
+    request preparation
+  - `Provider`: model factory, identity, capabilities, and provider-specific
+    typed options
+- Add a first-class `prepare(request)` boundary that compiles a canonical
+  Penguin request into the provider-native request body and transport metadata
+  without sending network traffic. This should become the main fixture,
+  debugging, replay-validation, and TUI request-inspection boundary.
+- Treat OpenRouter, OpenAI-compatible gateways, and local compatible servers as
+  provider/routes over a shared `openai_chat` protocol where possible, with
+  provider-specific body overlays rather than forked full adapters.
+- Layer request options by stability:
+  - portable generation settings
+  - typed provider-specific options
+  - raw HTTP/body/header overlays as the last-resort escape hatch
+- Expose model/provider capabilities from the provider contract so the TUI can
+  stay provider-agnostic: native tools, streaming, reasoning, cache hints,
+  context/output limits, resumability, and background/retrieval support.
+- Keep the provider package fixture-first: protocol/body compilation tests,
+  stream-event normalization tests, route/request preparation tests, and
+  separate opt-in recorded/live-provider smoke tests.
+
+Do not copy wholesale:
+
+- Effect/TypeScript runtime mechanics. Penguin should implement the same
+  boundaries with Python dataclasses/Pydantic/protocol classes.
+- OpenCode's tool runtime as-is. It is a useful comparison point, but Penguin's
+  tool runtime needs stronger permission, approval, process-session, CWM, and
+  durable-result semantics.
+- Prompt caching policy before the current provider lifecycle/replay/timeout
+  stability work is finished.
+
 Tool-runtime lessons from Codex/OpenCode are tracked in
 `context/tasks/tool-call-runtime-architecture.md`. This provider-contract plan
 should own wire-format normalization, provider-specific request shaping, stream
 events, finish reasons, usage, and error semantics. It should not duplicate the
 scheduler, permission, truncation, or process-runtime plan.
 
-Testing strategy is tracked in `context/tasks/testing-pyramid.md`. Provider
-contract work should use deterministic fake-provider and fault-injection tests
-as the confidence gate; live provider tests are opt-in smoke tests only.
+Testing strategy is tracked in `context/tasks/testing-pyramid.md`. The
+exhaustive provider/tool reliability checklist lives there. This file should
+track provider-contract implementation phases and progress against that
+checklist, not duplicate the entire test matrix. Provider contract work should
+use deterministic fake-provider and fault-injection tests as the confidence
+gate; live provider tests are opt-in smoke tests only.
 
 Provider reliability lessons from Codex/OpenCode should be adopted at the
 contract level where they are provider-agnostic:
@@ -72,6 +114,17 @@ contract level where they are provider-agnostic:
   identity, not ad hoc string matching
 - provider-specific resumability, such as OpenAI background responses, should
   be a capability behind the common lifecycle record
+
+Provider documentation checked for the streaming/error contract:
+
+- OpenAI Responses streaming documents typed stream events including
+  `response.completed` and `error`.
+- Anthropic Messages streaming documents a final `message_stop` event and
+  possible in-stream `error` events.
+- OpenRouter streaming/error docs describe pre-stream JSON errors and
+  mid-stream SSE errors with `finish_reason: "error"`; its Responses-compatible
+  endpoint may also emit typed error events such as `response.failed`,
+  `response.error`, or `error`.
 
 Important constraint:
 
@@ -108,7 +161,7 @@ Important constraint:
 - [x] Add a single provider registry/resolver instead of overlapping entry points
 - [x] Centralize normalization where possible
 - [x] Add a shared transform layer for request shaping and provider quirks
-- [ ] Keep provider-specific quirks at the adapter edge
+- [x] Keep provider-specific quirks at the adapter edge
 - [x] Preserve a first-class `openai_compatible` path for local inference backends and compatible gateways
 
 ### Phase 3 - Validation
@@ -116,7 +169,7 @@ Important constraint:
 - [x] Add explicit fixtures for streaming + tool-call edge cases
 - [x] Add reasoning-token cases where relevant
 - [x] Verify the same contract against native, gateway, and local-inference-compatible adapters
-- [ ] Add incomplete-stream and turn-release contract cases for provider
+- [x] Add incomplete-stream and turn-release contract cases for provider
       transports that stream
 
 ## Provider Request Lifecycle Contract
@@ -224,9 +277,48 @@ Current implementation note:
   CWM-truncated native tool history: unresolved function calls are dropped,
   complete call/output pairs are replayed in order, and metadata-rich
   tool-result-only records synthesize valid replay pairs.
-- Broader provider matrix coverage should extend these same cases to
-  OpenRouter/OpenAI-compatible and Anthropic before enabling provider-specific
-  replay enforcement outside Codex.
+- The shared provider contract matrix now covers documented mid-stream provider
+  error events across native OpenAI, OpenAI-compatible, Anthropic, and
+  OpenRouter paths.
+- The shared provider contract matrix now covers incomplete streams across
+  native OpenAI, OpenAI-compatible, Anthropic, and OpenRouter paths when a
+  stream ends before the provider's terminal signal after empty output, partial
+  text, or partial native tool-call output.
+- The shared provider contract matrix now covers next-turn release after
+  provider failures: the same handler instance can recover from a mid-stream
+  provider error or partial native tool-call disconnect and then complete a
+  later successful streamed request without stale pending tool calls or stale
+  error metadata.
+- The shared runtime now has explicit retry-policy coverage: retryable
+  canonical provider errors are replayed once only when no assistant text has
+  streamed and no provider-native tool call is pending; non-retryable failures
+  surface immediately.
+- Native OpenAI/OpenAI-compatible, Anthropic, and OpenRouter now expose
+  `LLMRequestLifecycle` records for completed and disconnected/failed streamed
+  calls in the shared provider matrix, extending the Codex OAuth lifecycle
+  work to typical provider paths.
+- `Session`, `APIClient`, and `Engine` now have the first provider lifecycle
+  persistence path: the active session stores serialized
+  `LLMRequestLifecycle` records after each LLM attempt, including failures, and
+  CWM trimming preserves those records outside model-visible history.
+- The shared matrix now also asserts provider response ids where fixtures
+  expose them, ordered multi-delta streaming, and cancellation as a distinct
+  terminal lifecycle state across first-class providers.
+- Runtime retry tests now cover retry success, retry exhaustion, and retry
+  suppression when a provider-native tool call is pending.
+- OpenRouter now has provider-aware stream watchdog tests for chunk stalls,
+  total-stream budgets, and timeout environment parsing.
+- Provider-native replay repair has started outside Codex: Anthropic marks
+  failed, cancelled, and interrupted replayed tool results as provider-native
+  error results, and OpenRouter repairs CWM-truncated chat history by
+  preserving only complete assistant-tool/tool-result pairs or synthesizing a
+  valid assistant tool call when a metadata-rich tool result survives alone.
+- OpenRouter replay tests now also reject duplicate assistant tool-call ids by
+  flattening malformed native tool history before provider submission.
+- Initial property/state-machine coverage now exercises retry-policy safety,
+  lifecycle serialization, lifecycle terminal-state invariants, and
+  tool-output truncation metadata. Mutation testing remains an explicit later
+  opt-in gate.
 
 ## Phase 2 Notes
 
@@ -318,8 +410,8 @@ That means:
 
 - LiteLLM is currently treated as a secondary compatibility path, not a first-class provider in the contract matrix.
 - It now exposes canonical error/usage/finish-reason hooks, but it is not yet gated by the same full matrix as `openai`, `anthropic`, `openrouter`, and `openai_compatible`.
-- LiteLLM follow-up work is deferred until after Phase 5 structural cleanup.
-- Link integration is not part of the current verification target.
+- LiteLLM follow-up work is explicitly deferred until after the current provider/tool reliability suite is built out for first-class providers.
+- Link integration is explicitly deferred and is not part of the current verification target.
 - The current priority is making typical `openai` and `openrouter` behavior solid before touching Link-specific end-to-end behavior.
 - Link-specific verification should be treated as Phase 6 work after the provider contract and module consolidation work are in a healthier state.
 
@@ -336,9 +428,10 @@ That means:
 
 Phase 3 follow-up items that are useful but not required to consider the validation phase complete:
 
-- add Link transport/integration coverage against the shared runtime path
-- decide whether LiteLLM should be upgraded to the same contract matrix or remain outside the first-class contract set
-- add Codex OAuth regression coverage after `context/tasks/openai-codex-oauth-tool-schema-fix.md` is implemented
+- build out the exhaustive provider/tool reliability suite from
+  `context/tasks/testing-pyramid.md`
+- keep Link transport/integration coverage deferred
+- keep LiteLLM full matrix parity deferred
 
 ## Overall Remaining Plan
 
@@ -347,16 +440,23 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Standardize retry, timeout, and rate-limit handling semantics behind canonical error categories
 - [x] Normalize `Retry-After` and retryability metadata where providers expose them
 - [x] Stop relying on provider-specific returned error strings as the main failure contract
-- [ ] Add provider request lifecycle records for model calls so retries,
+- [x] Add provider request lifecycle records for model calls so retries,
       disconnects, completions, cancellations, and failures share one
       observable state machine
 - [ ] Replace fixed streaming read-timeout behavior with provider-aware
       timeout/stall policy: bounded connect/write/pool timeouts, long or
       disabled read timeout for active streams, and Penguin-owned cancellation
       watchdogs
-- [ ] Normalize incomplete stream handling so a transport close without a
+- [x] Normalize incomplete stream handling so a transport close without a
       provider completion event is retryable/disconnected rather than a
       successful empty response
+- [ ] Add a provider-neutral request preparation boundary, similar to
+      OpenCode's `LLMClient.prepare`, that returns provider-native body,
+      protocol id, route/provider id, transport metadata, request payload hash,
+      and validation diagnostics without sending network traffic.
+- [ ] Use prepared-request capture as the default contract test boundary for
+      replay repair, CWM-truncated history, provider-native tool adjacency, and
+      TUI/debug inspection.
 
 ### 2. Finish tool-call and reasoning normalization
 
@@ -370,23 +470,30 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Move OpenAI/Responses-specific tool-call orchestration out of `penguin/engine.py`
 - [x] Move provider-specific reasoning fallback/debug shaping out of `penguin/web/routes.py`
 - [x] Stop using `penguin/core.py` to compensate for provider/runtime-specific tool event naming or metadata gaps
-- [ ] Move provider-specific request shaping and response quirks out of shared call sites where possible
-- [ ] Keep `Engine` and higher-level runtime code ignorant of provider-specific branching
+- [x] Move provider-specific request shaping and response quirks out of shared call sites where possible
+- [x] Keep `Engine` and higher-level runtime code ignorant of provider-specific branching
 - [ ] Keep provider-specific native tool replay at the adapter edge while
   consuming canonical `ToolCall` / `ToolResult` records from the tool runtime
-- [ ] Add provider-contract coverage for completed, failed, cancelled, and
+- [x] Add provider-contract coverage for completed, failed, cancelled, and
   interrupted tool-call replay, including provider-specific id normalization
-- [ ] Add provider-contract coverage for incomplete stream recovery and
+- [x] Add provider-contract coverage for incomplete stream recovery and
   stream-error turn release
-- [ ] Finish the unchecked Phase 2 item: keep provider-specific quirks at the adapter edge
+- [x] Finish the unchecked Phase 2 item: keep provider-specific quirks at the adapter edge
+- [ ] Introduce explicit `Protocol` / `Route` / `Provider` terminology, or the
+      Python equivalent, so shared wire protocols such as OpenAI Chat can be
+      reused by OpenRouter, OpenAI-compatible gateways, and local inference
+      backends without duplicating full adapter logic.
+- [ ] Move provider capability metadata into the provider/model contract so
+      engine, web, and TUI layers consume capabilities instead of checking
+      provider names.
 
 ### 4. Expand or consciously narrow coverage
 
 - [x] Decide whether LiteLLM is part of the long-term first-class provider contract or a secondary compatibility path
 - [ ] If LiteLLM remains in scope, add the same contract hooks and matrix coverage there
-  Deferred until after Phase 5 structural cleanup.
+  Deferred until after the first-class provider/tool reliability suite is built out.
 - [ ] Add Link-specific runtime/integration verification on top of the shared provider runtime
-  Deferred to Phase 6. Current focus is typical `openai` and `openrouter` behavior.
+  Deferred. Current focus is first-class provider reliability without Link-specific transport.
 
 ### 5. Structural cleanup after behavior stabilizes
 

--- a/context/tasks/llm-provider-contract.md
+++ b/context/tasks/llm-provider-contract.md
@@ -55,6 +55,10 @@ should own wire-format normalization, provider-specific request shaping, stream
 events, finish reasons, usage, and error semantics. It should not duplicate the
 scheduler, permission, truncation, or process-runtime plan.
 
+Testing strategy is tracked in `context/tasks/testing-pyramid.md`. Provider
+contract work should use deterministic fake-provider and fault-injection tests
+as the confidence gate; live provider tests are opt-in smoke tests only.
+
 Provider reliability lessons from Codex/OpenCode should be adopted at the
 contract level where they are provider-agnostic:
 
@@ -180,6 +184,34 @@ OpenAI-specific notes:
 - LiteLLM cleanup/runtime tests
 - streaming tests
 - provider adapter tests
+
+## Provider Reliability Test Matrix
+
+Phase 2/3 provider work should add hermetic fixtures before tightening runtime
+behavior. The fake-provider contract suite should cover:
+
+- completed text streams
+- completed native tool-call streams
+- terminal empty responses
+- stream closes before terminal event with no output
+- stream closes before terminal event after text output
+- stream closes before terminal event after a tool call
+- provider errors before and during streaming
+- timeout and idle-stream behavior
+- retry succeeds and retry exhausted behavior
+- next-turn release after failures
+- request replay after CWM category-priority truncation
+
+Provider-native tool replay tests should cover:
+
+- completed, failed, cancelled, and interrupted tool results
+- dangling tool calls repaired into explicit failed/cancelled outputs
+- provider-specific id normalization and adjacency rules
+- large tool outputs truncated before model replay with full output persisted
+
+The contract suite should use real log/bug cases as minimized fixtures where
+possible, especially `context/bugs/*` and `misc/web-server-logs-*`. Do not use
+live provider requests as the proof that a contract path is correct.
 
 ## Phase 2 Notes
 

--- a/context/tasks/llm-provider-contract.md
+++ b/context/tasks/llm-provider-contract.md
@@ -297,6 +297,10 @@ Current implementation note:
   `LLMRequestLifecycle` records for completed and disconnected/failed streamed
   calls in the shared provider matrix, extending the Codex OAuth lifecycle
   work to typical provider paths.
+- Native OpenAI/OpenAI-compatible, Anthropic, and OpenRouter now expose
+  provider-neutral prepared requests with protocol/route/provider ids,
+  transport metadata, stable payload hashes, sanitized headers, diagnostics,
+  and model/provider capability metadata.
 - `Session`, `APIClient`, and `Engine` now have the first provider lifecycle
   persistence path: the active session stores serialized
   `LLMRequestLifecycle` records after each LLM attempt, including failures, and
@@ -450,13 +454,16 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Normalize incomplete stream handling so a transport close without a
       provider completion event is retryable/disconnected rather than a
       successful empty response
-- [ ] Add a provider-neutral request preparation boundary, similar to
+- [x] Add a provider-neutral request preparation boundary, similar to
       OpenCode's `LLMClient.prepare`, that returns provider-native body,
       protocol id, route/provider id, transport metadata, request payload hash,
       and validation diagnostics without sending network traffic.
 - [ ] Use prepared-request capture as the default contract test boundary for
       replay repair, CWM-truncated history, provider-native tool adjacency, and
       TUI/debug inspection.
+  Initial provider-body capture exists for native OpenAI/OpenAI-compatible,
+  Anthropic, OpenRouter, and `APIClient`; the remaining work is to move the
+  replay/adjacency regression matrix onto this boundary.
 
 ### 2. Finish tool-call and reasoning normalization
 
@@ -479,13 +486,15 @@ Phase 3 follow-up items that are useful but not required to consider the validat
 - [x] Add provider-contract coverage for incomplete stream recovery and
   stream-error turn release
 - [x] Finish the unchecked Phase 2 item: keep provider-specific quirks at the adapter edge
-- [ ] Introduce explicit `Protocol` / `Route` / `Provider` terminology, or the
+- [x] Introduce explicit `Protocol` / `Route` / `Provider` terminology, or the
       Python equivalent, so shared wire protocols such as OpenAI Chat can be
       reused by OpenRouter, OpenAI-compatible gateways, and local inference
       backends without duplicating full adapter logic.
-- [ ] Move provider capability metadata into the provider/model contract so
+- [x] Move provider capability metadata into the provider/model contract so
       engine, web, and TUI layers consume capabilities instead of checking
       provider names.
+  `LLMPreparedRequest` now carries `protocol`, `route`, `provider`,
+  `transport`, request hash, diagnostics, and `LLMProviderCapabilities`.
 
 ### 4. Expand or consciously narrow coverage
 

--- a/context/tasks/testing-pyramid.md
+++ b/context/tasks/testing-pyramid.md
@@ -416,6 +416,11 @@ provider traffic:
   CWM-truncated history shape
 - replay fixtures minimized from `context/bugs/*` and `misc/web-server-logs-*`
 
+Initial request-capture coverage now exists through `LLMPreparedRequest` for
+native OpenAI/OpenAI-compatible, Anthropic, OpenRouter, and `APIClient`.
+The next expansion is to port the replay/adjacency/CWM-truncation matrix onto
+that prepared-request boundary so failures are caught before provider traffic.
+
 Critical provider lifecycle cases:
 
 - terminal event with text

--- a/context/tasks/testing-pyramid.md
+++ b/context/tasks/testing-pyramid.md
@@ -381,9 +381,18 @@ These should drive test design more than raw line coverage.
 
 ### Provider And Tool Reliability Suite
 
-This is the high-assurance suite needed for OpenAI/Codex, OpenRouter,
-Anthropic, and future provider stability work. It should be deterministic and
-offline by default, with live providers used only as opt-in smoke tests.
+This is the authoritative high-assurance checklist for OpenAI/Codex,
+OpenRouter, Anthropic, and future provider stability work. It should be
+deterministic and offline by default, with live providers used only as opt-in
+smoke tests.
+
+Scope decision:
+
+- First-class suite: OpenAI/Codex OAuth, native OpenAI, OpenAI-compatible,
+  Anthropic, and OpenRouter.
+- Deferred suite: Link end-to-end transport and LiteLLM full matrix parity.
+- Deferred does not mean ignored; it means these paths should not block the
+  current provider/runtime cleanup branch.
 
 Codex reference patterns worth copying:
 
@@ -421,6 +430,88 @@ Critical provider lifecycle cases:
 - retry is exhausted
 - next user turn works after failure
 
+Exhaustive provider/runtime matrix:
+
+- request starts with a lifecycle record before provider traffic is sent
+- request status reaches `running` after dispatch
+- streamed request status reaches `streaming` after the first provider event
+- completed stream records provider response id where available
+- completed stream records final finish reason, usage, reasoning, and terminal
+  event type
+- disconnected stream records canonical network/timeout error metadata
+- failed stream records provider-native error metadata without leaving stale
+  pending tool calls
+- cancelled request records `cancelled` separately from failed/disconnected
+- retry attempt records request identity, attempt number, and previous failure
+- lifecycle terminal states are idempotent and never regress to running
+- lifecycle records can be read through the shared runtime hook on every
+  first-class provider
+- lifecycle metadata survives adapter errors that surface through `APIClient`
+- lifecycle metadata is clear about whether a request can be resumed, polled,
+  retried, or must be replayed from canonical history
+- provider-specific continuation ids such as `previous_response_id` are used
+  only when the adapter can prove the next request is a safe prefix extension
+- provider request payload hash changes when model-visible history changes
+- provider request payload hash ignores irrelevant local-only metadata
+- provider request lifecycle records are ready to be persisted once session
+  storage owns first-class records
+
+Streaming and event grammar matrix:
+
+- text start/delta/end or equivalent provider events assemble in order
+- reasoning start/delta/end or equivalent provider events assemble in order
+- text and reasoning deltas interleaved by the provider remain separately
+  typed in Penguin
+- multiple text deltas preserve ordering and exact content
+- empty text deltas are ignored without changing finish state
+- provider terminal completion with no usage still completes cleanly
+- provider terminal completion with usage updates normalized usage
+- provider terminal completion after a native tool call returns a tool
+  interrupt, not an empty assistant response
+- provider terminal completion after partial text and a native tool call
+  preserves text and pending call state consistently
+- provider error event before output produces a structured provider failure
+- provider error event after text output returns/surfaces partial output only
+  when the policy explicitly allows it
+- malformed event payloads fail closed with canonical diagnostics
+- unknown non-terminal provider events are ignored or preserved as provider
+  metadata without crashing
+- duplicate terminal events do not duplicate output or regress lifecycle state
+- duplicate text/tool deltas are handled according to provider id/index rules
+- out-of-order tool deltas fail closed or normalize only when provider ids make
+  reconstruction unambiguous
+- missing terminal event after text is disconnected/retryable, not completed
+- missing terminal event after tool call clears unsafe pending state unless the
+  call is durably persisted for replay
+- direct HTTP SSE and SDK stream paths obey the same semantic contract
+
+Retry, timeout, and recovery matrix:
+
+- retryable network, timeout, rate-limit, and provider-unavailable failures
+  normalize to retryable `LLMError`
+- non-retryable bad-request, auth, model-not-found, and schema failures surface
+  immediately
+- retry is attempted only when no assistant chunk has been shown to the user
+- retry is skipped when a provider-native tool call is pending
+- retry is skipped after partial output unless explicit partial-output replay
+  policy exists
+- retry is bounded by policy and cannot loop indefinitely
+- retry exhaustion surfaces one structured recoverable failure
+- retry after stream disconnect clears stale provider stream accumulators
+- retry after partial tool-call disconnect clears unsafe pending tool state
+- retry after provider error leaves the next user turn able to proceed
+- retry after HTTP 429 respects `Retry-After` metadata where available
+- idle-stream timeout is distinct from total request timeout
+- connect/write/pool timeouts are bounded even when read timeout is long or
+  disabled for active streams
+- active-stream watchdog cancels only stalled streams, not long-running streams
+  that are still producing provider events
+- user cancellation records cancellation and releases the session
+- process shutdown or task cancellation does not persist a dangling running
+  lifecycle record as completed
+- provider-specific background/retrieval features are tested as optional
+  capabilities, not required for the common lifecycle contract
+
 Critical tool replay cases:
 
 - completed tool call/result replay
@@ -431,6 +522,71 @@ Critical tool replay cases:
 - large tool output truncated before model replay with full output persisted
 - CWM category-priority truncation does not create unresolved provider-native
   tool calls
+
+Provider-native request/replay matrix:
+
+- OpenAI/Codex Responses input items preserve valid completed
+  function_call/function_call_output adjacency
+- OpenAI/Codex unresolved function calls are dropped or repaired before replay
+- OpenAI/Codex metadata-rich output-only records synthesize valid replay pairs
+- OpenAI/Codex encrypted reasoning continuity is preserved only when the
+  provider contract allows it
+- OpenAI-compatible/OpenRouter assistant `tool_calls` are replayed only when
+  matching `tool` results survive
+- OpenAI-compatible/OpenRouter orphaned tool results synthesize a valid
+  assistant tool call when metadata is sufficient
+- OpenAI-compatible/OpenRouter orphaned assistant tool calls are flattened or
+  repaired before provider submission
+- Anthropic tool_use/tool_result adjacency is reconstructed from canonical
+  records
+- Anthropic failed/cancelled/interrupted tool results set provider-native
+  `is_error`
+- provider call ids remain stable across replay when safe
+- provider call ids are regenerated or normalized when duplicates would violate
+  provider constraints
+- replay preserves tool name, arguments, status, result preview, full-output
+  artifact reference, and truncation metadata
+- replay never sends provider-native call ids inside user-visible prose as a
+  substitute for native provider tool records
+- replay after CWM category-priority truncation is provider-valid for every
+  first-class provider
+- replay after failed tool execution shows an explicit failed result rather than
+  re-executing the tool silently
+- replay after interrupted tool execution shows an explicit interrupted or
+  cancelled result unless the scheduler owns a resumable process session
+- replay fixtures include minimized real bug/log transcripts, not only
+  synthetic happy paths
+
+Tool output and artifact matrix:
+
+- per-tool model-visible output truncation is deterministic
+- aggregate per-turn model-visible tool-output cap is enforced before provider
+  replay
+- full raw tool output is persisted outside the model-visible prompt when
+  truncated
+- tool result records include byte count, line count, truncation direction,
+  output hash, and artifact reference
+- model-visible truncated output includes enough context to continue safely
+- binary/image artifacts are referenced, not inlined into text tool output
+- huge outputs cannot cause provider request construction to exceed configured
+  model-visible limits
+- output hashes make repeated-loop detection stable without depending on full
+  output text
+
+Conversation and CWM matrix:
+
+- Penguin's CWM truncates message categories by priority and recency; it never
+  compacts or summarizes
+- truncation before a provider request cannot create malformed native tool
+  history
+- truncation of assistant tool call while result survives is repaired
+- truncation of tool result while assistant call survives is repaired
+- truncation of large tool outputs preserves artifact references
+- truncation keeps system/developer/tool-schema messages according to their
+  configured priority
+- truncation after provider failure leaves enough canonical history for the
+  next turn to proceed
+- request capture tests assert final provider-native payload shape after CWM
 
 The success bar is "prove the failure modes," not only "cover the lines." For
 provider/tool runtime changes, every bug fixed from logs should become a
@@ -443,6 +599,29 @@ Current provider-reliability progress:
 - Codex tests now cover incomplete empty, partial text, partial native tool,
   mid-stream provider error, completed native tool, next-turn release, and
   CWM-truncated native tool replay shapes.
+- The shared first-class provider matrix now covers completed lifecycle
+  metadata, provider response ids where available, ordered multiple text
+  deltas, cancellation as a distinct lifecycle terminal state, retry success,
+  retry exhaustion, retry skip when native tool calls are pending, incomplete
+  stream disconnects, and next-turn release after failures.
+- Provider lifecycle records are now first-class session records: canonical
+  `LLMRequestLifecycle` objects serialize through `Session`, `APIClient`
+  exposes the shared lifecycle hook, and `Engine` persists the latest provider
+  lifecycle after each LLM attempt, including failed attempts. CWM session
+  clones preserve those records without exposing them as model-visible content.
+- OpenRouter now has explicit chunk-stall and total-stream watchdog tests,
+  including provider-specific timeout environment handling.
+- Tool-output truncation now has deterministic unit/property coverage for
+  model-visible caps, byte/line/hash metadata, full-output artifact writes, and
+  artifact-safe IDs.
+- Initial Hypothesis property tests now cover retry policy, lifecycle
+  serialization, and tool-output truncation metadata. Initial state-machine
+  coverage now exercises provider lifecycle serialization and terminal-state
+  invariants.
+- Mutation testing is still a later opt-in gate; no mutation runner has been
+  wired into the default suite yet.
+- OpenRouter replay tests now reject duplicate assistant tool-call ids by
+  flattening malformed native history before provider submission.
 
 ### Project And Run Mode
 
@@ -524,6 +703,9 @@ uv run pytest tests -q --cov=penguin --cov-report=term-missing
 
 ### Phase 4 - Add Property And State-Machine Testing
 
+- [x] Initial provider/tool reliability property tests for retry policy,
+      lifecycle serialization, and tool-output truncation.
+- [x] Initial provider lifecycle state-machine tests.
 - [ ] Hypothesis tests for parser inputs.
 - [ ] Hypothesis tests for path policy.
 - [ ] Hypothesis tests for tool argument coercion.

--- a/context/tasks/testing-pyramid.md
+++ b/context/tasks/testing-pyramid.md
@@ -1,0 +1,618 @@
+# Penguin Testing Pyramid And Assurance Plan
+
+## Objective
+
+- Build a trustworthy, layered testing methodology for Penguin.
+- Keep AI-assisted development velocity while reducing model drift between what
+  contributors believe the code does and what it actually does.
+- Borrow SQLite's safety-critical testing philosophy without trying to apply
+  SQLite's exact 100% MC/DC standard uniformly across a fast-moving AI agent.
+- Aggressively encode Penguin's critical invariants so future agent-generated
+  changes are forced through executable checks.
+
+## Why This Exists
+
+Penguin is now evolving too quickly for one person to keep a complete mental
+model of the codebase in sync with reality.
+
+That is especially risky because Penguin is itself an AI coding agent. The same
+AI-assisted development loop that makes large changes possible also increases
+the chance of:
+
+- stale assumptions
+- hidden cross-module coupling
+- provider-specific behavior leaking across boundaries
+- test failures becoming normalized noise
+- regressions in stateful flows that are hard to see manually
+- tool, permission, session, or checkpoint behavior drifting from intent
+
+The answer is not just "more tests." The answer is a procedural assurance
+methodology: clean suite boundaries, explicit invariants, deterministic fake
+providers, property tests, state-machine tests, fuzzing, mutation testing, and
+formal verification where the model is small enough to be useful.
+
+## Inspiration: SQLite
+
+SQLite is the reference point for serious software assurance:
+
+- private TH3 harness
+- 100% branch coverage over core SQLite
+- 100% MC/DC over core SQLite
+- extensive fuzzing, crash tests, OOM tests, I/O failure tests, and mutation
+  testing
+- aviation-adjacent motivation through DO-178B-style validation needs
+
+Penguin should copy the mindset, not the exact shape.
+
+SQLite can justify maintaining 100% MC/DC across a compact C database engine
+because it is infrastructure used everywhere and stores durable state. Penguin
+has similarly high leverage, but the system surface is broader and more
+dynamic: LLM providers, tool execution, web/TUI interfaces, sessions, project
+orchestration, and multi-agent flows.
+
+So Penguin's first target should be:
+
+- 100% coverage of critical invariants
+- clean and trusted default suites
+- increasing package coverage by subsystem
+- formal verification for crisp state machines
+- live smoke tests only where real integration value exists
+
+## Current Baseline
+
+Observed local package coverage for `penguin`:
+
+```text
+covered lines: 23,038
+statements:     57,876
+missing lines:  34,838
+coverage:       39.8058% -> 40%
+```
+
+This was not a clean full-suite run.
+
+Known blockers encountered during measurement:
+
+- `tests/api/test_github_app_auth.py` exits during collection without GitHub App
+  environment variables.
+- `tests/llm/conftest.py` defines `pytest_plugins` in a non-top-level conftest,
+  which current pytest rejects.
+- `tests/test_agent_lifecycle.py` imports stale `SecurityConfig` from
+  `penguin.agent.schema`.
+- Many API and performance tests assume an external server at
+  `127.0.0.1:8000`.
+- The adjusted run produced a coverage total but still had many failures and
+  errors.
+- `penguin/llm/test1.py` is unparsable as Python source and must be removed,
+  moved, or excluded from coverage.
+
+Before coverage gates matter, the suite needs to be made believable.
+
+## Core Principle
+
+A flaky or ambiguous test suite is worse than no suite in an AI-assisted
+codebase because it trains humans and agents to discount failures.
+
+Default tests must be:
+
+- deterministic
+- offline
+- fast enough to run often
+- clearly scoped
+- clear about whether a failure is unit, integration, live-provider, or
+  environment-related
+
+## Target Pyramid
+
+### Layer 0 - Static Hygiene
+
+Purpose: catch cheap structural problems before runtime.
+
+Targets:
+
+- Ruff lint and format
+- import hygiene
+- package boundary checks
+- public API export checks
+- no tests inside `penguin/` runtime packages
+- no invalid Python files under package source
+- gradual type checking for stable subsystems
+
+Example commands:
+
+```bash
+ruff check .
+ruff format --check .
+uv run python -m compileall penguin
+```
+
+### Layer 1 - Unit Tests
+
+Purpose: fast, deterministic checks for isolated behavior.
+
+Good targets:
+
+- parser helpers
+- schema validation
+- provider normalization
+- permission predicates
+- path policy helpers
+- service functions
+- task state helpers
+- event normalization
+- small tool utilities
+
+Rules:
+
+- no network
+- no real provider credentials
+- no real web server process
+- no dependence on test order
+- use temporary directories and deterministic fixtures
+
+### Layer 2 - Property Tests
+
+Purpose: test classes of inputs, not just examples.
+
+Use Hypothesis where input space is broad or easy to get subtly wrong.
+
+High-value targets:
+
+- ActionXML / CodeAct parsing
+- tool argument parsing
+- path normalization and sandbox checks
+- permission engine decisions
+- patch/edit payload parsing
+- diff metadata
+- provider event normalization
+- conversation truncation, checkpoint, and replay edge cases
+- task dependency graph validation
+
+Examples of properties:
+
+- parsing never crashes on arbitrary text
+- malformed actions fail closed
+- normalized paths never escape allowed roots
+- permission denials remain denials after path spelling changes
+- serialized event streams can round-trip through storage
+
+### Layer 3 - State-Machine Tests
+
+Purpose: validate stateful workflows under many transition sequences.
+
+High-value targets:
+
+- task lifecycle
+- run mode
+- ITUV phases
+- conversation append/truncate/checkpoint flows
+- fork/revert/unrevert
+- multi-agent delegation
+- tool-call lifecycle
+- provider streaming lifecycle
+
+These should model explicit states and transitions rather than only replaying
+happy-path examples.
+
+### Layer 4 - Contract Tests
+
+Purpose: freeze cross-module and public behavior.
+
+Targets:
+
+- LLM provider contract matrix
+- tool runtime call/result contract
+- web service response shapes
+- TUI-facing session payloads
+- public `penguin` package exports
+- event stream grammar
+- checkpoint/fork/revert semantics
+
+Related task docs:
+
+- `context/tasks/llm-provider-contract.md`
+- `context/tasks/llm-testing-suite-overhaul.md`
+- `context/tasks/tool-call-runtime-architecture.md`
+- `context/tasks/forking-checkpoints-testing.md`
+
+Provider/tool reliability work should treat this layer as the primary
+confidence gate. A provider integration is not "stable" because one live
+request works; it is stable when the fake-provider contract suite proves the
+normal, partial, failed, retried, and replayed states.
+
+### Layer 5 - Hermetic Integration Tests
+
+Purpose: test assembled Penguin runtime without external services.
+
+Rules:
+
+- use FastAPI/TestClient or equivalent in-process clients for web tests
+- use fake LLM providers
+- use fake SDK clients
+- use fake or temporary filesystem roots
+- use fake git repos where necessary
+- no assumption that a server is running on port `8000` or `9000`
+
+High-value targets:
+
+- API routes through service layers
+- engine loop with fake providers
+- tool execution through registry/runtime
+- session creation and persistence
+- checkpoint/fork/revert flows
+- TUI-compatible backend routes
+
+### Layer 6 - E2E Smoke Tests
+
+Purpose: catch wiring regressions across the real user surfaces.
+
+Keep this layer small.
+
+Candidate smoke paths:
+
+- CLI starts and displays help/version
+- web server starts on configured `HOST` / `PORT`
+- one fake-provider chat flow through web API
+- one TUI-compatible session list/get/message flow
+- one checkpoint or fork/revert flow
+
+These tests should not be the place where core behavior is proven. They should
+prove that the assembled product still boots and routes correctly.
+
+### Layer 7 - Live Provider Smoke Tests
+
+Purpose: prove credentials, transport, provider catalogs, and cheap real
+requests still work.
+
+Rules:
+
+- opt-in only
+- env-gated
+- rate-limited
+- cheap models only
+- never required for the default local suite
+- failures clearly labeled as live-provider failures
+
+This layer should supplement, not replace, deterministic provider contract tests.
+
+### Layer 8 - Fuzzing
+
+Purpose: attack parser and boundary-heavy inputs.
+
+High-value targets:
+
+- action parser
+- XML/JSON-ish action payloads
+- patch/edit tools
+- tool argument schema coercion
+- provider streaming chunks
+- malformed conversation/history files
+- path inputs
+- event replay payloads
+
+Fuzz results should be minimized into regression tests.
+
+### Layer 9 - Mutation Testing
+
+Purpose: prove that tests catch meaningful logic changes, not just execute code.
+
+Start only on small, critical modules where mutation results are actionable.
+
+Initial targets:
+
+- permission engine
+- path security utilities
+- task state transitions
+- parser decisions
+- checkpoint/fork/revert state handling
+- provider contract normalization
+
+Do not run mutation testing across the entire repo initially. It will be noisy
+and expensive.
+
+### Layer 10 - Formal Verification
+
+Purpose: verify design-level invariants for small state machines.
+
+Good candidates:
+
+- permission state and fail-closed behavior
+- task lifecycle / ITUV gates
+- DAG task claiming under concurrent agents
+- checkpoint/fork/revert invariants
+- tool-call lifecycle and unresolved-call replay
+- session isolation
+
+Poor candidates:
+
+- whole `engine.py`
+- UI rendering
+- LLM quality
+- broad web routing
+- provider SDK behavior
+
+Related task doc:
+
+- `context/tasks/penguin_tla.md`
+
+## Critical Invariants
+
+These should drive test design more than raw line coverage.
+
+### Tool Runtime
+
+- Tool calls have stable IDs.
+- Tool calls are executed at most once unless explicitly retried.
+- Tool results are associated with the correct call ID.
+- Unresolved provider-native tool calls replay as explicit error/cancelled
+  results, not as dangling history.
+- Mutating tools are serialized until safe parallel metadata exists.
+- Approval and permission checks happen in the runtime path, not just in prompts.
+
+### Permissions And Paths
+
+- All permission checks fail closed.
+- Workspace/root policy cannot be bypassed by path spelling, symlinks, `..`, or
+  shell expansion.
+- Read-only tools cannot mutate state.
+- Approval grants are scoped and cannot accidentally authorize unrelated tools.
+
+### Sessions And Conversations
+
+- Session IDs do not bleed across users, agents, projects, or forks.
+- Conversation state is append-only except through explicit checkpoint, revert,
+  migration, or context-window-management truncation logic.
+- Penguin's CWM trims message categories by priority and recency; it does not
+  summarize or compact conversation content.
+- Forked sessions preserve lineage without mutating the source session.
+- Revert/unrevert is deterministic and exposes correct metadata to the TUI.
+- Checkpoint branches materialize as real sessions when exposed to user
+  workflows.
+
+### LLM Providers
+
+- Provider adapters normalize onto one canonical contract.
+- Streaming events preserve order, identity, finish reasons, usage, and
+  reasoning metadata where available.
+- Empty or malformed provider responses produce explicit diagnostics.
+- Provider-specific quirks stay at adapter edges.
+- Fake providers cover tool calls, empty responses, malformed chunks, duplicate
+  call IDs, retries, partial failures, and CWM category-priority truncation.
+
+### Provider And Tool Reliability Suite
+
+This is the high-assurance suite needed for OpenAI/Codex, OpenRouter,
+Anthropic, and future provider stability work. It should be deterministic and
+offline by default, with live providers used only as opt-in smoke tests.
+
+Codex reference patterns worth copying:
+
+- fake SSE and HTTP provider servers
+- captured request inspection
+- incomplete-stream and retry tests
+- stream-error turn-release tests
+- tool replay and tool-output truncation tests
+- rollout/history reconstruction tests
+- permission, sandbox, shell/process, and TUI surface suites
+
+Penguin should build equivalent Python fixtures rather than relying on real
+provider traffic:
+
+- fake Responses/OpenAI-compatible/Anthropic/OpenRouter stream emitters
+- fault injection for dropped sockets, idle streams, malformed events,
+  duplicate events, out-of-order events, partial tool-call deltas, and HTTP
+  429/500/503 responses
+- request capture helpers that assert provider-native tool adjacency,
+  `previous_response_id` safety, reasoning payloads, usage metadata, and
+  CWM-truncated history shape
+- replay fixtures minimized from `context/bugs/*` and `misc/web-server-logs-*`
+
+Critical provider lifecycle cases:
+
+- terminal event with text
+- terminal event with tool call
+- terminal event with empty text and no tool call
+- stream closes before terminal event with no output
+- stream closes before terminal event after text output
+- stream closes before terminal event after a tool call
+- provider error before any stream event
+- provider error after partial stream output
+- retry succeeds
+- retry is exhausted
+- next user turn works after failure
+
+Critical tool replay cases:
+
+- completed tool call/result replay
+- failed tool result replay
+- cancelled tool result replay
+- interrupted or dangling call repaired into explicit failure
+- duplicate provider call IDs rejected or normalized
+- large tool output truncated before model replay with full output persisted
+- CWM category-priority truncation does not create unresolved provider-native
+  tool calls
+
+The success bar is "prove the failure modes," not only "cover the lines." For
+provider/tool runtime changes, every bug fixed from logs should become a
+minimal deterministic fixture.
+
+### Project And Run Mode
+
+- Tasks cannot reach completed state without required validation gates.
+- Dependency order is respected.
+- A task cannot be claimed by two agents simultaneously.
+- Missing evidence fails closed.
+- Synthetic or continuous-mode tasks cannot escape the work graph silently.
+
+### Web And TUI Surface
+
+- Routes remain thin and delegate business logic into services.
+- TUI-facing payloads remain stable.
+- Auth-protected endpoints fail closed.
+- SSE and websocket events are scoped to the correct session.
+
+## Procedural Methodology
+
+Apply this loop subsystem by subsystem:
+
+1. Inventory the current tests and known failures.
+2. Define the subsystem's invariants in plain language.
+3. Add characterization tests for behavior that must be preserved.
+4. Add focused unit tests for local decisions.
+5. Add property tests for broad input spaces.
+6. Add state-machine tests for lifecycle behavior.
+7. Add contract tests for public or cross-module boundaries.
+8. Refactor only after the harness is believable.
+9. Add fuzz or mutation testing if the subsystem is critical.
+10. Promote the resulting command into CI or a documented local gate.
+
+This loop should be procedural enough that Penguin or another coding agent can
+execute it repeatedly.
+
+## Phase Plan
+
+### Phase 1 - Make The Default Suite Trustworthy
+
+- [ ] Fix collection blockers.
+- [ ] Remove or move package-internal `test_*.py` files under `penguin/`.
+- [ ] Remove or quarantine invalid source files such as `penguin/llm/test1.py`.
+- [ ] Mark env-gated tests instead of exiting during collection.
+- [ ] Replace server-assuming API tests with in-process clients or explicit
+      integration markers.
+- [ ] Add pytest markers for unit, contract, integration, e2e, live, slow,
+      fuzz, mutation, and formal-adjacent tests.
+- [ ] Document the default local command.
+
+Target command:
+
+```bash
+uv run pytest tests -q -m "not live and not e2e and not slow"
+```
+
+### Phase 2 - Establish Baseline Reporting
+
+- [ ] Add a project coverage config.
+- [ ] Define omitted files intentionally rather than accidentally.
+- [ ] Generate package and subsystem coverage reports.
+- [ ] Track coverage by subsystem instead of relying only on one global number.
+- [ ] Add an initial non-blocking coverage report in CI.
+
+Target command:
+
+```bash
+uv run pytest tests -q --cov=penguin --cov-report=term-missing
+```
+
+### Phase 3 - Protect Critical Invariants
+
+- [ ] Permission/path policy invariant suite.
+- [ ] Tool-call lifecycle invariant suite.
+- [ ] Provider fake-contract suite.
+- [ ] Provider/tool reliability suite covering incomplete streams, retries,
+      turn release, native tool replay, and CWM category-priority truncation.
+- [ ] Session/fork/revert/checkpoint invariant suite.
+- [ ] Project/task lifecycle invariant suite.
+- [ ] Web/TUI payload contract suite.
+
+### Phase 4 - Add Property And State-Machine Testing
+
+- [ ] Hypothesis tests for parser inputs.
+- [ ] Hypothesis tests for path policy.
+- [ ] Hypothesis tests for tool argument coercion.
+- [ ] State-machine tests for tasks/run mode.
+- [ ] State-machine tests for session fork/revert/checkpoint.
+- [ ] State-machine tests for tool-call lifecycle.
+
+### Phase 5 - Add Fuzz And Mutation Gates
+
+- [ ] Add fuzz harnesses for parser and patch/edit surfaces.
+- [ ] Convert fuzz discoveries into regression tests.
+- [ ] Add mutation testing for permission/path policy.
+- [ ] Add mutation testing for parser decisions.
+- [ ] Add mutation testing for task state transitions.
+- [ ] Keep mutation jobs opt-in or scheduled until they are cheap enough.
+
+### Phase 6 - Formal Verification For Small State Machines
+
+- [ ] Choose one first TLA+ target from `context/tasks/penguin_tla.md`.
+- [ ] Keep the spec small and directly mapped to implementation.
+- [ ] Encode invariants before implementation changes.
+- [ ] Add implementation tests that mirror the formal spec's key traces.
+- [ ] Treat formal specs as design verification, not as pytest replacement.
+
+### Phase 7 - CI And Agent Workflow Enforcement
+
+- [ ] Define required checks for normal PRs.
+- [ ] Define expanded checks for high-risk subsystems.
+- [ ] Add a testing checklist to agent task templates.
+- [ ] Require agents to state which test layer they changed or exercised.
+- [ ] Add coverage/invariant deltas to PR summaries where practical.
+
+## Suggested Markers
+
+```ini
+unit: isolated deterministic tests
+contract: public or cross-module behavioral contracts
+integration: local hermetic integration tests
+e2e: assembled product smoke tests
+live: real provider/network tests
+slow: too slow for the default loop
+fuzz: fuzz/property-discovery tests
+mutation: mutation testing entrypoints
+formal: implementation traces derived from formal specs
+```
+
+Default local development should run `unit`, `contract`, and fast hermetic
+integration tests.
+
+Live, E2E, fuzz, mutation, and formal model-checking jobs should be explicit.
+
+## Concrete First PR Candidates
+
+1. Fix pytest collection blockers.
+   - Replace import-time `sys.exit()` in GitHub App tests with proper skip/mark.
+   - Move `tests/llm` plugin declaration to a top-level conftest or remove it.
+   - Fix or delete stale `SecurityConfig` import test.
+
+2. Clean package-source test artifacts.
+   - Move `penguin/llm/test_*.py` and similar runtime-package tests into
+     `tests/` or `misc/tests/`.
+   - Remove or quarantine invalid Python files.
+
+3. Split API tests.
+   - Unit/service tests use in-process clients.
+   - Server-required tests get an explicit marker and documented startup path.
+
+4. Add pytest marker taxonomy.
+   - Register markers in `pyproject.toml`.
+   - Update docs with default and expanded commands.
+
+5. Add the first invariant suite.
+   - Recommended first target: permission/path policy.
+   - Reason: small, high-risk, deterministic, and a good mutation-testing
+     candidate.
+
+## Success Criteria
+
+Short term:
+
+- `pytest` collection is clean.
+- Default offline suite passes.
+- Coverage report runs without special manual exclusions.
+- Test failures clearly identify their layer.
+
+Medium term:
+
+- Critical subsystems have explicit invariant suites.
+- Fake providers cover normal and pathological model behavior.
+- Property tests protect parser/path/tool boundaries.
+- Coverage improves by subsystem with meaningful gates.
+
+Long term:
+
+- Penguin has a repeatable assurance process that agents can apply
+  procedurally.
+- Critical state machines have formal specs or model-derived tests.
+- High-risk modules are mutation-tested.
+- AI-assisted development remains fast without relying on stale human memory as
+  the main correctness mechanism.

--- a/context/tasks/testing-pyramid.md
+++ b/context/tasks/testing-pyramid.md
@@ -436,6 +436,14 @@ The success bar is "prove the failure modes," not only "cover the lines." For
 provider/tool runtime changes, every bug fixed from logs should become a
 minimal deterministic fixture.
 
+Current provider-reliability progress:
+
+- OpenAI/Codex OAuth has a reusable fake SSE/request-capture fixture module for
+  hermetic lifecycle and request-shape tests.
+- Codex tests now cover incomplete empty, partial text, partial native tool,
+  mid-stream provider error, completed native tool, next-turn release, and
+  CWM-truncated native tool replay shapes.
+
 ### Project And Run Mode
 
 - Tasks cannot reach completed state without required validation gates.

--- a/context/tasks/tool-call-runtime-architecture.md
+++ b/context/tasks/tool-call-runtime-architecture.md
@@ -576,6 +576,22 @@ Acceptance criteria:
 - repeated-loop detection uses normalized arguments and output hashes from
   `ToolResult`, not text previews
 
+Provider replay progress note:
+
+- `ToolResult` now carries byte count, line count, truncation direction,
+  output hash, and optional artifact path metadata, and
+  `prepare_model_visible_tool_output` provides a deterministic per-tool preview
+  plus full-output artifact write path.
+- Tool-output truncation has unit/property coverage for deterministic caps,
+  artifact writes, metadata preservation, and artifact-safe IDs.
+- Anthropic now marks `error`, `failed`, `cancelled`, and `interrupted`
+  historical tool results as provider-native `is_error` tool results.
+- OpenRouter/OpenAI-compatible chat replay now repairs CWM-truncated native
+  tool history at the adapter edge: complete assistant-tool/tool-result pairs
+  are preserved, orphaned assistant tool calls are flattened, and
+  metadata-rich tool-result-only records synthesize a valid assistant tool call
+  before replaying the tool result.
+
 Reference points:
 
 - OpenCode's tool wrapper truncates all tool outputs and stores full output

--- a/context/tasks/tool-call-runtime-architecture.md
+++ b/context/tasks/tool-call-runtime-architecture.md
@@ -92,6 +92,43 @@ Key ideas worth borrowing:
 Penguin does not need to clone Codex internals, but it should adopt the same
 separation of concerns.
 
+## Reference Harness Takeaways
+
+Local references reviewed:
+
+- `reference/codex`
+- `reference/opencode`
+
+Useful design lessons for Penguin:
+
+- Tool calls should be durable runtime objects, not assistant text conventions.
+  Codex carries `call_id`, tool name, payload, session, turn context,
+  cancellation token, and diff/output tracking through dispatch and persistence.
+- Tool output truncation should be universal, explicit, and artifact-backed.
+  OpenCode wraps tools with a default truncation layer, preserves the full
+  output locally, and returns model-visible hints for reading/searching the
+  saved output.
+- Parallelism needs scheduler-owned metadata. Codex only runs calls in parallel
+  when the configured tool explicitly supports it; other calls take an
+  exclusive gate. Penguin should keep serial execution as the default until
+  read-only, mutating, approval, streaming, and retry metadata are reliable.
+- Permission checks belong in the runtime path. Codex and OpenCode both attach
+  approval prompts, cached approvals, and permission context to tool execution
+  rather than relying only on prompt instructions.
+- Shell/process tools are a runtime family, not a generic function call. They
+  need cwd/env tracking, timeout/cancellation, stdout streaming, sandbox and
+  network approval, exit-code metadata, and persistent process state.
+- Tool history replay must be provider-safe. Dangling or interrupted tool calls
+  should replay as explicit error/cancelled tool results so providers with
+  strict adjacency rules never receive unresolved tool-use blocks.
+- Tool calls should be recorded before execution starts. Codex persists model
+  output items before dispatching tools, which keeps recovery coherent if the
+  process is cancelled, interrupted, or disconnected between call capture and
+  result persistence.
+- Provider quirks should stay at the adapter edge. Higher layers should see
+  canonical tool calls/results/events, while adapters handle provider-specific
+  tool-call IDs, message ordering, schemas, and finish reasons.
+
 ## Target Architecture
 
 Introduce a provider-neutral intermediate representation:
@@ -128,6 +165,8 @@ ToolResult(
     started_at: float,
     ended_at: float,
     output_hash: str,
+    output_path: str | None,
+    truncated: bool,
 )
 ```
 
@@ -187,6 +226,7 @@ Responsibilities:
 - serialize mutating calls
 - preserve deterministic result ordering
 - support cancellation and timeouts
+- enforce per-tool and aggregate output limits before model replay
 - emit start/end UI events consistently
 
 The first scheduler should be deliberately conservative:
@@ -202,9 +242,15 @@ Parallel execution can be added once the metadata and persistence are reliable.
 Responsibilities:
 
 - persist tool call id, name, arguments, status, output, and output hash
+- persist the call record before tool execution so cancellation/interruption can
+  replay the call as a cancelled or failed result instead of losing it
+- persist truncation metadata and a full-output artifact/reference when output
+  is too large for model-visible replay
 - distinguish assistant text from tool calls and tool results
 - make repeated-loop detection use tool identity and arguments
 - support reconstruction/debugging of a model turn
+- replay interrupted, cancelled, or failed tool calls as explicit tool results
+  rather than leaving provider-native tool calls dangling
 
 This should avoid relying on the first 200 characters of output as the primary
 identity for progress detection.
@@ -218,6 +264,8 @@ Responsibilities:
 - decide whether another model turn is needed
 - handle malformed tool syntax repair
 - handle empty tool-only loops based on `ToolCall`/`ToolResult` identity
+- retry empty non-tool continuations after tool-heavy turns with compacted tool
+  output before surfacing a terminal diagnostic
 
 The loop controller should not know individual tool semantics. It should reason
 about call/result metadata.
@@ -497,14 +545,110 @@ Related future work:
   terminal/session handling, debugger tools, dev-server process tools, result
   paging, richer metadata, and test/code-navigation suites.
 
+### Phase 6.5: Universal Tool Output Truncation And Replay Safety
+
+Goals:
+
+- persist native/provider tool-call records before dispatching tools
+- apply a single truncation policy to all model-visible tool outputs
+- preserve full raw output in a local artifact/result store when truncated
+- include line count, byte count, truncation direction, output hash, and output
+  artifact path/reference in `ToolResult`
+- enforce an aggregate per-turn model-visible tool-output cap in addition to
+  per-tool caps
+- make provider replay reconstruct native tool-call and tool-result adjacency
+  from persisted `ToolCall` / `ToolResult` records
+- convert interrupted, pending, or cancelled historical tool calls into
+  explicit error/cancelled tool results during replay
+
+Acceptance criteria:
+
+- if Penguin stops between tool-call capture and tool completion, replay can
+  reconstruct the pending call and emit an explicit cancelled/failed result
+- large command/read/search outputs do not get injected wholesale into the next
+  model turn
+- the model receives a concise truncation notice plus a safe way to inspect the
+  full output by result id or artifact path
+- empty-response recovery after tool-heavy turns retries once with compacted
+  recent tool output before returning a structured diagnostic
+- OpenAI/Codex, OpenRouter/OpenAI-compatible, and Anthropic replay tests cover
+  completed, failed, cancelled, and interrupted tool calls
+- repeated-loop detection uses normalized arguments and output hashes from
+  `ToolResult`, not text previews
+
+Reference points:
+
+- OpenCode's tool wrapper truncates all tool outputs and stores full output
+  under a local tool-output directory.
+- Codex's `ToolOutput` boundary owns conversion to provider response items and
+  truncates function output before model replay.
+
+### Phase 7: Runtime Permissions And Tool Metadata
+
+Goals:
+
+- move read-only/mutating, approval, external-state, network, destructive,
+  long-running, streaming, retry-safe, and parallel-safe metadata into the
+  registry/descriptor layer
+- make scheduler decisions consume registry metadata rather than adapter
+  guesses
+- require permission/approval checks in the runtime dispatch path
+- cache approvals by normalized tool name, arguments, cwd, sandbox/network
+  scope, and affected paths where applicable
+- surface permission-required and approval-denied outcomes as `ToolResult`
+  statuses that can be replayed to the model
+
+Acceptance criteria:
+
+- provider adapters only extract calls; they do not decide tool risk
+- mutating/unsafe calls are serialized by default
+- approval-denied and permission-required paths produce structured results and
+  UI events
+- tests cover denied, approved-once, approved-for-session, and unavailable-tool
+  behavior
+
+### Phase 8: Terminal/Process Runtime Foundation
+
+Goals:
+
+- define shell/process tool calls as a runtime family with lifecycle state
+- support persistent PTY/process sessions, stdin writes, output polling,
+  cancellation, interrupt/kill, cwd/env tracking, and exit-code/duration
+  metadata
+- stream stdout/stderr progress to UI events without dumping unbounded output
+  into conversation history
+- integrate sandbox, network approval, and permission metadata with process
+  execution
+- keep one-shot command execution as a compatibility wrapper over the process
+  runtime where practical
+
+Acceptance criteria:
+
+- long-running commands can remain running without blocking or losing process
+  identity
+- process output is page-able/reusable by result/session id
+- command timeout, cancellation, and user abort are distinguishable statuses
+- dev-server/test-watcher/REPL workflows do not require rerunning commands just
+  to recover state
+
+Related plan:
+
+- Larger terminal/process, debugger, dev-server, test-intelligence, and
+  code-navigation tool suites remain tracked in
+  `context/tasks/tool-system-future-improvements.md`. This phase only builds
+  the runtime foundation those suites need.
+
 ## Non-Goals
 
 - Do not remove ActionXML before a replacement path is stable.
 - Do not enable provider parallel tool calls before the scheduler can handle
   them safely.
-- Do not rewrite every tool implementation as part of Phase 1.
+- Do not rewrite every tool implementation as part of the early IR/scheduler
+  phases.
 - Do not make the engine depend on OpenAI/Codex-specific types.
 - Do not preserve the current giant action map as the long-term routing layer.
+- Do not build debugger/dev-server/test-intelligence suites before the process
+  runtime and tool-result persistence are stable.
 
 ## Risks
 
@@ -530,6 +674,33 @@ Mitigation:
 - make mutating tools serialized by default
 - test denied, approval-needed, and read-only paths
 
+### Tool Output Pressure
+
+Large or noisy tool outputs can destabilize provider continuations, especially
+after read/search/command-heavy turns.
+
+Mitigation:
+
+- enforce per-tool and aggregate model-visible output caps
+- persist full output outside conversation history
+- expose paging/search-by-result-id tools before encouraging large-output
+  workflows
+- add empty-response recovery for tool-heavy turns
+
+### Provider Replay Drift
+
+Native providers have different tool-call adjacency and id constraints.
+Incomplete or malformed replay can turn successful tool execution into provider
+errors or empty continuations.
+
+Mitigation:
+
+- persist canonical call/result pairs with stable ids
+- persist call records before execution starts
+- make adapters reconstruct provider-specific replay at the edge
+- synthesize explicit failed/cancelled results for interrupted tool calls
+- keep provider contract tests for replay ordering and id normalization
+
 ### Over-Abstracting Too Early
 
 A generic runtime can become another abstraction layer without removing the old
@@ -540,14 +711,48 @@ Mitigation:
 - start with minimal IR and serial scheduler
 - migrate one path at a time
 - delete compatibility layers when their callers are gone
+- keep the near-term tool-call IR under the tool runtime unless shared
+  cross-domain execution primitives justify a broader runtime package
+
+## Future Consideration: Shared Runtime Package
+
+Do not introduce a generic `penguin/runtime/` package just to make the tool-call
+IR feel more general. Keep the current work scoped to the tool-call execution
+runtime until Penguin has shared lifecycle primitives that are useful across
+tools, LLM/provider continuations, process sessions, sub-agents, approvals, and
+replay.
+
+A broader runtime package may make sense later if it can own concrete
+cross-domain primitives such as:
+
+- durable result records and artifact references
+- cancellation tokens
+- persistent process/session handles
+- approval records and cached permission decisions
+- execution leases
+- replay records for interrupted, failed, cancelled, or resumable work
+
+Until those primitives exist, `penguin/runtime/` risks becoming a vague bucket.
+The safer near-term boundary is:
+
+- `penguin.tools.runtime`: tool-call IR, tool-result IR, scheduling, truncation,
+  replay, and dispatch-facing policy
+- `penguin.llm.runtime`: provider/request helpers, native tool kwargs,
+  provider-output diagnostics, and adapter-adjacent logic
+- event/message buses: observation and routing, not execution lifecycle
+  ownership
 
 ## Open Questions
 
-- Should the IR live under `penguin/llm/runtime.py`, `penguin/tools/`, or a new
-  `penguin/runtime/` package?
+- Should the IR stay under `penguin/tools/` until shared runtime primitives
+  justify introducing `penguin/runtime/`?
 - Should ActionXML multiple-call execution remain opt-in at first?
 - Which tools are safe enough to mark parallel-safe initially?
 - Should model-visible tool schemas come entirely from the registry?
 - How should long-running process tools stream output into `ToolResult` records?
 - Should tool results be persisted as first-class session records rather than
   action-result messages?
+- Should full tool output artifacts live in conversation storage, workspace
+  artifacts, or a dedicated result store with retention cleanup?
+- What aggregate per-turn model-visible tool-output cap should Penguin enforce
+  by default?

--- a/context/tasks/tool-call-runtime-architecture.md
+++ b/context/tasks/tool-call-runtime-architecture.md
@@ -264,7 +264,7 @@ Responsibilities:
 - decide whether another model turn is needed
 - handle malformed tool syntax repair
 - handle empty tool-only loops based on `ToolCall`/`ToolResult` identity
-- retry empty non-tool continuations after tool-heavy turns with compacted tool
+- retry empty non-tool continuations after tool-heavy turns with bounded tool
   output before surfacing a terminal diagnostic
 
 The loop controller should not know individual tool semantics. It should reason
@@ -569,7 +569,7 @@ Acceptance criteria:
   model turn
 - the model receives a concise truncation notice plus a safe way to inspect the
   full output by result id or artifact path
-- empty-response recovery after tool-heavy turns retries once with compacted
+- empty-response recovery after tool-heavy turns retries once with bounded
   recent tool output before returning a structured diagnostic
 - OpenAI/Codex, OpenRouter/OpenAI-compatible, and Anthropic replay tests cover
   completed, failed, cancelled, and interrupted tool calls

--- a/context/tasks/tool-call-runtime-architecture.md
+++ b/context/tasks/tool-call-runtime-architecture.md
@@ -518,6 +518,10 @@ Phase 5.6 implementation note:
   the provider/model may still report reasoning-token usage. Audit provider and
   model capability metadata later so controllable reasoning config is applied
   only where the selected provider contract supports it.
+- Provider capability metadata now exists in `LLMProviderCapabilities` and is
+  attached to prepared provider requests. The remaining audit is model-level:
+  verify which specific endpoints/models should set native-tool, reasoning,
+  vision, resumable, and background flags.
 - LiteLLM, Gemini, Ollama, and other providers intentionally remain on the
   ActionXML fallback path until their native tool contracts are audited and
   tested.

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/session-hydration.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/session-hydration.ts
@@ -40,10 +40,31 @@ type SessionHydrationOptions = {
 
 function messageCreatedAt(message: Message): number {
   const value = message.time?.created
-  return typeof value === "number" ? value : 0
+  if (typeof value === "number") return value
+
+  const match = /^msg_(\d{10,13})(?:[._]\d+)?/.exec(message.id)
+  if (!match) return Number.MAX_SAFE_INTEGER
+
+  const raw = match[1]
+  const stamp = Number(raw)
+  if (!Number.isFinite(stamp)) return Number.MAX_SAFE_INTEGER
+  return raw.length === 10 ? stamp * 1000 : stamp
+}
+
+function parentID(message: Message): string | undefined {
+  if (message.role !== "assistant") return undefined
+  const value = message.parentID
+  if (!value || value === "root") return undefined
+  return value
 }
 
 export function compareMessagesByCreated(left: Message, right: Message): number {
+  const leftParent = parentID(left)
+  if (leftParent && leftParent === right.id) return 1
+
+  const rightParent = parentID(right)
+  if (rightParent && rightParent === left.id) return -1
+
   const diff = messageCreatedAt(left) - messageCreatedAt(right)
   if (diff !== 0) return diff
   return left.id.localeCompare(right.id)
@@ -52,15 +73,14 @@ export function compareMessagesByCreated(left: Message, right: Message): number 
 export function upsertPenguinMessage(existing: Message[] | undefined, incoming: Message): Message[] {
   if (!Array.isArray(existing) || existing.length === 0) return [incoming]
   const match = existing.findIndex((item) => item.id === incoming.id)
-  if (match !== -1) return existing.map((item, index) => (index === match ? incoming : item))
+  if (match !== -1) return existing.map((item, index) => (index === match ? incoming : item)).toSorted(compareMessagesByCreated)
   return [...existing, incoming].toSorted(compareMessagesByCreated)
 }
 
 function insertPreservedMessages(hydrated: Message[], preserved: Message[]): Message[] {
   const merged = [...hydrated]
   for (const message of preserved.toSorted(compareMessagesByCreated)) {
-    const messageTime = messageCreatedAt(message)
-    const insertAt = merged.findIndex((item) => messageTime < messageCreatedAt(item))
+    const insertAt = merged.findIndex((item) => compareMessagesByCreated(message, item) < 0)
     if (insertAt === -1) {
       merged.push(message)
       continue

--- a/penguin-tui/packages/opencode/test/cli/tui/sync-hydration.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/sync-hydration.test.ts
@@ -341,7 +341,7 @@ describe("sync hydration", () => {
     ])
   })
 
-  test("orders new live penguin messages by creation time", () => {
+  test("keeps live assistant response after its parent user when timestamps skew", () => {
     const optimistic = {
       ...user,
       id: "msg_local_user",
@@ -350,14 +350,60 @@ describe("sync hydration", () => {
     const streamed = {
       ...assistant,
       id: "msg_streamed_assistant",
+      parentID: "msg_local_user",
       time: { created: 10, completed: 11 },
     }
 
     const merged = upsertPenguinMessage([optimistic], streamed)
 
     expect(merged.map((item) => item.id)).toEqual([
-      "msg_streamed_assistant",
       "msg_local_user",
+      "msg_streamed_assistant",
+    ])
+  })
+
+  test("does not move messages without timestamps above current user turns", () => {
+    const optimistic = {
+      ...user,
+      id: "msg_1778539630840_00",
+      time: { created: 1_778_539_630_840 },
+    }
+    const streamed = {
+      ...assistant,
+      id: "msg_streamed_without_time",
+      time: undefined as unknown as Message["time"],
+    }
+
+    const merged = upsertPenguinMessage([optimistic], streamed)
+
+    expect(merged.map((item) => item.id)).toEqual([
+      "msg_1778539630840_00",
+      "msg_streamed_without_time",
+    ])
+  })
+
+  test("reorders corrected live assistant update after parent user", () => {
+    const parent = {
+      ...user,
+      id: "msg_parent_user",
+      time: { created: 20 },
+    }
+    const placeholder = {
+      ...assistant,
+      id: "msg_streamed_assistant",
+      time: undefined as unknown as Message["time"],
+    }
+    const updated = {
+      ...placeholder,
+      parentID: "msg_parent_user",
+      time: { created: 10, completed: 11 },
+    }
+
+    const merged = upsertPenguinMessage([placeholder, parent], updated)
+
+    expect(merged.map((item) => item.id)).toEqual([
+      "msg_parent_user",
+      "msg_streamed_assistant",
     ])
   })
 
@@ -396,6 +442,7 @@ describe("sync hydration", () => {
     const first = {
       ...assistant,
       id: "msg_streamed_assistant",
+      parentID: "msg_user_1",
       time: { created: 10 },
     }
     const updated = {

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -139,6 +139,7 @@ class LoopConfig:
     # Default completion status when loop ends without explicit signal
     default_completion_status: str = "completed"
 
+
 @dataclass
 class LoopState:
     """Consolidated state for iteration loops (run_response, run_task).
@@ -1127,7 +1128,9 @@ class Engine:
             conversation = getattr(cm, "conversation", None)
             session = getattr(conversation, "session", None)
             messages = getattr(session, "messages", None)
-            last_message = messages[-1] if isinstance(messages, list) and messages else None
+            last_message = (
+                messages[-1] if isinstance(messages, list) and messages else None
+            )
             if (
                 last_message is not None
                 and getattr(last_message, "role", None) == "assistant"
@@ -1136,7 +1139,9 @@ class Engine:
                 messages.pop()
                 if hasattr(conversation, "_modified"):
                     conversation._modified = True
-                if getattr(conversation, "session_manager", None) and getattr(session, "id", None):
+                if getattr(conversation, "session_manager", None) and getattr(
+                    session, "id", None
+                ):
                     try:
                         conversation.session_manager.mark_session_modified(session.id)
                     except Exception:
@@ -1448,7 +1453,9 @@ class Engine:
                 if (
                     last_response
                     and config.completion_phrases
-                    and any(phrase in last_response for phrase in config.completion_phrases)
+                    and any(
+                        phrase in last_response for phrase in config.completion_phrases
+                    )
                     and not termination_detected
                 ):
                     logger.info(
@@ -1456,9 +1463,15 @@ class Engine:
                         config.mode,
                     )
                     completion_status = (
-                        "pending_review" if config.mode == "task" else config.default_completion_status
+                        "pending_review"
+                        if config.mode == "task"
+                        else config.default_completion_status
                     )
-                    if config.mode == "task" and config.enable_events and config.task_metadata:
+                    if (
+                        config.mode == "task"
+                        and config.enable_events
+                        and config.task_metadata
+                    ):
                         await self._publish_task_event(
                             "COMPLETED",
                             config.task_metadata,
@@ -2238,6 +2251,59 @@ class Engine:
             logger.error("[EMPTY_RESPONSE] Details: %s", diagnostics)
             raise
 
+    def _persist_llm_request_lifecycle(
+        self,
+        cm: ConversationManager,
+        api_client: APIClient,
+    ) -> None:
+        """Persist latest provider request lifecycle on the active session."""
+
+        getter = getattr(api_client, "get_last_request_lifecycle", None)
+        if not callable(getter):
+            return
+        try:
+            lifecycle = getter()
+        except Exception:
+            logger.debug("Failed to read provider request lifecycle", exc_info=True)
+            return
+        if lifecycle is None:
+            return
+
+        session = None
+        session_getter = getattr(cm, "get_current_session", None)
+        if callable(session_getter):
+            try:
+                session = session_getter()
+            except Exception:
+                logger.debug("Failed to get current session", exc_info=True)
+                session = None
+        if session is None:
+            conversation = getattr(cm, "conversation", None)
+            session = getattr(conversation, "session", None)
+        if session is None:
+            return
+
+        try:
+            add_lifecycle = getattr(session, "add_llm_request_lifecycle", None)
+            if callable(add_lifecycle):
+                add_lifecycle(lifecycle)
+                return
+
+            record = (
+                lifecycle.to_dict()
+                if hasattr(lifecycle, "to_dict") and callable(lifecycle.to_dict)
+                else lifecycle
+            )
+            if not isinstance(record, dict):
+                return
+            metadata = getattr(session, "metadata", None)
+            if isinstance(metadata, dict):
+                records = metadata.setdefault("llm_request_lifecycles", [])
+                if isinstance(records, list):
+                    records.append(dict(record))
+        except Exception:
+            logger.debug("Failed to persist provider request lifecycle", exc_info=True)
+
     async def _handle_responses_tool_call(
         self,
         api_client: APIClient,
@@ -2754,9 +2820,12 @@ class Engine:
         extra_kwargs = self._prepare_responses_tools(tool_manager)
 
         # Step 2: Call LLM with retry on empty response
-        assistant_response = await self._call_llm_with_retry(
-            api_client, messages, streaming, stream_callback, extra_kwargs
-        )
+        try:
+            assistant_response = await self._call_llm_with_retry(
+                api_client, messages, streaming, stream_callback, extra_kwargs
+            )
+        finally:
+            self._persist_llm_request_lifecycle(cm, api_client)
 
         # Step 3: Finalize streaming response and persist message.
         # This must happen before Responses tool execution so any provider

--- a/penguin/llm/adapters/anthropic.py
+++ b/penguin/llm/adapters/anthropic.py
@@ -12,7 +12,14 @@ import anthropic
 from anthropic import AsyncAnthropic
 
 from .base import BaseAdapter
-from ..contracts import FinishReason, LLMError, LLMUsage
+from ..contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMRequestLifecycle,
+    LLMUsage,
+    ProviderRequestStatus,
+)
 from ..model_config import ModelConfig
 from ..provider_transform import build_llm_error, normalize_finish_reason
 
@@ -43,6 +50,7 @@ class AnthropicAdapter(BaseAdapter):
         self._last_tool_call: Optional[Dict[str, Any]] = None
         self._pending_tool_calls: List[Dict[str, Any]] = []
         self._tool_use_accs: Dict[int, Dict[str, Any]] = {}
+        self._last_request_lifecycle: Optional[LLMRequestLifecycle] = None
 
         # Add a logger for the adapter
         self.logger = logging.getLogger(__name__)
@@ -66,12 +74,125 @@ class AnthropicAdapter(BaseAdapter):
     def get_last_error(self) -> Optional[LLMError]:
         return self._last_error if isinstance(self._last_error, LLMError) else None
 
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
+        return self._last_request_lifecycle
+
+    def _start_request_lifecycle(
+        self,
+        *,
+        stream: bool,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        now = time.time()
+        self._last_request_lifecycle = LLMRequestLifecycle(
+            request_id=f"anthropic-{int(now * 1000)}",
+            provider=self.provider,
+            model=getattr(self.model_config, "model", ""),
+            status=ProviderRequestStatus.RUNNING,
+            stream=stream,
+            transport="sdk",
+            started_at=now,
+            last_event_at=now,
+            provider_data={"message_count": len(messages)},
+        )
+
+    def _update_request_lifecycle(
+        self,
+        *,
+        status: ProviderRequestStatus,
+        finish_reason: Optional[FinishReason] = None,
+        error: Optional[LLMError] = None,
+        event_type: Optional[str] = None,
+        provider_response_id: Optional[str] = None,
+    ) -> None:
+        lifecycle = getattr(self, "_last_request_lifecycle", None)
+        if lifecycle is None:
+            return
+        now = time.time()
+        lifecycle.status = status
+        lifecycle.last_event_at = now
+        if status in {
+            ProviderRequestStatus.COMPLETED,
+            ProviderRequestStatus.DISCONNECTED,
+            ProviderRequestStatus.FAILED,
+            ProviderRequestStatus.CANCELLED,
+        }:
+            lifecycle.ended_at = now
+        if finish_reason is not None:
+            lifecycle.finish_reason = finish_reason
+        if error is not None:
+            lifecycle.error = error
+        if event_type:
+            lifecycle.last_event_type = event_type
+        if provider_response_id:
+            lifecycle.provider_response_id = provider_response_id
+
+    def _finish_request_lifecycle_from_state(self) -> None:
+        error = self.get_last_error()
+        if error is not None:
+            status = (
+                ProviderRequestStatus.DISCONNECTED
+                if error.category in {ErrorCategory.NETWORK, ErrorCategory.TIMEOUT}
+                else ProviderRequestStatus.FAILED
+            )
+            self._update_request_lifecycle(
+                status=status,
+                finish_reason=error.finish_reason or self.get_last_finish_reason(),
+                error=error,
+            )
+            return
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.COMPLETED,
+            finish_reason=self.get_last_finish_reason(),
+        )
+
     def _set_last_finish_reason(self, finish_reason: Any) -> FinishReason:
         self._last_finish_reason = normalize_finish_reason(finish_reason)
         return self._last_finish_reason
 
     def get_last_finish_reason(self) -> FinishReason:
         return self._last_finish_reason
+
+    def _anthropic_stream_error_detail(self, chunk: Any) -> str:
+        error_payload = getattr(chunk, "error", None)
+        if isinstance(error_payload, dict):
+            message = error_payload.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+            return str(error_payload)[:500]
+        message = getattr(error_payload, "message", None)
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+        return str(error_payload or chunk)[:500]
+
+    def _record_anthropic_stream_error(self, chunk: Any) -> LLMError:
+        error = build_llm_error(
+            message=self._anthropic_stream_error_detail(chunk),
+            provider=self.provider,
+            model=getattr(self.model_config, "model", None),
+            finish_reason=FinishReason.ERROR,
+        )
+        self._set_last_error(error)
+        self._set_last_finish_reason(FinishReason.ERROR)
+        return error
+
+    def _record_anthropic_stream_incomplete(self, output_state: str) -> LLMError:
+        error = build_llm_error(
+            message=(
+                "Anthropic stream ended before message_stop "
+                f"(output_state={output_state})"
+            ),
+            provider=self.provider,
+            model=getattr(self.model_config, "model", None),
+            category=ErrorCategory.NETWORK,
+            retryable=True,
+            finish_reason=FinishReason.ERROR,
+        )
+        self._set_last_error(error)
+        self._set_last_finish_reason(FinishReason.ERROR)
+        self._pending_tool_calls = []
+        self._last_tool_call = None
+        return error
 
     def _append_reasoning(self, text: str) -> None:
         if text:
@@ -422,30 +543,64 @@ class AnthropicAdapter(BaseAdapter):
         - Non-streaming: calls create_completion and processes the response
         """
         self._reset_response_state()
-        if stream:
-            # Ensure callback is callable; pass through directly
-            final_text = await self.create_completion(
+        self._start_request_lifecycle(stream=stream, messages=messages)
+        try:
+            if stream:
+                # Ensure callback is callable; pass through directly
+                final_text = await self.create_completion(
+                    messages=messages,
+                    max_output_tokens=max_output_tokens,
+                    temperature=temperature,
+                    stream=True,
+                    stream_callback=stream_callback,
+                    **kwargs,
+                )
+                self._finish_request_lifecycle_from_state()
+                # create_completion returns a string when streaming
+                return final_text or ""
+
+            # Non-streaming path
+            response = await self.create_completion(
                 messages=messages,
                 max_output_tokens=max_output_tokens,
                 temperature=temperature,
-                stream=True,
-                stream_callback=stream_callback,
+                stream=False,
+                stream_callback=None,
                 **kwargs,
             )
-            # create_completion returns a string when streaming
-            return final_text or ""
-
-        # Non-streaming path
-        response = await self.create_completion(
-            messages=messages,
-            max_output_tokens=max_output_tokens,
-            temperature=temperature,
-            stream=False,
-            stream_callback=None,
-            **kwargs,
-        )
-        content, _ = self.process_response(response)
-        return content or ""
+            content, _ = self.process_response(response)
+            self._finish_request_lifecycle_from_state()
+            return content or ""
+        except asyncio.CancelledError:
+            error = build_llm_error(
+                message="Anthropic request was cancelled",
+                provider=self.provider,
+                model=getattr(self.model_config, "model", None),
+                category=ErrorCategory.RUNTIME,
+                retryable=False,
+                finish_reason=FinishReason.ERROR,
+            )
+            self._set_last_error(error)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.CANCELLED,
+                finish_reason=FinishReason.ERROR,
+                error=error,
+            )
+            raise
+        except Exception as exc:
+            error = self.get_last_error() or build_llm_error(
+                message=str(exc),
+                provider=self.provider,
+                model=getattr(self.model_config, "model", None),
+                finish_reason=FinishReason.ERROR,
+            )
+            self._set_last_error(error)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.FAILED,
+                finish_reason=error.finish_reason or FinishReason.ERROR,
+                error=error,
+            )
+            raise
 
     async def _handle_streaming(
         self,
@@ -463,6 +618,7 @@ class AnthropicAdapter(BaseAdapter):
         usage_info = None  # To store usage info if available
         chunk_count = 0
         received_content = False
+        saw_message_stop = False
 
         try:
             # Create the streaming response
@@ -476,6 +632,10 @@ class AnthropicAdapter(BaseAdapter):
             async for chunk in stream:
                 last_chunk_time = time.time()
                 chunk_count += 1
+                self._update_request_lifecycle(
+                    status=ProviderRequestStatus.STREAMING,
+                    event_type=str(getattr(chunk, "type", "")) or None,
+                )
 
                 # Extract text content based on chunk type
                 content = None
@@ -487,6 +647,7 @@ class AnthropicAdapter(BaseAdapter):
                     )
                     if hasattr(chunk, "type"):
                         if chunk.type == "message_stop":
+                            saw_message_stop = True
                             # Capture the final response object from the stream if possible
                             # Note: The structure might vary, need to check Anthropic docs/examples
                             # For now, just log that we stopped. The final object might not be in the chunk itself.
@@ -494,6 +655,13 @@ class AnthropicAdapter(BaseAdapter):
                                 "Stream processing stopped due to 'message_stop' event."
                             )
                             # We might get the final message object *after* the loop, see below
+                        elif chunk.type == "error":
+                            stream_error = self._record_anthropic_stream_error(chunk)
+                            self.logger.error(
+                                "Anthropic stream error event: %s",
+                                stream_error.message,
+                            )
+                            break
 
                         elif chunk.type == "content_block_delta" and hasattr(
                             chunk, "delta"
@@ -592,6 +760,12 @@ class AnthropicAdapter(BaseAdapter):
                     # Extract final stop reason and usage if not already captured
                     if not stop_reason:
                         stop_reason = final_response_object.stop_reason
+                    self._update_request_lifecycle(
+                        status=ProviderRequestStatus.STREAMING,
+                        provider_response_id=getattr(
+                            final_response_object, "id", None
+                        ),
+                    )
                     self._set_last_finish_reason(stop_reason)
                     if not usage_info:
                         usage_info = final_response_object.usage
@@ -610,6 +784,29 @@ class AnthropicAdapter(BaseAdapter):
 
             # Join all chunks to get the complete response
             complete_response = "".join(accumulated_response)
+
+            if not saw_message_stop and stream_error is None:
+                output_state = (
+                    "tool_call"
+                    if self.has_pending_tool_call()
+                    else "text"
+                    if complete_response
+                    else "empty"
+                )
+                stream_error = self._record_anthropic_stream_incomplete(output_state)
+
+            if stream_error:
+                error_message = str(stream_error)
+                if isinstance(stream_error, LLMError):
+                    error_message = stream_error.message
+                    self._set_last_error(stream_error)
+                self._set_last_finish_reason(FinishReason.ERROR)
+                if complete_response:
+                    return (
+                        f"{complete_response}\n\n"
+                        f"[Error: Stream interrupted by Anthropic: {error_message}]"
+                    )
+                return f"Error during response generation: {error_message}"
 
             if not complete_response.strip() and self.has_pending_tool_call():
                 self._set_last_finish_reason(FinishReason.TOOL_CALLS)
@@ -1027,7 +1224,7 @@ class AnthropicAdapter(BaseAdapter):
                             "content": tool_result_content,
                         }
                         status = str(tool_msg.get("status") or "").lower()
-                        if status in {"error", "failed"}:
+                        if status in {"error", "failed", "cancelled", "interrupted"}:
                             block["is_error"] = True
                         tool_result_blocks.append(block)
                     else:

--- a/penguin/llm/adapters/anthropic.py
+++ b/penguin/llm/adapters/anthropic.py
@@ -16,6 +16,8 @@ from ..contracts import (
     ErrorCategory,
     FinishReason,
     LLMError,
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
     LLMRequestLifecycle,
     LLMUsage,
     ProviderRequestStatus,
@@ -239,6 +241,90 @@ class AnthropicAdapter(BaseAdapter):
         if not isinstance(getattr(self, "_last_usage", None), dict):
             return {}
         return dict(self._last_usage)
+
+    def get_capabilities(self) -> LLMProviderCapabilities:
+        """Return Anthropic Messages capability metadata."""
+
+        return LLMProviderCapabilities(
+            provider=self.provider,
+            model=str(getattr(self.model_config, "model", "") or ""),
+            native_tools=True,
+            streaming=bool(getattr(self.model_config, "streaming_enabled", True)),
+            reasoning=bool(
+                getattr(self.model_config, "reasoning_enabled", False)
+                or self.model_config.get_reasoning_config()
+            ),
+            vision=self.supports_vision(),
+            max_context_tokens=getattr(
+                self.model_config,
+                "max_context_window_tokens",
+                None,
+            ),
+            max_output_tokens=getattr(self.model_config, "max_output_tokens", None),
+            provider_data={"api": "messages"},
+        )
+
+    async def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        """Prepare an Anthropic Messages request without sending it."""
+
+        legacy_max_tokens = kwargs.pop("max_tokens", None)
+        if max_output_tokens is None and legacy_max_tokens is not None:
+            max_output_tokens = legacy_max_tokens
+
+        formatted_messages = self.format_messages(messages)
+        system_message = None
+        for msg in messages:
+            if msg.get("role") == "system":
+                system_message = msg.get("content", "")
+                if system_message:
+                    system_message = str(system_message).rstrip()
+                break
+
+        request_params: Dict[str, Any] = {
+            "model": self.model_config.model,
+            "messages": formatted_messages,
+            "max_tokens": max_output_tokens
+            or self.model_config.max_output_tokens
+            or 4096,
+            "temperature": temperature or self.model_config.temperature or 0.7,
+            "stream": stream,
+        }
+        if system_message:
+            request_params["system"] = system_message
+        if kwargs.get("tools"):
+            request_params["tools"] = kwargs["tools"]
+        if kwargs.get("tool_choice"):
+            request_params["tool_choice"] = kwargs["tool_choice"]
+
+        reasoning_config = self.model_config.get_reasoning_config()
+        self._apply_output_effort(request_params, reasoning_config)
+        self._ensure_no_trailing_whitespace(request_params)
+
+        return LLMPreparedRequest(
+            provider=self.provider,
+            model=str(self.model_config.model),
+            protocol="anthropic_messages",
+            route="anthropic.messages",
+            body={
+                key: value
+                for key, value in request_params.items()
+                if value is not None
+            },
+            transport="sdk_stream" if stream else "sdk",
+            capabilities=self.get_capabilities(),
+            diagnostics={
+                "message_count": len(messages),
+                "formatted_message_count": len(formatted_messages),
+                "stream": stream,
+            },
+        )
 
     def has_pending_tool_call(self) -> bool:
         return bool(

--- a/penguin/llm/adapters/base.py
+++ b/penguin/llm/adapters/base.py
@@ -1,7 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from ..contracts import FinishReason, LLMError, LLMRequestLifecycle
+from ..contracts import (
+    FinishReason,
+    LLMError,
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
+    LLMRequestLifecycle,
+)
 
 
 class BaseAdapter(ABC):
@@ -85,6 +91,69 @@ class BaseAdapter(ABC):
     def get_last_usage(self) -> Dict[str, Any]:
         """Return normalized usage from the most recent request when available."""
         return {}
+
+    def get_capabilities(self) -> LLMProviderCapabilities:
+        """Return provider/model capability metadata for orchestration layers."""
+
+        model_config = getattr(self, "model_config", None)
+        return LLMProviderCapabilities(
+            provider=self.provider,
+            model=str(getattr(model_config, "model", "") or ""),
+            streaming=bool(getattr(model_config, "streaming_enabled", True)),
+            vision=self.supports_vision(),
+            max_context_tokens=getattr(model_config, "max_context_window_tokens", None),
+            max_output_tokens=getattr(model_config, "max_output_tokens", None),
+        )
+
+    async def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        """Prepare a provider-native request without sending it."""
+
+        legacy_max_tokens = kwargs.pop("max_tokens", None)
+        if max_output_tokens is None and legacy_max_tokens is not None:
+            max_output_tokens = legacy_max_tokens
+
+        model_config = getattr(self, "model_config", None)
+        body: Dict[str, Any] = {
+            "model": str(getattr(model_config, "model", "") or ""),
+            "messages": self.format_messages(messages),
+            "stream": stream,
+            **kwargs,
+        }
+        effective_max_tokens = max_output_tokens or getattr(
+            model_config,
+            "max_output_tokens",
+            None,
+        )
+        if effective_max_tokens is not None:
+            body["max_output_tokens"] = effective_max_tokens
+        effective_temperature = (
+            temperature
+            if temperature is not None
+            else getattr(model_config, "temperature", None)
+        )
+        if effective_temperature is not None:
+            body["temperature"] = effective_temperature
+
+        return LLMPreparedRequest(
+            provider=self.provider,
+            model=str(getattr(model_config, "model", "") or ""),
+            protocol="generic_messages",
+            route=f"{self.provider}.messages",
+            body={key: value for key, value in body.items() if value is not None},
+            transport="sdk_stream" if stream else "sdk",
+            capabilities=self.get_capabilities(),
+            diagnostics={
+                "message_count": len(messages),
+                "formatted_message_count": len(body.get("messages", [])),
+            },
+        )
 
     def has_pending_tool_call(self) -> bool:
         """Return whether a tool call is waiting to execute."""

--- a/penguin/llm/adapters/base.py
+++ b/penguin/llm/adapters/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from ..contracts import FinishReason, LLMError
+from ..contracts import FinishReason, LLMError, LLMRequestLifecycle
 
 
 class BaseAdapter(ABC):
@@ -101,6 +101,10 @@ class BaseAdapter(ABC):
 
     def get_last_error(self) -> Optional[LLMError]:
         """Return canonical error metadata from the latest request when available."""
+        return None
+
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
+        """Return lifecycle metadata from the latest provider request when available."""
         return None
 
     def get_last_finish_reason(self) -> FinishReason:

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -1532,6 +1532,26 @@ class OpenAIAdapter(BaseAdapter):
 
                         self._record_reasoning_debug_event(data.get("type"), data)
 
+                        if etype in {"error", "response.failed", "response.error"}:
+                            error_payload = data.get("error")
+                            response_payload = data.get("response")
+                            detail_payload = (
+                                error_payload
+                                if error_payload is not None
+                                else response_payload
+                                if response_payload is not None
+                                else data
+                            )
+                            detail = json.dumps(detail_payload, default=str)[:500]
+                            self._raise_codex_transport_error(
+                                error=RuntimeError(detail),
+                                payload=stream_payload,
+                                model_id=model_id,
+                                model_fallback=model_fallback,
+                                stage="stream_event_error",
+                                diag_id=diag_id,
+                            )
+
                         if self._capture_responses_tool_event(data):
                             self._set_last_finish_reason(FinishReason.TOOL_CALLS)
                         if (
@@ -1633,16 +1653,20 @@ class OpenAIAdapter(BaseAdapter):
         assert response is not None
 
         pending_tool_call = self.has_pending_tool_call()
-        if (
-            not saw_completed_event
-            and not pending_tool_call
-            and not completed_text
-            and not accumulated_content
-        ):
-            detail = (
-                "Codex stream ended before response.completed and produced no "
-                f"text or tool call (saw_done_marker={saw_done_marker})"
+        if not saw_completed_event:
+            output_state = (
+                "tool_call"
+                if pending_tool_call
+                else "text"
+                if completed_text or accumulated_content
+                else "empty"
             )
+            detail = (
+                "Codex stream ended before response.completed "
+                f"(output_state={output_state}, saw_done_marker={saw_done_marker})"
+            )
+            if pending_tool_call:
+                self._reset_tool_call_state()
             self._raise_codex_transport_error(
                 error=RuntimeError(detail),
                 payload=stream_payload,

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import io
 import json
 import logging
@@ -25,7 +26,14 @@ from penguin.web.services.provider_credentials import (
 )
 
 from ..api_client import ConnectionPoolManager
-from ..contracts import FinishReason, LLMError, LLMProviderError, LLMUsage
+from ..contracts import (
+    FinishReason,
+    LLMError,
+    LLMProviderError,
+    LLMRequestLifecycle,
+    LLMUsage,
+    ProviderRequestStatus,
+)
 from ..model_config import ModelConfig, normalize_openai_service_tier
 from ..provider_transform import (
     build_llm_error,
@@ -116,6 +124,7 @@ class OpenAIAdapter(BaseAdapter):
         self._last_finish_reason = FinishReason.UNKNOWN
         self._last_reasoning = ""
         self._last_reasoning_debug: Dict[str, Any] = {}
+        self._last_request_lifecycle: Optional[LLMRequestLifecycle] = None
         self._reset_tool_call_state()
 
     @property
@@ -159,6 +168,7 @@ class OpenAIAdapter(BaseAdapter):
         self._last_finish_reason = FinishReason.UNKNOWN
         self._last_reasoning = ""
         self._last_reasoning_debug = {}
+        self._last_request_lifecycle = None
 
     def _set_last_error(self, error: Optional[LLMError]) -> None:
         self._last_error = error
@@ -167,6 +177,11 @@ class OpenAIAdapter(BaseAdapter):
         if not isinstance(self._last_error, LLMError):
             return None
         return self._last_error
+
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
+        """Return lifecycle diagnostics for the last provider request."""
+
+        return self._last_request_lifecycle
 
     def _get_service_tier(self) -> Optional[str]:
         value = getattr(self.model_config, "service_tier", None)
@@ -806,6 +821,78 @@ class OpenAIAdapter(BaseAdapter):
                 trace[key] = value.strip()
         return trace
 
+    def _codex_http_timeout(self) -> httpx.Timeout:
+        """Use bounded setup timeouts without a fixed active-stream read cap."""
+
+        return httpx.Timeout(connect=30.0, read=None, write=60.0, pool=30.0)
+
+    def _codex_payload_hash(self, payload: Dict[str, Any]) -> str:
+        payload_text = json.dumps(payload, sort_keys=True, default=str)
+        return hashlib.sha256(payload_text.encode("utf-8")).hexdigest()
+
+    def _start_request_lifecycle(
+        self,
+        *,
+        request_id: str,
+        model_id: str,
+        payload: Dict[str, Any],
+        stream: bool,
+        transport: str,
+        model_fallback: bool,
+    ) -> None:
+        now = time.time()
+        input_payload = payload.get("input")
+        self._last_request_lifecycle = LLMRequestLifecycle(
+            request_id=request_id,
+            provider=self.provider,
+            model=model_id,
+            status=ProviderRequestStatus.PENDING,
+            stream=stream,
+            transport=transport,
+            request_payload_hash=self._codex_payload_hash(payload),
+            started_at=now,
+            last_event_at=now,
+            provider_data={
+                "model_fallback": model_fallback,
+                "input_items": len(input_payload)
+                if isinstance(input_payload, list)
+                else 0,
+                "store": payload.get("store"),
+                "service_tier": payload.get("service_tier"),
+            },
+        )
+
+    def _update_request_lifecycle(
+        self,
+        *,
+        status: ProviderRequestStatus,
+        event_type: str | None = None,
+        provider_response_id: str | None = None,
+        finish_reason: FinishReason | None = None,
+        error: LLMError | None = None,
+    ) -> None:
+        lifecycle = self._last_request_lifecycle
+        if lifecycle is None:
+            return
+        now = time.time()
+        lifecycle.status = status
+        lifecycle.last_event_at = now
+        if status in {
+            ProviderRequestStatus.COMPLETED,
+            ProviderRequestStatus.DISCONNECTED,
+            ProviderRequestStatus.FAILED,
+            ProviderRequestStatus.CANCELLED,
+        }:
+            lifecycle.ended_at = now
+        if event_type:
+            lifecycle.last_event_type = event_type
+        if provider_response_id:
+            lifecycle.provider_response_id = provider_response_id
+        if finish_reason is not None:
+            lifecycle.finish_reason = finish_reason
+        if error is not None:
+            lifecycle.error = error
+
     def _codex_model_for_oauth(self, model_id: str) -> tuple[str, bool]:
         value = str(model_id or "").strip()
         if "/" in value:
@@ -1221,8 +1308,18 @@ class OpenAIAdapter(BaseAdapter):
     ) -> str:
         started = time.monotonic()
         response: httpx.Response | None = None
+        if self._last_request_lifecycle is None:
+            self._start_request_lifecycle(
+                request_id=diag_id,
+                model_id=model_id,
+                payload=payload,
+                stream=False,
+                transport="http",
+                model_fallback=model_fallback,
+            )
+        self._update_request_lifecycle(status=ProviderRequestStatus.RUNNING)
         try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
+            async with httpx.AsyncClient(timeout=self._codex_http_timeout()) as client:
                 response = await client.post(
                     _OPENAI_CODEX_RESPONSES_URL,
                     headers=headers,
@@ -1297,6 +1394,10 @@ class OpenAIAdapter(BaseAdapter):
 
         if isinstance(body, str):
             self._set_last_finish_reason(FinishReason.STOP)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.COMPLETED,
+                finish_reason=FinishReason.STOP,
+            )
             self._finalize_reasoning_debug_snapshot(
                 visible_reasoning_chars=len(self.get_last_reasoning()),
                 visible_reasoning_summary_returned=bool(self.get_last_reasoning()),
@@ -1306,6 +1407,12 @@ class OpenAIAdapter(BaseAdapter):
             return body
         if isinstance(body, dict):
             self._record_reasoning_debug_event("response.completed", body)
+            response_id = body.get("id")
+            if isinstance(response_id, str) and response_id.strip():
+                self._update_request_lifecycle(
+                    status=ProviderRequestStatus.RUNNING,
+                    provider_response_id=response_id.strip(),
+                )
             self._set_last_usage(body.get("usage"))
             self._append_reasoning(self._extract_reasoning_from_response_object(body))
         tool_calls = self._extract_function_calls_from_response_object(body)
@@ -1315,6 +1422,10 @@ class OpenAIAdapter(BaseAdapter):
             self._set_last_finish_reason(FinishReason.TOOL_CALLS)
         else:
             self._set_last_finish_reason(FinishReason.STOP)
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.COMPLETED,
+            finish_reason=self.get_last_finish_reason(),
+        )
         self._finalize_reasoning_debug_snapshot(
             visible_reasoning_chars=len(self.get_last_reasoning()),
             visible_reasoning_summary_returned=bool(self.get_last_reasoning()),
@@ -1341,8 +1452,19 @@ class OpenAIAdapter(BaseAdapter):
         accumulated_reasoning = ""
         started = time.monotonic()
         response: httpx.Response | None = None
+        saw_done_marker = False
+        saw_completed_event = False
+        self._start_request_lifecycle(
+            request_id=diag_id,
+            model_id=model_id,
+            payload=stream_payload,
+            stream=True,
+            transport="sse",
+            model_fallback=model_fallback,
+        )
+        self._update_request_lifecycle(status=ProviderRequestStatus.RUNNING)
         try:
-            async with httpx.AsyncClient(timeout=60.0) as client:
+            async with httpx.AsyncClient(timeout=self._codex_http_timeout()) as client:
                 async with client.stream(
                     "POST",
                     _OPENAI_CODEX_RESPONSES_URL,
@@ -1379,6 +1501,11 @@ class OpenAIAdapter(BaseAdapter):
                             continue
                         data_str = line[6:]
                         if data_str.strip() == "[DONE]":
+                            saw_done_marker = True
+                            self._update_request_lifecycle(
+                                status=ProviderRequestStatus.STREAMING,
+                                event_type="[DONE]",
+                            )
                             break
 
                         try:
@@ -1388,6 +1515,20 @@ class OpenAIAdapter(BaseAdapter):
 
                         if not isinstance(data, dict):
                             continue
+
+                        etype = data.get("type")
+                        event_type = str(etype or "").strip()
+                        response_obj_for_lifecycle = data.get("response")
+                        provider_response_id = None
+                        if isinstance(response_obj_for_lifecycle, dict):
+                            raw_response_id = response_obj_for_lifecycle.get("id")
+                            if isinstance(raw_response_id, str):
+                                provider_response_id = raw_response_id.strip() or None
+                        self._update_request_lifecycle(
+                            status=ProviderRequestStatus.STREAMING,
+                            event_type=event_type or None,
+                            provider_response_id=provider_response_id,
+                        )
 
                         self._record_reasoning_debug_event(data.get("type"), data)
 
@@ -1399,7 +1540,6 @@ class OpenAIAdapter(BaseAdapter):
                         ):
                             self._set_last_finish_reason(FinishReason.TOOL_CALLS)
 
-                        etype = data.get("type")
                         if etype == "response.output_text.delta":
                             delta = data.get("delta", "")
                             if delta:
@@ -1419,6 +1559,7 @@ class OpenAIAdapter(BaseAdapter):
                             continue
 
                         if etype == "response.completed":
+                            saw_completed_event = True
                             response_obj = data.get("response")
                             if isinstance(response_obj, dict):
                                 self._set_last_usage(response_obj.get("usage"))
@@ -1491,6 +1632,26 @@ class OpenAIAdapter(BaseAdapter):
             )
         assert response is not None
 
+        pending_tool_call = self.has_pending_tool_call()
+        if (
+            not saw_completed_event
+            and not pending_tool_call
+            and not completed_text
+            and not accumulated_content
+        ):
+            detail = (
+                "Codex stream ended before response.completed and produced no "
+                f"text or tool call (saw_done_marker={saw_done_marker})"
+            )
+            self._raise_codex_transport_error(
+                error=RuntimeError(detail),
+                payload=stream_payload,
+                model_id=model_id,
+                model_fallback=model_fallback,
+                stage="stream_incomplete",
+                diag_id=diag_id,
+            )
+
         latency_ms = int((time.monotonic() - started) * 1000)
         trace = self._trace_headers(response)
         output_chars = len(completed_text) or len("".join(accumulated_content))
@@ -1524,13 +1685,16 @@ class OpenAIAdapter(BaseAdapter):
             self._last_reasoning_debug.get("event_types", []),
         )
 
-        pending_tool_call = self.has_pending_tool_call()
         if pending_tool_call:
             self._set_last_finish_reason(FinishReason.TOOL_CALLS)
 
         if completed_text:
             if not pending_tool_call:
                 self._set_last_finish_reason(FinishReason.STOP)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.COMPLETED,
+                finish_reason=self.get_last_finish_reason(),
+            )
             if not accumulated_content and stream_callback:
                 await self._safe_invoke_callback(
                     stream_callback,
@@ -1541,6 +1705,10 @@ class OpenAIAdapter(BaseAdapter):
 
         if not pending_tool_call:
             self._set_last_finish_reason(FinishReason.STOP)
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.COMPLETED,
+            finish_reason=self.get_last_finish_reason(),
+        )
         return "".join(accumulated_content)
 
     def _codex_error_detail(
@@ -1656,6 +1824,12 @@ class OpenAIAdapter(BaseAdapter):
             },
         )
         self._set_last_error(llm_error)
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.FAILED,
+            event_type=stage,
+            finish_reason=llm_error.finish_reason or FinishReason.ERROR,
+            error=llm_error,
+        )
         self._finalize_reasoning_debug_snapshot(
             status="error",
             visible_reasoning_chars=len(self.get_last_reasoning()),
@@ -1695,10 +1869,16 @@ class OpenAIAdapter(BaseAdapter):
             f"store={store_flag}, error_type={type(error).__name__}) detail={error}"
         )
         _log_error(error_message, exc_info=True)
+        error_category = "network"
+        if "timeout" in stage.lower() or isinstance(error, httpx.TimeoutException):
+            error_category = "timeout"
         llm_error = build_llm_error(
             message=error_message,
             provider=self.provider,
             model=model_id,
+            category=error_category,
+            finish_reason=FinishReason.ERROR,
+            retryable=True,
             provider_data={
                 "diag_id": diag_id,
                 "stage": stage,
@@ -1706,6 +1886,17 @@ class OpenAIAdapter(BaseAdapter):
             },
         )
         self._set_last_error(llm_error)
+        lifecycle_status = (
+            ProviderRequestStatus.DISCONNECTED
+            if stage == "stream_incomplete"
+            else ProviderRequestStatus.FAILED
+        )
+        self._update_request_lifecycle(
+            status=lifecycle_status,
+            event_type=stage,
+            finish_reason=FinishReason.ERROR,
+            error=llm_error,
+        )
         self._finalize_reasoning_debug_snapshot(
             status="error",
             visible_reasoning_chars=len(self.get_last_reasoning()),

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -27,6 +27,7 @@ from penguin.web.services.provider_credentials import (
 
 from ..api_client import ConnectionPoolManager
 from ..contracts import (
+    ErrorCategory,
     FinishReason,
     LLMError,
     LLMProviderError,
@@ -193,6 +194,77 @@ class OpenAIAdapter(BaseAdapter):
 
     def get_last_finish_reason(self) -> FinishReason:
         return self._last_finish_reason
+
+    def _responses_stream_error_detail(self, event: Any) -> str:
+        payload = event if isinstance(event, dict) else {}
+        error_payload: Any = payload.get("error") if payload else None
+        response_payload: Any = payload.get("response") if payload else None
+        if error_payload is None and event is not None:
+            error_payload = getattr(event, "error", None)
+        if response_payload is None and event is not None:
+            response_payload = getattr(event, "response", None)
+
+        detail_payload = (
+            error_payload
+            if error_payload is not None
+            else response_payload
+            if response_payload is not None
+            else event
+        )
+        if isinstance(detail_payload, dict):
+            message = detail_payload.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+            try:
+                return json.dumps(detail_payload, default=str)[:500]
+            except Exception:
+                return str(detail_payload)[:500]
+
+        message = getattr(detail_payload, "message", None)
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+        return str(detail_payload)[:500]
+
+    def _raise_responses_stream_error(self, event: Any) -> None:
+        detail = self._responses_stream_error_detail(event)
+        error = build_llm_error(
+            message=detail,
+            provider=self.provider,
+            model=getattr(self.model_config, "model", None),
+            finish_reason=FinishReason.ERROR,
+        )
+        self._set_last_finish_reason(FinishReason.ERROR)
+        self._set_last_error(error)
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.FAILED,
+            finish_reason=FinishReason.ERROR,
+            error=error,
+        )
+        raise LLMProviderError(error)
+
+    def _raise_responses_stream_incomplete(self, output_state: str) -> None:
+        detail = (
+            "OpenAI Responses stream ended before response.completed "
+            f"(output_state={output_state})"
+        )
+        error = build_llm_error(
+            message=detail,
+            provider=self.provider,
+            model=getattr(self.model_config, "model", None),
+            category=ErrorCategory.NETWORK,
+            retryable=True,
+            finish_reason=FinishReason.ERROR,
+        )
+        self._set_last_finish_reason(FinishReason.ERROR)
+        self._set_last_error(error)
+        if output_state == "tool_call":
+            self._reset_tool_call_state()
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.DISCONNECTED,
+            finish_reason=FinishReason.ERROR,
+            error=error,
+        )
+        raise LLMProviderError(error)
 
     def _append_reasoning(self, reasoning_text: str) -> None:
         if reasoning_text:
@@ -648,19 +720,56 @@ class OpenAIAdapter(BaseAdapter):
         if not uses_effort_style:
             request_params["temperature"] = temp_val
 
+        self._start_request_lifecycle(
+            request_id=f"openai-{int(time.time() * 1000)}",
+            model_id=self.model_config.model,
+            payload=request_params,
+            stream=stream,
+            transport="sdk",
+            model_fallback=False,
+        )
+        self._update_request_lifecycle(status=ProviderRequestStatus.RUNNING)
+
         if stream:
             # Note: `stream_options.include_usage` is a Chat Completions option and is
             # not supported by the Responses API. Additionally, some OpenAI SDK
             # versions don't accept `stream_options` on `responses.stream`, so we
             # intentionally ignore any user-provided `stream_options` here.
             try:
-                return await self._stream_with_sdk(request_params, stream_callback)
+                result = await self._stream_with_sdk(request_params, stream_callback)
+                self._update_request_lifecycle(
+                    status=ProviderRequestStatus.COMPLETED,
+                    finish_reason=self.get_last_finish_reason(),
+                )
+                return result
+            except LLMProviderError:
+                raise
             except Exception as e:
                 logger.warning(f"SDK streaming failed, falling back to HTTP SSE: {e}")
-                return await self._stream_with_http(request_params, stream_callback)
+                result = await self._stream_with_http(request_params, stream_callback)
+                self._update_request_lifecycle(
+                    status=ProviderRequestStatus.COMPLETED,
+                    finish_reason=self.get_last_finish_reason(),
+                )
+                return result
 
         # Non-streaming
-        resp = await self.client.responses.create(**request_params)
+        try:
+            resp = await self.client.responses.create(**request_params)
+        except Exception as exc:
+            error = build_llm_error(
+                message=str(exc),
+                provider=self.provider,
+                model=getattr(self.model_config, "model", None),
+                finish_reason=FinishReason.ERROR,
+            )
+            self._set_last_error(error)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.FAILED,
+                finish_reason=FinishReason.ERROR,
+                error=error,
+            )
+            raise
         self._set_last_usage(getattr(resp, "usage", None))
         self._append_reasoning(self._extract_reasoning_from_response_object(resp))
         tool_calls = self._extract_function_calls_from_response_object(resp)
@@ -672,6 +781,10 @@ class OpenAIAdapter(BaseAdapter):
             self._set_last_finish_reason(FinishReason.STOP)
 
         output_text = getattr(resp, "output_text", None)
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.COMPLETED,
+            finish_reason=self.get_last_finish_reason(),
+        )
         if isinstance(output_text, str):
             return output_text
         return self._extract_text_from_response_object(resp) or ""
@@ -686,29 +799,46 @@ class OpenAIAdapter(BaseAdapter):
         **kwargs: Any,
     ) -> str:
         """Unified interface expected by APIClient/BaseAdapter."""
-        if stream:
-            accumulated = await self.create_completion(
+        try:
+            if stream:
+                accumulated = await self.create_completion(
+                    messages=messages,
+                    max_output_tokens=max_output_tokens,
+                    temperature=temperature,
+                    stream=True,
+                    stream_callback=stream_callback,
+                    **kwargs,
+                )
+                return accumulated or ""
+            # Non-streaming path
+            resp = await self.create_completion(
                 messages=messages,
                 max_output_tokens=max_output_tokens,
                 temperature=temperature,
-                stream=True,
-                stream_callback=stream_callback,
+                stream=False,
+                stream_callback=None,
                 **kwargs,
             )
-            return accumulated or ""
-        # Non-streaming path
-        resp = await self.create_completion(
-            messages=messages,
-            max_output_tokens=max_output_tokens,
-            temperature=temperature,
-            stream=False,
-            stream_callback=None,
-            **kwargs,
-        )
-        # create_completion returns text for non-streaming
-        if isinstance(resp, str):
-            return resp
-        return str(resp)
+            # create_completion returns text for non-streaming
+            if isinstance(resp, str):
+                return resp
+            return str(resp)
+        except asyncio.CancelledError:
+            error = build_llm_error(
+                message="OpenAI request was cancelled",
+                provider=self.provider,
+                model=getattr(self.model_config, "model", None),
+                category=ErrorCategory.RUNTIME,
+                retryable=False,
+                finish_reason=FinishReason.ERROR,
+            )
+            self._set_last_error(error)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.CANCELLED,
+                finish_reason=FinishReason.ERROR,
+                error=error,
+            )
+            raise
 
     async def _resolve_oauth_record_for_request(self) -> Dict[str, Any] | None:
         record = get_provider_credential("openai")
@@ -871,7 +1001,7 @@ class OpenAIAdapter(BaseAdapter):
         finish_reason: FinishReason | None = None,
         error: LLMError | None = None,
     ) -> None:
-        lifecycle = self._last_request_lifecycle
+        lifecycle = getattr(self, "_last_request_lifecycle", None)
         if lifecycle is None:
             return
         now = time.time()
@@ -2110,6 +2240,7 @@ class OpenAIAdapter(BaseAdapter):
         """Stream using the official OpenAI SDK responses.stream API."""
         accumulated_content: List[str] = []
         accumulated_reasoning = ""
+        saw_completed_event = False
         try:
             # Async streaming context
             async with self.client.responses.stream(**request_params) as stream:  # type: ignore[attr-defined]
@@ -2119,6 +2250,20 @@ class OpenAIAdapter(BaseAdapter):
                         self._set_last_finish_reason(FinishReason.TOOL_CALLS)
 
                     etype = getattr(event, "type", None)
+                    provider_response_id = None
+                    response_payload = getattr(event, "response", None)
+                    if response_payload is not None:
+                        provider_response_id = getattr(response_payload, "id", None)
+                    self._update_request_lifecycle(
+                        status=ProviderRequestStatus.STREAMING,
+                        event_type=str(etype) if etype else None,
+                        provider_response_id=provider_response_id,
+                    )
+                    if etype in {"error", "response.failed", "response.error"}:
+                        self._raise_responses_stream_error(event)
+                    if etype == "response.completed":
+                        saw_completed_event = True
+                        continue
                     if etype == "response.output_text.delta":
                         delta = getattr(event, "delta", "")
                         if delta:
@@ -2146,7 +2291,20 @@ class OpenAIAdapter(BaseAdapter):
                                 reasoning_delta,
                                 "reasoning",
                             )
+                if not saw_completed_event:
+                    output_state = (
+                        "tool_call"
+                        if self.has_pending_tool_call()
+                        else "text"
+                        if accumulated_content
+                        else "empty"
+                    )
+                    self._raise_responses_stream_incomplete(output_state)
                 final = await stream.get_final_response()
+                self._update_request_lifecycle(
+                    status=ProviderRequestStatus.STREAMING,
+                    provider_response_id=getattr(final, "id", None),
+                )
                 self._set_last_usage(getattr(final, "usage", None))
                 final_reasoning = self._extract_reasoning_from_response_object(final)
                 if final_reasoning and not accumulated_reasoning.strip():
@@ -2206,6 +2364,7 @@ class OpenAIAdapter(BaseAdapter):
 
         accumulated_content: List[str] = []
         completed_text = ""
+        saw_completed_event = False
 
         # Use connection pool for efficient parallel LLM calls
         pool = ConnectionPoolManager.get_instance()
@@ -2237,6 +2396,8 @@ class OpenAIAdapter(BaseAdapter):
                         self._set_last_finish_reason(FinishReason.TOOL_CALLS)
 
                     etype = data.get("type")
+                    if etype in {"error", "response.failed", "response.error"}:
+                        self._raise_responses_stream_error(data)
                     if etype == "response.output_text.delta":
                         delta = data.get("delta", "")
                         if delta:
@@ -2250,6 +2411,7 @@ class OpenAIAdapter(BaseAdapter):
                         if isinstance(done_text, str) and done_text:
                             completed_text = done_text
                     elif etype == "response.completed":
+                        saw_completed_event = True
                         response_obj = data.get("response")
                         if isinstance(response_obj, dict):
                             self._set_last_usage(response_obj.get("usage"))
@@ -2279,6 +2441,15 @@ class OpenAIAdapter(BaseAdapter):
                     # Skip malformed lines
                     continue
         pending_tool_call = self.has_pending_tool_call()
+        if not saw_completed_event:
+            output_state = (
+                "tool_call"
+                if pending_tool_call
+                else "text"
+                if completed_text or accumulated_content
+                else "empty"
+            )
+            self._raise_responses_stream_incomplete(output_state)
         if pending_tool_call:
             self._set_last_finish_reason(FinishReason.TOOL_CALLS)
             if self._interrupt_on_tool_call():

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import hashlib
 import io
 import json
 import logging
@@ -30,10 +29,13 @@ from ..contracts import (
     ErrorCategory,
     FinishReason,
     LLMError,
+    LLMPreparedRequest,
     LLMProviderError,
+    LLMProviderCapabilities,
     LLMRequestLifecycle,
     LLMUsage,
     ProviderRequestStatus,
+    stable_payload_hash,
 )
 from ..model_config import ModelConfig, normalize_openai_service_tier
 from ..provider_transform import (
@@ -580,6 +582,192 @@ class OpenAIAdapter(BaseAdapter):
     def _interrupt_on_tool_call(self) -> bool:
         return bool(getattr(self.model_config, "interrupt_on_tool_call", False))
 
+    def get_capabilities(self) -> LLMProviderCapabilities:
+        """Return OpenAI/Responses capability metadata."""
+
+        return LLMProviderCapabilities(
+            provider=self.provider,
+            model=str(getattr(self.model_config, "model", "") or ""),
+            native_tools=True,
+            streaming=bool(getattr(self.model_config, "streaming_enabled", True)),
+            reasoning=bool(
+                getattr(self.model_config, "reasoning_enabled", False)
+                or self.model_config.get_reasoning_config()
+            ),
+            vision=self.supports_vision(),
+            resumable=True,
+            max_context_tokens=getattr(
+                self.model_config,
+                "max_context_window_tokens",
+                None,
+            ),
+            max_output_tokens=getattr(self.model_config, "max_output_tokens", None),
+            provider_data={
+                "api": "responses",
+                "oauth_codex_supported": True,
+                "service_tier": self._get_service_tier(),
+            },
+        )
+
+    def _build_native_responses_request_params(
+        self,
+        *,
+        processed_messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int],
+        temperature: Optional[float],
+        reasoning_config: Optional[Dict[str, Any]],
+        instructions: Optional[str],
+        previous_response_id: Optional[str],
+        conversation_id: Optional[str],
+        response_format: Optional[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        tool_choice: Optional[Union[str, Dict[str, Any]]],
+        service_tier: Optional[str],
+    ) -> Dict[str, Any]:
+        """Build the native Responses API request body."""
+
+        input_parts = self._build_input_parts(processed_messages)
+        if input_parts is not None:
+            request_params: Dict[str, Any] = {
+                "model": self.model_config.model,
+                "input": input_parts,
+                **(
+                    {"max_output_tokens": max_output_tokens}
+                    if max_output_tokens
+                    else {}
+                ),
+                **({"reasoning": reasoning_config} if reasoning_config else {}),
+            }
+        else:
+            input_text = self._build_transcript_input(processed_messages)
+            request_params = {
+                "model": self.model_config.model,
+                "input": input_text,
+                **(
+                    {"max_output_tokens": max_output_tokens}
+                    if max_output_tokens
+                    else {}
+                ),
+                **({"reasoning": reasoning_config} if reasoning_config else {}),
+            }
+
+        if instructions:
+            request_params["instructions"] = instructions
+        if previous_response_id:
+            request_params["previous_response_id"] = previous_response_id
+        if conversation_id:
+            request_params["conversation"] = conversation_id
+        if response_format:
+            request_params["response_format"] = response_format
+        if tools:
+            request_params["tools"] = tools
+        if tool_choice:
+            request_params["tool_choice"] = tool_choice
+        if service_tier:
+            request_params["service_tier"] = service_tier
+
+        try:
+            uses_effort_style = bool(self.model_config._uses_effort_style())
+        except Exception:
+            uses_effort_style = False
+        if not uses_effort_style:
+            request_params["temperature"] = temperature
+
+        return request_params
+
+    async def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        """Prepare the OpenAI provider request without sending it."""
+
+        legacy_max_tokens = kwargs.pop("max_tokens", None)
+        if max_output_tokens is None and legacy_max_tokens is not None:
+            max_output_tokens = legacy_max_tokens
+
+        processed_messages = await self._process_messages_for_vision(messages)
+        reasoning_config = self._prepare_reasoning_config(
+            self.model_config.get_reasoning_config(),
+            stream=stream,
+        )
+        temp_val = (
+            temperature if temperature is not None else self.model_config.temperature
+        )
+
+        instructions: Optional[str] = kwargs.get("instructions")
+        previous_response_id: Optional[str] = kwargs.get("previous_response_id")
+        conversation_id: Optional[str] = kwargs.get("conversation")
+        response_format: Optional[Dict[str, Any]] = kwargs.get("response_format")
+        tools = normalize_openai_responses_tools(kwargs.get("tools"))
+        tool_choice = normalize_openai_responses_tool_choice(kwargs.get("tool_choice"))
+        service_tier = self._get_service_tier()
+
+        oauth_record = self._peek_oauth_record_for_prepare()
+        if oauth_record is not None:
+            payload, model_id, model_fallback = self._build_codex_oauth_payload(
+                processed_messages=processed_messages,
+                temperature=temp_val,
+                reasoning_config=reasoning_config,
+                instructions=instructions,
+                previous_response_id=previous_response_id,
+                conversation_id=conversation_id,
+                response_format=response_format,
+                tools=tools,
+                tool_choice=tool_choice,
+                service_tier=service_tier,
+            )
+            return LLMPreparedRequest(
+                provider=self.provider,
+                model=model_id,
+                protocol="openai_responses",
+                route="openai.codex_oauth.responses",
+                body=payload,
+                transport="http_sse",
+                capabilities=self.get_capabilities(),
+                diagnostics={
+                    "message_count": len(messages),
+                    "processed_message_count": len(processed_messages),
+                    "model_fallback": model_fallback,
+                    "stream": stream,
+                },
+                provider_data={
+                    "endpoint": _OPENAI_CODEX_RESPONSES_URL,
+                    "header_names": ["Authorization", "Content-Type"],
+                },
+            )
+
+        request_params = self._build_native_responses_request_params(
+            processed_messages=processed_messages,
+            max_output_tokens=max_output_tokens,
+            temperature=temp_val,
+            reasoning_config=reasoning_config,
+            instructions=instructions,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            service_tier=service_tier,
+        )
+        return LLMPreparedRequest(
+            provider=self.provider,
+            model=str(self.model_config.model),
+            protocol="openai_responses",
+            route="openai.responses",
+            body=request_params,
+            transport="sdk_stream" if stream else "sdk",
+            capabilities=self.get_capabilities(),
+            diagnostics={
+                "message_count": len(messages),
+                "processed_message_count": len(processed_messages),
+                "stream": stream,
+            },
+        )
+
     async def create_completion(
         self,
         messages: List[Dict[str, Any]],
@@ -669,56 +857,19 @@ class OpenAIAdapter(BaseAdapter):
             bool(self.client.api_key),
         )
 
-        # Build input either as a compact string, or as structured content parts
-        # when images are present.
-        input_parts = self._build_input_parts(processed_messages)
-        if input_parts is not None:
-            request_params: Dict[str, Any] = {
-                "model": self.model_config.model,
-                "input": input_parts,
-                **(
-                    {"max_output_tokens": max_output_tokens}
-                    if max_output_tokens
-                    else {}
-                ),
-                **({"reasoning": reasoning_config} if reasoning_config else {}),
-            }
-        else:
-            input_text = self._build_transcript_input(processed_messages)
-            request_params = {
-                "model": self.model_config.model,
-                "input": input_text,
-                **(
-                    {"max_output_tokens": max_output_tokens}
-                    if max_output_tokens
-                    else {}
-                ),
-                **({"reasoning": reasoning_config} if reasoning_config else {}),
-            }
-
-        # Optional top-level params
-        if instructions:
-            request_params["instructions"] = instructions
-        if previous_response_id:
-            request_params["previous_response_id"] = previous_response_id
-        if conversation_id:
-            request_params["conversation"] = conversation_id
-        if response_format:
-            request_params["response_format"] = response_format
-        if tools:
-            request_params["tools"] = tools
-        if tool_choice:
-            request_params["tool_choice"] = tool_choice
-        if service_tier:
-            request_params["service_tier"] = service_tier
-        # Per OpenAI Responses API, o-/gpt-5 style reasoning models do not accept
-        # temperature.
-        try:
-            uses_effort_style = bool(self.model_config._uses_effort_style())
-        except Exception:
-            uses_effort_style = False
-        if not uses_effort_style:
-            request_params["temperature"] = temp_val
+        request_params = self._build_native_responses_request_params(
+            processed_messages=processed_messages,
+            max_output_tokens=max_output_tokens,
+            temperature=temp_val,
+            reasoning_config=reasoning_config,
+            instructions=instructions,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            service_tier=service_tier,
+        )
 
         self._start_request_lifecycle(
             request_id=f"openai-{int(time.time() * 1000)}",
@@ -927,6 +1078,37 @@ class OpenAIAdapter(BaseAdapter):
         self._apply_oauth_record_to_runtime(oauth_record)
         return oauth_record
 
+    def _peek_oauth_record_for_prepare(self) -> Dict[str, Any] | None:
+        """Read OAuth route metadata for request preparation without refresh."""
+
+        record = get_provider_credential("openai")
+        if isinstance(record, dict) and record.get("type") == "oauth":
+            access = record.get("access")
+            if isinstance(access, str) and access.strip():
+                return dict(record)
+
+        oauth_access = str(os.getenv("OPENAI_OAUTH_ACCESS_TOKEN") or "").strip()
+        if not oauth_access:
+            return None
+
+        oauth_record: Dict[str, Any] = {
+            "type": "oauth",
+            "access": oauth_access,
+        }
+        refresh = str(os.getenv("OPENAI_OAUTH_REFRESH_TOKEN") or "").strip()
+        if refresh:
+            oauth_record["refresh"] = refresh
+        expires_raw = str(os.getenv("OPENAI_OAUTH_EXPIRES_AT_MS") or "").strip()
+        if expires_raw:
+            try:
+                oauth_record["expires"] = int(expires_raw)
+            except ValueError:
+                pass
+        account_id = str(os.getenv("OPENAI_ACCOUNT_ID") or "").strip()
+        if account_id:
+            oauth_record["accountId"] = account_id
+        return oauth_record
+
     def _apply_oauth_record_to_runtime(self, oauth_record: Dict[str, Any]) -> None:
         access = oauth_record.get("access")
         if isinstance(access, str) and access.strip():
@@ -957,8 +1139,7 @@ class OpenAIAdapter(BaseAdapter):
         return httpx.Timeout(connect=30.0, read=None, write=60.0, pool=30.0)
 
     def _codex_payload_hash(self, payload: Dict[str, Any]) -> str:
-        payload_text = json.dumps(payload, sort_keys=True, default=str)
-        return hashlib.sha256(payload_text.encode("utf-8")).hexdigest()
+        return stable_payload_hash(payload)
 
     def _start_request_lifecycle(
         self,
@@ -1309,15 +1490,11 @@ class OpenAIAdapter(BaseAdapter):
 
         return sanitized
 
-    async def _create_oauth_codex_completion(
+    def _build_codex_oauth_payload(
         self,
         *,
         processed_messages: List[Dict[str, Any]],
-        oauth_record: Dict[str, Any],
-        max_output_tokens: int | None,
         temperature: float,
-        stream: bool,
-        stream_callback: Optional[Callable[[str], None]],
         reasoning_config: Dict[str, Any] | None,
         instructions: str | None,
         previous_response_id: str | None,
@@ -1326,9 +1503,12 @@ class OpenAIAdapter(BaseAdapter):
         tools: List[Dict[str, Any]] | None,
         tool_choice: Union[str, Dict[str, Any]] | None,
         service_tier: str | None,
-    ) -> str:
-        diag_id = self._new_codex_diag_id()
-        model_id, model_fallback = self._codex_model_for_oauth(self.model_config.model)
+    ) -> tuple[Dict[str, Any], str, bool]:
+        """Build the Codex OAuth Responses payload without sending it."""
+
+        model_id, model_fallback = self._codex_model_for_oauth(
+            self.model_config.model
+        )
         resolved_instructions, codex_messages = (
             self._prepare_codex_messages_and_instructions(
                 instructions,
@@ -1376,6 +1556,40 @@ class OpenAIAdapter(BaseAdapter):
         if not uses_effort_style:
             payload["temperature"] = temperature
 
+        return payload, model_id, model_fallback
+
+    async def _create_oauth_codex_completion(
+        self,
+        *,
+        processed_messages: List[Dict[str, Any]],
+        oauth_record: Dict[str, Any],
+        max_output_tokens: int | None,
+        temperature: float,
+        stream: bool,
+        stream_callback: Optional[Callable[[str], None]],
+        reasoning_config: Dict[str, Any] | None,
+        instructions: str | None,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        response_format: Dict[str, Any] | None,
+        tools: List[Dict[str, Any]] | None,
+        tool_choice: Union[str, Dict[str, Any]] | None,
+        service_tier: str | None,
+    ) -> str:
+        diag_id = self._new_codex_diag_id()
+        payload, model_id, model_fallback = self._build_codex_oauth_payload(
+            processed_messages=processed_messages,
+            temperature=temperature,
+            reasoning_config=reasoning_config,
+            instructions=instructions,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            service_tier=service_tier,
+        )
+
         access = str(oauth_record.get("access") or "").strip()
         account_id = str(oauth_record.get("accountId") or "").strip()
         headers: Dict[str, str] = {
@@ -1397,8 +1611,10 @@ class OpenAIAdapter(BaseAdapter):
             True,
             model_id,
             model_fallback,
-            len(input_items),
-            bool(resolved_instructions),
+            len(payload.get("input", []))
+            if isinstance(payload.get("input"), list)
+            else 0,
+            bool(payload.get("instructions")),
             payload.get("store"),
             service_tier,
             bool(account_id),

--- a/penguin/llm/adapters/openrouter.py
+++ b/penguin/llm/adapters/openrouter.py
@@ -22,6 +22,8 @@ from penguin.llm.contracts import (
     ErrorCategory,
     FinishReason,
     LLMError,
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
     LLMRequestLifecycle,
     ProviderRequestStatus,
 )
@@ -175,6 +177,12 @@ class OpenRouterGateway:
             self.logger.debug(
                 f"Request headers configured: {list(self.extra_headers.keys())}"
             )
+
+    @property
+    def provider(self) -> str:
+        """Return the provider identifier for the shared runtime contract."""
+
+        return "openrouter"
 
     def _stream_timeout_seconds(self, env_name: str, default: float) -> float:
         """Read a positive streaming timeout from the environment."""
@@ -346,6 +354,112 @@ class OpenRouterGateway:
 
     def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
         return self._last_request_lifecycle
+
+    def get_capabilities(self) -> LLMProviderCapabilities:
+        """Return OpenRouter Chat Completions capability metadata."""
+
+        return LLMProviderCapabilities(
+            provider=self.provider,
+            model=str(getattr(self.model_config, "model", "") or ""),
+            native_tools=True,
+            streaming=bool(getattr(self.model_config, "streaming_enabled", True)),
+            reasoning=bool(
+                getattr(self.model_config, "reasoning_enabled", False)
+                or self.model_config.get_reasoning_config()
+            ),
+            vision=self.supports_vision(),
+            max_context_tokens=getattr(
+                self.model_config,
+                "max_context_window_tokens",
+                None,
+            ),
+            max_output_tokens=getattr(self.model_config, "max_output_tokens", None),
+            provider_data={
+                "api": "chat_completions",
+                "base_url": self.base_url,
+            },
+        )
+
+    async def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        """Prepare the OpenRouter request without sending it."""
+
+        legacy_max_tokens = kwargs.pop("max_tokens", None)
+        if max_output_tokens is None and legacy_max_tokens is not None:
+            max_output_tokens = legacy_max_tokens
+
+        use_streaming = (
+            stream if stream is not None else self.model_config.streaming_enabled
+        )
+        processed_messages = await self._process_messages_for_vision(messages)
+        processed_messages = self._clean_conversation_format(processed_messages)
+        reasoning_config = self.model_config.get_reasoning_config()
+
+        request_params: Dict[str, Any] = {
+            "model": self.model_config.model,
+            "messages": processed_messages,
+            "max_tokens": max_output_tokens or self.model_config.max_output_tokens,
+            "temperature": temperature
+            if temperature is not None
+            else self.model_config.temperature,
+            "stream": use_streaming,
+            "extra_headers": self.extra_headers,
+            **kwargs,
+        }
+        if use_streaming:
+            raw_stream_options = request_params.get("stream_options")
+            stream_options = (
+                dict(raw_stream_options) if isinstance(raw_stream_options, dict) else {}
+            )
+            stream_options["include_usage"] = True
+            request_params["stream_options"] = stream_options
+        if reasoning_config:
+            request_params["reasoning"] = (
+                reasoning_config
+                if isinstance(reasoning_config, dict)
+                else {"enabled": True}
+            )
+
+        request_params = {
+            key: value for key, value in request_params.items() if value is not None
+        }
+        body = {
+            key: value
+            for key, value in request_params.items()
+            if key != "extra_headers"
+        }
+        transport = (
+            "http_sse"
+            if reasoning_config and use_streaming
+            else "http"
+            if reasoning_config
+            else "sdk_stream"
+            if use_streaming
+            else "sdk"
+        )
+        return LLMPreparedRequest(
+            provider=self.provider,
+            model=str(self.model_config.model),
+            protocol="openai_chat_completions",
+            route="openrouter.chat_completions",
+            body=body,
+            transport=transport,
+            headers=dict(self.extra_headers or {}),
+            capabilities=self.get_capabilities(),
+            diagnostics={
+                "message_count": len(messages),
+                "processed_message_count": len(processed_messages),
+                "stream": bool(use_streaming),
+                "reasoning_transport": bool(reasoning_config),
+            },
+            provider_data={"base_url": self.base_url},
+        )
 
     def _start_request_lifecycle(
         self,

--- a/penguin/llm/adapters/openrouter.py
+++ b/penguin/llm/adapters/openrouter.py
@@ -2,6 +2,7 @@ import os
 import logging
 import asyncio
 import json
+import time
 from typing import List, Dict, Optional, Any, Union, Callable, AsyncIterator
 
 # --- Added Imports for Vision Handling ---
@@ -17,7 +18,13 @@ from openai import AsyncOpenAI, APIError  # type: ignore
 
 # Connection pooling for parallel LLM calls
 from penguin.llm.api_client import ConnectionPoolManager
-from penguin.llm.contracts import FinishReason, LLMError
+from penguin.llm.contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMRequestLifecycle,
+    ProviderRequestStatus,
+)
 from penguin.llm.provider_transform import (
     build_llm_error,
     extract_retry_after_seconds,
@@ -84,6 +91,7 @@ class OpenRouterGateway:
         self._last_error: Optional[LLMError] = None
         self._last_finish_reason = FinishReason.UNKNOWN
         self._last_reasoning = ""
+        self._last_request_lifecycle: Optional[LLMRequestLifecycle] = None
 
         # --- Determine Base URL (before API key check) ---
         # Priority: explicit param > model_config > OpenRouter env override >
@@ -336,6 +344,78 @@ class OpenRouterGateway:
     def get_last_error(self) -> Optional[LLMError]:
         return self._last_error if isinstance(self._last_error, LLMError) else None
 
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
+        return self._last_request_lifecycle
+
+    def _start_request_lifecycle(
+        self,
+        *,
+        stream: bool,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        now = time.time()
+        self._last_request_lifecycle = LLMRequestLifecycle(
+            request_id=f"openrouter-{int(now * 1000)}",
+            provider="openrouter",
+            model=getattr(self.model_config, "model", ""),
+            status=ProviderRequestStatus.RUNNING,
+            stream=stream,
+            transport="sdk",
+            started_at=now,
+            last_event_at=now,
+            provider_data={"message_count": len(messages), "base_url": self.base_url},
+        )
+
+    def _update_request_lifecycle(
+        self,
+        *,
+        status: ProviderRequestStatus,
+        finish_reason: Optional[FinishReason] = None,
+        error: Optional[LLMError] = None,
+        event_type: Optional[str] = None,
+        provider_response_id: Optional[str] = None,
+    ) -> None:
+        lifecycle = getattr(self, "_last_request_lifecycle", None)
+        if lifecycle is None:
+            return
+        now = time.time()
+        lifecycle.status = status
+        lifecycle.last_event_at = now
+        if status in {
+            ProviderRequestStatus.COMPLETED,
+            ProviderRequestStatus.DISCONNECTED,
+            ProviderRequestStatus.FAILED,
+            ProviderRequestStatus.CANCELLED,
+        }:
+            lifecycle.ended_at = now
+        if finish_reason is not None:
+            lifecycle.finish_reason = finish_reason
+        if error is not None:
+            lifecycle.error = error
+        if event_type:
+            lifecycle.last_event_type = event_type
+        if provider_response_id:
+            lifecycle.provider_response_id = provider_response_id
+
+    def _finish_request_lifecycle_from_state(self) -> None:
+        error = self.get_last_error()
+        if error is not None:
+            status = (
+                ProviderRequestStatus.DISCONNECTED
+                if error.category in {ErrorCategory.NETWORK, ErrorCategory.TIMEOUT}
+                else ProviderRequestStatus.FAILED
+            )
+            self._update_request_lifecycle(
+                status=status,
+                finish_reason=error.finish_reason or self.get_last_finish_reason(),
+                error=error,
+            )
+            return
+        self._update_request_lifecycle(
+            status=ProviderRequestStatus.COMPLETED,
+            finish_reason=self.get_last_finish_reason(),
+        )
+
     def _set_last_finish_reason(self, finish_reason: Any) -> FinishReason:
         self._last_finish_reason = normalize_finish_reason(finish_reason)
         return self._last_finish_reason
@@ -358,18 +438,50 @@ class OpenRouterGateway:
         retry_after_seconds: Optional[float] = None,
         finish_reason: Any = None,
         provider_data: Optional[Dict[str, Any]] = None,
+        category: Any = None,
+        retryable: Optional[bool] = None,
     ) -> None:
-        self._set_last_error(
-            build_llm_error(
-                message=message,
-                provider="openrouter",
-                model=self.model_config.model,
-                status_code=status_code,
-                retry_after_seconds=retry_after_seconds,
-                finish_reason=finish_reason,
-                provider_data=provider_data,
-            )
+        error = build_llm_error(
+            message=message,
+            provider="openrouter",
+            model=self.model_config.model,
+            status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
+            finish_reason=finish_reason,
+            provider_data=provider_data,
+            category=category,
+            retryable=retryable,
         )
+        self._set_last_error(error)
+        status = (
+            ProviderRequestStatus.DISCONNECTED
+            if error.category in {ErrorCategory.NETWORK, ErrorCategory.TIMEOUT}
+            else ProviderRequestStatus.FAILED
+        )
+        self._update_request_lifecycle(
+            status=status,
+            finish_reason=error.finish_reason or self.get_last_finish_reason(),
+            error=error,
+        )
+
+    def _record_stream_incomplete(self, output_state: str) -> str:
+        message = (
+            "OpenRouter stream ended before finish_reason "
+            f"(output_state={output_state})"
+        )
+        self._record_error(
+            message=message,
+            finish_reason=FinishReason.ERROR,
+            category=ErrorCategory.NETWORK,
+            retryable=True,
+        )
+        self._set_last_finish_reason(FinishReason.ERROR)
+        self._pending_tool_calls = []
+        self._last_tool_call = None
+        self._tool_call_acc = {"name": None, "arguments": ""}
+        self._tool_call_accs = {}
+        self._finish_request_lifecycle_from_state()
+        return f"[Error: {message}]"
 
     def _tool_call_payload(self, tool_call: Any) -> Dict[str, Any]:
         payload = tool_call if isinstance(tool_call, dict) else {}
@@ -897,8 +1009,39 @@ class OpenRouterGateway:
         malformed tool context that can trigger SDK validation errors.
         """
         reformatted_messages = []
+        available_tool_call_ids: set[str] = set()
 
-        for message in messages:
+        def _following_tool_result_ids(start_index: int) -> set[str]:
+            result_ids: set[str] = set()
+            cursor = start_index
+            while cursor < len(messages) and messages[cursor].get("role") == "tool":
+                tool_call_id = str(
+                    messages[cursor].get("tool_call_id") or ""
+                ).strip()
+                if tool_call_id:
+                    result_ids.add(tool_call_id)
+                cursor += 1
+            return result_ids
+
+        def _tool_call_from_tool_message(
+            tool_message: Dict[str, Any]
+        ) -> Optional[Dict[str, Any]]:
+            tool_call_id = str(tool_message.get("tool_call_id") or "").strip()
+            name = str(
+                tool_message.get("name") or tool_message.get("action_type") or ""
+            ).strip()
+            if not tool_call_id or not name:
+                return None
+            arguments = tool_message.get("tool_arguments")
+            if not isinstance(arguments, str) or not arguments.strip():
+                arguments = "{}"
+            return {
+                "id": tool_call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments},
+            }
+
+        for index, message in enumerate(messages):
             reformatted_message = message.copy()
 
             # Handle content field
@@ -932,7 +1075,18 @@ class OpenRouterGateway:
                     and str(tool_call.get("function", {}).get("name") or "").strip()
                     for tool_call in tool_calls
                 )
-                if valid_tool_calls:
+                tool_call_ids = {
+                    str(tool_call.get("id") or "").strip()
+                    for tool_call in tool_calls
+                    if isinstance(tool_call, dict)
+                }
+                unique_tool_call_ids = len(tool_call_ids) == len(tool_calls)
+                following_tool_ids = _following_tool_result_ids(index + 1)
+                if (
+                    valid_tool_calls
+                    and unique_tool_call_ids
+                    and tool_call_ids.issubset(following_tool_ids)
+                ):
                     self.logger.debug(
                         "Preserving assistant tool_calls for OpenRouter continuity"
                     )
@@ -944,9 +1098,10 @@ class OpenRouterGateway:
                     for key, value in message.items():
                         if key not in ["role", "content", "tool_calls"]:
                             reformatted_message[key] = value
+                    available_tool_call_ids.update(tool_call_ids)
                 else:
                     self.logger.debug(
-                        "Flattening malformed assistant tool_calls to plain text"
+                        "Flattening orphaned or malformed assistant tool_calls to plain text"
                     )
                     reformatted_message = {
                         "role": "assistant",
@@ -958,7 +1113,7 @@ class OpenRouterGateway:
 
             elif message.get("role") == "tool":
                 tool_call_id = str(message.get("tool_call_id") or "").strip()
-                if tool_call_id:
+                if tool_call_id and tool_call_id in available_tool_call_ids:
                     self.logger.debug(
                         "Preserving tool message with tool_call_id for OpenRouter continuity"
                     )
@@ -967,6 +1122,33 @@ class OpenRouterGateway:
                         "tool_call_id": tool_call_id,
                         "content": message.get("content", ""),
                     }
+                    available_tool_call_ids.discard(tool_call_id)
+                elif tool_call_id:
+                    synthesized_tool_call = _tool_call_from_tool_message(message)
+                    if synthesized_tool_call:
+                        self.logger.debug(
+                            "Synthesizing assistant tool_call for orphaned OpenRouter tool message"
+                        )
+                        reformatted_messages.append(
+                            {
+                                "role": "assistant",
+                                "content": "",
+                                "tool_calls": [synthesized_tool_call],
+                            }
+                        )
+                        reformatted_message = {
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "content": message.get("content", ""),
+                        }
+                    else:
+                        self.logger.debug(
+                            "Flattening orphaned tool message without replay metadata"
+                        )
+                        reformatted_message = {
+                            "role": "user",
+                            "content": message.get("content", ""),
+                        }
                 else:
                     self.logger.debug(
                         "Flattening malformed tool message without tool_call_id"
@@ -1038,6 +1220,7 @@ class OpenRouterGateway:
         use_streaming = (
             stream if stream is not None else self.model_config.streaming_enabled
         )
+        self._start_request_lifecycle(stream=bool(use_streaming), messages=messages)
 
         legacy_max_tokens = kwargs.pop("max_tokens", None)
         if max_output_tokens is None and legacy_max_tokens is not None:
@@ -1205,6 +1388,11 @@ class OpenRouterGateway:
                             "No chunks were received before timeout. Try again or switch models.]"
                         )
 
+                    self._update_request_lifecycle(
+                        status=ProviderRequestStatus.STREAMING,
+                        event_type="chat.completion.chunk",
+                        provider_response_id=getattr(chunk, "id", None),
+                    )
                     self._set_last_usage(getattr(chunk, "usage", None))
                     raw_choices = getattr(chunk, "choices", None)
                     choice = (
@@ -1236,7 +1424,18 @@ class OpenRouterGateway:
                         if chunk_finish_reason == "error":
                             # Try to extract error info from the chunk
                             error_info = getattr(chunk, "error", None)
-                            if error_info:
+                            if isinstance(error_info, dict):
+                                error_message = (
+                                    error_info.get("message")
+                                    or "Unknown streaming error"
+                                )
+                                metadata = error_info.get("metadata")
+                                provider_name = (
+                                    metadata.get("provider_name")
+                                    if isinstance(metadata, dict)
+                                    else None
+                                ) or "unknown provider"
+                            elif error_info:
                                 error_message = (
                                     getattr(error_info, "message", None)
                                     or "Unknown streaming error"
@@ -1462,6 +1661,16 @@ class OpenRouterGateway:
                         return f"{full_response_content}\n\n[Error: Stream interrupted by {provider}: {error_msg}]"
                     return f"[Error: {provider} returned mid-stream error: {error_msg}]"
 
+                if sdk_last_finish_reason is None:
+                    output_state = (
+                        "tool_call"
+                        if self.has_pending_tool_call() or self._tool_call_accs
+                        else "text"
+                        if full_response_content
+                        else "empty"
+                    )
+                    return self._record_stream_incomplete(output_state)
+
                 # For streaming responses, we return only the content part
                 # The reasoning was already streamed via callback
                 if not full_response_content:
@@ -1491,8 +1700,10 @@ class OpenRouterGateway:
                     self.logger.warning(
                         f"[OpenRouterGateway] SDK streaming response was truncated (finish_reason='length'). Model: {self.model_config.model}"
                     )
+                    self._finish_request_lifecycle_from_state()
                     return f"{full_response_content}\n\n[Note: Response was truncated due to token limits. Consider increasing max_output_tokens or breaking your request into smaller parts.]"
 
+                self._finish_request_lifecycle_from_state()
                 return full_response_content
 
             else:  # Not streaming
@@ -1647,10 +1858,28 @@ class OpenRouterGateway:
                     self.logger.warning(
                         f"[OpenRouterGateway] SDK non-streaming response was truncated (finish_reason='length'). Model: {self.model_config.model}"
                     )
+                    self._finish_request_lifecycle_from_state()
                     return f"{full_response_content}\n\n[Note: Response was truncated due to token limits. Consider increasing max_output_tokens or breaking your request into smaller parts.]"
 
+                self._finish_request_lifecycle_from_state()
                 return full_response_content or ""  # Ensure string return
 
+        except asyncio.CancelledError:
+            error = build_llm_error(
+                message="OpenRouter request was cancelled",
+                provider="openrouter",
+                model=getattr(self.model_config, "model", None),
+                category=ErrorCategory.RUNTIME,
+                retryable=False,
+                finish_reason=FinishReason.ERROR,
+            )
+            self._set_last_error(error)
+            self._update_request_lifecycle(
+                status=ProviderRequestStatus.CANCELLED,
+                finish_reason=FinishReason.ERROR,
+                error=error,
+            )
+            raise
         except APIError as e:
             self.logger.error(f"OpenRouter API error: {e}", exc_info=True)
             # Safely extract attributes - OpenAI SDK APIError may have different structure
@@ -1783,6 +2012,7 @@ class OpenRouterGateway:
         stream_error: Optional[Dict[str, Any]] = None
         interrupted_reason: Optional[str] = None
         generation_id: Optional[str] = None
+        saw_done_marker = False
         stream_started_at = asyncio.get_running_loop().time()
         chunk_timeout_seconds = self._stream_chunk_timeout_seconds()
         total_timeout_seconds = self._stream_total_timeout_seconds()
@@ -1842,6 +2072,7 @@ class OpenRouterGateway:
                     data_str = line[6:]  # Remove "data: " prefix
 
                     if data_str.strip() == "[DONE]":
+                        saw_done_marker = True
                         break
 
                     try:
@@ -2023,6 +2254,16 @@ class OpenRouterGateway:
             if full_content:
                 return f"{full_content}\n\n[Error: Stream interrupted by {provider}: {error_msg}]"
             return f"[Error: {provider} returned mid-stream error: {error_msg}]"
+
+        if not interrupted_reason and (not saw_done_marker or last_finish_reason is None):
+            output_state = (
+                "tool_call"
+                if self.has_pending_tool_call() or self._tool_call_accs
+                else "text"
+                if full_content
+                else "empty"
+            )
+            return self._record_stream_incomplete(output_state)
 
         # Check for empty content and provide helpful message
         if not full_content:

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -4,12 +4,9 @@ import io
 import logging
 import os
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Callable, Union
 
 import httpx
-import yaml  # type: ignore
-import tiktoken  # type: ignore
 
 # TODO: decouple litellm from api_client. # Been done for quite a while.
 # TODO: greatly simplify api_client while maintaining full functionality
@@ -19,7 +16,7 @@ import tiktoken  # type: ignore
 # from litellm import acompletion, completion, token_counter, cost_per_token, completion_cost
 from PIL import Image  # type: ignore
 
-from .contracts import ErrorCategory, LLMError, LLMProviderError
+from .contracts import ErrorCategory, LLMError, LLMProviderError, LLMRequestLifecycle
 from .model_config import ModelConfig
 from .provider_registry import ProviderRegistry
 from .provider_transform import apply_model_config_transforms, build_llm_error
@@ -46,7 +43,8 @@ def _log_error(message: str, *args: Any, exc_info: bool = False) -> None:
 # Connection Pool Management for Parallel LLM Calls
 # ==============================================================================
 
-# TODO: review max_keepalive_connections and max_connections defaults based on expected concurrency and provider limits. 
+
+# TODO: review max_keepalive_connections and max_connections defaults based on expected concurrency and provider limits.
 # These seem like magic numbers and might need tuning based on real-world usage patterns and provider guidelines.
 # Much less configurable than the old connection pool, but also much simpler. We can always add more config options later if needed.
 class ConnectionPoolConfig:
@@ -487,6 +485,20 @@ class APIClient:
             return None
         return self._last_error
 
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]:
+        """Return lifecycle metadata from the latest provider request."""
+
+        handler = getattr(self, "client_handler", None)
+        getter = getattr(handler, "get_last_request_lifecycle", None)
+        if not callable(getter):
+            return None
+        try:
+            lifecycle = getter()
+        except Exception:
+            self.logger.debug("Failed to get handler request lifecycle", exc_info=True)
+            return None
+        return lifecycle if isinstance(lifecycle, LLMRequestLifecycle) else None
+
     def get_reasoning_debug_snapshot(self) -> Dict[str, Any]:
         """Return handler-provided reasoning debug details when available."""
 
@@ -524,8 +536,7 @@ class APIClient:
                 and "codex with a chatgpt account" in provider_detail
             ):
                 reason = (
-                    "Selected model is not available through ChatGPT-backed "
-                    "Codex auth"
+                    "Selected model is not available through ChatGPT-backed Codex auth"
                 )
             else:
                 reason = (

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -16,7 +16,14 @@ import httpx
 # from litellm import acompletion, completion, token_counter, cost_per_token, completion_cost
 from PIL import Image  # type: ignore
 
-from .contracts import ErrorCategory, LLMError, LLMProviderError, LLMRequestLifecycle
+from .contracts import (
+    ErrorCategory,
+    LLMError,
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
+    LLMProviderError,
+    LLMRequestLifecycle,
+)
 from .model_config import ModelConfig
 from .provider_registry import ProviderRegistry
 from .provider_transform import apply_model_config_transforms, build_llm_error
@@ -498,6 +505,82 @@ class APIClient:
             self.logger.debug("Failed to get handler request lifecycle", exc_info=True)
             return None
         return lifecycle if isinstance(lifecycle, LLMRequestLifecycle) else None
+
+    def get_provider_capabilities(self) -> LLMProviderCapabilities:
+        """Return provider/model capabilities from the active handler."""
+
+        handler = getattr(self, "client_handler", None)
+        getter = getattr(handler, "get_capabilities", None)
+        if callable(getter):
+            try:
+                capabilities = getter()
+            except Exception:
+                self.logger.debug(
+                    "Failed to get handler capabilities",
+                    exc_info=True,
+                )
+            else:
+                if isinstance(capabilities, LLMProviderCapabilities):
+                    return capabilities
+
+        return LLMProviderCapabilities(
+            provider=str(getattr(self.model_config, "provider", "") or ""),
+            model=str(getattr(self.model_config, "model", "") or ""),
+            streaming=bool(getattr(self.model_config, "streaming_enabled", True)),
+            max_context_tokens=getattr(
+                self.model_config,
+                "max_context_window_tokens",
+                None,
+            ),
+            max_output_tokens=getattr(self.model_config, "max_output_tokens", None),
+        )
+
+    async def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        max_output_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stream: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        """Prepare the provider-native request without sending network traffic."""
+
+        if not self.client_handler:
+            raise RuntimeError("APIClient handler not initialized.")
+
+        legacy_max_tokens = kwargs.pop("max_tokens", None)
+        if max_output_tokens is None and legacy_max_tokens is not None:
+            max_output_tokens = legacy_max_tokens
+
+        use_streaming = (
+            stream if stream is not None else self.model_config.streaming_enabled
+        )
+        prepared_messages = self._prepare_messages_with_system_prompt(messages)
+        preparer = getattr(self.client_handler, "prepare_request", None)
+        if not callable(preparer):
+            raise RuntimeError(
+                f"Handler {type(self.client_handler).__name__} does not support "
+                "request preparation"
+            )
+
+        prepared = preparer(
+            messages=prepared_messages,
+            max_output_tokens=max_output_tokens
+            or self.model_config.max_output_tokens,
+            temperature=temperature
+            if temperature is not None
+            else self.model_config.temperature,
+            stream=bool(use_streaming),
+            **kwargs,
+        )
+        if asyncio.iscoroutine(prepared):
+            prepared = await prepared
+        if not isinstance(prepared, LLMPreparedRequest):
+            raise RuntimeError(
+                f"Handler {type(self.client_handler).__name__} returned invalid "
+                "prepared request"
+            )
+        return prepared
 
     def get_reasoning_debug_snapshot(self) -> Dict[str, Any]:
         """Return handler-provided reasoning debug details when available."""

--- a/penguin/llm/contracts.py
+++ b/penguin/llm/contracts.py
@@ -13,7 +13,6 @@ from typing import (
     runtime_checkable,
 )
 
-
 StreamCallback = Callable[[str, str], Any]
 
 
@@ -54,6 +53,41 @@ class ErrorCategory(str, Enum):
     PROVIDER_UNAVAILABLE = "provider_unavailable"
     RUNTIME = "runtime"
     UNKNOWN = "unknown"
+
+
+class ProviderRequestStatus(str, Enum):
+    """Canonical lifecycle states for one provider model request."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    STREAMING = "streaming"
+    DISCONNECTED = "disconnected"
+    RETRYING = "retrying"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class LLMRequestLifecycle:
+    """Observable lifecycle metadata for one provider model request."""
+
+    request_id: str
+    provider: str
+    model: str
+    status: ProviderRequestStatus = ProviderRequestStatus.PENDING
+    stream: bool = False
+    transport: str = ""
+    request_payload_hash: Optional[str] = None
+    attempt: int = 1
+    started_at: float = 0.0
+    last_event_at: float = 0.0
+    ended_at: Optional[float] = None
+    provider_response_id: Optional[str] = None
+    last_event_type: Optional[str] = None
+    finish_reason: Optional[FinishReason] = None
+    error: Optional[LLMError] = None
+    provider_data: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -267,6 +301,13 @@ class ErrorReportingRuntime(Protocol):
 
 
 @runtime_checkable
+class RequestLifecycleRuntime(Protocol):
+    """Optional runtime extension for provider request lifecycle diagnostics."""
+
+    def get_last_request_lifecycle(self) -> Optional[LLMRequestLifecycle]: ...
+
+
+@runtime_checkable
 class ResultMetadataRuntime(Protocol):
     """Optional runtime extension for normalized finish/reasoning state."""
 
@@ -282,11 +323,14 @@ __all__ = [
     "LLMError",
     "LLMProviderError",
     "LLMRequest",
+    "LLMRequestLifecycle",
     "LLMResult",
     "LLMStreamEvent",
     "LLMToolCall",
     "LLMUsage",
+    "ProviderRequestStatus",
     "ProviderRuntime",
+    "RequestLifecycleRuntime",
     "ResultMetadataRuntime",
     "StreamCallback",
     "StreamEventType",

--- a/penguin/llm/contracts.py
+++ b/penguin/llm/contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
@@ -14,6 +16,18 @@ from typing import (
 )
 
 StreamCallback = Callable[[str, str], Any]
+
+
+def stable_payload_hash(payload: Any) -> str:
+    """Return a stable diagnostic hash for provider request payloads."""
+
+    payload_text = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(payload_text.encode("utf-8")).hexdigest()
 
 
 class FinishReason(str, Enum):
@@ -66,6 +80,82 @@ class ProviderRequestStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+
+
+@dataclass
+class LLMProviderCapabilities:
+    """Provider/model capabilities consumed by higher-level runtime layers."""
+
+    provider: str = ""
+    model: str = ""
+    native_tools: bool = False
+    streaming: bool = True
+    reasoning: bool = False
+    vision: bool = False
+    prompt_cache: bool = False
+    resumable: bool = False
+    background: bool = False
+    max_context_tokens: Optional[int] = None
+    max_output_tokens: Optional[int] = None
+    provider_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize capability metadata for diagnostics/UI payloads."""
+
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "native_tools": self.native_tools,
+            "streaming": self.streaming,
+            "reasoning": self.reasoning,
+            "vision": self.vision,
+            "prompt_cache": self.prompt_cache,
+            "resumable": self.resumable,
+            "background": self.background,
+            "max_context_tokens": self.max_context_tokens,
+            "max_output_tokens": self.max_output_tokens,
+            "provider_data": dict(self.provider_data or {}),
+        }
+
+
+@dataclass
+class LLMPreparedRequest:
+    """Provider-native request shape prepared without sending network traffic."""
+
+    provider: str
+    model: str
+    protocol: str
+    route: str
+    body: Dict[str, Any]
+    transport: str = ""
+    headers: Dict[str, str] = field(default_factory=dict)
+    request_payload_hash: str = ""
+    capabilities: Optional[LLMProviderCapabilities] = None
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+    provider_data: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.request_payload_hash:
+            self.request_payload_hash = stable_payload_hash(self.body)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize prepared request metadata for tests and inspection."""
+
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "protocol": self.protocol,
+            "route": self.route,
+            "body": dict(self.body or {}),
+            "transport": self.transport,
+            "headers": dict(self.headers or {}),
+            "request_payload_hash": self.request_payload_hash,
+            "capabilities": self.capabilities.to_dict()
+            if isinstance(self.capabilities, LLMProviderCapabilities)
+            else None,
+            "diagnostics": dict(self.diagnostics or {}),
+            "provider_data": dict(self.provider_data or {}),
+        }
 
 
 @dataclass
@@ -438,6 +528,8 @@ __all__ = [
     "ErrorReportingRuntime",
     "FinishReason",
     "LLMError",
+    "LLMPreparedRequest",
+    "LLMProviderCapabilities",
     "LLMProviderError",
     "LLMRequest",
     "LLMRequestLifecycle",
@@ -453,4 +545,5 @@ __all__ = [
     "StreamEventType",
     "ToolCallRuntime",
     "UsageReportingRuntime",
+    "stable_payload_hash",
 ]

--- a/penguin/llm/contracts.py
+++ b/penguin/llm/contracts.py
@@ -89,6 +89,76 @@ class LLMRequestLifecycle:
     error: Optional[LLMError] = None
     provider_data: Dict[str, Any] = field(default_factory=dict)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize lifecycle metadata for session storage."""
+
+        return {
+            "request_id": self.request_id,
+            "provider": self.provider,
+            "model": self.model,
+            "status": self.status.value,
+            "stream": self.stream,
+            "transport": self.transport,
+            "request_payload_hash": self.request_payload_hash,
+            "attempt": self.attempt,
+            "started_at": self.started_at,
+            "last_event_at": self.last_event_at,
+            "ended_at": self.ended_at,
+            "provider_response_id": self.provider_response_id,
+            "last_event_type": self.last_event_type,
+            "finish_reason": self.finish_reason.value
+            if isinstance(self.finish_reason, FinishReason)
+            else self.finish_reason,
+            "error": self.error.to_dict()
+            if isinstance(self.error, LLMError)
+            else None,
+            "provider_data": dict(self.provider_data or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "LLMRequestLifecycle":
+        """Deserialize lifecycle metadata from session storage."""
+
+        status = payload.get("status") or ProviderRequestStatus.PENDING
+        if not isinstance(status, ProviderRequestStatus):
+            try:
+                status = ProviderRequestStatus(str(status))
+            except Exception:
+                status = ProviderRequestStatus.PENDING
+
+        finish_reason = payload.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, FinishReason):
+            try:
+                finish_reason = FinishReason(str(finish_reason))
+            except Exception:
+                finish_reason = FinishReason.UNKNOWN
+
+        error_payload = payload.get("error")
+        error = (
+            LLMError.from_dict(error_payload)
+            if isinstance(error_payload, dict)
+            else None
+        )
+
+        return cls(
+            request_id=str(payload.get("request_id") or ""),
+            provider=str(payload.get("provider") or ""),
+            model=str(payload.get("model") or ""),
+            status=status,
+            stream=bool(payload.get("stream", False)),
+            transport=str(payload.get("transport") or ""),
+            request_payload_hash=payload.get("request_payload_hash"),
+            attempt=int(payload.get("attempt") or 1),
+            started_at=float(payload.get("started_at") or 0.0),
+            last_event_at=float(payload.get("last_event_at") or 0.0),
+            ended_at=payload.get("ended_at"),
+            provider_response_id=payload.get("provider_response_id"),
+            last_event_type=payload.get("last_event_type"),
+            finish_reason=finish_reason,
+            error=error,
+            provider_data=dict(payload.get("provider_data") or {}),
+        )
+
 
 @dataclass
 class LLMToolCall:
@@ -178,6 +248,53 @@ class LLMError:
     model: Optional[str] = None
     finish_reason: Optional[FinishReason] = None
     provider_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize canonical error metadata for diagnostics and storage."""
+
+        return {
+            "message": self.message,
+            "category": self.category.value,
+            "retryable": self.retryable,
+            "retry_after_seconds": self.retry_after_seconds,
+            "status_code": self.status_code,
+            "provider": self.provider,
+            "model": self.model,
+            "finish_reason": self.finish_reason.value
+            if isinstance(self.finish_reason, FinishReason)
+            else self.finish_reason,
+            "provider_data": dict(self.provider_data or {}),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "LLMError":
+        """Deserialize canonical error metadata from storage."""
+
+        category = payload.get("category") or ErrorCategory.UNKNOWN
+        if not isinstance(category, ErrorCategory):
+            try:
+                category = ErrorCategory(str(category))
+            except Exception:
+                category = ErrorCategory.UNKNOWN
+
+        finish_reason = payload.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, FinishReason):
+            try:
+                finish_reason = FinishReason(str(finish_reason))
+            except Exception:
+                finish_reason = FinishReason.UNKNOWN
+
+        return cls(
+            message=str(payload.get("message") or ""),
+            category=category,
+            retryable=bool(payload.get("retryable", False)),
+            retry_after_seconds=payload.get("retry_after_seconds"),
+            status_code=payload.get("status_code"),
+            provider=payload.get("provider"),
+            model=payload.get("model"),
+            finish_reason=finish_reason,
+            provider_data=dict(payload.get("provider_data") or {}),
+        )
 
 
 class LLMProviderError(RuntimeError):

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -14,6 +14,7 @@ from penguin.tools.runtime import (
 )
 from penguin.utils.errors import LLMEmptyResponseError
 
+from .contracts import LLMError
 from .provider_transform import (
     native_tool_format,
     normalize_anthropic_tools,
@@ -28,6 +29,38 @@ _REASONING_EFFORT_VARIANTS = {"none", "minimal", "low", "medium", "high", "xhigh
 _REASONING_MAX_VARIANTS = {"max"}
 _REASONING_DISABLE_VARIANTS = {"off"}
 logger = logging.getLogger(__name__)
+
+
+def _get_last_provider_error(api_client: Any) -> Optional[LLMError]:
+    try:
+        getter = getattr(api_client, "get_last_error", None)
+        provider_error = getter() if callable(getter) else None
+    except Exception:
+        return None
+    return provider_error if isinstance(provider_error, LLMError) else None
+
+
+def _is_provider_error_response(response: Optional[str]) -> bool:
+    if not isinstance(response, str):
+        return False
+    stripped = response.strip()
+    return stripped.startswith("[Error:") or stripped.startswith("Error:")
+
+
+def should_retry_provider_failure(
+    *,
+    provider_error: Optional[LLMError],
+    response: Optional[str],
+    streamed_assistant_chunk: bool,
+    pending_tool_call: bool,
+) -> bool:
+    """Return whether a failed provider call is safe to replay once."""
+
+    if provider_error is None or not provider_error.retryable:
+        return False
+    if streamed_assistant_chunk or pending_tool_call:
+        return False
+    return not response or not response.strip() or _is_provider_error_response(response)
 
 
 def _get_tool_payload(
@@ -290,10 +323,30 @@ async def call_with_retry(
         **extra_kwargs,
     )
 
+    pending_tool_call = handler_has_pending_tool_call(api_client)
+    provider_error = _get_last_provider_error(api_client)
+    if should_retry_provider_failure(
+        provider_error=provider_error,
+        response=assistant_response,
+        streamed_assistant_chunk=streamed_assistant_chunk,
+        pending_tool_call=pending_tool_call,
+    ):
+        assistant_response = await api_client.get_response(messages, stream=False)
+        if (
+            streaming
+            and stream_callback
+            and assistant_response
+            and assistant_response.strip()
+        ):
+            await _tracked_stream_callback(assistant_response, "assistant")
+            replayed_retry_response = True
+        pending_tool_call = handler_has_pending_tool_call(api_client)
+        provider_error = _get_last_provider_error(api_client)
+
     if not assistant_response or not assistant_response.strip():
         if streamed_assistant_chunk:
             return assistant_response or ""
-        if handler_has_pending_tool_call(api_client):
+        if pending_tool_call:
             return assistant_response or ""
         assistant_response = await api_client.get_response(messages, stream=False)
         if (
@@ -304,16 +357,12 @@ async def call_with_retry(
         ):
             await _tracked_stream_callback(assistant_response, "assistant")
             replayed_retry_response = True
+        pending_tool_call = handler_has_pending_tool_call(api_client)
+        provider_error = _get_last_provider_error(api_client)
 
     if not assistant_response or not assistant_response.strip():
-        if handler_has_pending_tool_call(api_client):
+        if pending_tool_call:
             return assistant_response or ""
-        provider_error = None
-        try:
-            getter = getattr(api_client, "get_last_error", None)
-            provider_error = getter() if callable(getter) else None
-        except Exception:
-            provider_error = None
         diagnostics = build_empty_response_diagnostics(
             messages=messages,
             raw_response=assistant_response,

--- a/penguin/system/context_window.py
+++ b/penguin/system/context_window.py
@@ -423,7 +423,10 @@ class ContextWindowManager:
             id=session.id,
             created_at=session.created_at,
             last_active=session.last_active,
-            metadata=session.metadata.copy()
+            metadata=session.metadata.copy(),
+            llm_request_lifecycles=[
+                dict(record) for record in session.llm_request_lifecycles
+            ],
         )
             
         # Analyze current message state
@@ -616,7 +619,10 @@ class ContextWindowManager:
                 created_at=session.created_at,
                 last_active=session.last_active,
                 metadata=session.metadata.copy(),
-                messages=[msg for msg in session.messages]
+                messages=[msg for msg in session.messages],
+                llm_request_lifecycles=[
+                    dict(record) for record in session.llm_request_lifecycles
+                ],
             )
 
         # Sort by timestamp to identify oldest vs newest
@@ -633,7 +639,10 @@ class ContextWindowManager:
             id=session.id,
             created_at=session.created_at,
             last_active=session.last_active,
-            metadata=session.metadata.copy()
+            metadata=session.metadata.copy(),
+            llm_request_lifecycles=[
+                dict(record) for record in session.llm_request_lifecycles
+            ],
         )
 
         # Process each message
@@ -773,8 +782,16 @@ class ContextWindowManager:
                     created_at=trimmed_session.created_at,
                     last_active=trimmed_session.last_active,
                     metadata=trimmed_session.metadata.copy(),
-                    messages=system_msgs + [msg for msg in trimmed_session.messages 
-                                           if msg.category != MessageCategory.SYSTEM]
+                    messages=system_msgs
+                    + [
+                        msg
+                        for msg in trimmed_session.messages
+                        if msg.category != MessageCategory.SYSTEM
+                    ],
+                    llm_request_lifecycles=[
+                        dict(record)
+                        for record in trimmed_session.llm_request_lifecycles
+                    ],
                 )
                 
                 # Use fixed session instead

--- a/penguin/system/state.py
+++ b/penguin/system/state.py
@@ -6,14 +6,21 @@ manage conversation state, including messages, sessions, and categories.
 """
 
 import json
+import logging
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, Callable
-import logging
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _default_session_id() -> str:
+    """Create Penguin's timestamped session id."""
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"session_{timestamp}_{uuid.uuid4().hex[:8]}"
 
 
 class SystemState(Enum):
@@ -26,13 +33,14 @@ class SystemState(Enum):
 
 class TaskState(Enum):
     """State machine for tasks in the Penguin system."""
-    PENDING = "pending"     # Task is created but not started
-    ACTIVE = "active"       # Task is currently in progress
-    PAUSED = "paused"       # Task execution is temporarily paused, can be resumed
-    COMPLETED = "completed" # Task is successfully completed
-    FAILED = "failed"       # Task execution failed
-    BLOCKED = "blocked"     # Task is blocked by dependencies
-    
+
+    PENDING = "pending"  # Task is created but not started
+    ACTIVE = "active"  # Task is currently in progress
+    PAUSED = "paused"  # Task execution is temporarily paused, can be resumed
+    COMPLETED = "completed"  # Task is successfully completed
+    FAILED = "failed"  # Task execution failed
+    BLOCKED = "blocked"  # Task is blocked by dependencies
+
     @classmethod
     def get_valid_transitions(cls, current_state):
         """Returns valid state transitions from the current state."""
@@ -42,35 +50,38 @@ class TaskState(Enum):
             cls.PAUSED: [cls.ACTIVE, cls.FAILED, cls.BLOCKED],
             cls.COMPLETED: [],  # Terminal state
             cls.FAILED: [cls.PENDING],  # Allow retry from failed
-            cls.BLOCKED: [cls.PENDING, cls.ACTIVE] # When dependencies resolved
+            cls.BLOCKED: [cls.PENDING, cls.ACTIVE],  # When dependencies resolved
         }
         return transitions.get(current_state, [])
 
 
 class MessageCategory(Enum):
     """Categories of messages for priority-based handling in the context window."""
-    SYSTEM = 1    # System instructions, never truncated
-    CONTEXT = 2   # Important reference information. Declarative notes, context folders, etc.
-    DIALOG = 3    # Main conversation between user and assistant
-    SYSTEM_OUTPUT = 4   # Results from tool executions, system outputs, etc.
-    ERROR = 5           # Error messages from the system or tools
-    INTERNAL = "internal" # For core's internal thoughts/plans if exposed
-    UNKNOWN = "unknown" # Added to handle cases where category might not be set
-    
-    # TODO: Consider ERROR as a category? 
-    
+
+    SYSTEM = 1  # System instructions, never truncated
+    # Important reference information: declarative notes, context folders, etc.
+    CONTEXT = 2
+    DIALOG = 3  # Main conversation between user and assistant
+    SYSTEM_OUTPUT = 4  # Results from tool executions, system outputs, etc.
+    ERROR = 5  # Error messages from the system or tools
+    INTERNAL = "internal"  # For core's internal thoughts/plans if exposed
+    UNKNOWN = "unknown"  # Added to handle cases where category might not be set
+
+    # TODO: Consider ERROR as a category?
+
+
 @dataclass
 class Message:
     """
     Represents a single message in a conversation.
-    
+
     Messages have a role (user, assistant, system), content, and a category
     that determines its importance for context window management.
-    
+
     The content field can be any type, supporting:
     - Plain text (str)
     - Structured content for multi-modal messages (list/dict)
-    
+
     And later supports:
 
     - Images (via OpenAI format {"type": "image_url", "image_url": {...}})
@@ -79,6 +90,7 @@ class Message:
     - Video (via adapter-specific format)
     - Other structured content as needed
     """
+
     role: str
     content: Any
     category: MessageCategory
@@ -90,14 +102,14 @@ class Message:
     agent_id: Optional[str] = None
     recipient_id: Optional[str] = None
     message_type: str = "message"  # message|action|status
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert message to a dictionary for serialization."""
         result = asdict(self)
         # Convert enum to string for serialization
         result["category"] = self.category.name
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Message":
         """Create a Message instance from a dictionary."""
@@ -112,27 +124,24 @@ class Message:
         data.setdefault("agent_id", None)
         data.setdefault("recipient_id", None)
         data.setdefault("message_type", "message")
-        
+
         return cls(**data)
-    
+
     def to_api_format(self) -> Dict[str, Any]:
         """Format message for API consumption."""
-        return {
-            "role": self.role,
-            "content": self.content
-        }
-    
+        return {"role": self.role, "content": self.content}
+
     def fallback_estimate_tokens(self) -> int:
         """
-        Last-resort fallback for estimating token count when provider tokenizer 
+        Last-resort fallback for estimating token count when provider tokenizer
         and tiktoken are unavailable.
-        
+
         This is a rough approximation and should only be used when proper tokenizers
         cannot be accessed.
         """
         if self.tokens > 0:
             return self.tokens
-            
+
         # Simple approximation: ~4 characters per token
         if isinstance(self.content, str):
             return len(self.content) // 4 + 1
@@ -164,40 +173,67 @@ class Message:
 class Session:
     """
     Represents a conversation session containing multiple messages.
-    
+
     Sessions have their own identity and metadata, and manage a collection
     of messages that belong to the conversation.
     """
-    id: str = field(default_factory=lambda: f"session_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}")
+
+    id: str = field(default_factory=_default_session_id)
     messages: List[Message] = field(default_factory=list)
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     last_active: str = field(default_factory=lambda: datetime.now().isoformat())
     metadata: Dict[str, Any] = field(default_factory=dict)
-    
+    llm_request_lifecycles: List[Dict[str, Any]] = field(default_factory=list)
+
     @property
     def message_count(self) -> int:
         """Get the number of messages in this session."""
         return len(self.messages)
-    
+
     @property
     def total_tokens(self) -> int:
         """Get total token count for all messages in this session."""
         return sum(msg.tokens for msg in self.messages)
-    
+
     def get_messages_by_category(self, category: MessageCategory) -> List[Message]:
         """Get all messages of a specific category."""
         return [msg for msg in self.messages if msg.category == category]
-    
+
     def get_formatted_history(self) -> List[Dict[str, Any]]:
         """Get messages formatted for API consumption."""
         return [msg.to_api_format() for msg in self.messages]
-    
+
     def add_message(self, message: Message) -> None:
         """Add a message to the session."""
         self.messages.append(message)
         self.last_active = datetime.now().isoformat()
         self.metadata["message_count"] = len(self.messages)
-    
+
+    def add_llm_request_lifecycle(self, lifecycle: Any) -> None:
+        """Persist one provider request lifecycle record on this session."""
+
+        if hasattr(lifecycle, "to_dict") and callable(lifecycle.to_dict):
+            record = lifecycle.to_dict()
+        elif isinstance(lifecycle, dict):
+            record = dict(lifecycle)
+        else:
+            raise TypeError("lifecycle must be a dictionary or to_dict object")
+
+        if not isinstance(record, dict):
+            raise TypeError("lifecycle.to_dict() must return a dictionary")
+
+        record = dict(record)
+        request_id = str(record.get("request_id") or "").strip()
+        if request_id:
+            self.llm_request_lifecycles = [
+                existing_record
+                for existing_record in self.llm_request_lifecycles
+                if str(existing_record.get("request_id") or "").strip() != request_id
+            ]
+        self.llm_request_lifecycles.append(record)
+        self.last_active = datetime.now().isoformat()
+        self.metadata["llm_request_lifecycle_count"] = len(self.llm_request_lifecycles)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert session to a dictionary for serialization."""
         return {
@@ -205,24 +241,32 @@ class Session:
             "created_at": self.created_at,
             "last_active": self.last_active,
             "metadata": self.metadata,
-            "messages": [msg.to_dict() for msg in self.messages]
+            "messages": [msg.to_dict() for msg in self.messages],
+            "llm_request_lifecycles": [
+                dict(record) for record in self.llm_request_lifecycles
+            ],
         }
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Session":
         """Create a Session instance from a dictionary."""
+        data = dict(data)
         # Handle the messages separately
         messages_data = data.pop("messages", [])
+        lifecycles_data = data.pop("llm_request_lifecycles", [])
         session = cls(**data)
-        
+
         # Add the messages
         session.messages = [Message.from_dict(msg) for msg in messages_data]
+        session.llm_request_lifecycles = [
+            dict(record) for record in lifecycles_data if isinstance(record, dict)
+        ]
         return session
-    
+
     def to_json(self) -> str:
         """Convert session to JSON string."""
         return json.dumps(self.to_dict(), indent=2)
-    
+
     @classmethod
     def from_json(cls, json_str: str) -> "Session":
         """Create a Session instance from a JSON string."""
@@ -231,37 +275,45 @@ class Session:
             return cls.from_dict(data)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON format: {e}")
-    
+
     def validate(self) -> bool:
         """Validate session data integrity."""
         # Check for required fields
         if not self.id or not isinstance(self.id, str):
-            logger.warning(f"Session validation failed: Invalid or missing ID. Got: {self.id!r}")
+            logger.warning(
+                f"Session validation failed: Invalid or missing ID. Got: {self.id!r}"
+            )
             return False
-        
+
         # Validate timestamps
         try:
             datetime.fromisoformat(self.created_at)
             datetime.fromisoformat(self.last_active)
         except (ValueError, TypeError) as e:
-            logger.warning(f"Session validation failed: Invalid timestamp. Created: {self.created_at!r}, Last Active: {self.last_active!r}. Error: {e}")
+            logger.warning(
+                f"Session validation failed: Invalid timestamp. Created: {self.created_at!r}, Last Active: {self.last_active!r}. Error: {e}"
+            )
             return False
-        
+
         # Validate messages
         for i, msg in enumerate(self.messages):
             if not isinstance(msg, Message):
-                logger.warning(f"Session validation failed: Message at index {i} is not a valid Message object. Type: {type(msg)}")
+                logger.warning(
+                    f"Session validation failed: Message at index {i} is not a valid Message object. Type: {type(msg)}"
+                )
                 return False
             if not msg.role or not isinstance(msg.role, str):
-                logger.warning(f"Session validation failed: Message at index {i} has an invalid or missing role. Role: {msg.role!r}")
+                logger.warning(
+                    f"Session validation failed: Message at index {i} has an invalid or missing role. Role: {msg.role!r}"
+                )
                 return False
-                
+
         return True
-    
+
     def update_token_counts(self, counter_function: Callable[[Any], int]) -> None:
         """
         Update token counts for all messages using the provided counter function.
-        
+
         Args:
             counter_function: Function that takes content and returns token count
         """
@@ -275,31 +327,33 @@ class Session:
                 # Use fallback estimation in case of failure
                 msg.tokens = msg.fallback_estimate_tokens()
                 total_tokens += msg.tokens
-                logger.warning(f"Using fallback token estimation for message {msg.id}: {e}")
-        
+                logger.warning(
+                    f"Using fallback token estimation for message {msg.id}: {e}"
+                )
+
         # Update session metadata
         self.metadata["token_count"] = total_tokens
-        
+
         return total_tokens
 
 
 def create_message(
-    role: str, 
-    content: Any, 
+    role: str,
+    content: Any,
     category: MessageCategory,
     metadata: Optional[Dict[str, Any]] = None,
-    tokens: int = 0
+    tokens: int = 0,
 ) -> Message:
     """
     Helper function to create a new message.
-    
+
     Args:
         role: Message role (user, assistant, system)
         content: Message content (text or structured data)
         category: Message category for priority handling
         metadata: Optional metadata for the message
         tokens: Optional pre-calculated token count
-        
+
     Returns:
         Message object
     """
@@ -308,21 +362,21 @@ def create_message(
         content=content,
         category=category,
         metadata=metadata or {},
-        tokens=tokens
+        tokens=tokens,
     )
 
 
 def create_session() -> Session:
     """
     Helper function to create a new empty session.
-    
+
     Returns:
         Session object
     """
     return Session(
         metadata={
             "created_at": datetime.now().isoformat(),
-            "message_count": 0
+            "message_count": 0,
         }
     )
 

--- a/penguin/tools/runtime.py
+++ b/penguin/tools/runtime.py
@@ -15,6 +15,7 @@ import json
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Literal, Optional, Union, cast
 
 from penguin.utils.parser import CodeActAction, parse_action
@@ -53,10 +54,50 @@ class ToolResult:
     started_at: float = field(default_factory=time.time)
     ended_at: float = field(default_factory=time.time)
     output_hash: str = ""
+    byte_count: int = 0
+    line_count: int = 0
+    truncated: bool = False
+    truncation_direction: str = "none"
+    artifact_path: Optional[str] = None
 
     def __post_init__(self) -> None:
+        output_text = str(self.output if self.output is not None else "")
         if not self.output_hash:
-            object.__setattr__(self, "output_hash", hash_tool_output(self.output))
+            object.__setattr__(self, "output_hash", hash_tool_output(output_text))
+        if self.byte_count <= 0 and output_text:
+            object.__setattr__(self, "byte_count", len(output_text.encode("utf-8")))
+        if self.line_count <= 0 and output_text:
+            object.__setattr__(self, "line_count", output_text.count("\n") + 1)
+
+
+@dataclass(frozen=True)
+class ToolOutputView:
+    """Model-visible preview plus full-output artifact metadata."""
+
+    model_output: str
+    full_output: str
+    truncated: bool
+    byte_count: int
+    line_count: int
+    output_hash: str
+    truncation_direction: str = "none"
+    artifact_path: Optional[str] = None
+    artifact_id: Optional[str] = None
+    max_chars: Optional[int] = None
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return serializable output metadata for tool result records."""
+
+        return {
+            "truncated": self.truncated,
+            "byte_count": self.byte_count,
+            "line_count": self.line_count,
+            "output_hash": self.output_hash,
+            "truncation_direction": self.truncation_direction,
+            "artifact_path": self.artifact_path,
+            "artifact_id": self.artifact_id,
+            "max_chars": self.max_chars,
+        }
 
 
 @dataclass(frozen=True)
@@ -81,6 +122,128 @@ def hash_tool_output(output: Any) -> str:
 
     output_text = str(output if output is not None else "")
     return hashlib.sha256(output_text.encode()).hexdigest()
+
+
+def _line_count(output_text: str) -> int:
+    """Count model-visible output lines without treating empty output as one line."""
+
+    return output_text.count("\n") + 1 if output_text else 0
+
+
+def _safe_artifact_id(artifact_id: Optional[str], output_hash: str) -> str:
+    """Return a filesystem-safe artifact id."""
+
+    raw_id = str(artifact_id or "").strip()
+    if raw_id and all(char.isalnum() or char in {"-", "_", "."} for char in raw_id):
+        return raw_id[:96]
+    return output_hash[:16]
+
+
+def _truncate_output_preview(
+    output_text: str,
+    *,
+    budget: int,
+    direction: Literal["head", "tail", "middle"],
+) -> str:
+    """Return a deterministic preview that fits the provided character budget."""
+
+    if budget <= 0:
+        return ""
+    if len(output_text) <= budget:
+        return output_text
+    if direction == "head":
+        return output_text[:budget]
+    if direction == "middle":
+        left = max(budget // 2, 0)
+        right = max(budget - left, 0)
+        return f"{output_text[:left]}{output_text[-right:]}"[:budget]
+    return output_text[-budget:]
+
+
+def prepare_model_visible_tool_output(
+    output: Any,
+    *,
+    max_chars: Optional[int] = None,
+    artifact_dir: Optional[Union[str, Path]] = None,
+    artifact_id: Optional[str] = None,
+    truncation_direction: Literal["head", "tail", "middle"] = "tail",
+) -> ToolOutputView:
+    """Build a capped model-visible tool output and optional full artifact.
+
+    Args:
+        output: Raw full tool output.
+        max_chars: Maximum characters to expose to the model. ``None`` means
+            no truncation.
+        artifact_dir: Directory where full output should be written when
+            truncation occurs.
+        artifact_id: Optional stable id for the artifact filename.
+        truncation_direction: Which part of the output should be retained in
+            the model-visible preview.
+
+    Returns:
+        A ``ToolOutputView`` with preview, full-output metadata, and optional
+        artifact path.
+    """
+
+    full_output = str(output if output is not None else "")
+    output_hash = hash_tool_output(full_output)
+    byte_count = len(full_output.encode("utf-8"))
+    line_count = _line_count(full_output)
+
+    if max_chars is None or len(full_output) <= max_chars:
+        return ToolOutputView(
+            model_output=full_output,
+            full_output=full_output,
+            truncated=False,
+            byte_count=byte_count,
+            line_count=line_count,
+            output_hash=output_hash,
+            artifact_id=artifact_id,
+            max_chars=max_chars,
+        )
+
+    artifact_path: Optional[str] = None
+    safe_id = _safe_artifact_id(artifact_id, output_hash)
+    if artifact_dir is not None:
+        directory = Path(artifact_dir)
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"tool-output-{safe_id}.txt"
+        path.write_text(full_output, encoding="utf-8")
+        artifact_path = str(path)
+
+    effective_max = max(int(max_chars), 0)
+    notice_parts = [
+        "Tool output truncated",
+        f"bytes={byte_count}",
+        f"lines={line_count}",
+        f"hash={output_hash}",
+    ]
+    if artifact_path:
+        notice_parts.append(f"artifact={artifact_path}")
+    notice = "\n\n[" + " ".join(notice_parts) + "]"
+    preview_budget = max(effective_max - len(notice), 0)
+    preview = _truncate_output_preview(
+        full_output,
+        budget=preview_budget,
+        direction=truncation_direction,
+    )
+    if preview_budget <= 0:
+        model_output = notice[:effective_max]
+    else:
+        model_output = f"{preview}{notice}"[:effective_max]
+
+    return ToolOutputView(
+        model_output=model_output,
+        full_output=full_output,
+        truncated=True,
+        byte_count=byte_count,
+        line_count=line_count,
+        output_hash=output_hash,
+        truncation_direction=truncation_direction,
+        artifact_path=artifact_path,
+        artifact_id=safe_id,
+        max_chars=max_chars,
+    )
 
 
 def _stable_json(value: Any) -> str:
@@ -147,6 +310,15 @@ def _metadata_from_result(action_result: dict[str, Any]) -> dict[str, Any]:
     return metadata if isinstance(metadata, dict) else {}
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Convert metadata values to ints without raising on malformed records."""
+
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
 def _tool_result_to_action_result(tool_result: ToolResult) -> dict[str, Any]:
     """Convert a normalized tool result into a legacy action-result dict.
 
@@ -163,16 +335,23 @@ def _tool_result_to_action_result(tool_result: ToolResult) -> dict[str, Any]:
     """
 
     structured_output = tool_result.structured_output or {}
-    tool_arguments = _first_non_none(
-        structured_output, ("tool_arguments", "arguments")
-    )
+    tool_arguments = _first_non_none(structured_output, ("tool_arguments", "arguments"))
+    metadata = {
+        **structured_output,
+        "output_hash": tool_result.output_hash,
+        "byte_count": tool_result.byte_count,
+        "line_count": tool_result.line_count,
+        "truncated": tool_result.truncated,
+        "truncation_direction": tool_result.truncation_direction,
+        "artifact_path": tool_result.artifact_path,
+    }
     return {
         "action": tool_result.name,
         "result": tool_result.output,
         "status": tool_result.status,
         "tool_call_id": tool_result.call_id,
         "output_hash": tool_result.output_hash,
-        "metadata": structured_output,
+        "metadata": metadata,
         "tool_arguments": tool_arguments,
     }
 
@@ -208,9 +387,7 @@ def tool_loop_signature(action_result: Any) -> dict[str, Any]:
         action_result, ("tool_arguments", "arguments", "params")
     )
     if arguments is None:
-        arguments = _first_non_none(
-            metadata, ("tool_arguments", "arguments", "params")
-        )
+        arguments = _first_non_none(metadata, ("tool_arguments", "arguments", "params"))
     normalized_arguments = _normalize_arguments(arguments)
     argument_fields = (
         normalized_arguments if isinstance(normalized_arguments, dict) else {}
@@ -448,9 +625,7 @@ def tool_call_from_responses_info(tool_info: dict[str, Any]) -> Optional[ToolCal
         or f"call_{uuid.uuid4().hex}"
     )
     raw_args = (
-        tool_info.get("arguments")
-        if tool_info.get("arguments") is not None
-        else "{}"
+        tool_info.get("arguments") if tool_info.get("arguments") is not None else "{}"
     )
     arguments: ToolArguments = (
         raw_args if isinstance(raw_args, (dict, str)) else str(raw_args)
@@ -497,7 +672,9 @@ def _format_browser_tool_output(action_result: dict[str, Any]) -> str:
         loaded = action_result.get("loaded")
         if loaded is not None:
             lines.append(f"loaded: {loaded}")
-        lines.append("next: inspect page_info or take a screenshot before retrying open_tab")
+        lines.append(
+            "next: inspect page_info or take a screenshot before retrying open_tab"
+        )
 
     if action == "browser_harness_screenshot":
         filepath = action_result.get("filepath")
@@ -560,6 +737,7 @@ def tool_result_from_action_result(
     raw_name = action_result.get("action", action_result.get("name", ""))
     name = str(raw_name).strip()
     output = _model_visible_tool_output(action_result)
+    metadata = _metadata_from_result(action_result)
     raw_status = str(action_result.get("status") or "completed").strip().lower()
     status = cast(
         ToolResultStatus,
@@ -582,6 +760,35 @@ def tool_result_from_action_result(
         structured_output=structured_output,
         started_at=started_at if started_at is not None else time.time(),
         ended_at=ended_at if ended_at is not None else time.time(),
+        byte_count=_coerce_int(
+            action_result.get("byte_count", metadata.get("byte_count")),
+            default=0,
+        ),
+        line_count=_coerce_int(
+            action_result.get("line_count", metadata.get("line_count")),
+            default=0,
+        ),
+        truncated=bool(
+            action_result.get("truncated", metadata.get("truncated", False))
+        ),
+        truncation_direction=str(
+            action_result.get(
+                "truncation_direction",
+                metadata.get("truncation_direction", "none"),
+            )
+            or "none"
+        ),
+        artifact_path=(
+            str(
+                action_result.get(
+                    "artifact_path",
+                    metadata.get("artifact_path"),
+                )
+            )
+            if action_result.get("artifact_path", metadata.get("artifact_path"))
+            is not None
+            else None
+        ),
     )
 
 
@@ -657,12 +864,14 @@ __all__ = [
     "ToolExecutionPolicy",
     "ToolExecutor",
     "ToolLoopIdentity",
+    "ToolOutputView",
     "ToolResult",
     "ToolResultStatus",
     "execute_tool_calls_serially",
     "hash_tool_output",
     "image_artifacts_from_action_result",
     "legacy_action_result_from_tool_result",
+    "prepare_model_visible_tool_output",
     "select_tool_calls_for_policy",
     "tool_call_from_responses_info",
     "tool_calls_from_actionxml",

--- a/penguin/tui_adapter/part_events.py
+++ b/penguin/tui_adapter/part_events.py
@@ -4,14 +4,13 @@ This module provides dataclasses and adapters to convert Penguin's internal
 streaming events to OpenCode-compatible message/part events for the TUI.
 """
 
-from dataclasses import dataclass, field
-from typing import Literal, Optional, Dict, Any, Tuple, Callable, Awaitable
-from enum import Enum
 import json
 import os
 import re
 import time
-import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Tuple
 
 
 class PartType(Enum):
@@ -73,7 +72,8 @@ class EventEnvelope:
 
     def to_sse(self) -> str:
         """Convert to Server-Sent Event format."""
-        return f"data: {json.dumps({'type': self.type, 'properties': self.properties})}\n\n"
+        payload = {"type": self.type, "properties": self.properties}
+        return f"data: {json.dumps(payload)}\n\n"
 
 
 class PartEventAdapter:
@@ -96,6 +96,7 @@ class PartEventAdapter:
         self._current_message_id: Optional[str] = None
         self._current_reasoning_part_id: Optional[str] = None
         self._current_text_part_id: Optional[str] = None
+        self._last_user_message_id: Optional[str] = None
         self._stream_active: bool = False
         self._active_tool_parts: set[str] = set()
         self._active_tool_counts_by_message: Dict[str, int] = {}
@@ -117,6 +118,8 @@ class PartEventAdapter:
 
     def set_session(self, session_id: str):
         """Set current session ID for all subsequent events."""
+        if self._session_id != session_id:
+            self._last_user_message_id = None
         self._session_id = session_id
 
     def set_directory(self, directory: Optional[str]) -> None:
@@ -137,6 +140,9 @@ class PartEventAdapter:
             pass
         cwd = self._default_directory or os.getenv("PENGUIN_CWD") or os.getcwd()
         return {"cwd": cwd, "root": cwd}
+
+    def _assistant_parent_id(self) -> str:
+        return self._last_user_message_id or "root"
 
     def _mode(self) -> str:
         """Resolve OpenCode message mode from execution context."""
@@ -321,7 +327,7 @@ class PartEventAdapter:
             provider_id=provider_id,
             variant=variant,
             agent_id=agent_id,
-            parent_id="root",
+            parent_id=self._assistant_parent_id(),
             path=self._path(),
             mode=self._mode(),
         )
@@ -383,7 +389,7 @@ class PartEventAdapter:
                 provider_id=provider_id,
                 variant=variant,
                 agent_id=agent_id,
-                parent_id="root",
+                parent_id=self._assistant_parent_id(),
                 path=self._path(),
                 mode=self._mode(),
             )
@@ -703,6 +709,7 @@ class PartEventAdapter:
             path=self._path(),
             mode=self._mode(),
         )
+        self._last_user_message_id = resolved_message_id
 
         # Create text part for user message
         part_id = self._next_id("part")
@@ -738,7 +745,7 @@ class PartEventAdapter:
                 time_created=time.time(),
                 time_completed=time.time(),
                 agent_id="default",
-                parent_id="root",
+                parent_id=self._assistant_parent_id(),
                 path=self._path(),
                 mode=self._mode(),
             )
@@ -828,4 +835,4 @@ class PartEventAdapter:
         )
 
 
-__all__ = ["PartType", "Part", "Message", "EventEnvelope", "PartEventAdapter"]
+__all__ = ["EventEnvelope", "Message", "Part", "PartEventAdapter", "PartType"]

--- a/tests/llm/codex_oauth_fixtures.py
+++ b/tests/llm/codex_oauth_fixtures.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from penguin.llm.adapters.openai import OpenAIAdapter
+from penguin.llm.model_config import ModelConfig
+
+
+class SDKClient:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.default_headers = default_headers
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+        lines: list[str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.headers = dict(headers or {})
+        self._lines = list(lines or [])
+        self.content = (
+            json.dumps(self._payload).encode("utf-8") if payload is not None else b""
+        )
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+    async def aread(self) -> bytes:
+        return self.content
+
+    async def aiter_lines(self):  # type: ignore[no-untyped-def]
+        for line in self._lines:
+            yield line
+
+
+class FakeStreamContext:
+    def __init__(self, response: FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> FakeResponse:
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+        del exc_type, exc, tb
+        return False
+
+
+def codex_sse(payload: dict[str, Any]) -> str:
+    return "data: " + json.dumps(payload, separators=(",", ":"))
+
+
+def codex_text_delta(text: str) -> str:
+    return codex_sse({"type": "response.output_text.delta", "delta": text})
+
+
+def codex_completed(
+    response_id: str = "resp_test",
+    *,
+    usage: dict[str, Any] | None = None,
+) -> str:
+    response: dict[str, Any] = {"id": response_id}
+    if usage is not None:
+        response["usage"] = usage
+    return codex_sse({"type": "response.completed", "response": response})
+
+
+def codex_completed_text(text: str, response_id: str = "resp_test") -> list[str]:
+    return [
+        codex_text_delta(text),
+        codex_completed(response_id),
+        "data: [DONE]",
+    ]
+
+
+def codex_function_call_lines(
+    *,
+    item_id: str = "item_1",
+    call_id: str = "call_1",
+    name: str = "read_file",
+    arguments: str = '{"path":"README.md"}',
+) -> list[str]:
+    return [
+        codex_sse(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": item_id,
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": "",
+                },
+            }
+        ),
+        codex_sse(
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": item_id,
+                "delta": arguments,
+            }
+        ),
+        codex_sse(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": item_id,
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments,
+                    "status": "completed",
+                },
+            }
+        ),
+    ]
+
+
+class FakeCodexTransport:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+        self.timeouts: list[Any] = []
+
+    def async_client_class(self):  # type: ignore[no-untyped-def]
+        transport = self
+
+        class _FakeAsyncClient:
+            def __init__(self, timeout: Any) -> None:
+                self.timeout = timeout
+                transport.timeouts.append(timeout)
+
+            async def __aenter__(self) -> "_FakeAsyncClient":
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+                del exc_type, exc, tb
+                return False
+
+            def stream(self, method: str, url: str, headers=None, json=None):  # type: ignore[no-untyped-def]
+                transport.requests.append(
+                    {
+                        "method": method,
+                        "url": url,
+                        "headers": dict(headers or {}),
+                        "json": dict(json or {}),
+                    }
+                )
+                return FakeStreamContext(transport.responses.pop(0))
+
+        return _FakeAsyncClient
+
+
+def install_oauth_codex_test_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_OAUTH_ACCESS_TOKEN", "oauth-access")
+    monkeypatch.setenv("OPENAI_ACCOUNT_ID", "acct-1")
+    monkeypatch.setattr("penguin.llm.adapters.openai.AsyncOpenAI", SDKClient)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda provider_id: {
+            "type": "oauth",
+            "access": "oauth-access",
+            "refresh": "oauth-refresh",
+            "expires": 9_999_999_999_000,
+            "accountId": "acct-1",
+        }
+        if provider_id == "openai"
+        else None,
+    )
+
+
+def codex_adapter() -> OpenAIAdapter:
+    return OpenAIAdapter(
+        ModelConfig(
+            model="gpt-5.2",
+            provider="openai",
+            client_preference="native",
+            api_key="sk-test",
+            streaming_enabled=False,
+        )
+    )

--- a/tests/llm/provider_contract_fixtures.py
+++ b/tests/llm/provider_contract_fixtures.py
@@ -20,6 +20,7 @@ class OpenAIStreamEvent:
     part: Any = None
     item: Any = None
     item_id: str = ""
+    error: Any = None
 
 
 class OpenAIResponse:
@@ -28,7 +29,9 @@ class OpenAIResponse:
         *,
         output_text: str,
         usage: dict[str, Any] | None = None,
+        response_id: str = "resp-test",
     ) -> None:
+        self.id = response_id
         self.output_text = output_text
         self.usage = dict(usage or {})
 
@@ -59,6 +62,8 @@ class OpenAIResponseStream:
             raise StopAsyncIteration
         event = self._events[self._idx]
         self._idx += 1
+        if isinstance(event, BaseException):
+            raise event
         return event
 
     async def get_final_response(self) -> OpenAIResponse:
@@ -69,16 +74,24 @@ class OpenAIResponsesStub:
     def __init__(
         self,
         *,
-        stream_response: OpenAIResponseStream,
+        stream_response: OpenAIResponseStream | list[OpenAIResponseStream],
         create_response: OpenAIResponse,
     ) -> None:
-        self.stream_response = stream_response
+        self.stream_responses = (
+            list(stream_response)
+            if isinstance(stream_response, list)
+            else [stream_response]
+        )
+        self.stream_response = self.stream_responses[0]
         self.create_response = create_response
         self.last_stream_kwargs: dict[str, Any] | None = None
         self.last_create_kwargs: dict[str, Any] | None = None
 
     def stream(self, **kwargs: Any) -> OpenAIResponseStream:
         self.last_stream_kwargs = dict(kwargs)
+        if not self.stream_responses:
+            raise AssertionError("No queued OpenAI stream response")
+        self.stream_response = self.stream_responses.pop(0)
         return self.stream_response
 
     async def create(self, **kwargs: Any) -> OpenAIResponse:
@@ -109,11 +122,13 @@ class AnthropicStreamChunk:
         *,
         content_block: Any = None,
         index: int = 0,
+        error: Any = None,
     ) -> None:
         self.type = chunk_type
         self.delta = delta
         self.content_block = content_block
         self.index = index
+        self.error = error
 
 
 class AnthropicCountResponse:
@@ -143,7 +158,9 @@ class AnthropicResponse:
         text: str,
         usage: AnthropicUsage,
         stop_reason: str = "end_turn",
+        response_id: str = "msg-test",
     ) -> None:
+        self.id = response_id
         self.content = [SimpleNamespace(type="text", text=text)]
         self.stop_reason = stop_reason
         self.usage = usage
@@ -172,7 +189,10 @@ class AnthropicStream:
     async def __anext__(self) -> AnthropicStreamChunk:
         if not self._chunks:
             raise StopAsyncIteration
-        return self._chunks.pop(0)
+        chunk = self._chunks.pop(0)
+        if isinstance(chunk, BaseException):
+            raise chunk
+        return chunk
 
     async def get_final_message(self) -> AnthropicResponse:
         return self._final_message
@@ -182,16 +202,24 @@ class AnthropicMessagesStub:
     def __init__(
         self,
         *,
-        stream_response: AnthropicStream,
+        stream_response: AnthropicStream | list[AnthropicStream],
         create_response: AnthropicResponse,
     ) -> None:
-        self.stream_response = stream_response
+        self.stream_responses = (
+            list(stream_response)
+            if isinstance(stream_response, list)
+            else [stream_response]
+        )
+        self.stream_response = self.stream_responses[0]
         self.create_response = create_response
         self.last_kwargs: dict[str, Any] | None = None
 
     async def create(self, **kwargs: Any) -> Any:
         self.last_kwargs = dict(kwargs)
         if kwargs.get("stream"):
+            if not self.stream_responses:
+                raise AssertionError("No queued Anthropic stream response")
+            self.stream_response = self.stream_responses.pop(0)
             return self.stream_response
         return self.create_response
 
@@ -215,24 +243,34 @@ class OpenRouterStream:
             raise StopAsyncIteration
         chunk = self._chunks[self._idx]
         self._idx += 1
+        if isinstance(chunk, BaseException):
+            raise chunk
         return chunk
 
 
 class OpenRouterCompletionsStub:
-    def __init__(self, *, stream_response: Any, create_response: Any) -> None:
-        self.stream_response = stream_response
+    def __init__(self, *, stream_response: Any | list[Any], create_response: Any) -> None:
+        self.stream_responses = (
+            list(stream_response)
+            if isinstance(stream_response, list)
+            else [stream_response]
+        )
+        self.stream_response = self.stream_responses[0]
         self.create_response = create_response
         self.last_kwargs: dict[str, Any] | None = None
 
     async def create(self, **kwargs: Any) -> Any:
         self.last_kwargs = dict(kwargs)
         if kwargs.get("stream"):
+            if not self.stream_responses:
+                raise AssertionError("No queued OpenRouter stream response")
+            self.stream_response = self.stream_responses.pop(0)
             return self.stream_response
         return self.create_response
 
 
 class OpenRouterClientStub:
-    def __init__(self, *, stream_response: Any, create_response: Any) -> None:
+    def __init__(self, *, stream_response: Any | list[Any], create_response: Any) -> None:
         self.chat = SimpleNamespace(
             completions=OpenRouterCompletionsStub(
                 stream_response=stream_response,
@@ -251,10 +289,12 @@ def make_openrouter_chunk(
     tool_calls: list[dict[str, Any]] | None = None,
     finish_reason: str | None = None,
     usage: dict[str, Any] | None = None,
+    error: dict[str, Any] | None = None,
 ) -> Any:
     return SimpleNamespace(
         id="chatcmpl-test",
         model=model,
+        error=error,
         choices=[
             {
                 "delta": {
@@ -277,6 +317,7 @@ def build_openai_handler(
     usage: dict[str, Any],
     interrupt_on_tool_call: bool = False,
     reasoning_enabled: bool = False,
+    stream_event_sequences: Iterable[Iterable[OpenAIStreamEvent]] | None = None,
 ) -> OpenAIAdapter:
     config = ModelConfig(
         model="gpt-5.4",
@@ -290,11 +331,19 @@ def build_openai_handler(
     )
     adapter_cls = OpenAIAdapter if provider == "openai" else OpenAICompatibleAdapter
     adapter = adapter_cls(config)
+    event_sequences = (
+        list(stream_event_sequences)
+        if stream_event_sequences is not None
+        else [stream_events]
+    )
     responses = OpenAIResponsesStub(
-        stream_response=OpenAIResponseStream(
-            events=stream_events,
-            final_response=OpenAIResponse(output_text=final_text, usage=usage),
-        ),
+        stream_response=[
+            OpenAIResponseStream(
+                events=events,
+                final_response=OpenAIResponse(output_text=final_text, usage=usage),
+            )
+            for events in event_sequences
+        ],
         create_response=OpenAIResponse(output_text=final_text, usage=usage),
     )
     adapter.client = OpenAIClientStub(responses)  # type: ignore[assignment]
@@ -308,6 +357,7 @@ def build_anthropic_handler(
     usage: AnthropicUsage,
     reasoning_enabled: bool = False,
     interrupt_on_tool_call: bool = False,
+    stream_chunk_sequences: Iterable[Iterable[AnthropicStreamChunk]] | None = None,
 ) -> AnthropicAdapter:
     config = ModelConfig(
         model="claude-sonnet-4-6",
@@ -323,14 +373,29 @@ def build_anthropic_handler(
     adapter.model_config = config
     adapter.logger = logging.getLogger(__name__)
     adapter._last_usage = {}
+    adapter._last_error = None
+    adapter._last_finish_reason = FinishReason.UNKNOWN
+    adapter._last_reasoning = ""
+    adapter._last_tool_call = None
+    adapter._pending_tool_calls = []
+    adapter._tool_use_accs = {}
+    adapter._last_request_lifecycle = None
+    chunk_sequences = (
+        list(stream_chunk_sequences)
+        if stream_chunk_sequences is not None
+        else [stream_chunks]
+    )
     adapter.async_client = cast(
         Any,
         SimpleNamespace(
             messages=AnthropicMessagesStub(
-                stream_response=AnthropicStream(
-                    chunks=stream_chunks,
-                    final_message=AnthropicResponse(text=final_text, usage=usage),
-                ),
+                stream_response=[
+                    AnthropicStream(
+                        chunks=chunks,
+                        final_message=AnthropicResponse(text=final_text, usage=usage),
+                    )
+                    for chunks in chunk_sequences
+                ],
                 create_response=AnthropicResponse(text=final_text, usage=usage),
             )
         ),
@@ -351,8 +416,14 @@ def build_openrouter_handler(
     reasoning_enabled: bool = False,
     interrupt_on_tool_call: bool = False,
     model_id: str = "openai/gpt-4.1-mini",
+    stream_chunk_sequences: Iterable[Iterable[Any]] | None = None,
 ) -> OpenRouterGateway:
-    stream_response = OpenRouterStream(stream_chunks)
+    chunk_sequences = (
+        list(stream_chunk_sequences)
+        if stream_chunk_sequences is not None
+        else [stream_chunks]
+    )
+    stream_response = [OpenRouterStream(chunks) for chunks in chunk_sequences]
     create_response = SimpleNamespace(
         choices=[
             SimpleNamespace(

--- a/tests/llm/test_openai_oauth_subscription_flow.py
+++ b/tests/llm/test_openai_oauth_subscription_flow.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import json
-import os
 import logging
+import os
 from typing import Any
 
 import pytest
 
 from penguin.llm.adapters.openai import OpenAIAdapter
+from penguin.llm.contracts import (
+    ErrorCategory,
+    LLMProviderError,
+    ProviderRequestStatus,
+)
 from penguin.llm.model_config import ModelConfig
 from penguin.web.services.provider_auth import ProviderOAuthError
 
@@ -92,8 +97,9 @@ async def test_oauth_request_uses_stored_record_without_env_access(
     seen: dict[str, Any] = {}
 
     class _FakeAsyncClient:
-        def __init__(self, timeout: float) -> None:
+        def __init__(self, timeout: Any) -> None:
             self.timeout = timeout
+            seen["timeout"] = timeout
 
         async def __aenter__(self) -> _FakeAsyncClient:
             return self
@@ -167,8 +173,9 @@ async def test_oauth_request_routes_to_codex_with_required_headers(
     seen: dict[str, Any] = {}
 
     class _FakeAsyncClient:
-        def __init__(self, timeout: float) -> None:
+        def __init__(self, timeout: Any) -> None:
             self.timeout = timeout
+            seen["timeout"] = timeout
 
         async def __aenter__(self) -> _FakeAsyncClient:
             return self
@@ -225,6 +232,8 @@ async def test_oauth_request_routes_to_codex_with_required_headers(
     assert seen["headers"]["ChatGPT-Account-Id"] == "acct-1"
     assert seen["json"]["store"] is False
     assert seen["json"]["stream"] is True
+    assert getattr(seen["timeout"], "read", object()) is None
+    assert getattr(seen["timeout"], "connect", None) == 30.0
     assert "max_output_tokens" not in seen["json"]
     assert isinstance(seen["json"]["input"], list)
     assert all(item.get("role") != "system" for item in seen["json"]["input"])
@@ -1114,3 +1123,160 @@ async def test_oauth_codex_status_error_emits_diag_and_trace(
     assert "status=503" in message
     assert "service unavailable" in message
     assert "trace={'x-request-id': 'req_123', 'cf-ray': 'ray_456'}" in message
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.FAILED
+    assert lifecycle.error is not None
+    assert lifecycle.error.category == ErrorCategory.PROVIDER_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_incomplete_empty_stream_records_disconnected_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_OAUTH_ACCESS_TOKEN", "oauth-access")
+    monkeypatch.setattr("penguin.llm.adapters.openai.AsyncOpenAI", _SDKClient)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda provider_id: {
+            "type": "oauth",
+            "access": "oauth-access",
+            "refresh": "oauth-refresh",
+            "expires": 9_999_999_999_000,
+            "accountId": "acct-1",
+        }
+        if provider_id == "openai"
+        else None,
+    )
+
+    class _FakeAsyncClient:
+        def __init__(self, timeout: Any) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+            del exc_type, exc, tb
+            return False
+
+        def stream(self, method: str, url: str, headers=None, json=None):  # type: ignore[no-untyped-def]
+            del method, url, headers, json
+            return _FakeStreamContext(
+                _FakeResponse(
+                    200,
+                    lines=["data: [DONE]"],
+                )
+            )
+
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient", _FakeAsyncClient
+    )
+
+    model_config = ModelConfig(
+        model="gpt-5.2",
+        provider="openai",
+        client_preference="native",
+        api_key="sk-test",
+        streaming_enabled=False,
+    )
+    adapter = OpenAIAdapter(model_config)
+
+    with pytest.raises(LLMProviderError) as exc:
+        await adapter.get_response(
+            [{"role": "user", "content": "hello"}],
+            stream=False,
+        )
+
+    assert "stream_incomplete" in str(exc.value)
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.DISCONNECTED
+    assert lifecycle.stream is True
+    assert lifecycle.transport == "sse"
+    assert lifecycle.last_event_type == "stream_incomplete"
+    assert lifecycle.request_payload_hash
+    assert lifecycle.error is not None
+    assert lifecycle.error.category == ErrorCategory.NETWORK
+    assert lifecycle.error.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_incomplete_stream_does_not_lock_next_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_OAUTH_ACCESS_TOKEN", "oauth-access")
+    monkeypatch.setattr("penguin.llm.adapters.openai.AsyncOpenAI", _SDKClient)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda provider_id: {
+            "type": "oauth",
+            "access": "oauth-access",
+            "refresh": "oauth-refresh",
+            "expires": 9_999_999_999_000,
+            "accountId": "acct-1",
+        }
+        if provider_id == "openai"
+        else None,
+    )
+
+    responses = [
+        _FakeResponse(200, lines=["data: [DONE]"]),
+        _FakeResponse(
+            200,
+            lines=[
+                'data: {"type":"response.output_text.delta","delta":"recovered"}',
+                (
+                    'data: {"type":"response.completed","response":'
+                    '{"id":"resp_recovered","usage":{"input_tokens":1,'
+                    '"output_tokens":1,"total_tokens":2}}}'
+                ),
+                "data: [DONE]",
+            ],
+        ),
+    ]
+
+    class _FakeAsyncClient:
+        def __init__(self, timeout: Any) -> None:
+            self.timeout = timeout
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+            del exc_type, exc, tb
+            return False
+
+        def stream(self, method: str, url: str, headers=None, json=None):  # type: ignore[no-untyped-def]
+            del method, url, headers, json
+            return _FakeStreamContext(responses.pop(0))
+
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient", _FakeAsyncClient
+    )
+
+    model_config = ModelConfig(
+        model="gpt-5.2",
+        provider="openai",
+        client_preference="native",
+        api_key="sk-test",
+        streaming_enabled=False,
+    )
+    adapter = OpenAIAdapter(model_config)
+
+    with pytest.raises(LLMProviderError):
+        await adapter.get_response(
+            [{"role": "user", "content": "first"}],
+            stream=False,
+        )
+
+    result = await adapter.get_response(
+        [{"role": "user", "content": "second"}],
+        stream=False,
+    )
+
+    assert result == "recovered"
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.COMPLETED
+    assert lifecycle.provider_response_id == "resp_recovered"

--- a/tests/llm/test_openai_oauth_subscription_flow.py
+++ b/tests/llm/test_openai_oauth_subscription_flow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
@@ -16,59 +15,19 @@ from penguin.llm.contracts import (
 from penguin.llm.model_config import ModelConfig
 from penguin.web.services.provider_auth import ProviderOAuthError
 
-
-class _SDKClient:
-    def __init__(
-        self,
-        *,
-        api_key: str,
-        base_url: str | None = None,
-        default_headers: dict[str, str] | None = None,
-    ) -> None:
-        self.api_key = api_key
-        self.base_url = base_url
-        self.default_headers = default_headers
-
-
-class _FakeResponse:
-    def __init__(
-        self,
-        status_code: int,
-        payload: dict[str, Any] | None = None,
-        *,
-        headers: dict[str, str] | None = None,
-        lines: list[str] | None = None,
-    ) -> None:
-        self.status_code = status_code
-        self._payload = payload if payload is not None else {}
-        self.headers = dict(headers or {})
-        self._lines = list(lines or [])
-        self.content = (
-            json.dumps(self._payload).encode("utf-8") if payload is not None else b""
-        )
-        self.text = json.dumps(self._payload)
-
-    def json(self) -> dict[str, Any]:
-        return dict(self._payload)
-
-    async def aread(self) -> bytes:
-        return self.content
-
-    async def aiter_lines(self):
-        for line in self._lines:
-            yield line
-
-
-class _FakeStreamContext:
-    def __init__(self, response: _FakeResponse) -> None:
-        self._response = response
-
-    async def __aenter__(self) -> _FakeResponse:
-        return self._response
-
-    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
-        del exc_type, exc, tb
-        return False
+from .codex_oauth_fixtures import (
+    FakeCodexTransport as _FakeCodexTransport,
+    FakeResponse as _FakeResponse,
+    FakeStreamContext as _FakeStreamContext,
+    SDKClient as _SDKClient,
+    codex_adapter as _codex_adapter,
+    codex_completed as _codex_completed,
+    codex_completed_text as _codex_completed_text,
+    codex_function_call_lines as _codex_function_call_lines,
+    codex_sse as _codex_sse,
+    codex_text_delta as _codex_text_delta,
+    install_oauth_codex_test_auth as _install_oauth_codex_test_auth,
+)
 
 
 @pytest.mark.asyncio
@@ -114,10 +73,7 @@ async def test_oauth_request_uses_stored_record_without_env_access(
             seen["account"] = dict(headers or {}).get("ChatGPT-Account-Id")
             response = _FakeResponse(
                 200,
-                lines=[
-                    'data: {"type":"response.output_text.delta","delta":"stored-oauth-answer"}',
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("stored-oauth-answer"),
             )
             return _FakeStreamContext(response)
 
@@ -191,13 +147,7 @@ async def test_oauth_request_routes_to_codex_with_required_headers(
             seen["json"] = dict(json or {})
             response = _FakeResponse(
                 200,
-                lines=[
-                    (
-                        'data: {"type":"response.output_text.delta",'
-                        '"delta":"codex-answer"}'
-                    ),
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("codex-answer"),
             )
             return _FakeStreamContext(response)
 
@@ -294,10 +244,7 @@ async def test_oauth_request_preserves_requested_model_id(
             seen["model"] = (json or {}).get("model")
             response = _FakeResponse(
                 200,
-                lines=[
-                    'data: {"type":"response.output_text.delta","delta":"ok"}',
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("ok"),
             )
             return _FakeStreamContext(response)
 
@@ -360,10 +307,7 @@ async def test_oauth_request_normalizes_responses_function_tools(
             seen["json"] = dict(json or {})
             response = _FakeResponse(
                 200,
-                lines=[
-                    'data: {"type":"response.output_text.delta","delta":"ok"}',
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("ok"),
             )
             return _FakeStreamContext(response)
 
@@ -541,10 +485,7 @@ async def test_oauth_request_includes_reasoning_summary_auto_and_encrypted_conte
             seen["json"] = dict(json or {})
             response = _FakeResponse(
                 200,
-                lines=[
-                    'data: {"type":"response.output_text.delta","delta":"ok"}',
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("ok"),
             )
             return _FakeStreamContext(response)
 
@@ -909,6 +850,241 @@ def test_codex_input_items_drop_duplicate_function_call_ids() -> None:
     } in items
 
 
+def test_codex_input_items_preserve_only_complete_tool_pairs_after_cwm_trimming() -> (
+    None
+):
+    model_config = ModelConfig(
+        model="gpt-5.4",
+        provider="openai",
+        client_preference="native",
+        api_key="sk-test",
+    )
+    adapter = OpenAIAdapter(model_config)
+
+    items = adapter._build_codex_input_items(
+        [
+            {
+                "role": "assistant",
+                "content": "This call lost its SYSTEM_OUTPUT result during trimming.",
+                "tool_calls": [
+                    {
+                        "id": "call_trimmed_output",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"README.md"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_trimmed_call",
+                "content": "tool output without enough metadata to replay",
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_keep",
+                        "type": "function",
+                        "function": {
+                            "name": "list_directory",
+                            "arguments": '{"path":"."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_keep",
+                "name": "list_directory",
+                "tool_arguments": '{"path":"."}',
+                "content": "README.md\npenguin\n",
+            },
+        ]
+    )
+
+    function_items = [
+        item
+        for item in items
+        if item.get("type") in {"function_call", "function_call_output"}
+    ]
+
+    assert function_items == [
+        {
+            "type": "function_call",
+            "call_id": "call_keep",
+            "name": "list_directory",
+            "arguments": '{"path":"."}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_keep",
+            "output": "README.md\npenguin",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_request_drops_tool_call_when_cwm_trims_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [_FakeResponse(200, lines=_codex_completed_text("ok"))]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    result = await adapter.get_response(
+        [
+            {"role": "user", "content": "continue"},
+            {
+                "role": "assistant",
+                "content": "I'll inspect the file.",
+                "tool_calls": [
+                    {
+                        "id": "call_without_output",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"README.md"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "try again from here"},
+        ],
+        stream=False,
+    )
+
+    assert result == "ok"
+    sent_items = transport.requests[0]["json"]["input"]
+    assert all(item.get("call_id") != "call_without_output" for item in sent_items)
+    assert not any(item.get("type") == "function_call" for item in sent_items)
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_request_replays_completed_tool_pair_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [_FakeResponse(200, lines=_codex_completed_text("ok"))]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    result = await adapter.get_response(
+        [
+            {"role": "user", "content": "list the workspace"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_complete",
+                        "type": "function",
+                        "function": {
+                            "name": "list_directory",
+                            "arguments": '{"path":"."}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_complete",
+                "name": "list_directory",
+                "tool_arguments": '{"path":"."}',
+                "content": "README.md\npenguin\n",
+            },
+            {"role": "user", "content": "summarize the result"},
+        ],
+        stream=False,
+    )
+
+    assert result == "ok"
+    sent_items = transport.requests[0]["json"]["input"]
+    function_items = [
+        item
+        for item in sent_items
+        if item.get("type") in {"function_call", "function_call_output"}
+    ]
+    assert function_items == [
+        {
+            "type": "function_call",
+            "call_id": "call_complete",
+            "name": "list_directory",
+            "arguments": '{"path":"."}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_complete",
+            "output": "README.md\npenguin",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_request_synthesizes_call_when_only_tool_result_survives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [_FakeResponse(200, lines=_codex_completed_text("ok"))]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    result = await adapter.get_response(
+        [
+            {"role": "user", "content": "continue"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_result_only",
+                "name": "code_execution",
+                "tool_arguments": '{"code":"print(7)"}',
+                "content": "7\nRESULT=7",
+            },
+            {"role": "user", "content": "use that result"},
+        ],
+        stream=False,
+    )
+
+    assert result == "ok"
+    sent_items = transport.requests[0]["json"]["input"]
+    function_items = [
+        item
+        for item in sent_items
+        if item.get("type") in {"function_call", "function_call_output"}
+    ]
+    assert function_items == [
+        {
+            "type": "function_call",
+            "call_id": "call_result_only",
+            "name": "code_execution",
+            "arguments": '{"code":"print(7)"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_result_only",
+            "output": "7\nRESULT=7",
+        },
+    ]
+
+
 @pytest.mark.asyncio
 async def test_oauth_request_refreshes_before_codex_call(
     monkeypatch: pytest.MonkeyPatch,
@@ -966,10 +1142,7 @@ async def test_oauth_request_refreshes_before_codex_call(
             seen["stream"] = bool((json or {}).get("stream"))
             response = _FakeResponse(
                 200,
-                lines=[
-                    'data: {"type":"response.output_text.delta","delta":"refreshed"}',
-                    "data: [DONE]",
-                ],
+                lines=_codex_completed_text("refreshed"),
             )
             return _FakeStreamContext(response)
 
@@ -1134,53 +1307,20 @@ async def test_oauth_codex_status_error_emits_diag_and_trace(
 async def test_oauth_codex_incomplete_empty_stream_records_disconnected_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("OPENAI_OAUTH_ACCESS_TOKEN", "oauth-access")
-    monkeypatch.setattr("penguin.llm.adapters.openai.AsyncOpenAI", _SDKClient)
-    monkeypatch.setattr(
-        "penguin.llm.adapters.openai.get_provider_credential",
-        lambda provider_id: {
-            "type": "oauth",
-            "access": "oauth-access",
-            "refresh": "oauth-refresh",
-            "expires": 9_999_999_999_000,
-            "accountId": "acct-1",
-        }
-        if provider_id == "openai"
-        else None,
-    )
-
-    class _FakeAsyncClient:
-        def __init__(self, timeout: Any) -> None:
-            self.timeout = timeout
-
-        async def __aenter__(self) -> _FakeAsyncClient:
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
-            del exc_type, exc, tb
-            return False
-
-        def stream(self, method: str, url: str, headers=None, json=None):  # type: ignore[no-untyped-def]
-            del method, url, headers, json
-            return _FakeStreamContext(
-                _FakeResponse(
-                    200,
-                    lines=["data: [DONE]"],
-                )
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [
+            _FakeResponse(
+                200,
+                lines=["data: [DONE]"],
             )
-
+        ]
+    )
     monkeypatch.setattr(
-        "penguin.llm.adapters.openai.httpx.AsyncClient", _FakeAsyncClient
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
     )
-
-    model_config = ModelConfig(
-        model="gpt-5.2",
-        provider="openai",
-        client_preference="native",
-        api_key="sk-test",
-        streaming_enabled=False,
-    )
-    adapter = OpenAIAdapter(model_config)
+    adapter = _codex_adapter()
 
     with pytest.raises(LLMProviderError) as exc:
         await adapter.get_response(
@@ -1199,6 +1339,169 @@ async def test_oauth_codex_incomplete_empty_stream_records_disconnected_lifecycl
     assert lifecycle.error is not None
     assert lifecycle.error.category == ErrorCategory.NETWORK
     assert lifecycle.error.retryable is True
+    assert transport.requests[0]["json"]["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_partial_text_without_completed_is_disconnected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [
+            _FakeResponse(
+                200,
+                lines=[
+                    _codex_text_delta("partial"),
+                    "data: [DONE]",
+                ],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    with pytest.raises(LLMProviderError) as exc:
+        await adapter.get_response(
+            [{"role": "user", "content": "hello"}],
+            stream=False,
+        )
+
+    assert "output_state=text" in str(exc.value)
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.DISCONNECTED
+    assert lifecycle.last_event_type == "stream_incomplete"
+    assert lifecycle.error is not None
+    assert lifecycle.error.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_partial_tool_call_without_completed_is_not_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [
+            _FakeResponse(
+                200,
+                lines=[
+                    *_codex_function_call_lines(),
+                    "data: [DONE]",
+                ],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    with pytest.raises(LLMProviderError) as exc:
+        await adapter.get_response(
+            [{"role": "user", "content": "read README"}],
+            stream=False,
+        )
+
+    assert "output_state=tool_call" in str(exc.value)
+    assert adapter.has_pending_tool_call() is False
+    assert adapter.get_and_clear_pending_tool_calls() == []
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.DISCONNECTED
+    assert lifecycle.last_event_type == "stream_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_completed_tool_call_remains_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [
+            _FakeResponse(
+                200,
+                lines=[
+                    *_codex_function_call_lines(call_id="call_done"),
+                    _codex_completed("resp_tool"),
+                    "data: [DONE]",
+                ],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    result = await adapter.get_response(
+        [{"role": "user", "content": "read README"}],
+        stream=False,
+    )
+
+    assert result == ""
+    assert adapter.has_pending_tool_call() is True
+    pending = adapter.get_and_clear_pending_tool_calls()
+    assert pending == [
+        {
+            "item_id": "item_1",
+            "call_id": "call_done",
+            "name": "read_file",
+            "arguments": '{"path":"README.md"}',
+        }
+    ]
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.COMPLETED
+    assert lifecycle.provider_response_id == "resp_tool"
+
+
+@pytest.mark.asyncio
+async def test_oauth_codex_stream_event_error_records_failed_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_oauth_codex_test_auth(monkeypatch)
+    transport = _FakeCodexTransport(
+        [
+            _FakeResponse(
+                200,
+                lines=[
+                    _codex_sse(
+                        {
+                            "type": "error",
+                            "error": {
+                                "type": "server_error",
+                                "message": "synthetic stream error",
+                            },
+                        }
+                    )
+                ],
+            )
+        ]
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.httpx.AsyncClient",
+        transport.async_client_class(),
+    )
+    adapter = _codex_adapter()
+
+    with pytest.raises(LLMProviderError) as exc:
+        await adapter.get_response(
+            [{"role": "user", "content": "hello"}],
+            stream=False,
+        )
+
+    assert "stream_event_error" in str(exc.value)
+    assert "synthetic stream error" in str(exc.value)
+    lifecycle = adapter.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.FAILED
+    assert lifecycle.last_event_type == "stream_event_error"
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_openrouter_tool_continuity.py
+++ b/tests/llm/test_openrouter_tool_continuity.py
@@ -34,15 +34,28 @@ def test_clean_conversation_preserves_valid_assistant_tool_calls() -> None:
                     },
                 }
             ],
-        }
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_patch_123",
+            "content": '{"ok":true}',
+            "name": "patch_files",
+        },
     ]
 
     cleaned = gateway._clean_conversation_format(messages)
 
-    assert cleaned == messages
+    assert cleaned == [
+        messages[0],
+        {
+            "role": "tool",
+            "tool_call_id": "call_patch_123",
+            "content": '{"ok":true}',
+        },
+    ]
 
 
-def test_clean_conversation_preserves_valid_tool_result_messages() -> None:
+def test_clean_conversation_synthesizes_call_for_orphaned_tool_result() -> None:
     gateway = _gateway()
 
     messages = [
@@ -52,6 +65,7 @@ def test_clean_conversation_preserves_valid_tool_result_messages() -> None:
             "content": '{"error":"permission_denied"}',
             "name": "patch_files",
             "tool_arguments": '{"path":"a.ts"}',
+            "status": "failed",
         }
     ]
 
@@ -59,10 +73,101 @@ def test_clean_conversation_preserves_valid_tool_result_messages() -> None:
 
     assert cleaned == [
         {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_patch_123",
+                    "type": "function",
+                    "function": {
+                        "name": "patch_files",
+                        "arguments": '{"path":"a.ts"}',
+                    },
+                }
+            ],
+        },
+        {
             "role": "tool",
             "tool_call_id": "call_patch_123",
             "content": '{"error":"permission_denied"}',
         }
+    ]
+
+
+def test_clean_conversation_flattens_orphaned_assistant_tool_calls() -> None:
+    gateway = _gateway()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Trying individual patch operations instead.",
+            "tool_calls": [
+                {
+                    "id": "call_patch_123",
+                    "type": "function",
+                    "function": {
+                        "name": "patch_files",
+                        "arguments": '{"path":"a.ts","patch":"..."}',
+                    },
+                }
+            ],
+        }
+    ]
+
+    cleaned = gateway._clean_conversation_format(messages)
+
+    assert cleaned == [
+        {
+            "role": "assistant",
+            "content": "Trying individual patch operations instead.",
+        }
+    ]
+
+
+def test_clean_conversation_flattens_duplicate_assistant_tool_call_ids() -> None:
+    gateway = _gateway()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Running two operations.",
+            "tool_calls": [
+                {
+                    "id": "call_dup",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"README.md"}',
+                    },
+                },
+                {
+                    "id": "call_dup",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"architecture.md"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_dup",
+            "content": "# README",
+        },
+    ]
+
+    cleaned = gateway._clean_conversation_format(messages)
+
+    assert cleaned == [
+        {
+            "role": "assistant",
+            "content": "Running two operations.",
+        },
+        {
+            "role": "user",
+            "content": "# README",
+        },
     ]
 
 

--- a/tests/llm/test_prepared_request_contract.py
+++ b/tests/llm/test_prepared_request_contract.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from penguin.llm.api_client import APIClient
+from penguin.llm.contracts import (
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
+    stable_payload_hash,
+)
+
+from .provider_contract_fixtures import (
+    ANTHROPIC_USAGE,
+    OPENAI_USAGE,
+    OPENROUTER_USAGE,
+    build_anthropic_handler,
+    build_openai_handler,
+    build_openrouter_handler,
+)
+
+
+def _messages() -> list[dict[str, object]]:
+    return [
+        {"role": "system", "content": "System rules."},
+        {"role": "user", "content": "Hello"},
+    ]
+
+
+def _tool_schema() -> list[dict[str, object]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+        }
+    ]
+
+
+def test_stable_payload_hash_is_deterministic() -> None:
+    first = {"b": [2, 1], "a": {"nested": True}}
+    second = {"a": {"nested": True}, "b": [2, 1]}
+
+    assert stable_payload_hash(first) == stable_payload_hash(second)
+
+
+def test_prepared_request_serializes_capabilities() -> None:
+    prepared = LLMPreparedRequest(
+        provider="fixture",
+        model="model-a",
+        protocol="fixture_protocol",
+        route="fixture.route",
+        body={"model": "model-a", "input": "hello"},
+        capabilities=LLMProviderCapabilities(
+            provider="fixture",
+            model="model-a",
+            native_tools=True,
+        ),
+    )
+
+    payload = prepared.to_dict()
+
+    assert payload["request_payload_hash"] == stable_payload_hash(prepared.body)
+    assert payload["capabilities"]["native_tools"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_id", ["openai", "openai_compatible"])
+async def test_openai_family_prepares_responses_request(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_id: str,
+) -> None:
+    monkeypatch.delenv("OPENAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda _provider_id: None,
+    )
+    handler = build_openai_handler(
+        provider=provider_id,
+        stream_events=[],
+        final_text="answer",
+        usage=OPENAI_USAGE,
+    )
+
+    prepared = await handler.prepare_request(
+        _messages(),
+        max_output_tokens=123,
+        stream=True,
+        tools=_tool_schema(),
+        tool_choice="auto",
+    )
+
+    assert prepared.provider == provider_id
+    assert prepared.protocol == "openai_responses"
+    assert prepared.route == "openai.responses"
+    assert prepared.transport == "sdk_stream"
+    assert prepared.body["model"] == "gpt-5.4"
+    assert "input" in prepared.body
+    assert prepared.body["max_output_tokens"] == 123
+    assert prepared.body["tools"][0]["type"] == "function"
+    assert prepared.body["tool_choice"] == "auto"
+    assert prepared.capabilities is not None
+    assert prepared.capabilities.native_tools is True
+
+
+@pytest.mark.asyncio
+async def test_openai_prepare_codex_oauth_route_does_not_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fail_refresh(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise AssertionError("prepare_request must not refresh OAuth credentials")
+
+    monkeypatch.delenv("OPENAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda _provider_id: {
+            "type": "oauth",
+            "access": "oauth-access",
+            "refresh": "oauth-refresh",
+            "expires": 0,
+        },
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.refresh_provider_oauth",
+        _fail_refresh,
+    )
+    handler = build_openai_handler(
+        provider="openai",
+        stream_events=[],
+        final_text="answer",
+        usage=OPENAI_USAGE,
+    )
+
+    prepared = await handler.prepare_request(_messages(), stream=False)
+
+    assert prepared.route == "openai.codex_oauth.responses"
+    assert prepared.transport == "http_sse"
+    assert prepared.body["store"] is False
+    assert "Authorization" not in prepared.headers
+
+
+@pytest.mark.asyncio
+async def test_anthropic_prepares_messages_request() -> None:
+    handler = build_anthropic_handler(
+        stream_chunks=[],
+        final_text="answer",
+        usage=ANTHROPIC_USAGE,
+    )
+    tools = [
+        {
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        }
+    ]
+
+    prepared = await handler.prepare_request(
+        _messages(),
+        max_output_tokens=321,
+        temperature=0.2,
+        stream=True,
+        tools=tools,
+    )
+
+    assert prepared.provider == "anthropic"
+    assert prepared.protocol == "anthropic_messages"
+    assert prepared.route == "anthropic.messages"
+    assert prepared.transport == "sdk_stream"
+    assert prepared.body["system"] == "System rules."
+    assert prepared.body["max_tokens"] == 321
+    assert prepared.body["temperature"] == 0.2
+    assert prepared.body["messages"][0]["role"] == "user"
+    assert prepared.body["tools"] == tools
+    assert prepared.capabilities is not None
+    assert prepared.capabilities.native_tools is True
+
+
+@pytest.mark.asyncio
+async def test_openrouter_prepares_chat_completions_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = build_openrouter_handler(
+        monkeypatch,
+        stream_chunks=[],
+        final_text="answer",
+        usage=OPENROUTER_USAGE,
+    )
+    handler.extra_headers["X-Test"] = "prepared"
+
+    prepared = await handler.prepare_request(
+        _messages(),
+        max_output_tokens=456,
+        temperature=0.3,
+        stream=True,
+        tools=_tool_schema(),
+    )
+
+    assert prepared.provider == "openrouter"
+    assert prepared.protocol == "openai_chat_completions"
+    assert prepared.route == "openrouter.chat_completions"
+    assert prepared.transport == "sdk_stream"
+    assert prepared.headers["X-Test"] == "prepared"
+    assert prepared.body["model"] == "openai/gpt-4.1-mini"
+    assert prepared.body["max_tokens"] == 456
+    assert prepared.body["temperature"] == 0.3
+    assert prepared.body["stream"] is True
+    assert prepared.body["stream_options"] == {"include_usage": True}
+    assert "extra_headers" not in prepared.body
+    assert prepared.body["tools"][0]["type"] == "function"
+
+
+@pytest.mark.asyncio
+async def test_api_client_delegates_prepared_request_to_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda _provider_id: None,
+    )
+    handler = build_openai_handler(
+        provider="openai",
+        stream_events=[],
+        final_text="answer",
+        usage=OPENAI_USAGE,
+    )
+    client = APIClient.__new__(APIClient)
+    client.model_config = handler.model_config
+    client.system_prompt = "Injected system prompt."
+    client.client_handler = handler
+    client.logger = logging.getLogger(__name__)
+
+    prepared = await client.prepare_request(
+        [{"role": "user", "content": "Hello"}],
+        max_output_tokens=111,
+        stream=False,
+    )
+
+    assert prepared.protocol == "openai_responses"
+    assert "Injected system prompt." in str(prepared.body["input"])
+    assert prepared.body["max_output_tokens"] == 111

--- a/tests/llm/test_provider_contract_matrix.py
+++ b/tests/llm/test_provider_contract_matrix.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
 
-from penguin.llm.contracts import FinishReason
+from penguin.llm.contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMProviderError,
+    ProviderRequestStatus,
+)
 
 from .provider_contract_fixtures import (
     ANTHROPIC_USAGE,
@@ -46,7 +52,8 @@ def _build_handler(
         )
         if scenario == "nonstream":
             events = [
-                OpenAIStreamEvent(type="response.output_text.delta", delta="answer")
+                OpenAIStreamEvent(type="response.output_text.delta", delta="answer"),
+                OpenAIStreamEvent(type="response.completed"),
             ]
             return build_openai_handler(
                 provider=provider_id,
@@ -56,12 +63,34 @@ def _build_handler(
             )
         if scenario == "stream_text":
             events = [
-                OpenAIStreamEvent(type="response.output_text.delta", delta="answer")
+                OpenAIStreamEvent(type="response.created"),
+                OpenAIStreamEvent(type="response.output_text.delta", delta="answer"),
+                OpenAIStreamEvent(type="response.completed"),
             ]
             return build_openai_handler(
                 provider=provider_id,
                 stream_events=events,
                 final_text="answer",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "cancelled_stream":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[asyncio.CancelledError()],
+                final_text="",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "multi_delta":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[
+                    OpenAIStreamEvent(
+                        type="response.output_text.delta", delta="hello "
+                    ),
+                    OpenAIStreamEvent(type="response.output_text.delta", delta="world"),
+                    OpenAIStreamEvent(type="response.completed"),
+                ],
+                final_text="hello world",
                 usage=OPENAI_USAGE,
             )
         if scenario == "reasoning":
@@ -71,6 +100,7 @@ def _build_handler(
                     delta="thinking...",
                 ),
                 OpenAIStreamEvent(type="response.output_text.delta", delta="answer"),
+                OpenAIStreamEvent(type="response.completed"),
             ]
             return build_openai_handler(
                 provider=provider_id,
@@ -107,11 +137,129 @@ def _build_handler(
                         "status": "completed",
                     },
                 ),
+                OpenAIStreamEvent(type="response.completed"),
             ]
             return build_openai_handler(
                 provider=provider_id,
                 stream_events=events,
                 final_text="",
+                usage=OPENAI_USAGE,
+                interrupt_on_tool_call=True,
+            )
+        if scenario == "stream_error":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[
+                    OpenAIStreamEvent(
+                        type="error",
+                        error={
+                            "code": "server_error",
+                            "message": "synthetic OpenAI stream error",
+                        },
+                    )
+                ],
+                final_text="",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "incomplete_empty":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[],
+                final_text="",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "incomplete_partial_text":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[
+                    OpenAIStreamEvent(
+                        type="response.output_text.delta",
+                        delta="partial",
+                    )
+                ],
+                final_text="partial",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "incomplete_partial_tool":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[
+                    OpenAIStreamEvent(
+                        type="response.output_item.added",
+                        item={
+                            "type": "function_call",
+                            "id": "item_1",
+                            "call_id": "call_incomplete",
+                            "name": "read_file",
+                            "arguments": "",
+                        },
+                    ),
+                    OpenAIStreamEvent(
+                        type="response.function_call_arguments.delta",
+                        item_id="item_1",
+                        delta='{"path":"README.md"}',
+                    ),
+                ],
+                final_text="",
+                usage=OPENAI_USAGE,
+                interrupt_on_tool_call=True,
+            )
+        if scenario == "stream_error_then_success":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[],
+                stream_event_sequences=[
+                    [
+                        OpenAIStreamEvent(
+                            type="error",
+                            error={
+                                "code": "server_error",
+                                "message": "synthetic OpenAI stream error",
+                            },
+                        )
+                    ],
+                    [
+                        OpenAIStreamEvent(
+                            type="response.output_text.delta",
+                            delta="recovered",
+                        ),
+                        OpenAIStreamEvent(type="response.completed"),
+                    ],
+                ],
+                final_text="recovered",
+                usage=OPENAI_USAGE,
+            )
+        if scenario == "incomplete_partial_tool_then_success":
+            return build_openai_handler(
+                provider=provider_id,
+                stream_events=[],
+                stream_event_sequences=[
+                    [
+                        OpenAIStreamEvent(
+                            type="response.output_item.added",
+                            item={
+                                "type": "function_call",
+                                "id": "item_1",
+                                "call_id": "call_incomplete",
+                                "name": "read_file",
+                                "arguments": "",
+                            },
+                        ),
+                        OpenAIStreamEvent(
+                            type="response.function_call_arguments.delta",
+                            item_id="item_1",
+                            delta='{"path":"README.md"}',
+                        ),
+                    ],
+                    [
+                        OpenAIStreamEvent(
+                            type="response.output_text.delta",
+                            delta="recovered",
+                        ),
+                        OpenAIStreamEvent(type="response.completed"),
+                    ],
+                ],
+                final_text="recovered",
                 usage=OPENAI_USAGE,
                 interrupt_on_tool_call=True,
             )
@@ -126,6 +274,7 @@ def _build_handler(
         if scenario == "stream_text":
             return build_anthropic_handler(
                 stream_chunks=[
+                    AnthropicStreamChunk("message_start"),
                     AnthropicStreamChunk(
                         "content_block_delta",
                         AnthropicStreamDelta("text_delta", text="answer"),
@@ -133,6 +282,28 @@ def _build_handler(
                     AnthropicStreamChunk("message_stop"),
                 ],
                 final_text="answer",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "cancelled_stream":
+            return build_anthropic_handler(
+                stream_chunks=[asyncio.CancelledError()],
+                final_text="",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "multi_delta":
+            return build_anthropic_handler(
+                stream_chunks=[
+                    AnthropicStreamChunk(
+                        "content_block_delta",
+                        AnthropicStreamDelta("text_delta", text="hello "),
+                    ),
+                    AnthropicStreamChunk(
+                        "content_block_delta",
+                        AnthropicStreamDelta("text_delta", text="world"),
+                    ),
+                    AnthropicStreamChunk("message_stop"),
+                ],
+                final_text="hello world",
                 usage=ANTHROPIC_USAGE,
             )
         if scenario == "reasoning":
@@ -177,6 +348,113 @@ def _build_handler(
                 usage=ANTHROPIC_USAGE,
                 interrupt_on_tool_call=True,
             )
+        if scenario == "stream_error":
+            return build_anthropic_handler(
+                stream_chunks=[
+                    AnthropicStreamChunk(
+                        "error",
+                        error={
+                            "type": "overloaded_error",
+                            "message": "synthetic Anthropic stream error",
+                        },
+                    )
+                ],
+                final_text="",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "incomplete_empty":
+            return build_anthropic_handler(
+                stream_chunks=[],
+                final_text="",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "incomplete_partial_text":
+            return build_anthropic_handler(
+                stream_chunks=[
+                    AnthropicStreamChunk(
+                        "content_block_delta",
+                        AnthropicStreamDelta("text_delta", text="partial"),
+                    ),
+                ],
+                final_text="partial",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "incomplete_partial_tool":
+            return build_anthropic_handler(
+                stream_chunks=[
+                    AnthropicStreamChunk(
+                        "content_block_start",
+                        content_block=type(
+                            "ToolUseBlock",
+                            (),
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_incomplete",
+                                "name": "read_file",
+                                "input": {"path": "README.md"},
+                            },
+                        )(),
+                    ),
+                ],
+                final_text="",
+                usage=ANTHROPIC_USAGE,
+                interrupt_on_tool_call=True,
+            )
+        if scenario == "stream_error_then_success":
+            return build_anthropic_handler(
+                stream_chunks=[],
+                stream_chunk_sequences=[
+                    [
+                        AnthropicStreamChunk(
+                            "error",
+                            error={
+                                "type": "overloaded_error",
+                                "message": "synthetic Anthropic stream error",
+                            },
+                        )
+                    ],
+                    [
+                        AnthropicStreamChunk(
+                            "content_block_delta",
+                            AnthropicStreamDelta("text_delta", text="recovered"),
+                        ),
+                        AnthropicStreamChunk("message_stop"),
+                    ],
+                ],
+                final_text="recovered",
+                usage=ANTHROPIC_USAGE,
+            )
+        if scenario == "incomplete_partial_tool_then_success":
+            return build_anthropic_handler(
+                stream_chunks=[],
+                stream_chunk_sequences=[
+                    [
+                        AnthropicStreamChunk(
+                            "content_block_start",
+                            content_block=type(
+                                "ToolUseBlock",
+                                (),
+                                {
+                                    "type": "tool_use",
+                                    "id": "toolu_incomplete",
+                                    "name": "read_file",
+                                    "input": {"path": "README.md"},
+                                },
+                            )(),
+                        ),
+                    ],
+                    [
+                        AnthropicStreamChunk(
+                            "content_block_delta",
+                            AnthropicStreamDelta("text_delta", text="recovered"),
+                        ),
+                        AnthropicStreamChunk("message_stop"),
+                    ],
+                ],
+                final_text="recovered",
+                usage=ANTHROPIC_USAGE,
+                interrupt_on_tool_call=True,
+            )
 
     if provider_id == "openrouter":
         if scenario == "nonstream":
@@ -192,12 +470,42 @@ def _build_handler(
                 stream_chunks=[
                     make_openrouter_chunk(
                         model="openai/gpt-4.1-mini",
+                        content="",
+                    ),
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
                         content="answer",
                         finish_reason="stop",
                         usage=OPENROUTER_USAGE,
                     )
                 ],
                 final_text="answer",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "cancelled_stream":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[asyncio.CancelledError()],
+                final_text="",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "multi_delta":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
+                        content="hello ",
+                        usage=OPENROUTER_USAGE,
+                    ),
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
+                        content="world",
+                        finish_reason="stop",
+                        usage=OPENROUTER_USAGE,
+                    ),
+                ],
+                final_text="hello world",
                 usage=OPENROUTER_USAGE,
             )
         if scenario == "reasoning":
@@ -237,10 +545,135 @@ def _build_handler(
                                 },
                             }
                         ],
+                        finish_reason="tool_calls",
                         usage=OPENROUTER_USAGE,
                     )
                 ],
                 final_text="",
+                usage=OPENROUTER_USAGE,
+                interrupt_on_tool_call=True,
+            )
+        if scenario == "stream_error":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
+                        finish_reason="error",
+                        error={
+                            "code": "server_error",
+                            "message": "synthetic OpenRouter stream error",
+                            "metadata": {"provider_name": "fixture-provider"},
+                        },
+                    )
+                ],
+                final_text="",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "incomplete_empty":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[],
+                final_text="",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "incomplete_partial_text":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
+                        content="partial",
+                        usage=OPENROUTER_USAGE,
+                    )
+                ],
+                final_text="partial",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "incomplete_partial_tool":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[
+                    make_openrouter_chunk(
+                        model="openai/gpt-4.1-mini",
+                        tool_calls=[
+                            {
+                                "index": 0,
+                                "id": "call_incomplete",
+                                "type": "function",
+                                "function": {
+                                    "name": "read_file",
+                                    "arguments": '{"path":"README.md"}',
+                                },
+                            }
+                        ],
+                        usage=OPENROUTER_USAGE,
+                    )
+                ],
+                final_text="",
+                usage=OPENROUTER_USAGE,
+                interrupt_on_tool_call=True,
+            )
+        if scenario == "stream_error_then_success":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[],
+                stream_chunk_sequences=[
+                    [
+                        make_openrouter_chunk(
+                            model="openai/gpt-4.1-mini",
+                            finish_reason="error",
+                            error={
+                                "code": "server_error",
+                                "message": "synthetic OpenRouter stream error",
+                                "metadata": {"provider_name": "fixture-provider"},
+                            },
+                        )
+                    ],
+                    [
+                        make_openrouter_chunk(
+                            model="openai/gpt-4.1-mini",
+                            content="recovered",
+                            finish_reason="stop",
+                            usage=OPENROUTER_USAGE,
+                        )
+                    ],
+                ],
+                final_text="recovered",
+                usage=OPENROUTER_USAGE,
+            )
+        if scenario == "incomplete_partial_tool_then_success":
+            return build_openrouter_handler(
+                monkeypatch,
+                stream_chunks=[],
+                stream_chunk_sequences=[
+                    [
+                        make_openrouter_chunk(
+                            model="openai/gpt-4.1-mini",
+                            tool_calls=[
+                                {
+                                    "index": 0,
+                                    "id": "call_incomplete",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "read_file",
+                                        "arguments": '{"path":"README.md"}',
+                                    },
+                                }
+                            ],
+                            usage=OPENROUTER_USAGE,
+                        )
+                    ],
+                    [
+                        make_openrouter_chunk(
+                            model="openai/gpt-4.1-mini",
+                            content="recovered",
+                            finish_reason="stop",
+                            usage=OPENROUTER_USAGE,
+                        )
+                    ],
+                ],
+                final_text="recovered",
                 usage=OPENROUTER_USAGE,
                 interrupt_on_tool_call=True,
             )
@@ -299,6 +732,43 @@ async def test_provider_contract_streaming_callback_matrix(
 
     assert result == "answer"
     assert chunks == [("answer", "assistant")]
+    lifecycle = handler.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.provider == provider_id
+    assert lifecycle.model
+    assert lifecycle.stream is True
+    assert lifecycle.status == ProviderRequestStatus.COMPLETED
+    assert lifecycle.finish_reason == FinishReason.STOP
+    assert lifecycle.last_event_type is not None
+    assert lifecycle.provider_response_id is not None
+    assert lifecycle.ended_at is not None
+    assert lifecycle.ended_at >= lifecycle.started_at
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["openai", "openai_compatible", "anthropic", "openrouter"],
+)
+@pytest.mark.asyncio
+async def test_provider_contract_multiple_text_deltas_preserve_order(
+    provider_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _build_handler(provider_id, monkeypatch, scenario="multi_delta")
+    chunks: list[tuple[str, str]] = []
+
+    async def on_chunk(chunk: str, message_type: str) -> None:
+        chunks.append((chunk, message_type))
+
+    result = await handler.get_response(
+        [{"role": "user", "content": "hello"}],
+        stream=True,
+        stream_callback=on_chunk,
+    )
+
+    assert result == "hello world"
+    assert chunks == [("hello ", "assistant"), ("world", "assistant")]
+    assert handler.get_last_finish_reason() == FinishReason.STOP
 
 
 @pytest.mark.parametrize(
@@ -358,6 +828,176 @@ async def test_provider_contract_tool_call_interrupt_matrix(
     assert tool_call["name"] == "read_file"
     assert tool_call["arguments"] == '{"path":"README.md"}'
     assert handler.get_and_clear_last_tool_call() is None
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["openai", "openai_compatible", "anthropic", "openrouter"],
+)
+@pytest.mark.asyncio
+async def test_provider_contract_mid_stream_error_matrix(
+    provider_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _build_handler(provider_id, monkeypatch, scenario="stream_error")
+    chunks: list[tuple[str, str]] = []
+
+    async def on_chunk(chunk: str, message_type: str) -> None:
+        chunks.append((chunk, message_type))
+
+    try:
+        result = await handler.get_response(
+            [{"role": "user", "content": "hello"}],
+            stream=True,
+            stream_callback=on_chunk,
+        )
+    except LLMProviderError as exc:
+        result = str(exc)
+
+    last_error = handler.get_last_error()
+    assert last_error is not None
+    assert "synthetic" in last_error.message
+    assert "synthetic" in result
+    assert handler.get_last_finish_reason() == FinishReason.ERROR
+    assert handler.has_pending_tool_call() is False
+    assert chunks == []
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_chunk"),
+    [
+        ("incomplete_empty", None),
+        ("incomplete_partial_text", ("partial", "assistant")),
+        ("incomplete_partial_tool", None),
+    ],
+)
+@pytest.mark.parametrize(
+    "provider_id",
+    ["openai", "openai_compatible", "anthropic", "openrouter"],
+)
+@pytest.mark.asyncio
+async def test_provider_contract_incomplete_stream_matrix(
+    provider_id: str,
+    scenario: str,
+    expected_chunk: tuple[str, str] | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _build_handler(provider_id, monkeypatch, scenario=scenario)
+    chunks: list[tuple[str, str]] = []
+
+    async def on_chunk(chunk: str, message_type: str) -> None:
+        chunks.append((chunk, message_type))
+
+    try:
+        result = await handler.get_response(
+            [{"role": "user", "content": "hello"}],
+            stream=True,
+            stream_callback=on_chunk,
+        )
+    except LLMProviderError as exc:
+        result = str(exc)
+
+    last_error = handler.get_last_error()
+    assert last_error is not None
+    assert last_error.category == ErrorCategory.NETWORK
+    assert last_error.retryable is True
+    assert "ended before" in last_error.message
+    assert "ended before" in result
+    assert handler.get_last_finish_reason() == FinishReason.ERROR
+    assert handler.has_pending_tool_call() is False
+    if expected_chunk is None:
+        assert chunks == []
+    else:
+        assert expected_chunk in chunks
+    lifecycle = handler.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.DISCONNECTED
+    assert lifecycle.error is not None
+    assert lifecycle.error.category == ErrorCategory.NETWORK
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["openai", "openai_compatible", "anthropic", "openrouter"],
+)
+@pytest.mark.asyncio
+async def test_provider_contract_cancelled_stream_lifecycle_matrix(
+    provider_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _build_handler(provider_id, monkeypatch, scenario="cancelled_stream")
+
+    with pytest.raises(asyncio.CancelledError):
+        await handler.get_response(
+            [{"role": "user", "content": "cancel"}],
+            stream=True,
+            stream_callback=lambda *_args: None,
+        )
+
+    lifecycle = handler.get_last_request_lifecycle()
+    assert lifecycle is not None
+    assert lifecycle.status == ProviderRequestStatus.CANCELLED
+    assert lifecycle.ended_at is not None
+    assert lifecycle.error is not None
+    assert lifecycle.error.retryable is False
+    assert handler.get_last_error() is lifecycle.error
+    assert handler.has_pending_tool_call() is False
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["stream_error_then_success", "incomplete_partial_tool_then_success"],
+)
+@pytest.mark.parametrize(
+    "provider_id",
+    ["openai", "openai_compatible", "anthropic", "openrouter"],
+)
+@pytest.mark.asyncio
+async def test_provider_contract_failure_releases_next_turn_matrix(
+    provider_id: str,
+    scenario: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = _build_handler(provider_id, monkeypatch, scenario=scenario)
+
+    first_chunks: list[tuple[str, str]] = []
+
+    async def on_first_chunk(chunk: str, message_type: str) -> None:
+        first_chunks.append((chunk, message_type))
+
+    try:
+        first_result = await handler.get_response(
+            [{"role": "user", "content": "first"}],
+            stream=True,
+            stream_callback=on_first_chunk,
+        )
+    except LLMProviderError as exc:
+        first_result = str(exc)
+
+    first_error = handler.get_last_error()
+    assert first_error is not None
+    assert handler.get_last_finish_reason() == FinishReason.ERROR
+    assert handler.has_pending_tool_call() is False
+    assert handler.get_and_clear_pending_tool_calls() == []
+    assert first_result
+
+    second_chunks: list[tuple[str, str]] = []
+
+    async def on_second_chunk(chunk: str, message_type: str) -> None:
+        second_chunks.append((chunk, message_type))
+
+    second_result = await handler.get_response(
+        [{"role": "user", "content": "second"}],
+        stream=True,
+        stream_callback=on_second_chunk,
+    )
+
+    assert second_result == "recovered"
+    assert ("recovered", "assistant") in second_chunks
+    assert handler.get_last_error() is None
+    assert handler.get_last_finish_reason() == FinishReason.STOP
+    assert handler.has_pending_tool_call() is False
+    assert handler.get_and_clear_pending_tool_calls() == []
 
 
 @pytest.mark.asyncio
@@ -588,6 +1228,53 @@ def test_anthropic_repairs_orphaned_tool_result_adjacency() -> None:
                     "type": "tool_result",
                     "tool_use_id": "toolu_1",
                     "content": "/tmp/project",
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.parametrize("status", ["error", "failed", "cancelled", "interrupted"])
+def test_anthropic_marks_failed_tool_replay_statuses_as_errors(status: str) -> None:
+    handler = build_anthropic_handler(
+        stream_chunks=[AnthropicStreamChunk("message_stop")],
+        final_text="answer",
+        usage=ANTHROPIC_USAGE,
+    )
+
+    formatted = handler.format_messages(
+        [
+            {
+                "role": "tool",
+                "tool_call_id": "toolu_failed",
+                "name": "shell",
+                "tool_arguments": '{"command":"long-running"}',
+                "content": f"tool execution {status}",
+                "status": status,
+            },
+        ]
+    )
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_failed",
+                    "name": "shell",
+                    "input": {"command": "long-running"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_failed",
+                    "content": f"tool execution {status}",
+                    "is_error": True,
                 }
             ],
         },

--- a/tests/llm/test_provider_lifecycle_state_machine.py
+++ b/tests/llm/test_provider_lifecycle_state_machine.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from hypothesis import settings, strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, initialize, invariant, rule
+
+from penguin.llm.contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMRequestLifecycle,
+    ProviderRequestStatus,
+)
+
+
+TERMINAL_STATUSES = {
+    ProviderRequestStatus.COMPLETED,
+    ProviderRequestStatus.DISCONNECTED,
+    ProviderRequestStatus.FAILED,
+    ProviderRequestStatus.CANCELLED,
+}
+
+
+@settings(max_examples=25, stateful_step_count=20)
+class LifecycleSerializationMachine(RuleBasedStateMachine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lifecycle = LLMRequestLifecycle(
+            request_id="req-state-machine",
+            provider="provider",
+            model="model",
+            status=ProviderRequestStatus.PENDING,
+            stream=True,
+            transport="test",
+            started_at=1.0,
+            last_event_at=1.0,
+        )
+
+    @initialize()
+    def initialize_lifecycle(self) -> None:
+        self.lifecycle = LLMRequestLifecycle(
+            request_id="req-state-machine",
+            provider="provider",
+            model="model",
+            status=ProviderRequestStatus.PENDING,
+            stream=True,
+            transport="test",
+            started_at=1.0,
+            last_event_at=1.0,
+        )
+
+    @rule(status=st.sampled_from(list(ProviderRequestStatus)))
+    def update_status(self, status: ProviderRequestStatus) -> None:
+        self.lifecycle.status = status
+        self.lifecycle.last_event_at += 1.0
+        if status in TERMINAL_STATUSES:
+            self.lifecycle.ended_at = self.lifecycle.last_event_at
+        else:
+            self.lifecycle.ended_at = None
+
+    @rule(finish_reason=st.sampled_from(list(FinishReason)))
+    def update_finish_reason(self, finish_reason: FinishReason) -> None:
+        self.lifecycle.finish_reason = finish_reason
+        self.lifecycle.last_event_type = f"finish:{finish_reason.value}"
+
+    @rule(category=st.sampled_from(list(ErrorCategory)), retryable=st.booleans())
+    def record_error(self, category: ErrorCategory, retryable: bool) -> None:
+        self.lifecycle.error = LLMError(
+            message=f"{category.value} error",
+            category=category,
+            retryable=retryable,
+            provider=self.lifecycle.provider,
+            model=self.lifecycle.model,
+        )
+        self.lifecycle.status = (
+            ProviderRequestStatus.DISCONNECTED
+            if category in {ErrorCategory.NETWORK, ErrorCategory.TIMEOUT}
+            else ProviderRequestStatus.FAILED
+        )
+        self.lifecycle.last_event_at += 1.0
+        self.lifecycle.ended_at = self.lifecycle.last_event_at
+
+    @rule()
+    def round_trip_through_storage_record(self) -> None:
+        reloaded = LLMRequestLifecycle.from_dict(self.lifecycle.to_dict())
+
+        assert reloaded.request_id == self.lifecycle.request_id
+        assert reloaded.provider == self.lifecycle.provider
+        assert reloaded.model == self.lifecycle.model
+        assert reloaded.status == self.lifecycle.status
+        assert reloaded.finish_reason == self.lifecycle.finish_reason
+        assert reloaded.ended_at == self.lifecycle.ended_at
+        if self.lifecycle.error is None:
+            assert reloaded.error is None
+        else:
+            assert reloaded.error is not None
+            assert reloaded.error.category == self.lifecycle.error.category
+            assert reloaded.error.retryable == self.lifecycle.error.retryable
+
+        self.lifecycle = reloaded
+
+    @invariant()
+    def terminal_statuses_have_end_timestamp(self) -> None:
+        if self.lifecycle.status in TERMINAL_STATUSES:
+            assert self.lifecycle.ended_at is not None
+
+
+TestLifecycleSerialization = LifecycleSerializationMachine.TestCase

--- a/tests/llm/test_provider_reliability_properties.py
+++ b/tests/llm/test_provider_reliability_properties.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from hypothesis import given, settings, strategies as st
+
+from penguin.llm.contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMRequestLifecycle,
+    ProviderRequestStatus,
+)
+from penguin.llm.runtime import should_retry_provider_failure
+from penguin.tools.runtime import hash_tool_output, prepare_model_visible_tool_output
+
+
+text_strategy = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",)),
+    max_size=1000,
+)
+
+
+@given(output=text_strategy, max_chars=st.integers(min_value=1, max_value=200))
+@settings(max_examples=100)
+def test_tool_output_truncation_property_preserves_full_metadata(
+    output: str,
+    max_chars: int,
+) -> None:
+    view = prepare_model_visible_tool_output(output, max_chars=max_chars)
+
+    assert view.full_output == output
+    assert view.output_hash == hash_tool_output(output)
+    assert view.byte_count == len(output.encode("utf-8"))
+    assert view.line_count == (output.count("\n") + 1 if output else 0)
+    assert len(view.model_output) <= max_chars
+    assert view.truncated is (len(output) > max_chars)
+    if not view.truncated:
+        assert view.model_output == output
+
+
+@given(
+    retryable=st.booleans(),
+    streamed_assistant_chunk=st.booleans(),
+    pending_tool_call=st.booleans(),
+    response=st.one_of(
+        st.none(),
+        st.sampled_from(["", "   ", "Error: synthetic", "[Error: synthetic]"]),
+        text_strategy.filter(lambda value: not value.strip().startswith("Error:")),
+    ),
+)
+@settings(max_examples=100)
+def test_retry_policy_property_never_replays_unsafe_failures(
+    retryable: bool,
+    streamed_assistant_chunk: bool,
+    pending_tool_call: bool,
+    response: str | None,
+) -> None:
+    provider_error = LLMError(
+        message="synthetic",
+        category=ErrorCategory.NETWORK,
+        retryable=retryable,
+    )
+
+    decision = should_retry_provider_failure(
+        provider_error=provider_error,
+        response=response,
+        streamed_assistant_chunk=streamed_assistant_chunk,
+        pending_tool_call=pending_tool_call,
+    )
+
+    assert decision is (
+        retryable
+        and not streamed_assistant_chunk
+        and not pending_tool_call
+        and (
+            not response
+            or not response.strip()
+            or response.strip().startswith(("Error:", "[Error:"))
+        )
+    )
+
+
+@given(
+    status=st.sampled_from(list(ProviderRequestStatus)),
+    finish_reason=st.one_of(st.none(), st.sampled_from(list(FinishReason))),
+    error_category=st.one_of(st.none(), st.sampled_from(list(ErrorCategory))),
+    retryable=st.booleans(),
+)
+@settings(max_examples=100)
+def test_lifecycle_serialization_property_round_trips_canonical_fields(
+    status: ProviderRequestStatus,
+    finish_reason: FinishReason | None,
+    error_category: ErrorCategory | None,
+    retryable: bool,
+) -> None:
+    error = (
+        LLMError(
+            message="synthetic",
+            category=error_category,
+            retryable=retryable,
+            provider="provider",
+            model="model",
+            finish_reason=finish_reason,
+        )
+        if error_category is not None
+        else None
+    )
+    lifecycle = LLMRequestLifecycle(
+        request_id="req-property",
+        provider="provider",
+        model="model",
+        status=status,
+        stream=True,
+        transport="test",
+        attempt=2,
+        started_at=1.0,
+        last_event_at=2.0,
+        ended_at=3.0,
+        provider_response_id="resp-property",
+        last_event_type="event",
+        finish_reason=finish_reason,
+        error=error,
+        provider_data={"key": "value"},
+    )
+
+    reloaded = LLMRequestLifecycle.from_dict(lifecycle.to_dict())
+
+    assert reloaded.request_id == lifecycle.request_id
+    assert reloaded.provider == lifecycle.provider
+    assert reloaded.model == lifecycle.model
+    assert reloaded.status == status
+    assert reloaded.finish_reason == finish_reason
+    assert reloaded.provider_data == lifecycle.provider_data
+    if error is None:
+        assert reloaded.error is None
+    else:
+        assert reloaded.error is not None
+        assert reloaded.error.category == error_category
+        assert reloaded.error.retryable is retryable

--- a/tests/llm/test_provider_stream_watchdogs.py
+++ b/tests/llm/test_provider_stream_watchdogs.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from penguin.llm.openrouter_gateway import OpenRouterGateway
+
+
+class DelayedAsyncIterator:
+    def __init__(self, values: list[Any], *, delay_seconds: float = 0.0) -> None:
+        self._values = list(values)
+        self._delay_seconds = delay_seconds
+
+    def __aiter__(self) -> "DelayedAsyncIterator":
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._values:
+            raise StopAsyncIteration
+        if self._delay_seconds:
+            await asyncio.sleep(self._delay_seconds)
+        return self._values.pop(0)
+
+
+def _gateway() -> OpenRouterGateway:
+    gateway = OpenRouterGateway.__new__(OpenRouterGateway)
+    gateway.logger = logging.getLogger("test.openrouter.watchdog")
+    return gateway
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_watchdog_times_out_stalled_chunk() -> None:
+    gateway = _gateway()
+    started_at = asyncio.get_running_loop().time()
+
+    with pytest.raises(TimeoutError):
+        await gateway._next_stream_item(
+            DelayedAsyncIterator(["chunk"], delay_seconds=0.05),
+            wait_timeout=0.001,
+            total_timeout=1.0,
+            started_at=started_at,
+            phase="test stream",
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_watchdog_times_out_total_budget() -> None:
+    gateway = _gateway()
+    started_at = asyncio.get_running_loop().time() - 10.0
+
+    with pytest.raises(TimeoutError, match="total timeout"):
+        await gateway._next_stream_item(
+            DelayedAsyncIterator(["chunk"]),
+            wait_timeout=1.0,
+            total_timeout=0.001,
+            started_at=started_at,
+            phase="test stream",
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_watchdog_allows_active_chunk() -> None:
+    gateway = _gateway()
+    started_at = asyncio.get_running_loop().time()
+
+    chunk = await gateway._next_stream_item(
+        DelayedAsyncIterator(["chunk"]),
+        wait_timeout=1.0,
+        total_timeout=1.0,
+        started_at=started_at,
+        phase="test stream",
+    )
+
+    assert chunk == "chunk"
+
+
+def test_openrouter_stream_watchdog_reads_provider_timeout_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = _gateway()
+
+    monkeypatch.setenv("PENGUIN_OPENROUTER_STREAM_CHUNK_TIMEOUT_SECONDS", "0.25")
+    monkeypatch.setenv("PENGUIN_OPENROUTER_STREAM_TOTAL_TIMEOUT_SECONDS", "2.5")
+
+    assert gateway._stream_chunk_timeout_seconds() == 0.25
+    assert gateway._stream_total_timeout_seconds() == 2.5
+
+
+def test_openrouter_stream_watchdog_rejects_invalid_timeout_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = _gateway()
+
+    monkeypatch.setenv("PENGUIN_OPENROUTER_STREAM_CHUNK_TIMEOUT_SECONDS", "-1")
+    monkeypatch.setenv("PENGUIN_OPENROUTER_STREAM_TOTAL_TIMEOUT_SECONDS", "bad")
+
+    assert gateway._stream_chunk_timeout_seconds() == 75.0
+    assert gateway._stream_total_timeout_seconds() == 300.0

--- a/tests/system/test_context_lifecycle_records.py
+++ b/tests/system/test_context_lifecycle_records.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from penguin.system.context_window import ContextWindowManager
+from penguin.system.state import Message, MessageCategory, Session
+
+
+def test_context_window_trim_preserves_llm_request_lifecycle_records() -> None:
+    cwm = ContextWindowManager(token_counter=lambda content: len(str(content)))
+    cwm.max_context_window_tokens = 1
+
+    session = Session()
+    session.add_message(
+        Message(
+            role="user",
+            content="this message is intentionally over budget",
+            category=MessageCategory.DIALOG,
+        )
+    )
+    session.add_llm_request_lifecycle(
+        {
+            "request_id": "req-cwm-1",
+            "provider": "openai",
+            "model": "gpt-test",
+            "status": "completed",
+        }
+    )
+
+    trimmed = cwm.trim_session(session)
+
+    assert trimmed.llm_request_lifecycles == session.llm_request_lifecycles

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -9,7 +9,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from penguin.engine import Engine, EngineSettings
+from penguin.llm.contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMRequestLifecycle,
+    ProviderRequestStatus,
+)
 from penguin.system.execution_context import ExecutionContext, execution_context_scope
+from penguin.system.state import Session
 
 
 def test_engine_initializes_without_run_state_attribute_error() -> None:
@@ -187,6 +195,291 @@ async def test_call_llm_with_retry_replays_non_stream_retry_into_stream_callback
     assert result == "fallback answer"
     assert streamed == [("fallback answer", "assistant")]
     assert api_client.get_response.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_replays_retryable_provider_failure_once() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    retryable_error = LLMError(
+        message="stream disconnected",
+        category=ErrorCategory.NETWORK,
+        retryable=True,
+        provider="openai",
+        model="gpt-test",
+    )
+    current_error: LLMError | None = None
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        nonlocal current_error
+        del messages, stream_callback, kwargs
+        if stream:
+            current_error = retryable_error
+            return "Error: LLM network request failed. Diagnostic ID: test"
+        current_error = None
+        return "recovered answer"
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        get_last_error=lambda: current_error,
+        client_handler=SimpleNamespace(),
+    )
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=None,
+        extra_kwargs={},
+    )
+
+    assert result == "recovered answer"
+    assert api_client.get_response.await_count == 2
+    assert api_client.get_response.await_args_list[1].kwargs["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_surfaces_non_retryable_provider_failure() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    current_error = LLMError(
+        message="bad request",
+        category=ErrorCategory.BAD_REQUEST,
+        retryable=False,
+        provider="openai",
+        model="gpt-test",
+    )
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        del messages, stream, stream_callback, kwargs
+        return "Error: LLM upstream rejected the request. Diagnostic ID: test"
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        get_last_error=lambda: current_error,
+        client_handler=SimpleNamespace(),
+    )
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=None,
+        extra_kwargs={},
+    )
+
+    assert result == "Error: LLM upstream rejected the request. Diagnostic ID: test"
+    assert api_client.get_response.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_skips_retryable_failure_when_tool_pending() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    current_error = LLMError(
+        message="stream disconnected after tool call",
+        category=ErrorCategory.NETWORK,
+        retryable=True,
+        provider="openai",
+        model="gpt-test",
+    )
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        del messages, stream, stream_callback, kwargs
+        return "Error: LLM network request failed. Diagnostic ID: test"
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        get_last_error=lambda: current_error,
+        client_handler=SimpleNamespace(has_pending_tool_call=lambda: True),
+    )
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=None,
+        extra_kwargs={},
+    )
+
+    assert result == "Error: LLM network request failed. Diagnostic ID: test"
+    assert api_client.get_response.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_call_llm_with_retry_surfaces_retry_exhaustion_once() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    retryable_error = LLMError(
+        message="stream disconnected",
+        category=ErrorCategory.NETWORK,
+        retryable=True,
+        provider="openai",
+        model="gpt-test",
+    )
+    responses = [
+        "Error: LLM network request failed. Diagnostic ID: first",
+        "Error: LLM network request failed. Diagnostic ID: second",
+    ]
+
+    async def _fake_get_response(messages, stream=None, stream_callback=None, **kwargs):
+        del messages, stream, stream_callback, kwargs
+        return responses.pop(0)
+
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=_fake_get_response),
+        get_last_error=lambda: retryable_error,
+        client_handler=SimpleNamespace(),
+    )
+
+    result = await engine._call_llm_with_retry(
+        cast(Any, api_client),
+        [{"role": "user", "content": "hi"}],
+        streaming=True,
+        stream_callback=None,
+        extra_kwargs={},
+    )
+
+    assert result == "Error: LLM network request failed. Diagnostic ID: second"
+    assert api_client.get_response.await_count == 2
+
+
+def test_session_persists_llm_request_lifecycle_records() -> None:
+    lifecycle = LLMRequestLifecycle(
+        request_id="req-lifecycle-1",
+        provider="openai",
+        model="gpt-test",
+        status=ProviderRequestStatus.COMPLETED,
+        stream=True,
+        transport="responses",
+        attempt=2,
+        started_at=10.0,
+        last_event_at=12.0,
+        ended_at=12.5,
+        provider_response_id="resp_1",
+        last_event_type="response.completed",
+        finish_reason=FinishReason.STOP,
+        provider_data={"message_count": 3},
+    )
+
+    session = Session()
+    session.add_llm_request_lifecycle(lifecycle)
+    session.add_llm_request_lifecycle(
+        {
+            **lifecycle.to_dict(),
+            "status": ProviderRequestStatus.FAILED.value,
+        }
+    )
+
+    assert len(session.llm_request_lifecycles) == 1
+    assert session.llm_request_lifecycles[0]["status"] == "failed"
+    assert session.metadata["llm_request_lifecycle_count"] == 1
+
+    reloaded = Session.from_dict(session.to_dict())
+
+    assert reloaded.llm_request_lifecycles == session.llm_request_lifecycles
+
+
+def test_engine_persists_latest_provider_lifecycle_on_active_session() -> None:
+    engine = Engine(
+        EngineSettings(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    lifecycle = LLMRequestLifecycle(
+        request_id="req-engine-1",
+        provider="openrouter",
+        model="openai/gpt-test",
+        status=ProviderRequestStatus.DISCONNECTED,
+        stream=True,
+        started_at=20.0,
+        last_event_at=21.0,
+        ended_at=21.0,
+        error=LLMError(
+            message="stream stalled",
+            category=ErrorCategory.TIMEOUT,
+            retryable=True,
+        ),
+    )
+    session = Session()
+    cm = SimpleNamespace(get_current_session=lambda: session)
+    api_client = SimpleNamespace(get_last_request_lifecycle=lambda: lifecycle)
+
+    engine._persist_llm_request_lifecycle(cast(Any, cm), cast(Any, api_client))
+
+    assert session.llm_request_lifecycles == [lifecycle.to_dict()]
+
+
+@pytest.mark.asyncio
+async def test_llm_step_persists_lifecycle_even_when_provider_raises() -> None:
+    session = Session()
+    conversation = SimpleNamespace(
+        get_formatted_messages=MagicMock(
+            return_value=[{"role": "user", "content": "hi"}]
+        ),
+        session=session,
+        add_assistant_message=MagicMock(),
+    )
+    conversation_manager = SimpleNamespace(
+        conversation=conversation,
+        core=None,
+        get_current_session=lambda: session,
+    )
+    lifecycle = LLMRequestLifecycle(
+        request_id="req-failed-1",
+        provider="anthropic",
+        model="claude-test",
+        status=ProviderRequestStatus.FAILED,
+        stream=False,
+        started_at=30.0,
+        last_event_at=30.1,
+        ended_at=30.1,
+        error=LLMError(
+            message="upstream rejected request",
+            category=ErrorCategory.BAD_REQUEST,
+            retryable=False,
+        ),
+    )
+    api_client = SimpleNamespace(
+        get_response=AsyncMock(side_effect=RuntimeError("boom")),
+        get_last_request_lifecycle=lambda: lifecycle,
+        get_last_error=lambda: lifecycle.error,
+        client_handler=SimpleNamespace(),
+    )
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, conversation_manager),
+        cast(Any, api_client),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    with pytest.raises(RuntimeError):
+        await engine._llm_step(tools_enabled=False, streaming=False)
+
+    assert session.llm_request_lifecycles == [lifecycle.to_dict()]
 
 
 def test_scoped_conversation_manager_clones_default_agent_session() -> None:

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -38,6 +38,7 @@ class _DummyResponseStream:
                 _DummyStreamEvent(type="response.output_text.delta", delta=d)
                 for d in (deltas or [])
             ]
+            self._events.append(_DummyStreamEvent(type="response.completed"))
         self._idx = 0
         self._final_text = final_text
 
@@ -93,6 +94,7 @@ class _DummyResponsesWithReasoning(_DummyResponses):
                     delta="thinking...",
                 ),
                 _DummyStreamEvent(type="response.output_text.delta", delta="answer"),
+                _DummyStreamEvent(type="response.completed"),
             ],
             final_text="answer",
         )
@@ -129,6 +131,7 @@ class _DummyResponsesWithToolCall(_DummyResponses):
                         "status": "completed",
                     },
                 ),
+                _DummyStreamEvent(type="response.completed"),
             ],
             final_text="",
         )

--- a/tests/test_part_event_persist_callback.py
+++ b/tests/test_part_event_persist_callback.py
@@ -72,6 +72,29 @@ async def test_part_adapter_user_message_preserves_supplied_message_id() -> None
 
 
 @pytest.mark.asyncio
+async def test_part_adapter_assistant_message_uses_last_user_as_parent() -> None:
+    bus = _EventBus()
+    adapter = PartEventAdapter(bus)
+    adapter.set_session("session_parent")
+
+    await adapter.on_user_message_with_metadata(
+        "hello",
+        message_id="msg_client_parent",
+        agent_id="build",
+    )
+    await adapter.on_stream_start(agent_id="build")
+
+    assistant_updates = [
+        item
+        for item in _opencode_events(bus, "message.updated")
+        if item.get("role") == "assistant"
+    ]
+
+    assert assistant_updates
+    assert assistant_updates[-1]["parentID"] == "msg_client_parent"
+
+
+@pytest.mark.asyncio
 async def test_tool_only_lifecycle_balances_session_status_and_completes_message():
     bus = _EventBus()
     adapter = PartEventAdapter(bus)

--- a/tests/test_tool_output_truncation.py
+++ b/tests/test_tool_output_truncation.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from penguin.tools.runtime import (
+    ToolResult,
+    hash_tool_output,
+    legacy_action_result_from_tool_result,
+    prepare_model_visible_tool_output,
+    tool_result_from_action_result,
+)
+
+
+def test_model_visible_tool_output_truncates_and_writes_full_artifact(
+    tmp_path: Path,
+) -> None:
+    full_output = "\n".join(f"line-{idx:03d}" for idx in range(100))
+
+    view = prepare_model_visible_tool_output(
+        full_output,
+        max_chars=180,
+        artifact_dir=tmp_path,
+        artifact_id="call_read",
+        truncation_direction="tail",
+    )
+
+    assert view.truncated is True
+    assert len(view.model_output) <= 180
+    assert "Tool output truncated" in view.model_output
+    assert view.byte_count == len(full_output.encode("utf-8"))
+    assert view.line_count == 100
+    assert view.output_hash == hash_tool_output(full_output)
+    assert view.artifact_path is not None
+    assert Path(view.artifact_path).read_text(encoding="utf-8") == full_output
+
+
+def test_model_visible_tool_output_keeps_small_output_inline(tmp_path: Path) -> None:
+    view = prepare_model_visible_tool_output(
+        "short output",
+        max_chars=100,
+        artifact_dir=tmp_path,
+    )
+
+    assert view.model_output == "short output"
+    assert view.full_output == "short output"
+    assert view.truncated is False
+    assert view.artifact_path is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_model_visible_tool_output_handles_tiny_budget(tmp_path: Path) -> None:
+    view = prepare_model_visible_tool_output(
+        "x" * 100,
+        max_chars=12,
+        artifact_dir=tmp_path,
+        artifact_id="../../unsafe",
+    )
+
+    assert view.truncated is True
+    assert len(view.model_output) == 12
+    assert view.artifact_path is not None
+    assert Path(view.artifact_path).name.startswith("tool-output-")
+    assert Path(view.artifact_path).read_text(encoding="utf-8") == "x" * 100
+
+
+def test_tool_result_records_output_metadata() -> None:
+    result = ToolResult(
+        call_id="call_1",
+        name="execute_command",
+        status="completed",
+        output="a\nb",
+        truncated=True,
+        truncation_direction="tail",
+        artifact_path="/tmp/tool-output-call_1.txt",
+    )
+
+    assert result.byte_count == 3
+    assert result.line_count == 2
+    assert result.output_hash == hash_tool_output("a\nb")
+    assert legacy_action_result_from_tool_result(result) == {
+        "action": "execute_command",
+        "result": "a\nb",
+        "status": "completed",
+    }
+
+
+def test_action_result_to_tool_result_preserves_output_metadata() -> None:
+    result = tool_result_from_action_result(
+        {
+            "action": "execute_command",
+            "result": "tail",
+            "status": "completed",
+            "metadata": {
+                "byte_count": 5000,
+                "line_count": 250,
+                "truncated": True,
+                "truncation_direction": "tail",
+                "artifact_path": "/tmp/full.txt",
+            },
+        },
+        call_id="call_1",
+    )
+
+    assert result.byte_count == 5000
+    assert result.line_count == 250
+    assert result.truncated is True
+    assert result.truncation_direction == "tail"
+    assert result.artifact_path == "/tmp/full.txt"


### PR DESCRIPTION
## Summary

This PR stabilizes Penguin’s first-class LLM provider contract across OpenAI/Codex, native OpenAI/OpenAI-compatible, Anthropic, and OpenRouter.

It adds/extends canonical request lifecycle records, prepared-request metadata, provider capability surfaces, replay repair coverage, retry policy behavior, and incomplete-stream handling. It also fixes a Penguin TUI ordering issue by making message sorting parent-aware and by emitting assistant `parentID` metadata from the OpenCode adapter.

## Changes

- Add shared provider request lifecycle metadata for completed, failed, disconnected, cancelled, and retried calls.
- Add provider-neutral prepared request capture with protocol, route, provider, transport, diagnostics, payload hash, sanitized headers, and capabilities.
- Expand provider matrix coverage for OpenAI/OpenAI-compatible, Anthropic, OpenRouter, and `APIClient`.
- Add replay repair coverage for CWM-truncated native tool history and duplicate provider tool-call IDs.
- Normalize retry behavior around incomplete streams, provider errors, and pending native tool calls.
- Add initial provider/tool reliability property/state-machine coverage notes.
- Update provider/tool/testing plan docs with current progress and deferred Link/LiteLLM scope.
- Fix TUI chronology by sorting assistant messages after their parent user and avoiding missing timestamps sorting to the top.

## Tests

- `uv run pytest -q tests/llm`
- `uv run pytest -q tests/test_openai_adapter_streaming.py tests/test_engine_initialization.py tests/test_tool_output_truncation.py tests/system/test_context_lifecycle_records.py`
- `uv run pytest -q tests/test_part_event_persist_callback.py`
- `bun test test/cli/tui/sync-hydration.test.ts`
- `bun run typecheck`
- `uv run ruff check penguin/tui_adapter/part_events.py tests/test_part_event_persist_callback.py`
- `git diff --check`

## Notes

Link end-to-end verification and full LiteLLM matrix parity are intentionally deferred. The next PR should move to `tool-call-runtime-architecture.md`, especially Phase 5.5/6.5 work before enabling parallel tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Tool outputs now support smart truncation with full-output artifact preservation and metadata tracking.
  * Enhanced message ordering in conversations with parent/child relationship awareness.

* **Bug Fixes**
  * Improved provider request lifecycle tracking and recovery for incomplete/failed streams.
  * Better retry logic for transient provider failures with proper error categorization.
  * Session state and request metadata now preserved during context window trimming.

* **Tests**
  * Added comprehensive provider reliability matrix and lifecycle state machine validation.
  * New property-based tests for tool output truncation and request lifecycle serialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maximooch/penguin/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->