### PR TITLE
Avoid context-sized OpenRouter output caps

### DIFF
--- a/penguin/core.py
+++ b/penguin/core.py
@@ -3553,6 +3553,18 @@ class PenguinCore:
             new_model_config.max_history_tokens = safe_window
         if max_output is not None:
             new_model_config.max_output_tokens = max_output
+        if (
+            safe_window is not None
+            and new_model_config.max_output_tokens is not None
+            and new_model_config.max_output_tokens > safe_window
+        ):
+            logger.warning(
+                "Clamping model '%s' max_output_tokens from %s to safe window %s",
+                runtime_model_id,
+                new_model_config.max_output_tokens,
+                safe_window,
+            )
+            new_model_config.max_output_tokens = safe_window
 
         user_explicit_vision = model_specific.get("vision_enabled")
         if user_explicit_vision is not None:

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -3527,9 +3527,7 @@ class PenguinCore:
                 model_specific.get("max_output_tokens")
                 or model_specific.get("max_tokens")
             )
-        if max_output is None:
-            max_output = safe_window
-        elif safe_window is not None and max_output > safe_window:
+        if max_output is not None and safe_window is not None and max_output > safe_window:
             logger.warning(
                 "Clamping model '%s' max_output_tokens from %s to safe window %s",
                 runtime_model_id,

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -501,7 +501,7 @@ class ModelSpecs:
     model_id: str
     name: str
     context_length: int
-    max_output_tokens: int
+    max_output_tokens: Optional[int]
     provider: str
     pricing_prompt: Optional[float] = None  # per 1M tokens
     pricing_completion: Optional[float] = None  # per 1M tokens
@@ -716,8 +716,19 @@ class ModelSpecsService:
         max_output = model.get("top_provider", {}).get("max_completion_tokens")
         if not max_output:
             max_output = model.get("max_output_tokens")
-        if not max_output:
-            max_output = context_length // 4 if context_length else 4096
+        try:
+            max_output = int(max_output) if max_output else None
+        except (TypeError, ValueError):
+            max_output = None
+        if context_length and max_output and max_output >= int(context_length * 0.8):
+            logger.debug(
+                "Ignoring suspicious OpenRouter max_completion_tokens=%s for %s "
+                "with context_length=%s",
+                max_output,
+                model_id,
+                context_length,
+            )
+            max_output = None
 
         provider = model_id.split("/")[0] if "/" in model_id else "unknown"
 

--- a/tests/llm/test_model_specs.py
+++ b/tests/llm/test_model_specs.py
@@ -85,6 +85,20 @@ def mock_api_response():
                 "top_provider": {"max_completion_tokens": 32768},
                 "architecture": {"modality": "text"},
             },
+            {
+                "id": "moonshotai/kimi-k2.6",
+                "name": "Kimi K2.6",
+                "context_length": 262144,
+                "top_provider": {"max_completion_tokens": 262142},
+                "architecture": {"modality": "text"},
+            },
+            {
+                "id": "z-ai/glm-5.1",
+                "name": "GLM 5.1",
+                "context_length": 202752,
+                "top_provider": {"max_completion_tokens": None},
+                "architecture": {"modality": "text"},
+            },
         ]
     }
 
@@ -240,6 +254,48 @@ class TestServiceCaching:
             assert result.model_id == "openai/gpt-4o"
             assert result.context_length == 128000
             mock_client.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_suspicious_context_sized_completion_cap_is_ignored(
+        self,
+        service,
+        mock_api_response,
+    ):
+        """Context-sized OpenRouter completion caps are not usable output caps."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_api_response
+            mock_response.raise_for_status = MagicMock()
+            mock_client.get.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await service.get_specs("moonshotai/kimi-k2.6")
+
+            assert result is not None
+            assert result.context_length == 262144
+            assert result.max_output_tokens is None
+
+    @pytest.mark.asyncio
+    async def test_missing_completion_cap_remains_unknown(
+        self,
+        service,
+        mock_api_response,
+    ):
+        """Missing OpenRouter completion caps should not be guessed from context."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_api_response
+            mock_response.raise_for_status = MagicMock()
+            mock_client.get.return_value = mock_response
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await service.get_specs("z-ai/glm-5.1")
+
+            assert result is not None
+            assert result.context_length == 202752
+            assert result.max_output_tokens is None
 
     @pytest.mark.asyncio
     async def test_force_refresh_bypasses_cache(self, service, mock_api_response):
@@ -434,8 +490,8 @@ class TestServicePreload:
 
             count = await service.preload_all()
 
-            assert count == 4  # 4 models in mock response
-            assert len(service.list_cached_models()) == 4
+            assert count == 6  # 6 models in mock response
+            assert len(service.list_cached_models()) == 6
             assert "openai/gpt-4o" in service.list_cached_models()
             assert "anthropic/claude-opus-4" in service.list_cached_models()
 

--- a/tests/llm/test_model_specs.py
+++ b/tests/llm/test_model_specs.py
@@ -258,9 +258,9 @@ class TestServiceCaching:
     @pytest.mark.asyncio
     async def test_suspicious_context_sized_completion_cap_is_ignored(
         self,
-        service,
-        mock_api_response,
-    ):
+        service: ModelSpecsService,
+        mock_api_response: dict[str, Any],
+    ) -> None:
         """Context-sized OpenRouter completion caps are not usable output caps."""
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
@@ -279,9 +279,9 @@ class TestServiceCaching:
     @pytest.mark.asyncio
     async def test_missing_completion_cap_remains_unknown(
         self,
-        service,
-        mock_api_response,
-    ):
+        service: ModelSpecsService,
+        mock_api_response: dict[str, Any],
+    ) -> None:
         """Missing OpenRouter completion caps should not be guessed from context."""
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()

--- a/tests/test_core_provider_resolution.py
+++ b/tests/test_core_provider_resolution.py
@@ -3,19 +3,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
-from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 import pytest
 
 from penguin.core import PenguinCore
+from penguin.llm.model_config import ModelConfig
 from penguin.llm.model_config import safe_context_window
-
-
-def _as_any(value: object) -> Any:
-    return cast(Any, value)
 
 
 def _attach_core_helpers(core_like: SimpleNamespace) -> None:
@@ -23,7 +18,7 @@ def _attach_core_helpers(core_like: SimpleNamespace) -> None:
         lambda model_id,
         provider,
         client_preference: PenguinCore._canonicalize_runtime_model_id(  # noqa: E501
-            _as_any(core_like),
+            core_like,
             model_id,
             provider,
             client_preference,
@@ -31,7 +26,7 @@ def _attach_core_helpers(core_like: SimpleNamespace) -> None:
     )
     core_like._build_model_config_for_model = (
         lambda model_id: PenguinCore._build_model_config_for_model(  # noqa: E501
-            _as_any(core_like),
+            core_like,
             model_id,
         )
     )
@@ -51,7 +46,7 @@ def test_resolve_model_provider_prefers_config_entry() -> None:
     )
 
     provider, client_pref = PenguinCore._resolve_model_provider(
-        _as_any(core_like),
+        core_like,
         "openai/gpt-5",
     )
 
@@ -66,11 +61,11 @@ def test_resolve_model_provider_uses_native_for_openai_and_anthropic() -> None:
     )
 
     openai_provider, openai_pref = PenguinCore._resolve_model_provider(
-        _as_any(core_like),
+        core_like,
         "openai/gpt-5",
     )
     anthropic_provider, anthropic_pref = PenguinCore._resolve_model_provider(
-        _as_any(core_like),
+        core_like,
         "anthropic/claude-4-5-sonnet",
     )
 
@@ -85,7 +80,7 @@ def test_resolve_model_provider_keeps_openrouter_gateway() -> None:
     )
 
     provider, client_pref = PenguinCore._resolve_model_provider(
-        _as_any(core_like),
+        core_like,
         "openrouter/openai/gpt-5-codex",
     )
 
@@ -111,7 +106,7 @@ async def test_request_model_config_inherits_top_level_service_tier() -> None:
     core_like._resolve_model_provider = _resolve
 
     model_config, _ = await PenguinCore._build_model_config_for_model(
-        _as_any(core_like),
+        core_like,
         "openai/gpt-5.5",
     )
 
@@ -136,7 +131,7 @@ async def test_load_model_resolves_provider_before_fetch() -> None:
         state["resolved"] = True
         return "openrouter", "openrouter"
 
-    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
         del context_window_tokens
         applied["model"] = str(config.model)
 
@@ -149,7 +144,7 @@ async def test_load_model_resolves_provider_before_fetch() -> None:
     core_like._apply_new_model_config = _apply
 
     with patch("penguin.core.fetch_model_specs", new=AsyncMock(side_effect=_fetch)):
-        ok = await PenguinCore.load_model(_as_any(core_like), "openrouter/openai/gpt-5")
+        ok = await PenguinCore.load_model(core_like, "openrouter/openai/gpt-5")
 
     assert ok is True
     assert applied["model"] == "openai/gpt-5"
@@ -169,7 +164,7 @@ async def test_load_model_allows_native_anthropic_without_openrouter_specs() -> 
         del model_id
         return "anthropic", "native"
 
-    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
         del context_window_tokens
         applied.update(
             {
@@ -186,7 +181,7 @@ async def test_load_model_allows_native_anthropic_without_openrouter_specs() -> 
         "penguin.core.fetch_model_specs", new=AsyncMock(return_value={})
     ) as fetch:
         ok = await PenguinCore.load_model(
-            _as_any(core_like),
+            core_like,
             "anthropic/claude-3-7-sonnet-latest",
         )
 
@@ -210,14 +205,14 @@ async def test_load_model_surfaces_reason_when_openrouter_specs_missing() -> Non
         del model_id
         return "openrouter", "openrouter"
 
-    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
         del config, context_window_tokens
 
     core_like._resolve_model_provider = _resolve
     core_like._apply_new_model_config = _apply
 
     with patch("penguin.core.fetch_model_specs", new=AsyncMock(return_value={})):
-        ok = await PenguinCore.load_model(_as_any(core_like), "openrouter/openai/gpt-5")
+        ok = await PenguinCore.load_model(core_like, "openrouter/openai/gpt-5")
 
     assert ok is False
     assert isinstance(core_like._last_model_load_error, str)
@@ -226,7 +221,7 @@ async def test_load_model_surfaces_reason_when_openrouter_specs_missing() -> Non
 
 @pytest.mark.asyncio
 async def test_load_model_does_not_use_context_window_as_output_cap() -> None:
-    applied: dict[str, Any] = {}
+    applied: dict[str, object] = {}
     core_like = SimpleNamespace(
         config=SimpleNamespace(model_configs={}),
         model_config=SimpleNamespace(client_preference="openrouter"),
@@ -238,7 +233,7 @@ async def test_load_model_does_not_use_context_window_as_output_cap() -> None:
         del model_id
         return "openrouter", "openrouter"
 
-    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
         applied["model"] = str(config.model)
         applied["max_output_tokens"] = getattr(config, "max_output_tokens", None)
         applied["context_window_tokens"] = context_window_tokens
@@ -255,7 +250,7 @@ async def test_load_model_does_not_use_context_window_as_output_cap() -> None:
             }
         ),
     ):
-        ok = await PenguinCore.load_model(_as_any(core_like), "openrouter/z-ai/glm-5.1")
+        ok = await PenguinCore.load_model(core_like, "openrouter/z-ai/glm-5.1")
 
     assert ok is True
     assert applied["model"] == "z-ai/glm-5.1"
@@ -265,7 +260,7 @@ async def test_load_model_does_not_use_context_window_as_output_cap() -> None:
 
 @pytest.mark.asyncio
 async def test_load_model_clamps_explicit_max_output_tokens_to_safe_window() -> None:
-    applied: dict[str, Any] = {}
+    applied: dict[str, object] = {}
     core_like = SimpleNamespace(
         config=SimpleNamespace(model_configs={}),
         model_config=SimpleNamespace(current_model="old/model", service_tier=None),
@@ -279,7 +274,7 @@ async def test_load_model_clamps_explicit_max_output_tokens_to_safe_window() -> 
         del model_id
         return "openrouter", "openrouter"
 
-    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
         applied["model"] = str(config.model)
         applied["max_output_tokens"] = getattr(config, "max_output_tokens", None)
         applied["context_window_tokens"] = context_window_tokens
@@ -296,7 +291,52 @@ async def test_load_model_clamps_explicit_max_output_tokens_to_safe_window() -> 
             }
         ),
     ):
-        ok = await PenguinCore.load_model(_as_any(core_like), "openrouter/z-ai/glm-5.1")
+        ok = await PenguinCore.load_model(core_like, "openrouter/z-ai/glm-5.1")
+
+    assert ok is True
+    assert applied["model"] == "z-ai/glm-5.1"
+    assert applied["max_output_tokens"] == safe_context_window(204800)
+    assert applied["context_window_tokens"] == safe_context_window(204800)
+
+
+@pytest.mark.asyncio
+async def test_load_model_clamps_for_model_max_output_tokens_to_safe_window() -> None:
+    applied: dict[str, object] = {}
+    core_like = SimpleNamespace(
+        config=SimpleNamespace(
+            model_configs={
+                "openrouter/z-ai/glm-5.1": {
+                    "max_output_tokens": 202752,
+                }
+            }
+        ),
+        model_config=SimpleNamespace(client_preference="openrouter"),
+        _last_model_load_error=None,
+    )
+    _attach_core_helpers(core_like)
+
+    def _resolve(model_id: str) -> tuple[str, str]:
+        del model_id
+        return "openrouter", "openrouter"
+
+    def _apply(config: ModelConfig, context_window_tokens: int | None = None) -> None:
+        applied["model"] = str(config.model)
+        applied["max_output_tokens"] = config.max_output_tokens
+        applied["context_window_tokens"] = context_window_tokens
+
+    core_like._resolve_model_provider = _resolve
+    core_like._apply_new_model_config = _apply
+
+    with patch(
+        "penguin.core.fetch_model_specs",
+        new=AsyncMock(
+            return_value={
+                "context_length": 204800,
+                "max_output_tokens": None,
+            }
+        ),
+    ):
+        ok = await PenguinCore.load_model(core_like, "openrouter/z-ai/glm-5.1")
 
     assert ok is True
     assert applied["model"] == "z-ai/glm-5.1"

--- a/tests/test_core_provider_resolution.py
+++ b/tests/test_core_provider_resolution.py
@@ -225,13 +225,54 @@ async def test_load_model_surfaces_reason_when_openrouter_specs_missing() -> Non
 
 
 @pytest.mark.asyncio
-async def test_load_model_clamps_max_output_tokens_to_safe_window() -> None:
+async def test_load_model_does_not_use_context_window_as_output_cap() -> None:
     applied: dict[str, Any] = {}
     core_like = SimpleNamespace(
         config=SimpleNamespace(model_configs={}),
         model_config=SimpleNamespace(client_preference="openrouter"),
         _last_model_load_error=None,
     )
+    _attach_core_helpers(core_like)
+
+    def _resolve(model_id: str) -> tuple[str, str]:
+        del model_id
+        return "openrouter", "openrouter"
+
+    def _apply(config: Any, context_window_tokens: Any = None) -> None:
+        applied["model"] = str(config.model)
+        applied["max_output_tokens"] = getattr(config, "max_output_tokens", None)
+        applied["context_window_tokens"] = context_window_tokens
+
+    core_like._resolve_model_provider = _resolve
+    core_like._apply_new_model_config = _apply
+
+    with patch(
+        "penguin.core.fetch_model_specs",
+        new=AsyncMock(
+            return_value={
+                "context_length": 204800,
+                "max_output_tokens": None,
+            }
+        ),
+    ):
+        ok = await PenguinCore.load_model(_as_any(core_like), "openrouter/z-ai/glm-5.1")
+
+    assert ok is True
+    assert applied["model"] == "z-ai/glm-5.1"
+    assert applied["max_output_tokens"] is None
+    assert applied["context_window_tokens"] == safe_context_window(204800)
+
+
+@pytest.mark.asyncio
+async def test_load_model_clamps_explicit_max_output_tokens_to_safe_window() -> None:
+    applied: dict[str, Any] = {}
+    core_like = SimpleNamespace(
+        config=SimpleNamespace(model_configs={}),
+        model_config=SimpleNamespace(current_model="old/model", service_tier=None),
+        api_client=None,
+        _last_model_load_error=None,
+    )
+
     _attach_core_helpers(core_like)
 
     def _resolve(model_id: str) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- keep unknown OpenRouter output caps unset instead of falling back to the context window
- ignore suspicious OpenRouter completion caps that are effectively the full context window
- add regressions for Kimi/GLM-style metadata and explicit cap clamping

## Tests
- pytest tests/test_core_provider_resolution.py tests/llm/test_model_specs.py tests/llm/test_openrouter_base_url_isolation.py tests/llm/test_openrouter_tool_continuity.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of maximum output token limits to prevent unrealistic values from being applied and to respect explicitly configured limits without inappropriate defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maximooch/penguin/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->