### PR TITLE
bug: fix screenshot image MIME encoding

### DIFF
--- a/context/journal/2026-05-21.md
+++ b/context/journal/2026-05-21.md
@@ -1,0 +1,5 @@
+---
+timestamp: 2026-05-21T04:53:43Z
+entry_type: completion
+---
+Investigated browser screenshot rejection. Root cause was PNG screenshot files transcoded to JPEG bytes but labeled with the original PNG MIME in OpenAI/OpenRouter data URIs; fixed adapters to emit `data:image/jpeg` and added regression tests.

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -5,7 +5,6 @@ import base64
 import io
 import json
 import logging
-import mimetypes
 import os
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
@@ -2555,10 +2554,7 @@ class OpenAIAdapter(BaseAdapter):
                 img.save(buffer, format="JPEG")
                 image_bytes = buffer.getvalue()
             b64 = base64.b64encode(image_bytes).decode("utf-8")
-            mime, _ = mimetypes.guess_type(image_path)
-            if not mime or not mime.startswith("image"):
-                mime = "image/jpeg"
-            return f"data:{mime};base64,{b64}"
+            return f"data:image/jpeg;base64,{b64}"
         except Exception as e:
             logger.error(f"Failed to encode image '{image_path}': {e}")
             return None

--- a/penguin/llm/adapters/openrouter.py
+++ b/penguin/llm/adapters/openrouter.py
@@ -8,7 +8,6 @@ from typing import List, Dict, Optional, Any, Union, Callable, AsyncIterator
 # --- Added Imports for Vision Handling ---
 import base64
 import io
-import mimetypes
 from PIL import Image as PILImage  # Use alias for PIL Image # type: ignore
 # --- End Added Imports ---
 
@@ -1030,10 +1029,7 @@ class OpenRouterGateway:
                 image_bytes = buffer.getvalue()
 
             base64_image = base64.b64encode(image_bytes).decode("utf-8")
-            mime_type, _ = mimetypes.guess_type(image_path)
-            if not mime_type or not mime_type.startswith("image"):
-                mime_type = "image/jpeg"
-            data_uri = f"data:{mime_type};base64,{base64_image}"
+            data_uri = f"data:image/jpeg;base64,{base64_image}"
             self.logger.debug(f"Encoded image to data URI (length: {len(data_uri)})")
             return data_uri
         except FileNotFoundError:

--- a/tests/llm/test_openrouter_vision_encoding.py
+++ b/tests/llm/test_openrouter_vision_encoding.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from PIL import Image
+
+from penguin.llm.model_config import ModelConfig
+from penguin.llm.openrouter_gateway import OpenRouterGateway
+
+
+@pytest.mark.asyncio
+async def test_openrouter_vision_encoding_labels_transcoded_png_as_jpeg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-fixture")
+    image_path = tmp_path / "browser-screenshot.png"
+    Image.new("RGB", (8, 6), color=(0, 0, 255)).save(image_path)
+    gateway = OpenRouterGateway(
+        ModelConfig(
+            model="openai/gpt-5",
+            provider="openrouter",
+            client_preference="openrouter",
+            api_key="sk-or-v1-fixture",
+        )
+    )
+
+    processed = await gateway._process_messages_for_vision(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect screenshot"},
+                    {"type": "image_url", "image_path": str(image_path)},
+                ],
+            }
+        ]
+    )
+
+    image_url = processed[0]["content"][1]["image_url"]["url"]
+    assert image_url.startswith("data:image/jpeg;base64,")
+    assert base64.b64decode(image_url.split(",", 1)[1])[:3] == b"\xff\xd8\xff"

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from PIL import Image
 
 from penguin.llm.adapters.openai import OpenAIAdapter
 from penguin.llm.model_config import ModelConfig
+
+
+def _image_payload_magic(data_uri: str) -> bytes:
+    return base64.b64decode(data_uri.split(",", 1)[1])[:3]
 
 
 @dataclass(frozen=True)
@@ -135,6 +141,38 @@ class _DummyResponsesWithToolCall(_DummyResponses):
             ],
             final_text="",
         )
+
+
+@pytest.mark.asyncio
+async def test_openai_vision_encoding_labels_transcoded_png_as_jpeg(
+    tmp_path,
+) -> None:
+    image_path = tmp_path / "browser-screenshot.png"
+    Image.new("RGB", (8, 6), color=(0, 0, 255)).save(image_path)
+    adapter = OpenAIAdapter(
+        ModelConfig(
+            model="gpt-5",
+            provider="openai",
+            client_preference="native",
+            api_key="sk-test",
+        )
+    )
+
+    processed = await adapter._process_messages_for_vision(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect screenshot"},
+                    {"type": "image_url", "image_path": str(image_path)},
+                ],
+            }
+        ]
+    )
+
+    image_url = processed[0]["content"][1]["image_url"]["url"]
+    assert image_url.startswith("data:image/jpeg;base64,")
+    assert _image_payload_magic(image_url) == b"\xff\xd8\xff"
 
 
 class _DummyOpenAIClient:


### PR DESCRIPTION
## Summary
- Fix local image encoding for OpenAI/OpenRouter by labeling transcoded screenshot bytes as `image/jpeg`
- Add regression tests proving `.png` browser screenshots are encoded with JPEG MIME and JPEG magic bytes
- Journal the investigation outcome for continuity

## Root Cause
Browser screenshots are saved as PNG artifacts, but the LLM adapters downscale/transcode local images to JPEG before sending them upstream. The data URI MIME was still inferred from the original file extension, so providers received `data:image/png` with JPEG bytes and rejected the image.

## Tests
- `pytest -q tests/test_openai_adapter_streaming.py tests/llm/test_openrouter_vision_encoding.py tests/test_browser_harness_tools.py -q`

## Notes
- No backend browser harness changes were required.
- Existing unrelated worktree files were intentionally left out of this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image format labeling where screenshots were being transcoded to JPEG but incorrectly marked with their original format, ensuring proper image handling in vision features.

* **Tests**
  * Added regression tests to verify correct image format encoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maximooch/penguin/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->