### PR TITLE
Improve Penguin TUI session loading and scoped usage compatibility

### DIFF
--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -946,6 +946,43 @@ Follow-up investigation - 2026-06-04, addressed in Phase 6.1:
   - path/vcs/lsp/formatter route shapes
 - [ ] Keep Penguin-only product features behind explicit Penguin endpoints.
 
+### 6.5. TUI startup performance
+
+Investigation snapshot - 2026-06-08:
+
+- The 5-10s perceived TUI startup delay is primarily in launch/runtime
+  initialization, not in the Penguin HTTP bootstrap. API bootstrap requests are
+  visible after the process is already up.
+- Python startup currently imports more than the launcher needs:
+  `penguin/__init__.py` eagerly imports core/config/engine paths, and
+  `penguin/cli/__init__.py` imports the full Typer CLI before the OpenCode TUI
+  launcher path can run.
+- The launcher prefers local source execution when
+  `penguin-tui/packages/opencode` exists, so development worktrees commonly run
+  `bun run --conditions=browser ./src/index.ts` instead of a built binary or
+  lighter sidecar path.
+- The TUI also waits on terminal background-color probing and starts the
+  OpenCode worker/server/config machinery even when running as a Penguin
+  web-backed client.
+- Measured local examples during investigation:
+  - `uv run penguin-tui --help`: about 2.5s
+  - local Bun source help path: about 4.3s warm and 11.5s cold
+  - built arm64 OpenCode binary help path: about 2.4s
+
+Planned work:
+
+- [ ] Lazy-load Python package and CLI imports so `penguin-tui` reaches the
+      launcher without importing PenguinCore/config/engine.
+- [ ] Make launch-mode selection explicit. `--use-global-opencode` should
+      bypass local source preference, and a future env/flag should choose
+      source, built dist, sidecar, or global binary deliberately.
+- [ ] Move terminal background-color probing after first paint or cap its wait
+      more aggressively.
+- [ ] Audit whether Penguin web-backed mode can defer or skip OpenCode worker
+      initialization until a feature actually needs it.
+- [ ] Add lightweight startup timing instrumentation around Python launcher,
+      Bun/binary spawn, first render, and Penguin bootstrap completion.
+
 ### 7. Testing and verification
 
 - [ ] Add focused tests for extracted helpers before behavior changes.

--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -883,6 +883,11 @@ Deferred to Phase 6:
 - Usage refresh is still a TUI-side follow-up request after idle/completed
   transitions. Backend status/session events should eventually carry durable
   usage truth.
+- Session-scoped context-window stats now refresh through
+  `GET /api/v1/sessions/{session_id}/token-usage` after hydration/status
+  transitions. Remaining follow-up: backend status/session events should
+  eventually carry durable usage truth so the TUI does not need a follow-up
+  request.
 - Session snapshot hydration still compensates for replay and optimistic-message
   gaps. Backend message/part replay parity should eventually shrink this helper.
 
@@ -905,6 +910,19 @@ Follow-up investigation - 2026-05-30:
   explicit directory-scoped lists and canonicalize provider/model IDs at the
   backend compatibility boundary.
 
+Follow-up investigation - 2026-06-04, addressed in Phase 6.1:
+
+- Context-window stats should be session scoped in the TUI. The backend exposes
+  `GET /api/v1/token-usage?session_id=...` and
+  `GET /api/v1/sessions/{session_id}/token-usage`; `refreshSessionUsage` now
+  uses the session-specific route instead of rehydrating `/session/{id}`.
+- The compatibility boundary makes session-specific token/CWM usage
+  authoritative: compute from the located session and owning session/agent
+  context window on the backend, then have the TUI update `session_usage` from
+  the session token-usage route after hydration and idle/completed transitions.
+- Keep `_opencode_usage_v1` in `/session/{id}` as a fast bootstrap/fallback
+  snapshot, not the source of truth for session context-window meters.
+
 ### 6. Push compatibility toward Penguin backend
 
 - [ ] Identify client workarounds that exist because Penguin endpoints are not
@@ -921,6 +939,7 @@ Follow-up investigation - 2026-05-30:
   - provider/model metadata
   - unknown-directory legacy/recovery session filtering
   - provider/model ID canonicalization before TUI validation
+  - session-scoped token/CWM usage from session-specific token-usage routes
   - permission/question flows
   - path/vcs/lsp/formatter route shapes
 - [ ] Keep Penguin-only product features behind explicit Penguin endpoints.

--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -938,6 +938,8 @@ Follow-up investigation - 2026-06-04, addressed in Phase 6.1:
   - busy/idle status truth
   - provider/model metadata
   - unknown-directory legacy/recovery session filtering
+  - paginated/cursor-backed session list loading so the TUI can replace the
+    temporary deep fixed fetch used by the Penguin session dialog
   - provider/model ID canonicalization before TUI validation
   - session-scoped token/CWM usage from session-specific token-usage routes
   - permission/question flows

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -7,7 +7,7 @@ import { Locale } from "@/util/locale"
 import { useKeybind } from "../context/keybind"
 import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
-import { PenguinSessionArraySchema, type PenguinSession } from "../context/sync-bootstrap"
+import { parsePenguinSessionArray, type PenguinSession } from "../context/sync-bootstrap"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
@@ -64,8 +64,7 @@ export function DialogSessionList() {
       const response = await sdk.fetch(url)
       if (!response.ok) return undefined
       const data = await response.json().catch(() => undefined)
-      const parsed = PenguinSessionArraySchema.safeParse(data)
-      return parsed.success ? (parsed.data as PenguinSession[]) : undefined
+      return parsePenguinSessionArray(data)
     }
 
     if (!query) return undefined

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -27,7 +27,7 @@ const OPENCODE_SESSION_SEARCH_LIMIT = 30
 
 function isBlankPenguinSession(session: Session | PenguinSession) {
   const penguin = session as PenguinSession
-  const fallbackTitle = penguin.fallback_title === true || session.title === `Session ${session.id.slice(-8)}`
+  const fallbackTitle = penguin.fallback_title === true
   return fallbackTitle && penguin.display_message_count === 0
 }
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -7,6 +7,7 @@ import { Locale } from "@/util/locale"
 import { useKeybind } from "../context/keybind"
 import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
+import type { PenguinSession } from "../context/sync-bootstrap"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
@@ -19,8 +20,16 @@ import {
 import type { Session } from "@opencode-ai/sdk/v2"
 import "opentui-spinner/solid"
 
+// TODO: Replace this deep fixed fetch with paginated/cursor loading once the
+// Penguin session dialog has backend pagination and incremental list rendering.
 const PENGUIN_SESSION_DIALOG_LIMIT = 1000
 const OPENCODE_SESSION_SEARCH_LIMIT = 30
+
+function isBlankPenguinSession(session: Session | PenguinSession) {
+  const penguin = session as PenguinSession
+  const fallbackTitle = penguin.fallback_title === true || session.title === `Session ${session.id.slice(-8)}`
+  return fallbackTitle && penguin.display_message_count === 0
+}
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -49,7 +58,7 @@ export function DialogSessionList() {
       const response = await sdk.fetch(url)
       if (!response.ok) return undefined
       const data = await response.json().catch(() => undefined)
-      return Array.isArray(data) ? (data as Session[]) : undefined
+      return Array.isArray(data) ? (data as PenguinSession[]) : undefined
     }
 
     if (!query) return undefined
@@ -61,7 +70,11 @@ export function DialogSessionList() {
 
   const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
-  const sessions = createMemo(() => expandSessionSearchResults(searchResults(), sync.data.session))
+  const sessions = createMemo(() =>
+    expandSessionSearchResults(searchResults(), sync.data.session).filter(
+      (session) => !sdk.penguin || !isBlankPenguinSession(session),
+    ),
+  )
 
   const options = createMemo(() => {
     const today = new Date().toDateString()

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -7,7 +7,7 @@ import { Locale } from "@/util/locale"
 import { useKeybind } from "../context/keybind"
 import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
-import type { PenguinSession } from "../context/sync-bootstrap"
+import { PenguinSessionArraySchema, type PenguinSession } from "../context/sync-bootstrap"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
@@ -29,6 +29,12 @@ function isBlankPenguinSession(session: Session | PenguinSession) {
   const penguin = session as PenguinSession
   const fallbackTitle = penguin.fallback_title === true
   return fallbackTitle && penguin.display_message_count === 0
+}
+
+function appendSessionIfMissing<T extends { id: string }>(sessions: T[], session: T | undefined) {
+  if (!session) return sessions
+  if (sessions.some((item) => item.id === session.id)) return sessions
+  return [...sessions, session]
 }
 
 export function DialogSessionList() {
@@ -58,7 +64,8 @@ export function DialogSessionList() {
       const response = await sdk.fetch(url)
       if (!response.ok) return undefined
       const data = await response.json().catch(() => undefined)
-      return Array.isArray(data) ? (data as PenguinSession[]) : undefined
+      const parsed = PenguinSessionArraySchema.safeParse(data)
+      return parsed.success ? (parsed.data as PenguinSession[]) : undefined
     }
 
     if (!query) return undefined
@@ -70,11 +77,17 @@ export function DialogSessionList() {
 
   const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
-  const sessions = createMemo(() =>
-    expandSessionSearchResults(searchResults(), sync.data.session).filter(
-      (session) => !sdk.penguin || !isBlankPenguinSession(session),
-    ),
-  )
+  const sessions = createMemo(() => {
+    const activeSessionID = currentSessionID()
+    const currentSession = sync.data.session.find((item) => item.id === activeSessionID)
+    const expanded = expandSessionSearchResults(searchResults(), sync.data.session)
+    const withCurrent =
+      sdk.penguin && !search().trim() ? appendSessionIfMissing(expanded, currentSession) : expanded
+
+    return withCurrent.filter(
+      (session) => !sdk.penguin || session.id === activeSessionID || !isBlankPenguinSession(session),
+    )
+  })
 
   const options = createMemo(() => {
     const today = new Date().toDateString()

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -10,8 +10,17 @@ import { useSDK } from "../context/sdk"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
-import { expandSessionSearchResults, formatSessionListTitle, getSessionListEntries } from "../util/session-family"
+import {
+  expandSessionSearchResults,
+  formatSessionListTitle,
+  getSessionListEntries,
+  upsertSessionRecord,
+} from "../util/session-family"
+import type { Session } from "@opencode-ai/sdk/v2"
 import "opentui-spinner/solid"
+
+const PENGUIN_SESSION_DIALOG_LIMIT = 1000
+const OPENCODE_SESSION_SEARCH_LIMIT = 30
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -24,10 +33,27 @@ export function DialogSessionList() {
 
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
+  const sessionListQuery = createMemo(() => ({
+    directory: sync.data.path.directory || sdk.directory,
+    search: search(),
+  }))
 
-  const [searchResults] = createResource(search, async (query) => {
+  const [searchResults] = createResource(sessionListQuery, async (input) => {
+    const query = input.search.trim()
+    if (sdk.penguin) {
+      const url = new URL("/session", sdk.url)
+      if (input.directory) url.searchParams.set("directory", input.directory)
+      url.searchParams.set("limit", String(PENGUIN_SESSION_DIALOG_LIMIT))
+      if (query) url.searchParams.set("search", query)
+
+      const response = await sdk.fetch(url)
+      if (!response.ok) return undefined
+      const data = await response.json().catch(() => undefined)
+      return Array.isArray(data) ? (data as Session[]) : undefined
+    }
+
     if (!query) return undefined
-    const result = await sdk.client.session.list({ search: query, limit: 30 })
+    const result = await sdk.client.session.list({ search: query, limit: OPENCODE_SESSION_SEARCH_LIMIT })
     return result.data ?? []
   })
 
@@ -82,6 +108,10 @@ export function DialogSessionList() {
         setToDelete(undefined)
       }}
       onSelect={(option) => {
+        const selected = sessions().find((item) => item.id === option.value)
+        if (selected) {
+          sync.set("session", upsertSessionRecord(sync.data.session, selected))
+        }
         route.navigate({
           type: "session",
           sessionID: option.value,

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
@@ -10,6 +10,7 @@ import type {
 } from "@opencode-ai/sdk/v2"
 import type { Path } from "@opencode-ai/sdk"
 import { Log } from "@/util/log"
+import z from "zod"
 
 type BootstrapFetch = (input: string | URL, init?: RequestInit) => Promise<Response>
 
@@ -36,6 +37,36 @@ export type PenguinSession = Session & {
   display_message_count?: number
   fallback_title?: boolean
 }
+
+const PenguinSessionTimeSchema = z
+  .object({
+    created: z.number(),
+    updated: z.number(),
+    compacting: z.number().optional(),
+    archived: z.number().optional(),
+  })
+  .passthrough()
+
+export const PenguinSessionSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    time: PenguinSessionTimeSchema,
+    parentID: z.string().optional(),
+    directory: z.string().optional(),
+    agent_mode: z.string().optional(),
+    agent_id: z.string().optional(),
+    parent_agent_id: z.string().optional(),
+    providerID: z.string().optional(),
+    modelID: z.string().optional(),
+    variant: z.string().optional(),
+    message_count: z.number().optional(),
+    display_message_count: z.number().optional(),
+    fallback_title: z.boolean().optional(),
+  })
+  .passthrough()
+
+export const PenguinSessionArraySchema = z.array(PenguinSessionSchema)
 
 export type PenguinBootstrapState = {
   agent: Agent[]

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
@@ -32,6 +32,9 @@ export type PenguinSession = Session & {
   providerID?: string
   modelID?: string
   variant?: string
+  message_count?: number
+  display_message_count?: number
+  fallback_title?: boolean
 }
 
 export type PenguinBootstrapState = {
@@ -251,6 +254,13 @@ function mapPenguinSession(input: {
   if (modelID) payload.modelID = modelID
   const variant = typeof input.item.variant === "string" ? input.item.variant : undefined
   if (variant) payload.variant = variant
+  const messageCount = typeof input.item.message_count === "number" ? input.item.message_count : undefined
+  if (messageCount !== undefined) payload.message_count = messageCount
+  const displayMessageCount =
+    typeof input.item.display_message_count === "number" ? input.item.display_message_count : undefined
+  if (displayMessageCount !== undefined) payload.display_message_count = displayMessageCount
+  const fallbackTitle = typeof input.item.fallback_title === "boolean" ? input.item.fallback_title : undefined
+  if (fallbackTitle !== undefined) payload.fallback_title = fallbackTitle
   const agentID = typeof input.item.agent_id === "string" ? input.item.agent_id : undefined
   if (agentID) payload.agent_id = agentID
   const parentAgentID = typeof input.item.parent_agent_id === "string" ? input.item.parent_agent_id : undefined

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync-bootstrap.ts
@@ -68,6 +68,17 @@ export const PenguinSessionSchema = z
 
 export const PenguinSessionArraySchema = z.array(PenguinSessionSchema)
 
+export function parsePenguinSessionArray(value: unknown): PenguinSession[] | undefined {
+  if (!Array.isArray(value)) return undefined
+
+  const sessions: PenguinSession[] = []
+  for (const item of value) {
+    const parsed = PenguinSessionSchema.safeParse(item)
+    if (parsed.success) sessions.push(parsed.data as PenguinSession)
+  }
+  return sessions
+}
+
 export type PenguinBootstrapState = {
   agent: Agent[]
   command: Command[]

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -174,7 +174,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       if (usageRefreshInFlight.has(sessionID) || now - last < 400) return
       usageRefreshInFlight.add(sessionID)
       usageRefreshAt.set(sessionID, now)
-      const url = new URL(`/session/${encodeURIComponent(sessionID)}`, sdk.url)
+      const url = new URL(`/api/v1/sessions/${encodeURIComponent(sessionID)}/token-usage`, sdk.url)
       sdk.fetch(url)
         .then((res) => (res.ok ? res.json() : undefined))
         .then((data) => {
@@ -218,6 +218,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }),
       )
       fullSyncedSessions.add(sessionID)
+      refreshSessionUsage(sessionID)
     }
 
     sdk.event.listen((e) => {

--- a/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
@@ -131,6 +131,9 @@ describe("sync bootstrap", () => {
           agent_mode: "build",
           providerID: "openai",
           modelID: "gpt-5.5",
+          message_count: 0,
+          display_message_count: 0,
+          fallback_title: false,
           usage: {
             current_total_tokens: 42,
             max_context_window_tokens: 100,
@@ -160,6 +163,9 @@ describe("sync bootstrap", () => {
       agent_mode: "build",
       providerID: "openai",
       modelID: "gpt-5.5",
+      message_count: 0,
+      display_message_count: 0,
+      fallback_title: false,
     })
     expect(result.session_usage.ses_1?.current_total_tokens).toBe(42)
     expect(result.session_status.ses_1).toEqual({ type: "idle" })

--- a/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import {
   fetchBootstrapJson,
   mapPenguinBootstrap,
+  PenguinSessionArraySchema,
   parsePenguinUsage,
   unwrapBootstrapData,
 } from "../../../src/cli/cmd/tui/context/sync-bootstrap"
@@ -94,6 +95,32 @@ describe("sync bootstrap", () => {
       },
     })
     expect(parsePenguinUsage({ usage: {} })).toBeUndefined()
+  })
+
+  test("validates Penguin session list payloads", () => {
+    expect(
+      PenguinSessionArraySchema.safeParse([
+        {
+          id: "ses_1",
+          title: "Mapped Session",
+          time: {
+            created: 100,
+            updated: 200,
+          },
+          display_message_count: 1,
+          fallback_title: false,
+        },
+      ]).success,
+    ).toBe(true)
+
+    expect(
+      PenguinSessionArraySchema.safeParse([
+        {
+          id: "ses_1",
+          title: "Missing Time",
+        },
+      ]).success,
+    ).toBe(false)
   })
 
   test("maps Penguin bootstrap responses into TUI store state", () => {

--- a/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
+++ b/penguin-tui/packages/opencode/test/cli/tui/sync-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import {
   fetchBootstrapJson,
   mapPenguinBootstrap,
+  parsePenguinSessionArray,
   PenguinSessionArraySchema,
   parsePenguinUsage,
   unwrapBootstrapData,
@@ -121,6 +122,27 @@ describe("sync bootstrap", () => {
         },
       ]).success,
     ).toBe(false)
+  })
+
+  test("keeps valid Penguin session rows when one row is malformed", () => {
+    expect(
+      parsePenguinSessionArray([
+        {
+          id: "ses_1",
+          title: "Mapped Session",
+          time: {
+            created: 100,
+            updated: 200,
+          },
+        },
+        {
+          id: "ses_2",
+          title: "Missing Time",
+        },
+      ])?.map((item) => item.id),
+    ).toEqual(["ses_1"])
+
+    expect(parsePenguinSessionArray({ data: [] })).toBeUndefined()
   })
 
   test("maps Penguin bootstrap responses into TUI store state", () => {

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -2095,6 +2095,7 @@ class PenguinCore:
         metadata = getattr(session, "metadata", None)
         if not isinstance(metadata, dict):
             metadata = {}
+        usage_snapshot = metadata.get("_opencode_usage_v1")
 
         metadata_agent_id = metadata.get("agent_id")
         if isinstance(metadata_agent_id, str):
@@ -2119,7 +2120,6 @@ class PenguinCore:
                     agent_id=agent_id,
                 )
             elif metadata_agent_id == agent_id and not message_agent_ids:
-                usage_snapshot = metadata.get("_opencode_usage_v1")
                 if isinstance(usage_snapshot, dict):
                     usage = dict(usage_snapshot)
                 else:
@@ -2136,8 +2136,10 @@ class PenguinCore:
             messages = getattr(session, "messages", []) or []
             if messages:
                 usage = self._usage_from_session_messages(session, manager=manager)
+                PenguinCore._preserve_session_usage_truncations(
+                    usage, usage_snapshot
+                )
             else:
-                usage_snapshot = metadata.get("_opencode_usage_v1")
                 if isinstance(usage_snapshot, dict):
                     usage = dict(usage_snapshot)
                 else:
@@ -2152,6 +2154,32 @@ class PenguinCore:
             usage["agent_id"] = metadata_agent_id
 
         return usage
+
+    @staticmethod
+    def _preserve_session_usage_truncations(
+        usage: Dict[str, Any], usage_snapshot: Any
+    ) -> None:
+        """Copy persisted truncation telemetry onto recomputed usage totals."""
+        if not isinstance(usage_snapshot, dict):
+            return
+        snapshot_truncations = usage_snapshot.get("truncations")
+        if not isinstance(snapshot_truncations, dict):
+            return
+
+        current_truncations = usage.get("truncations")
+        preserved = (
+            dict(current_truncations) if isinstance(current_truncations, dict) else {}
+        )
+        for key in (
+            "total_truncations",
+            "messages_removed",
+            "tokens_freed",
+            "by_category",
+            "recent_events",
+        ):
+            if key in snapshot_truncations:
+                preserved[key] = snapshot_truncations[key]
+        usage["truncations"] = preserved
 
     def _usage_from_session_messages(
         self,

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -2157,7 +2157,7 @@ class PenguinCore:
 
     @staticmethod
     def _preserve_session_usage_truncations(
-        usage: Dict[str, Any], usage_snapshot: Any
+        usage: Dict[str, Any], usage_snapshot: Optional[Mapping[str, Any]]
     ) -> None:
         """Copy persisted truncation telemetry onto recomputed usage totals."""
         if not isinstance(usage_snapshot, dict):

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -2185,10 +2185,15 @@ class PenguinCore:
                 category_name = "UNKNOWN"
             categories[category_name] = categories.get(category_name, 0) + token_count
 
-        session_conversation_manager = getattr(session, "conversation_manager", None)
-        context_source = (
-            session_conversation_manager or manager or self.conversation_manager
-        )
+        context_source = None
+        for candidate in (
+            getattr(session, "conversation_manager", None),
+            manager,
+            getattr(self, "conversation_manager", None),
+        ):
+            if getattr(candidate, "context_window", None) is not None:
+                context_source = candidate
+                break
         context_window = getattr(context_source, "context_window", None)
         max_tokens = int(getattr(context_window, "max_context_window_tokens", 0) or 0)
         available_tokens = (

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -2133,11 +2133,15 @@ class PenguinCore:
                     "error": "agent token usage not found for session",
                 }
         else:
-            usage_snapshot = metadata.get("_opencode_usage_v1")
-            if isinstance(usage_snapshot, dict):
-                usage = dict(usage_snapshot)
-            else:
+            messages = getattr(session, "messages", []) or []
+            if messages:
                 usage = self._usage_from_session_messages(session, manager=manager)
+            else:
+                usage_snapshot = metadata.get("_opencode_usage_v1")
+                if isinstance(usage_snapshot, dict):
+                    usage = dict(usage_snapshot)
+                else:
+                    usage = self._usage_from_session_messages(session, manager=manager)
 
         usage["scope"] = "session"
         usage["session_id"] = session_id

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -10,6 +10,7 @@ import subprocess
 from typing import Any, Optional
 
 from penguin import __version__
+from penguin.web.services.provider_catalog import canonical_model_id
 
 TRANSCRIPT_KEY = "_opencode_transcript_v1"
 USAGE_KEY = "_opencode_usage_v1"
@@ -48,6 +49,28 @@ def _normalize_non_empty_string(value: Any) -> Optional[str]:
     return normalized or None
 
 
+def _normalize_provider_id(value: Any) -> Optional[str]:
+    normalized = _normalize_non_empty_string(value)
+    return normalized.lower() if normalized else None
+
+
+def _normalize_model_id(provider_id: Optional[str], value: Any) -> Optional[str]:
+    normalized = _normalize_non_empty_string(value)
+    if not normalized:
+        return None
+
+    model_id = canonical_model_id(provider_id or "", normalized)
+    if (provider_id or "").lower() in {
+        "anthropic",
+        "google",
+        "ollama",
+        "openai",
+        "openrouter",
+    }:
+        return model_id.lower()
+    return model_id
+
+
 def _normalize_title_source(value: Any) -> Optional[str]:
     if not isinstance(value, str):
         return None
@@ -72,7 +95,7 @@ def _resolve_session_model_state(
     message_model = message_meta.get("model")
     message_model_dict = message_model if isinstance(message_model, dict) else {}
 
-    provider_id = (
+    provider_id = _normalize_provider_id(
         _normalize_non_empty_string(message_meta.get("providerID"))
         or _normalize_non_empty_string(message_meta.get("provider_id"))
         or _normalize_non_empty_string(message_model_dict.get("providerID"))
@@ -83,7 +106,8 @@ def _resolve_session_model_state(
             getattr(getattr(core, "model_config", None), "provider", None)
         )
     )
-    model_id = (
+    model_id = _normalize_model_id(
+        provider_id,
         _normalize_non_empty_string(message_meta.get("modelID"))
         or _normalize_non_empty_string(message_meta.get("model_id"))
         or _normalize_non_empty_string(message_model_dict.get("modelID"))

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -49,12 +49,30 @@ def _normalize_non_empty_string(value: Any) -> Optional[str]:
     return normalized or None
 
 
-def _normalize_provider_id(value: Any) -> Optional[str]:
+def _normalize_provider_id(value: object) -> Optional[str]:
+    """Normalize a provider identifier.
+
+    Args:
+        value: Candidate provider identifier.
+
+    Returns:
+        Lowercased non-empty provider id, or None when value is not a string.
+    """
     normalized = _normalize_non_empty_string(value)
     return normalized.lower() if normalized else None
 
 
-def _normalize_model_id(provider_id: Optional[str], value: Any) -> Optional[str]:
+def _normalize_model_id(provider_id: Optional[str], value: object) -> Optional[str]:
+    """Normalize a model identifier for a provider.
+
+    Args:
+        provider_id: Optional normalized provider identifier.
+        value: Candidate model identifier.
+
+    Returns:
+        Canonical model id, lowercased for providers with case-insensitive
+        catalog ids, or None when value is not a non-empty string.
+    """
     normalized = _normalize_non_empty_string(value)
     if not normalized:
         return None

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -185,7 +185,17 @@ def _load_session_view_only(manager: Any, session_id: str) -> Optional[Any]:
     """Load a session for inspection without changing shared current_session."""
     previous = getattr(manager, "current_session", None)
     try:
-        return manager.load_session(session_id)
+        session = manager.load_session(session_id)
+        loaded_id = str(getattr(session, "id", "")) if session is not None else ""
+        if session is not None and loaded_id != str(session_id):
+            logger.debug(
+                "session.view.load_mismatch requested=%s returned=%s manager=%s",
+                session_id,
+                loaded_id,
+                hex(id(manager)),
+            )
+            return None
+        return session
     except Exception:
         logger.warning(
             "session.view.load_failed session=%s manager=%s",
@@ -217,6 +227,53 @@ def _infer_title(session: Any) -> str:
             if line:
                 return line[:64]
     return f"Session {str(getattr(session, 'id', 'unknown'))[-8:]}"
+
+
+def _has_fallback_title(session: Any) -> bool:
+    """Return whether session title falls back to its id suffix."""
+    metadata = getattr(session, "metadata", {})
+    if isinstance(metadata, dict) and isinstance(metadata.get("title"), str):
+        if metadata["title"].strip():
+            return False
+
+    messages = getattr(session, "messages", [])
+    for item in messages:
+        if getattr(item, "role", None) != "user":
+            continue
+        content = getattr(item, "content", "")
+        if isinstance(content, str) and content.split("\n", 1)[0].strip():
+            return False
+    return True
+
+
+def _display_message_count(session: Any) -> int:
+    """Count messages expected to produce visible TUI session rows."""
+    metadata = getattr(session, "metadata", {})
+    transcript = metadata.get(TRANSCRIPT_KEY) if isinstance(metadata, dict) else None
+    transcript_count = 0
+
+    if isinstance(transcript, dict):
+        messages = transcript.get("messages")
+        order = transcript.get("order")
+        if isinstance(messages, dict) and isinstance(order, list):
+            for message_id in order:
+                entry = messages.get(message_id)
+                if not isinstance(entry, dict):
+                    continue
+                parts = entry.get("parts")
+                part_order = entry.get("part_order")
+                if isinstance(parts, dict) and isinstance(part_order, list):
+                    if any(
+                        isinstance(parts.get(part_id), dict) for part_id in part_order
+                    ):
+                        transcript_count += 1
+
+    legacy_count = sum(
+        1
+        for message in getattr(session, "messages", [])
+        if getattr(message, "role", "") in {"user", "assistant", "tool"}
+    )
+    return max(transcript_count, legacy_count)
 
 
 def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]:
@@ -263,6 +320,7 @@ def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]
     if updated <= 0:
         updated = created
 
+    messages = getattr(session, "messages", [])
     payload: dict[str, Any] = {
         "id": str(session.id),
         "slug": str(session.id),
@@ -270,6 +328,9 @@ def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]
         "directory": directory,
         "agent_mode": "build",
         "title": _infer_title(session),
+        "message_count": len(messages) if isinstance(messages, list) else 0,
+        "display_message_count": _display_message_count(session),
+        "fallback_title": _has_fallback_title(session),
         "version": __version__,
         "time": {
             "created": created,

--- a/penguin/web/services/session_view.py
+++ b/penguin/web/services/session_view.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 import logging
 import os
-from pathlib import Path
 import subprocess
+from datetime import datetime
+from pathlib import Path
 from typing import Any, Optional
 
 from penguin import __version__
@@ -184,6 +184,57 @@ def _iter_session_managers(core: Any) -> list[Any]:
     return unique
 
 
+def _session_file_ids(manager: Any) -> list[str]:
+    """Return session ids found on disk for a manager."""
+    base_path = getattr(manager, "base_path", None)
+    if not base_path:
+        return []
+
+    try:
+        root = Path(base_path)
+    except TypeError:
+        return []
+    if not root.exists() or not root.is_dir():
+        return []
+
+    session_format = getattr(manager, "format", "json")
+    if not isinstance(session_format, str) or not session_format.strip():
+        session_format = "json"
+
+    ids: list[str] = []
+    for path in root.glob(f"*.{session_format}"):
+        if path.name == f"session_index.{session_format}":
+            continue
+        ids.append(path.stem)
+    return ids
+
+
+def _manager_session_ids(manager: Any) -> list[str]:
+    """Return unique cached, indexed, and file-backed session ids."""
+    ids: list[str] = []
+    seen: set[str] = set()
+    sources = (
+        getattr(manager, "sessions", {}),
+        getattr(manager, "session_index", {}),
+        _session_file_ids(manager),
+    )
+
+    for source in sources:
+        if isinstance(source, dict):
+            values = source.keys()
+        elif isinstance(source, list):
+            values = source
+        else:
+            continue
+        for value in values:
+            session_id = str(value)
+            if not session_id or session_id in seen:
+                continue
+            seen.add(session_id)
+            ids.append(session_id)
+    return ids
+
+
 def _find_session(core: Any, session_id: str) -> tuple[Optional[Any], Optional[Any]]:
     """Find a session and its manager by id."""
     for manager in _iter_session_managers(core):
@@ -193,6 +244,10 @@ def _find_session(core: Any, session_id: str) -> tuple[Optional[Any], Optional[A
 
         index = getattr(manager, "session_index", {})
         if isinstance(index, dict) and session_id in index:
+            session = _load_session_view_only(manager, session_id)
+            if session is not None:
+                return session, manager
+        if session_id in _session_file_ids(manager):
             session = _load_session_view_only(manager, session_id)
             if session is not None:
                 return session, manager
@@ -294,6 +349,24 @@ def _display_message_count(session: Any) -> int:
     return max(transcript_count, legacy_count)
 
 
+def _explicit_session_directory(core: Any, session: Any) -> tuple[str, str]:
+    """Return a persisted or in-memory session directory, without runtime fallback."""
+    metadata = getattr(session, "metadata", {})
+    session_dirs = getattr(core, "_opencode_session_directories", {})
+
+    if isinstance(metadata, dict):
+        raw_directory = metadata.get("directory")
+        if isinstance(raw_directory, str) and raw_directory.strip():
+            return raw_directory, "metadata"
+
+    if isinstance(session_dirs, dict):
+        mapped = session_dirs.get(str(getattr(session, "id", "")))
+        if isinstance(mapped, str) and mapped.strip():
+            return mapped, "session_map"
+
+    return "", "missing"
+
+
 def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]:
     """Build OpenCode-compatible Session.Info payload."""
     runtime = getattr(core, "runtime_config", None)
@@ -301,18 +374,8 @@ def _build_session_info(core: Any, session: Any, manager: Any) -> dict[str, Any]
         runtime, "project_root", None
     )
     metadata = getattr(session, "metadata", {})
-    session_dirs = getattr(core, "_opencode_session_directories", {})
 
-    directory = ""
-    directory_source = "missing"
-    if isinstance(session_dirs, dict):
-        mapped = session_dirs.get(str(session.id))
-        if isinstance(mapped, str) and mapped.strip():
-            directory = mapped
-            directory_source = "session_map"
-    if isinstance(metadata, dict) and isinstance(metadata.get("directory"), str):
-        directory = metadata["directory"]
-        directory_source = "metadata"
+    directory, directory_source = _explicit_session_directory(core, session)
     if not directory and runtime_dir:
         directory = str(runtime_dir)
         directory_source = "runtime"
@@ -923,11 +986,7 @@ def list_session_infos(
     normalized_directory = _normalize_existing_directory(directory)
 
     for manager in _iter_session_managers(core):
-        index = getattr(manager, "session_index", {})
-        if not isinstance(index, dict):
-            continue
-
-        for session_id in list(index.keys()):
+        for session_id in _manager_session_ids(manager):
             session = None
             cached = getattr(manager, "sessions", {})
             if isinstance(cached, dict) and session_id in cached:
@@ -937,16 +996,21 @@ def list_session_infos(
             if session is None:
                 continue
 
-            info = _build_session_info(core, session, manager)
-
-            if roots and info.get("parentID"):
-                continue
             if normalized_directory:
-                session_directory = _normalize_existing_directory(info.get("directory"))
+                explicit_directory, _directory_source = _explicit_session_directory(
+                    core,
+                    session,
+                )
+                session_directory = _normalize_existing_directory(explicit_directory)
                 if not session_directory:
                     continue
                 if not _directory_matches(session_directory, normalized_directory):
                     continue
+
+            info = _build_session_info(core, session, manager)
+
+            if roots and info.get("parentID"):
+                continue
             if start is not None and info["time"]["updated"] < start:
                 continue
             if lowered_search and lowered_search not in info["title"].lower():

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -1170,7 +1170,7 @@ def test_session_view_skips_recovery_substitute_from_view_load() -> None:
             self.sessions.clear()
             self.current_session = None
 
-        def load_session(self, session_id: str):
+        def load_session(self, session_id: str) -> Session | None:
             if session_id == corrupt.id:
                 self.current_session = recovery
                 return recovery

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -128,6 +128,39 @@ def test_list_session_infos_sorted_and_filtered():
     assert [item["id"] for item in filtered] == ["session_a"]
 
 
+def test_session_info_marks_blank_fallback_title_sessions():
+    blank = _session("session_20260608_185439", "", "2026-02-01T00:00:00")
+    blank.metadata.pop("title", None)
+    active = _session("session_20260608_190001", "", "2026-02-02T00:00:00")
+    active.metadata.pop("title", None)
+    manual = _session("session_manual_suffix", "", "2026-02-03T00:00:00")
+    manual.metadata["title"] = f"Session {manual.id[-8:]}"
+    active.messages.append(
+        Message(
+            id="msg_user_active",
+            role="user",
+            content="Assess PM system gaps",
+            category=MessageCategory.DIALOG,
+            timestamp="2026-02-02T00:00:00",
+        )
+    )
+    core = _core([blank, active, manual])
+
+    result = {item["id"]: item for item in list_session_infos(core)}
+
+    assert result[blank.id]["title"] == f"Session {blank.id[-8:]}"
+    assert result[blank.id]["fallback_title"] is True
+    assert result[blank.id]["message_count"] == 0
+    assert result[blank.id]["display_message_count"] == 0
+    assert result[active.id]["title"] == "Assess PM system gaps"
+    assert result[active.id]["fallback_title"] is False
+    assert result[active.id]["message_count"] == 1
+    assert result[active.id]["display_message_count"] == 1
+    assert result[manual.id]["title"] == f"Session {manual.id[-8:]}"
+    assert result[manual.id]["fallback_title"] is False
+    assert result[manual.id]["display_message_count"] == 0
+
+
 def test_list_session_infos_directory_filter_matches_exact_directory_only(
     tmp_path: Path,
 ):
@@ -1125,6 +1158,42 @@ def test_list_session_infos_does_not_mutate_current_session() -> None:
 
     assert [item["id"] for item in result] == ["session_target", "session_current"]
     assert manager.current_session is current
+
+
+def test_session_view_skips_recovery_substitute_from_view_load() -> None:
+    corrupt = _session("session_corrupt", "Corrupt", "2026-02-01T00:00:00")
+    recovery = _session("recovery_20260608_185439", "Recovery", "2026-02-02T00:00:00")
+
+    class _RecoverySubstituteManager(_Manager):
+        def __init__(self) -> None:
+            super().__init__([corrupt])
+            self.sessions.clear()
+            self.current_session = None
+
+        def load_session(self, session_id: str):
+            if session_id == corrupt.id:
+                self.current_session = recovery
+                return recovery
+            return None
+
+    manager = _RecoverySubstituteManager()
+    conversation_manager = SimpleNamespace(
+        session_manager=manager,
+        agent_session_managers={"default": manager},
+    )
+    runtime_config = SimpleNamespace(
+        active_root="/tmp/workspace", project_root="/tmp/workspace"
+    )
+    model_config = SimpleNamespace(model="test-model", provider="test-provider")
+    core = SimpleNamespace(
+        conversation_manager=conversation_manager,
+        runtime_config=runtime_config,
+        model_config=model_config,
+    )
+
+    assert list_session_infos(core) == []
+    assert get_session_info(core, corrupt.id) is None
+    assert manager.current_session is None
 
 
 def test_get_session_info_returns_none_for_missing_session():

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 from datetime import datetime
 from pathlib import Path
-import subprocess
 from types import SimpleNamespace
 
 import pytest
 
+from penguin.system.session_manager import SessionManager
 from penguin.system.state import Message, MessageCategory, Session
 from penguin.web.services.session_summary import summarize_session_title
 from penguin.web.services.session_view import (
@@ -16,10 +18,10 @@ from penguin.web.services.session_view import (
     PROVIDER_ID_KEY,
     REVERT_KEY,
     SUMMARY_KEY,
-    TODO_KEY,
     TITLE_SOURCE_AUTO,
     TITLE_SOURCE_KEY,
     TITLE_SOURCE_MANUAL,
+    TODO_KEY,
     TRANSCRIPT_KEY,
     USAGE_KEY,
     VARIANT_KEY,
@@ -32,8 +34,8 @@ from penguin.web.services.session_view import (
     list_session_infos,
     list_session_statuses,
     remove_session_info,
-    update_session_todo,
     update_session_info,
+    update_session_todo,
 )
 
 
@@ -226,6 +228,67 @@ def test_list_session_infos_directory_filter_falls_back_to_exact_directory(
     result = list_session_infos(core, directory=str(alpha_dir))
 
     assert [item["id"] for item in result] == ["session_alpha"]
+
+
+def test_list_session_infos_directory_filter_excludes_unknown_directory(
+    tmp_path: Path,
+):
+    alpha_dir = tmp_path / "alpha"
+    alpha_dir.mkdir()
+
+    alpha = _session("session_alpha", "Alpha", "2026-02-01T00:00:00")
+    alpha.metadata["directory"] = str(alpha_dir)
+
+    unknown = _session("session_unknown", "Unknown", "2026-02-02T00:00:00")
+    unknown.metadata.pop("directory", None)
+
+    core = _core([alpha, unknown])
+    core.runtime_config.active_root = str(alpha_dir)
+    core.runtime_config.project_root = str(alpha_dir)
+
+    result = list_session_infos(core, directory=str(alpha_dir))
+
+    assert [item["id"] for item in result] == ["session_alpha"]
+
+
+def test_list_session_infos_loads_project_session_missing_from_index(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    manager = SessionManager(
+        base_path=str(tmp_path / "conversations"),
+        auto_save_interval=0,
+    )
+    session = _session(
+        "session_missing_index",
+        "PM System Roadmap",
+        "2026-06-08T19:47:18",
+    )
+    session.metadata["directory"] = str(project_dir)
+    session_path = manager.base_path / f"{session.id}.json"
+    session_path.write_text(json.dumps(session.to_dict()), encoding="utf-8")
+
+    conversation_manager = SimpleNamespace(
+        session_manager=manager,
+        agent_session_managers={},
+    )
+    core = SimpleNamespace(
+        conversation_manager=conversation_manager,
+        runtime_config=SimpleNamespace(
+            active_root=str(project_dir),
+            project_root=str(project_dir),
+        ),
+        model_config=SimpleNamespace(model="test-model", provider="test-provider"),
+    )
+
+    result = list_session_infos(core, directory=str(project_dir))
+    info = get_session_info(core, session.id)
+
+    assert [item["id"] for item in result] == [session.id]
+    assert info is not None
+    assert info["title"] == "PM System Roadmap"
 
 
 def test_session_info_includes_usage_snapshot():

--- a/tests/api/test_session_view_service.py
+++ b/tests/api/test_session_view_service.py
@@ -1132,6 +1132,31 @@ def test_get_session_info_returns_none_for_missing_session():
     assert get_session_info(core, "session_missing") is None
 
 
+def test_get_session_info_canonicalizes_openai_model_metadata():
+    session = _session("session_model_case", "Model Case", "2026-02-03T00:00:00")
+    session.metadata[PROVIDER_ID_KEY] = "OpenAI"
+    session.metadata[MODEL_ID_KEY] = "openai/GPT-5.5"
+    core = _core([session])
+
+    info = get_session_info(core, session.id)
+
+    assert info is not None
+    assert info["providerID"] == "openai"
+    assert info["modelID"] == "gpt-5.5"
+
+
+def test_get_session_info_canonicalizes_global_model_fallback():
+    session = _session("session_global_model", "Global Model", "2026-02-03T00:00:00")
+    core = _core([session])
+    core.model_config = SimpleNamespace(provider="OpenAI", model="openai/GPT-5.5")
+
+    info = get_session_info(core, session.id)
+
+    assert info is not None
+    assert info["providerID"] == "openai"
+    assert info["modelID"] == "gpt-5.5"
+
+
 def test_create_update_remove_session_info_round_trip():
     core = _core([])
 

--- a/tests/api/test_token_usage_routes.py
+++ b/tests/api/test_token_usage_routes.py
@@ -252,6 +252,27 @@ async def test_session_token_usage_uses_session_manager_context_window() -> None
 
 
 @pytest.mark.asyncio
+async def test_session_token_usage_falls_back_to_conversation_context_window() -> None:
+    core = _core([_session("session_scoped", 600)])
+    core.conversation_manager.context_window = SimpleNamespace(
+        max_context_window_tokens=1_200
+    )
+    delattr(core.conversation_manager.session_manager, "context_window")
+
+    response = await get_session_token_usage(
+        "session_scoped",
+        conversation_id=None,
+        agent_id=None,
+        core=core,
+    )
+
+    usage = response["usage"]
+    assert usage["max_context_window_tokens"] == 1_200
+    assert usage["available_tokens"] == 600
+    assert usage["percentage"] == 50.0
+
+
+@pytest.mark.asyncio
 async def test_token_usage_filters_session_messages_by_agent_id() -> None:
     session = Session(id="session_agent")
     session.messages.extend(

--- a/tests/api/test_token_usage_routes.py
+++ b/tests/api/test_token_usage_routes.py
@@ -125,6 +125,69 @@ async def test_token_usage_query_is_session_scoped_without_runtime_bleed() -> No
 
 
 @pytest.mark.asyncio
+async def test_session_token_usage_prefers_messages_over_stale_snapshot() -> None:
+    session = _session("session_stale_snapshot", 321)
+    session.metadata["_opencode_usage_v1"] = {
+        "current_total_tokens": 99_999,
+        "max_context_window_tokens": 200_000,
+        "available_tokens": 100_001,
+        "percentage": 49.9995,
+        "categories": {"DIALOG": 99_999},
+        "truncations": {
+            "total_truncations": 9,
+            "messages_removed": 99,
+            "tokens_freed": 88_888,
+            "by_category": {},
+            "recent_events": [],
+        },
+    }
+
+    response = await get_session_token_usage(
+        "session_stale_snapshot",
+        conversation_id=None,
+        agent_id=None,
+        core=_core([session]),
+    )
+
+    usage = response["usage"]
+    assert usage["scope"] == "session"
+    assert usage["current_total_tokens"] == 321
+    assert usage["categories"]["DIALOG"] == 321
+    assert usage["truncations"]["total_truncations"] == 0
+
+
+@pytest.mark.asyncio
+async def test_session_token_usage_uses_snapshot_when_messages_are_missing() -> None:
+    session = Session(id="session_snapshot_only")
+    session.metadata["_opencode_usage_v1"] = {
+        "current_total_tokens": 44,
+        "max_context_window_tokens": 200_000,
+        "available_tokens": 199_956,
+        "percentage": 0.022,
+        "categories": {"DIALOG": 44},
+        "truncations": {
+            "total_truncations": 1,
+            "messages_removed": 2,
+            "tokens_freed": 333,
+            "by_category": {},
+            "recent_events": [],
+        },
+    }
+
+    response = await get_session_token_usage(
+        "session_snapshot_only",
+        conversation_id=None,
+        agent_id=None,
+        core=_core([session]),
+    )
+
+    usage = response["usage"]
+    assert usage["scope"] == "session"
+    assert usage["current_total_tokens"] == 44
+    assert usage["truncations"]["tokens_freed"] == 333
+
+
+@pytest.mark.asyncio
 async def test_token_usage_without_session_is_marked_runtime() -> None:
     response = await get_token_usage(
         session_id=None,

--- a/tests/api/test_token_usage_routes.py
+++ b/tests/api/test_token_usage_routes.py
@@ -153,7 +153,8 @@ async def test_session_token_usage_prefers_messages_over_stale_snapshot() -> Non
     assert usage["scope"] == "session"
     assert usage["current_total_tokens"] == 321
     assert usage["categories"]["DIALOG"] == 321
-    assert usage["truncations"]["total_truncations"] == 0
+    assert usage["truncations"]["total_truncations"] == 9
+    assert usage["truncations"]["tokens_freed"] == 88_888
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR tightens Penguin’s OpenCode-compatible TUI session behavior after the upstream TUI sync work.

- fetches session-scoped token/CWM usage from the backend instead of relying on stale global or snapshot-only state
- loads a deeper Penguin session list so older sessions remain reachable from the TUI dialog
- canonicalizes Penguin/OpenAI model IDs before TUI validation, fixing cases like `openai/GPT-5.5`
- preserves Penguin fast mode during prompt/session transitions
- prevents view-only session listing from surfacing transient `recovery_*` sessions that later 404
- hides blank fallback-titled Penguin sessions from the TUI session picker when they have no displayable messages
- adds TODO/plan coverage for future cursor-backed pagination

## Notes

The blank-session filter is intentionally conservative: it only hides Penguin sessions when the backend marks them as fallback-titled and reports zero displayable messages. Valid old sessions with real visible content remain listed even if they lack a generated title.

## Validation

- `pytest -q tests/api/test_session_view_service.py`
- `bun test test/cli/tui/sync-bootstrap.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session list UI with better filtering and blank-session hiding; selecting a session now updates local sync state.

* **Improvements**
  * Session metadata enriched with message counts and fallback title detection.
  * Token-usage now prioritizes recomputed values from session messages and refreshes from session-scoped usage endpoints.
  * Canonicalized provider/model IDs and stricter session validation on load; support for paginated session lists.

* **Bug Fixes**
  * Corrupt/recovery-substitute sessions are skipped from session views.

* **Tests**
  * Added tests for session views and token-usage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->