### PR TITLE
bug: scope token usage by session

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -617,6 +617,13 @@ The web/API surface is intentionally being brought back into alignment with back
 - Clarification answer/resume now has an explicit web route (`POST /api/v1/tasks/{task_id}/clarification/resume`) rather than existing only as an internal runtime capability.
 - SSE/OpenCode event compatibility now includes session-scoped clarification status bridging so web clients can observe `clarification_needed` and `clarification_answered` state instead of silently missing those transitions.
 - The programmatic `PenguinAPI` wrapper is being kept aligned with the web routes so embedded callers and HTTP callers do not receive different lifecycle semantics.
+- Token/context-window telemetry is explicitly scoped. `GET /api/v1/token-usage`
+  without identifiers reports runtime/global core usage with `scope="runtime"`;
+  `GET /api/v1/token-usage?session_id=...` and
+  `GET /api/v1/sessions/{session_id}/token-usage` report persisted
+  session-scoped usage with `scope="session"` or fail explicitly for missing
+  sessions/agent scopes. Clients must not render transcript-specific context
+  horizon lines from runtime/global telemetry.
 
 This matters because a technically working route that hides clarification, phase truth, or non-terminal outcomes is still a broken interface. The surface has to tell the same truth as the runtime or users end up debugging documentation-shaped lies.
 

--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -650,7 +650,71 @@ Execute a task in the background.
 
 #### GET `/api/v1/token-usage`
 
-Get current token usage statistics.
+Get token/context-window usage telemetry.
+
+Without query parameters, this endpoint returns runtime/global core telemetry and
+sets `usage.scope` to `"runtime"`. Runtime usage is useful for process-level
+diagnostics, but clients must not treat it as proof that a specific transcript
+was trimmed.
+
+For transcript-aware UI, request a session-scoped payload:
+
+```bash
+curl "http://127.0.0.1:9000/api/v1/token-usage?session_id=sess_abc"
+```
+
+Equivalent session route:
+
+```bash
+curl "http://127.0.0.1:9000/api/v1/sessions/sess_abc/token-usage"
+```
+
+**Query Parameters:**
+- `session_id` (optional): Session to inspect. When present, Penguin never
+  silently falls back to runtime/global usage.
+- `conversation_id` (optional): Conversation identifier to echo in the scoped
+  response. Used as the lookup id when `session_id` is omitted.
+- `agent_id` (optional): Filter scoped session usage by `Message.agent_id`.
+  If the agent is not represented in the session, the endpoint returns `404`
+  instead of returning whole-session totals.
+
+**Session-scoped response:**
+
+```json
+{
+  "usage": {
+    "scope": "session",
+    "session_id": "sess_abc",
+    "conversation_id": "sess_abc",
+    "current_total_tokens": 12345,
+    "max_context_window_tokens": 200000,
+    "available_tokens": 187655,
+    "percentage": 6.17,
+    "categories": {
+      "SYSTEM": 12000,
+      "DIALOG": 345,
+      "SYSTEM_OUTPUT": 0
+    },
+    "truncations": {
+      "total_truncations": 0,
+      "messages_removed": 0,
+      "tokens_freed": 0,
+      "by_category": {},
+      "recent_events": []
+    }
+  }
+}
+```
+
+Missing scoped lookups return `404` with `usage.scope`/`detail.scope` set to
+`"missing"`. Consumers such as Link should render transcript-specific context
+horizon lines only when `usage.scope == "session"`.
+
+#### GET `/api/v1/sessions/{session_id}/token-usage`
+
+Session-scoped alias for `/api/v1/token-usage?session_id=...`. It accepts the
+same optional `conversation_id` and `agent_id` query parameters and has the same
+404 behavior for missing sessions or missing agent scopes.
 
 #### GET `/api/v1/context-files`
 

--- a/docs/docs/api_reference/core.md
+++ b/docs/docs/api_reference/core.md
@@ -557,14 +557,30 @@ Gets total tokens used in current session.
 ### `get_token_usage`
 
 ```python
-def get_token_usage(self) -> Dict[str, Dict[str, int]]
+def get_token_usage(
+    self,
+    session_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]
 ```
 
-Gets detailed token usage statistics.
+Returns runtime or scoped token/context-window telemetry.
+
+- With no identifiers, returns runtime/global core telemetry with
+  `scope="runtime"`.
+- With `session_id` or `conversation_id`, returns persisted session/conversation
+  telemetry with `scope="session"`; missing scoped lookups return
+  `scope="missing"` data for HTTP layers to translate to `404`.
+- With `agent_id`, scoped usage is filtered by `Message.agent_id`. Penguin does
+  not return whole-session totals for a missing agent scope.
 
 ```python
-stats = core.get_token_usage()
-print(stats["session"]["prompt_tokens"], stats["session"]["completion_tokens"])
+runtime_stats = core.get_token_usage()
+session_stats = core.get_token_usage(session_id="sess_abc")
+
+print(runtime_stats["scope"])
+print(session_stats["current_total_tokens"])
 ```
 
 ## Action Handling
@@ -648,10 +664,16 @@ Returns information about the currently loaded model including all configuration
 ### `get_token_usage`
 
 ```python
-def get_token_usage(self) -> Dict[str, Dict[str, int]]
+def get_token_usage(
+    self,
+    session_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+) -> Dict[str, Any]
 ```
 
-Returns detailed token usage statistics with enhanced structure for CLI and UI display.
+Returns runtime/global usage or session-scoped context-window telemetry for CLI
+and UI display. Transcript-specific UI should require `scope="session"`.
 
 ## Usage Examples
 

--- a/docs/docs/api_reference/example_requests.md
+++ b/docs/docs/api_reference/example_requests.md
@@ -26,3 +26,15 @@ curl -X POST http://127.0.0.1:9000/api/v1/tasks/execute \
   -H "Content-Type: application/json" \
   -d '{"name": "Build project", "description": "Set up repo"}'
 ```
+
+## Get Session-Scoped Token Usage
+```bash
+curl "http://127.0.0.1:9000/api/v1/token-usage?session_id=example-session"
+
+# Equivalent session route
+curl "http://127.0.0.1:9000/api/v1/sessions/example-session/token-usage"
+```
+
+Only responses with `usage.scope == "session"` are safe for transcript-specific
+context-window meters or context horizon UI. The unscoped endpoint returns
+runtime/global telemetry with `usage.scope == "runtime"`.

--- a/docs/docs/usage/api_usage.md
+++ b/docs/docs/usage/api_usage.md
@@ -243,11 +243,20 @@ print(f"Task execution started: {response.json()}")
 ```python
 import requests
 
-# Get token usage stats
+# Get runtime/global token usage stats
 response = requests.get("http://127.0.0.1:9000/api/v1/token-usage")
 usage = response.json()["usage"]
+print(f"Usage scope: {usage['scope']}")
 
-print(f"Main model usage: {usage['main_model']['total']} tokens")
+# Get transcript-safe, session-scoped context-window telemetry
+response = requests.get(
+    "http://127.0.0.1:9000/api/v1/token-usage",
+    params={"session_id": "example-session"},
+)
+usage = response.json()["usage"]
+
+if usage["scope"] == "session":
+    print(f"Session context usage: {usage['current_total_tokens']} tokens")
 ```
 
 ### Context Files

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -1911,10 +1911,33 @@ class PenguinCore:
         conversation_id: Optional[str] = None,
         agent_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Get token usage via conversation manager or a specific session.
+        """Return runtime or scoped token/context-window telemetry.
 
-        Supplying a session/conversation id returns persisted session-scoped
-        telemetry and never falls back to the global runtime window silently.
+        Args:
+            session_id: Optional session identifier to scope usage. Takes
+                precedence over the runtime context window and never falls back
+                to runtime usage when not found.
+            conversation_id: Optional conversation identifier. Used as the
+                lookup id when ``session_id`` is absent and echoed in scoped
+                responses.
+            agent_id: Optional agent identifier. When scoped usage is requested,
+                filters messages by ``Message.agent_id`` or uses an isolated
+                session whose metadata owner matches this id. Missing ownership
+                returns ``scope="missing"`` instead of whole-session totals.
+
+        Returns:
+            Dict[str, Any]: Runtime calls return ``scope="runtime"`` plus the
+            conversation manager's legacy usage fields. Scoped calls return
+            ``scope="session"``, ``session_id``, ``conversation_id``, optional
+            ``agent_id``, ``current_total_tokens``,
+            ``max_context_window_tokens``, ``available_tokens``, ``percentage``,
+            ``categories``, and ``truncations``. Missing scoped lookups return
+            ``scope="missing"`` with identifiers and ``error`` for HTTP layers
+            to translate to 404.
+
+        Raises:
+            None. Runtime telemetry failures are logged and return zeroed
+            runtime usage; missing scoped lookups are returned as data.
         """
 
         def _normalize(value: Optional[str]) -> Optional[str]:
@@ -1927,10 +1950,11 @@ class PenguinCore:
         requested_conversation_id = _normalize(conversation_id) or requested_session_id
 
         if requested_session_id:
+            requested_agent_id = _normalize(agent_id)
             usage = self._get_session_token_usage(
                 requested_session_id,
                 conversation_id=requested_conversation_id,
-                agent_id=_normalize(agent_id),
+                agent_id=requested_agent_id,
             )
             if usage is not None:
                 return usage
@@ -1938,6 +1962,7 @@ class PenguinCore:
                 "scope": "missing",
                 "session_id": requested_session_id,
                 "conversation_id": requested_conversation_id,
+                **({"agent_id": requested_agent_id} if requested_agent_id else {}),
                 "error": "session token usage not found",
             }
 
@@ -1993,26 +2018,73 @@ class PenguinCore:
         if not isinstance(metadata, dict):
             metadata = {}
 
-        usage_snapshot = metadata.get("_opencode_usage_v1")
-        if isinstance(usage_snapshot, dict):
-            usage = dict(usage_snapshot)
+        metadata_agent_id = metadata.get("agent_id")
+        if isinstance(metadata_agent_id, str):
+            metadata_agent_id = metadata_agent_id.strip() or None
         else:
-            usage = self._usage_from_session_messages(session)
+            metadata_agent_id = None
+
+        if agent_id:
+            message_agent_ids = {
+                message_agent_id.strip()
+                for message in getattr(session, "messages", []) or []
+                if isinstance(
+                    message_agent_id := getattr(message, "agent_id", None),
+                    str,
+                )
+                and message_agent_id.strip()
+            }
+            if agent_id in message_agent_ids:
+                usage = self._usage_from_session_messages(
+                    session,
+                    agent_id=agent_id,
+                )
+            elif metadata_agent_id == agent_id and not message_agent_ids:
+                usage_snapshot = metadata.get("_opencode_usage_v1")
+                if isinstance(usage_snapshot, dict):
+                    usage = dict(usage_snapshot)
+                else:
+                    usage = self._usage_from_session_messages(session)
+            else:
+                return {
+                    "scope": "missing",
+                    "session_id": session_id,
+                    "conversation_id": conversation_id or session_id,
+                    "agent_id": agent_id,
+                    "error": "agent token usage not found for session",
+                }
+        else:
+            usage_snapshot = metadata.get("_opencode_usage_v1")
+            if isinstance(usage_snapshot, dict):
+                usage = dict(usage_snapshot)
+            else:
+                usage = self._usage_from_session_messages(session)
 
         usage["scope"] = "session"
         usage["session_id"] = session_id
         usage["conversation_id"] = conversation_id or session_id
         if agent_id:
             usage["agent_id"] = agent_id
-        elif isinstance(metadata.get("agent_id"), str):
-            usage["agent_id"] = metadata["agent_id"]
+        elif metadata_agent_id:
+            usage["agent_id"] = metadata_agent_id
 
         return usage
 
-    def _usage_from_session_messages(self, session: Any) -> Dict[str, Any]:
+    def _usage_from_session_messages(
+        self,
+        session: Any,
+        *,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Build a conservative session-scoped usage payload from messages."""
 
         messages = getattr(session, "messages", []) or []
+        if agent_id:
+            messages = [
+                message
+                for message in messages
+                if getattr(message, "agent_id", None) == agent_id
+            ]
         categories: Dict[str, int] = {category.name: 0 for category in MessageCategory}
         current_total_tokens = 0
 

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -1905,16 +1905,53 @@ class PenguinCore:
         await self._emit_opencode_session_status(sid, "idle")
         return aborted
 
-    def get_token_usage(self) -> Dict[str, Dict[str, int]]:
-        """Get token usage via conversation manager"""
+    def get_token_usage(
+        self,
+        session_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get token usage via conversation manager or a specific session.
+
+        Supplying a session/conversation id returns persisted session-scoped
+        telemetry and never falls back to the global runtime window silently.
+        """
+
+        def _normalize(value: Optional[str]) -> Optional[str]:
+            if not isinstance(value, str):
+                return None
+            stripped = value.strip()
+            return stripped or None
+
+        requested_session_id = _normalize(session_id) or _normalize(conversation_id)
+        requested_conversation_id = _normalize(conversation_id) or requested_session_id
+
+        if requested_session_id:
+            usage = self._get_session_token_usage(
+                requested_session_id,
+                conversation_id=requested_conversation_id,
+                agent_id=_normalize(agent_id),
+            )
+            if usage is not None:
+                return usage
+            return {
+                "scope": "missing",
+                "session_id": requested_session_id,
+                "conversation_id": requested_conversation_id,
+                "error": "session token usage not found",
+            }
+
         try:
             if not self.conversation_manager:
                 return {
+                    "scope": "runtime",
                     "total": {"input": 0, "output": 0},
                     "session": {"input": 0, "output": 0},
                 }
 
             usage = self.conversation_manager.get_token_usage()
+            if isinstance(usage, dict):
+                usage = {"scope": "runtime", **usage}
 
             # Emit UI event for token update (only if event loop is running)
             try:
@@ -1934,9 +1971,85 @@ class PenguinCore:
         except Exception as e:
             logger.error(f"Error getting token usage: {e}")
             return {
+                "scope": "runtime",
                 "total": {"input": 0, "output": 0},
                 "session": {"input": 0, "output": 0},
             }
+
+    def _get_session_token_usage(
+        self,
+        session_id: str,
+        *,
+        conversation_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return usage for one persisted session without global fallback."""
+
+        session, _manager = self._find_session_store(session_id)
+        if session is None:
+            return None
+
+        metadata = getattr(session, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        usage_snapshot = metadata.get("_opencode_usage_v1")
+        if isinstance(usage_snapshot, dict):
+            usage = dict(usage_snapshot)
+        else:
+            usage = self._usage_from_session_messages(session)
+
+        usage["scope"] = "session"
+        usage["session_id"] = session_id
+        usage["conversation_id"] = conversation_id or session_id
+        if agent_id:
+            usage["agent_id"] = agent_id
+        elif isinstance(metadata.get("agent_id"), str):
+            usage["agent_id"] = metadata["agent_id"]
+
+        return usage
+
+    def _usage_from_session_messages(self, session: Any) -> Dict[str, Any]:
+        """Build a conservative session-scoped usage payload from messages."""
+
+        messages = getattr(session, "messages", []) or []
+        categories: Dict[str, int] = {category.name: 0 for category in MessageCategory}
+        current_total_tokens = 0
+
+        for message in messages:
+            token_count = int(getattr(message, "tokens", 0) or 0)
+            current_total_tokens += token_count
+
+            category = getattr(message, "category", None)
+            if hasattr(category, "name"):
+                category_name = category.name
+            elif isinstance(category, str):
+                category_name = category
+            else:
+                category_name = "UNKNOWN"
+            categories[category_name] = categories.get(category_name, 0) + token_count
+
+        context_window = getattr(self.conversation_manager, "context_window", None)
+        max_tokens = int(getattr(context_window, "max_context_window_tokens", 0) or 0)
+        available_tokens = (
+            max(max_tokens - current_total_tokens, 0) if max_tokens else 0
+        )
+        percentage = (current_total_tokens / max_tokens) * 100 if max_tokens else 0
+
+        return {
+            "current_total_tokens": current_total_tokens,
+            "max_context_window_tokens": max_tokens,
+            "available_tokens": available_tokens,
+            "percentage": percentage,
+            "categories": categories,
+            "truncations": {
+                "total_truncations": 0,
+                "messages_removed": 0,
+                "tokens_freed": 0,
+                "by_category": {},
+                "recent_events": [],
+            },
+        }
 
     def set_system_prompt(self, prompt: str) -> None:
         """Set the system prompt for both core and API client."""
@@ -3076,6 +3189,7 @@ class PenguinCore:
                             ),
                             "available_tokens": token_data.get("available_tokens", 0),
                             "percentage": token_data.get("percentage", 0),
+                            "categories": token_data.get("categories", {}),
                             "truncations": token_data.get("truncations", {}),
                         }
                 except Exception:

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -86,6 +86,123 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _empty_truncations() -> Dict[str, Any]:
+    """Return an empty truncation payload matching API telemetry shape."""
+
+    return {
+        "total_truncations": 0,
+        "messages_removed": 0,
+        "tokens_freed": 0,
+        "by_category": {},
+        "recent_events": [],
+    }
+
+
+def _truncations_from_tracker(tracker: Any) -> Dict[str, Any]:
+    """Normalize a context-window truncation tracker for telemetry."""
+
+    if tracker is None:
+        return _empty_truncations()
+
+    by_category: Dict[str, int] = {}
+    for category in MessageCategory:
+        try:
+            by_category[category.name] = int(tracker.get_category_truncations(category))
+        except Exception:
+            by_category[category.name] = 0
+
+    recent_events = []
+    try:
+        events = tracker.get_recent_events(limit=5)
+    except Exception:
+        events = []
+    for event in events:
+        category = getattr(event, "category", None)
+        recent_events.append(
+            {
+                "category": category.name
+                if hasattr(category, "name")
+                else str(category),
+                "messages_removed": int(getattr(event, "messages_removed", 0) or 0),
+                "tokens_freed": int(getattr(event, "tokens_freed", 0) or 0),
+                "timestamp": getattr(event, "timestamp", ""),
+            }
+        )
+
+    return {
+        "total_truncations": int(getattr(tracker, "session_total_truncations", 0) or 0),
+        "messages_removed": int(
+            getattr(tracker, "session_total_messages_removed", 0) or 0
+        ),
+        "tokens_freed": int(getattr(tracker, "session_total_tokens_freed", 0) or 0),
+        "by_category": by_category,
+        "recent_events": recent_events,
+    }
+
+
+def _usage_from_context_window(context_window: Any) -> Dict[str, Any]:
+    """Return standardized usage telemetry for one context window."""
+
+    cw_usage = context_window.get_token_usage()
+    categories: Dict[str, int] = {}
+    for category in MessageCategory:
+        try:
+            categories[category.name] = int(context_window.get_usage(category) or 0)
+        except Exception:
+            categories[category.name] = 0
+
+    max_tokens = int(
+        cw_usage.get("max", getattr(context_window, "max_context_window_tokens", 0))
+        or 0
+    )
+    current_total_tokens = int(cw_usage.get("total", 0) or 0)
+    available_tokens = int(
+        cw_usage.get("available", getattr(context_window, "available_tokens", 0)) or 0
+    )
+
+    return {
+        "current_total_tokens": current_total_tokens,
+        "max_tokens": max_tokens,
+        "max_context_window_tokens": max_tokens,
+        "available_tokens": available_tokens,
+        "percentage": cw_usage.get("usage_percentage", 0),
+        "categories": categories,
+        "truncations": _truncations_from_tracker(
+            getattr(context_window, "truncation_tracker", None)
+        ),
+    }
+
+
+def _usage_from_session_messages(
+    session: Any,
+    max_context_window_tokens: int = 0,
+) -> Dict[str, Any]:
+    """Build conservative usage telemetry directly from one session's messages."""
+
+    categories: Dict[str, int] = {category.name: 0 for category in MessageCategory}
+    current_total_tokens = 0
+    for message in getattr(session, "messages", []) or []:
+        token_count = int(getattr(message, "tokens", 0) or 0)
+        current_total_tokens += token_count
+        category = getattr(message, "category", None)
+        category_name = category.name if hasattr(category, "name") else str(category)
+        categories[category_name] = categories.get(category_name, 0) + token_count
+
+    max_tokens = int(max_context_window_tokens or 0)
+    available_tokens = max(max_tokens - current_total_tokens, 0) if max_tokens else 0
+    percentage = (current_total_tokens / max_tokens) * 100 if max_tokens else 0
+
+    return {
+        "current_total_tokens": current_total_tokens,
+        "max_tokens": max_tokens,
+        "max_context_window_tokens": max_tokens,
+        "available_tokens": available_tokens,
+        "percentage": percentage,
+        "categories": categories,
+        "truncations": _empty_truncations(),
+    }
+
+
 def _context_previews_enabled() -> bool:
     """Return whether normal trace logs may include message previews."""
 
@@ -481,6 +598,27 @@ class _ScopedConversationManager:
         if hasattr(self._base_manager, "get_current_context_window"):
             return self._base_manager.get_current_context_window()
         return getattr(self._base_manager, "context_window", None)
+
+    def get_token_usage(self) -> Dict[str, Any]:
+        """Return token usage for this scoped conversation, not the base manager."""
+
+        conversation = self._conversation
+        session = getattr(conversation, "session", None)
+        context_window = getattr(conversation, "context_window", None)
+        if context_window is None:
+            try:
+                windows = getattr(self._base_manager, "agent_context_windows", None)
+                if isinstance(windows, dict):
+                    context_window = windows.get(self._agent_id)
+            except Exception:
+                context_window = None
+
+        if context_window is not None:
+            return _usage_from_context_window(context_window)
+
+        base_window = getattr(self._base_manager, "context_window", None)
+        max_tokens = int(getattr(base_window, "max_context_window_tokens", 0) or 0)
+        return _usage_from_session_messages(session, max_tokens)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._base_manager, name)

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -108,26 +108,42 @@ def _truncations_from_tracker(tracker: Any) -> Dict[str, Any]:
     for category in MessageCategory:
         try:
             by_category[category.name] = int(tracker.get_category_truncations(category))
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "failed to get_category_truncations for %s: %s",
+                category,
+                exc,
+                exc_info=True,
+            )
             by_category[category.name] = 0
 
     recent_events = []
     try:
         events = tracker.get_recent_events(limit=5)
-    except Exception:
+    except Exception as exc:
+        logger.debug("failed to get_recent_events: %s", exc, exc_info=True)
         events = []
     for event in events:
-        category = getattr(event, "category", None)
-        recent_events.append(
-            {
-                "category": category.name
-                if hasattr(category, "name")
-                else str(category),
-                "messages_removed": int(getattr(event, "messages_removed", 0) or 0),
-                "tokens_freed": int(getattr(event, "tokens_freed", 0) or 0),
-                "timestamp": getattr(event, "timestamp", ""),
-            }
-        )
+        try:
+            category = getattr(event, "category", None)
+            recent_events.append(
+                {
+                    "category": category.name
+                    if hasattr(category, "name")
+                    else str(category),
+                    "messages_removed": int(
+                        getattr(event, "messages_removed", 0) or 0
+                    ),
+                    "tokens_freed": int(getattr(event, "tokens_freed", 0) or 0),
+                    "timestamp": getattr(event, "timestamp", ""),
+                }
+            )
+        except Exception as exc:
+            logger.debug(
+                "failed to normalize truncation event: %s",
+                exc,
+                exc_info=True,
+            )
 
     return {
         "total_truncations": int(getattr(tracker, "session_total_truncations", 0) or 0),

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -80,6 +80,7 @@ from penguin.web.services.session_view import (
 from penguin.web.services.session_fork import fork_session
 from penguin.web.services.session_revert import revert_session, unrevert_session
 from penguin.web.services.session_summary import summarize_session_title
+from penguin.web.services.token_usage import get_token_usage_payload
 from penguin.web.middleware.auth import (
     AuthenticationError,
     AuthConfig,
@@ -5425,9 +5426,42 @@ async def execute_task_via_runmode(
 
 
 @router.get("/api/v1/token-usage")
-async def get_token_usage(core: PenguinCore = Depends(get_core)):
-    """Get current token usage statistics."""
-    return {"usage": core.get_token_usage()}
+async def get_token_usage(
+    session_id: Optional[str] = Query(default=None),
+    conversation_id: Optional[str] = Query(default=None),
+    agent_id: Optional[str] = Query(default=None),
+    core: PenguinCore = Depends(get_core),
+):
+    """Get token usage statistics.
+
+    When a session/conversation id is provided, usage is session scoped. Without
+    identifiers this preserves the legacy runtime response but labels it as
+    runtime scoped for callers that need transcript-safe telemetry.
+    """
+
+    return get_token_usage_payload(
+        core,
+        session_id=session_id,
+        conversation_id=conversation_id,
+        agent_id=agent_id,
+    )
+
+
+@router.get("/api/v1/sessions/{session_id}/token-usage")
+async def get_session_token_usage(
+    session_id: str,
+    conversation_id: Optional[str] = Query(default=None),
+    agent_id: Optional[str] = Query(default=None),
+    core: PenguinCore = Depends(get_core),
+):
+    """Get token usage statistics for a specific session."""
+
+    return get_token_usage_payload(
+        core,
+        session_id=session_id,
+        conversation_id=conversation_id or session_id,
+        agent_id=agent_id,
+    )
 
 
 @router.get("/api/v1/conversations")

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -5431,7 +5431,7 @@ async def get_token_usage(
     conversation_id: Optional[str] = Query(default=None),
     agent_id: Optional[str] = Query(default=None),
     core: PenguinCore = Depends(get_core),
-):
+) -> Dict[str, Any]:
     """Get token usage statistics.
 
     When a session/conversation id is provided, usage is session scoped. Without
@@ -5453,7 +5453,7 @@ async def get_session_token_usage(
     conversation_id: Optional[str] = Query(default=None),
     agent_id: Optional[str] = Query(default=None),
     core: PenguinCore = Depends(get_core),
-):
+) -> Dict[str, Any]:
     """Get token usage statistics for a specific session."""
 
     return get_token_usage_payload(

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -295,6 +295,7 @@ def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]
                 ),
                 "available_tokens": usage_snapshot.get("available_tokens", 0),
                 "percentage": usage_snapshot.get("percentage", 0),
+                "categories": usage_snapshot.get("categories", {}),
                 "truncations": usage_snapshot.get("truncations", {}),
             }
 

--- a/penguin/web/services/token_usage.py
+++ b/penguin/web/services/token_usage.py
@@ -1,0 +1,26 @@
+"""Token usage service helpers for route handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+
+
+def get_token_usage_payload(
+    core: Any,
+    *,
+    session_id: str | None = None,
+    conversation_id: str | None = None,
+    agent_id: str | None = None,
+) -> dict[str, Any]:
+    """Build token usage response payload, preserving explicit scope metadata."""
+
+    usage = core.get_token_usage(
+        session_id=session_id,
+        conversation_id=conversation_id,
+        agent_id=agent_id,
+    )
+    if usage.get("scope") == "missing":
+        raise HTTPException(status_code=404, detail=usage)
+    return {"usage": usage}

--- a/tests/api/test_token_usage_routes.py
+++ b/tests/api/test_token_usage_routes.py
@@ -52,6 +52,11 @@ class _ConversationManager:
         }
 
 
+class _AgentConversationManager(_ConversationManager):
+    def get_token_usage(self) -> dict[str, object]:
+        raise AssertionError("agent-scoped session queries must not use runtime usage")
+
+
 def _message(category: MessageCategory, tokens: int) -> Message:
     return Message(role="user", content="x", category=category, tokens=tokens)
 
@@ -62,7 +67,7 @@ def _session(session_id: str, tokens: int) -> Session:
     return session
 
 
-def _core(sessions: list[Session]) -> Any:
+def _core(sessions: list[Session]) -> SimpleNamespace:
     core = SimpleNamespace()
 
     core.conversation_manager = _ConversationManager(sessions)
@@ -72,6 +77,16 @@ def _core(sessions: list[Session]) -> Any:
     core._usage_from_session_messages = usage_from_messages.__get__(core)
     core.get_token_usage = PenguinCore.get_token_usage.__get__(core)
     return core
+
+
+def _message_for_agent(agent_id: str, tokens: int) -> Message:
+    return Message(
+        role="user",
+        content="x",
+        category=MessageCategory.DIALOG,
+        tokens=tokens,
+        agent_id=agent_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -134,3 +149,49 @@ async def test_session_token_usage_path_returns_404_for_missing_session() -> Non
 
     assert exc.value.status_code == 404
     assert exc.value.detail["scope"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_token_usage_filters_session_messages_by_agent_id() -> None:
+    session = Session(id="session_agent")
+    session.messages.extend(
+        [
+            _message_for_agent("agent-a", 10),
+            _message_for_agent("agent-b", 40),
+        ]
+    )
+    core = _core([session])
+    core.conversation_manager = _AgentConversationManager([session])
+
+    response = await get_token_usage(
+        session_id="session_agent",
+        conversation_id=None,
+        agent_id="agent-a",
+        core=core,
+    )
+
+    usage = response["usage"]
+    assert usage["scope"] == "session"
+    assert usage["agent_id"] == "agent-a"
+    assert usage["current_total_tokens"] == 10
+    assert usage["categories"]["DIALOG"] == 10
+
+
+@pytest.mark.asyncio
+async def test_token_usage_returns_404_for_missing_agent_scope() -> None:
+    session = Session(id="session_agent")
+    session.messages.append(_message_for_agent("agent-a", 10))
+    core = _core([session])
+    core.conversation_manager = _AgentConversationManager([session])
+
+    with pytest.raises(HTTPException) as exc:
+        await get_token_usage(
+            session_id="session_agent",
+            conversation_id=None,
+            agent_id="agent-b",
+            core=core,
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["scope"] == "missing"
+    assert exc.value.detail["agent_id"] == "agent-b"

--- a/tests/api/test_token_usage_routes.py
+++ b/tests/api/test_token_usage_routes.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from penguin.core import PenguinCore
+from penguin.system.state import Message, MessageCategory, Session
+from penguin.web.routes import get_session_token_usage, get_token_usage
+
+
+class _Manager:
+    def __init__(self, sessions: list[Session]) -> None:
+        self.sessions = {session.id: (session, False) for session in sessions}
+        self.session_index = {
+            session.id: {"token_count": session.total_tokens} for session in sessions
+        }
+
+    def load_session(self, session_id: str) -> Session | None:
+        item = self.sessions.get(session_id)
+        if item is None:
+            return None
+        return item[0]
+
+
+class _ContextWindow:
+    max_context_window_tokens = 200_000
+
+
+class _ConversationManager:
+    def __init__(self, sessions: list[Session]) -> None:
+        self.context_window = _ContextWindow()
+        self.session_manager = _Manager(sessions)
+        self.agent_session_managers: dict[str, Any] = {}
+
+    def get_token_usage(self) -> dict[str, Any]:
+        return {
+            "current_total_tokens": 99_000,
+            "max_context_window_tokens": 200_000,
+            "available_tokens": 101_000,
+            "percentage": 49.5,
+            "categories": {"DIALOG": 99_000},
+            "truncations": {
+                "total_truncations": 4,
+                "messages_removed": 47,
+                "tokens_freed": 67_000,
+                "by_category": {},
+                "recent_events": [],
+            },
+        }
+
+
+def _message(category: MessageCategory, tokens: int) -> Message:
+    return Message(role="user", content="x", category=category, tokens=tokens)
+
+
+def _session(session_id: str, tokens: int) -> Session:
+    session = Session(id=session_id)
+    session.messages.append(_message(MessageCategory.DIALOG, tokens))
+    return session
+
+
+def _core(sessions: list[Session]) -> Any:
+    core = SimpleNamespace()
+
+    core.conversation_manager = _ConversationManager(sessions)
+    core._find_session_store = PenguinCore._find_session_store.__get__(core)
+    core._get_session_token_usage = PenguinCore._get_session_token_usage.__get__(core)
+    usage_from_messages = PenguinCore._usage_from_session_messages
+    core._usage_from_session_messages = usage_from_messages.__get__(core)
+    core.get_token_usage = PenguinCore.get_token_usage.__get__(core)
+    return core
+
+
+@pytest.mark.asyncio
+async def test_token_usage_query_is_session_scoped_without_runtime_bleed() -> None:
+    session_a = _session("session_a", 70_000)
+    session_a.metadata["_opencode_usage_v1"] = {
+        "current_total_tokens": 70_000,
+        "max_context_window_tokens": 200_000,
+        "available_tokens": 130_000,
+        "percentage": 35.0,
+        "categories": {"DIALOG": 70_000},
+        "truncations": {
+            "total_truncations": 2,
+            "messages_removed": 47,
+            "tokens_freed": 67_000,
+            "by_category": {},
+            "recent_events": [],
+        },
+    }
+    session_b = _session("session_b", 123)
+
+    response = await get_token_usage(
+        session_id="session_b",
+        conversation_id=None,
+        agent_id=None,
+        core=_core([session_a, session_b]),
+    )
+
+    usage = response["usage"]
+    assert usage["scope"] == "session"
+    assert usage["session_id"] == "session_b"
+    assert usage["current_total_tokens"] == 123
+    assert usage["truncations"]["messages_removed"] == 0
+    assert usage["truncations"]["tokens_freed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_token_usage_without_session_is_marked_runtime() -> None:
+    response = await get_token_usage(
+        session_id=None,
+        conversation_id=None,
+        agent_id=None,
+        core=_core([_session("session_a", 10)]),
+    )
+
+    usage = response["usage"]
+    assert usage["scope"] == "runtime"
+    assert usage["truncations"]["messages_removed"] == 47
+
+
+@pytest.mark.asyncio
+async def test_session_token_usage_path_returns_404_for_missing_session() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await get_session_token_usage(
+            "missing_session",
+            conversation_id=None,
+            agent_id=None,
+            core=_core([]),
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail["scope"] == "missing"

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -760,7 +760,7 @@ def test_scoped_conversation_manager_reports_scoped_context_window_usage() -> No
     from penguin.system.context_window import ContextWindowManager
     from penguin.system.state import MessageCategory
 
-    scoped_window = ContextWindowManager(token_counter=lambda content: 0)
+    scoped_window = ContextWindowManager(token_counter=lambda _content: 0)
     scoped_window.max_context_window_tokens = 1_000
     scoped_window.update_usage(MessageCategory.DIALOG, 125)
     scoped_window.truncation_tracker.record_truncation(
@@ -770,7 +770,7 @@ def test_scoped_conversation_manager_reports_scoped_context_window_usage() -> No
         total_messages_before=5,
         total_messages_after=3,
     )
-    global_window = ContextWindowManager(token_counter=lambda content: 0)
+    global_window = ContextWindowManager(token_counter=lambda _content: 0)
     global_window.max_context_window_tokens = 1_000
     global_window.update_usage(MessageCategory.DIALOG, 900)
     global_window.truncation_tracker.record_truncation(
@@ -802,7 +802,7 @@ def test_scoped_conversation_manager_does_not_fall_back_to_global_window() -> No
     from penguin.system.context_window import ContextWindowManager
     from penguin.system.state import Message, MessageCategory
 
-    global_window = ContextWindowManager(token_counter=lambda content: 0)
+    global_window = ContextWindowManager(token_counter=lambda _content: 0)
     global_window.max_context_window_tokens = 1_000
     global_window.update_usage(MessageCategory.DIALOG, 900)
     global_window.truncation_tracker.record_truncation(

--- a/tests/test_engine_initialization.py
+++ b/tests/test_engine_initialization.py
@@ -756,6 +756,90 @@ def test_preloaded_scoped_conversation_manager_is_adopted_within_run_state() -> 
     assert adopted is preloaded
 
 
+def test_scoped_conversation_manager_reports_scoped_context_window_usage() -> None:
+    from penguin.system.context_window import ContextWindowManager
+    from penguin.system.state import MessageCategory
+
+    scoped_window = ContextWindowManager(token_counter=lambda content: 0)
+    scoped_window.max_context_window_tokens = 1_000
+    scoped_window.update_usage(MessageCategory.DIALOG, 125)
+    scoped_window.truncation_tracker.record_truncation(
+        MessageCategory.DIALOG,
+        messages_removed=2,
+        tokens_freed=300,
+        total_messages_before=5,
+        total_messages_after=3,
+    )
+    global_window = ContextWindowManager(token_counter=lambda content: 0)
+    global_window.max_context_window_tokens = 1_000
+    global_window.update_usage(MessageCategory.DIALOG, 900)
+    global_window.truncation_tracker.record_truncation(
+        MessageCategory.DIALOG,
+        messages_removed=47,
+        tokens_freed=67_000,
+        total_messages_before=50,
+        total_messages_after=3,
+    )
+    session = SimpleNamespace(id="session-scoped", messages=[])
+    conversation = SimpleNamespace(session=session, context_window=scoped_window)
+    base_manager = SimpleNamespace(
+        core=None,
+        get_agent_conversation=MagicMock(return_value=conversation),
+        context_window=global_window,
+        agent_context_windows={},
+    )
+
+    scoped = _ScopedConversationManager(cast(Any, base_manager), "agent-a")
+    usage = scoped.get_token_usage()
+
+    assert usage["current_total_tokens"] == 125
+    assert usage["categories"]["DIALOG"] == 125
+    assert usage["truncations"]["messages_removed"] == 2
+    assert usage["truncations"]["tokens_freed"] == 300
+
+
+def test_scoped_conversation_manager_does_not_fall_back_to_global_window() -> None:
+    from penguin.system.context_window import ContextWindowManager
+    from penguin.system.state import Message, MessageCategory
+
+    global_window = ContextWindowManager(token_counter=lambda content: 0)
+    global_window.max_context_window_tokens = 1_000
+    global_window.update_usage(MessageCategory.DIALOG, 900)
+    global_window.truncation_tracker.record_truncation(
+        MessageCategory.DIALOG,
+        messages_removed=47,
+        tokens_freed=67_000,
+        total_messages_before=50,
+        total_messages_after=3,
+    )
+    session = SimpleNamespace(
+        id="session-scoped",
+        messages=[
+            Message(
+                role="user",
+                content="hi",
+                category=MessageCategory.DIALOG,
+                tokens=12,
+            )
+        ],
+    )
+    conversation = SimpleNamespace(session=session, context_window=None)
+    base_manager = SimpleNamespace(
+        core=None,
+        get_agent_conversation=MagicMock(return_value=conversation),
+        context_window=global_window,
+        agent_context_windows={},
+    )
+
+    scoped = _ScopedConversationManager(cast(Any, base_manager), "agent-a")
+    usage = scoped.get_token_usage()
+
+    assert usage["current_total_tokens"] == 12
+    assert usage["categories"]["DIALOG"] == 12
+    assert usage["truncations"]["messages_removed"] == 0
+    assert usage["truncations"]["tokens_freed"] == 0
+
+
 @pytest.mark.asyncio
 async def test_llm_step_returns_usage_from_active_api_client() -> None:
     conversation = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add session/conversation-aware token usage lookup for /api/v1/token-usage
- add /api/v1/sessions/{session_id}/token-usage
- mark legacy global usage as scope=runtime and missing session lookups as 404
- persist categories in Link/OpenCode usage snapshots
- make scoped conversation managers report scoped context window usage instead of base/global manager usage

## Tests
- python -m pytest tests/api/test_token_usage_routes.py tests/test_engine_initialization.py tests/api/test_session_view_service.py tests/test_core_system_diagnostics.py::TestPenguinCoreSystemDiagnostics::test_get_token_usage_success tests/test_core_system_diagnostics.py::TestPenguinCoreSystemDiagnostics::test_get_token_usage_no_conversation_manager tests/test_core_system_diagnostics.py::TestPenguinCoreSystemDiagnostics::test_get_token_usage_exception_handling -q
- python -m pytest tests/api/test_token_usage_routes.py tests/test_engine_initialization.py tests/api/test_session_view_service.py -q
- uv run ruff check penguin/web/services/token_usage.py tests/api/test_token_usage_routes.py --isolated --select F,E,W,I,RUF --line-length 88
- uv run ruff format --check penguin/web/services/token_usage.py tests/api/test_token_usage_routes.py --isolated --line-length 88

Note: repo-wide ruff still reports pre-existing lint debt in large legacy files; new files pass isolated ruff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage reporting now supports scoped queries by session, conversation, and agent identifiers.
  * New endpoint added for retrieving session-specific token usage data.
  * Token usage data now includes category breakdowns for better tracking.

* **Tests**
  * Added comprehensive tests for token usage routes and scoped usage computation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maximooch/penguin/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->