### PR TITLE
Do not synthesize OpenRouter output caps from context

### DIFF
--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -861,15 +861,13 @@ class APIClient:
                 context_limit_int is not None
                 and estimated_input_tokens is not None
                 and estimated_input_tokens > 0
+                and effective_max_output_tokens is not None
             ):
                 available_output_tokens = max(
                     context_limit_int - estimated_input_tokens - 512,
                     1,
                 )
-                if (
-                    effective_max_output_tokens is None
-                    or effective_max_output_tokens > available_output_tokens
-                ):
+                if effective_max_output_tokens > available_output_tokens:
                     self.logger.warning(
                         "[APIClient:%s] Clamping max_output_tokens from %s to %s "
                         "based on context_limit=%s estimated_input_tokens=%s",

--- a/tests/llm/test_prepared_request_contract.py
+++ b/tests/llm/test_prepared_request_contract.py
@@ -5,6 +5,7 @@ import logging
 import pytest
 
 from penguin.llm.api_client import APIClient
+from penguin.llm.model_config import ModelConfig
 from penguin.llm.contracts import (
     LLMPreparedRequest,
     LLMProviderCapabilities,
@@ -252,3 +253,83 @@ async def test_api_client_delegates_prepared_request_to_handler(
     assert prepared.protocol == "openai_responses"
     assert "Injected system prompt." in str(prepared.body["input"])
     assert prepared.body["max_output_tokens"] == 111
+
+
+@pytest.mark.asyncio
+async def test_api_client_does_not_synthesize_max_tokens_from_context_window() -> None:
+    class _Handler:
+        model_config = None
+        received_max_output_tokens: int | None = -1
+
+        def get_capabilities(self) -> LLMProviderCapabilities:
+            return LLMProviderCapabilities(provider="openrouter")
+
+        async def get_response(self, **kwargs: object) -> str:
+            value = kwargs.get("max_output_tokens")
+            self.received_max_output_tokens = value if isinstance(value, int) else None
+            return "ok"
+
+    handler = _Handler()
+    client = APIClient.__new__(APIClient)
+    client.model_config = ModelConfig(
+        model="moonshotai/kimi-k2.6",
+        provider="openrouter",
+        client_preference="openrouter",
+    )
+    client.model_config.max_context_window_tokens = 272000
+    client.model_config.max_output_tokens = None
+    client.system_prompt = None
+    client.client_handler = handler
+    client.logger = logging.getLogger(__name__)
+    client._last_error = None
+    client._last_response_result = None
+    client._clear_handler_error = lambda: None
+    client._get_handler_error = lambda: None
+    client._build_response_result = lambda **kwargs: None
+    client._prepare_messages_with_system_prompt = lambda messages: messages
+    client.count_tokens = lambda _messages: 46421
+
+    result = await client.get_response(_messages(), stream=False)
+
+    assert result == "ok"
+    assert handler.received_max_output_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_api_client_clamps_explicit_max_tokens_to_available_context() -> None:
+    class _Handler:
+        model_config = None
+        received_max_output_tokens: int | None = None
+
+        def get_capabilities(self) -> LLMProviderCapabilities:
+            return LLMProviderCapabilities(provider="openrouter")
+
+        async def get_response(self, **kwargs: object) -> str:
+            value = kwargs.get("max_output_tokens")
+            self.received_max_output_tokens = value if isinstance(value, int) else None
+            return "ok"
+
+    handler = _Handler()
+    client = APIClient.__new__(APIClient)
+    client.model_config = ModelConfig(
+        model="moonshotai/kimi-k2.6",
+        provider="openrouter",
+        client_preference="openrouter",
+    )
+    client.model_config.max_context_window_tokens = 272000
+    client.model_config.max_output_tokens = 100000
+    client.system_prompt = None
+    client.client_handler = handler
+    client.logger = logging.getLogger(__name__)
+    client._last_error = None
+    client._last_response_result = None
+    client._clear_handler_error = lambda: None
+    client._get_handler_error = lambda: None
+    client._build_response_result = lambda **kwargs: None
+    client._prepare_messages_with_system_prompt = lambda messages: messages
+    client.count_tokens = lambda _messages: 225000
+
+    result = await client.get_response(_messages(), stream=False)
+
+    assert result == "ok"
+    assert handler.received_max_output_tokens == 46488


### PR DESCRIPTION
## Summary
- keep  unset when no explicit cap is configured
- continue clamping explicit output caps to remaining context budget
- add APIClient regressions for the Kimi/OpenRouter context-budget failure mode

## Why
The runtime request path was converting remaining context budget into  when  was unset. With a 272k local context setting and ~46k input tokens, Penguin sent , which OpenRouter rejected against Kimi's 262k endpoint limit.

## Tests
- pytest tests/llm/test_prepared_request_contract.py -q
- pytest tests/llm/test_prepared_request_contract.py tests/test_core_provider_resolution.py tests/llm/test_model_specs.py tests/llm/test_openrouter_base_url_isolation.py tests/llm/test_openrouter_tool_continuity.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved output token limit handling: API client now only clamps explicitly configured token limits to the available context window, preventing unnecessary constraints when no limit is explicitly set.

* **Tests**
  * Added verification tests for API client output token behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maximooch/penguin/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->