### PR TITLE
Speed up Penguin TUI startup critical path

### DIFF
--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -971,17 +971,55 @@ Investigation snapshot - 2026-06-08:
 
 Planned work:
 
-- [ ] Lazy-load Python package and CLI imports so `penguin-tui` reaches the
+- [x] Lazy-load Python package and CLI imports so `penguin-tui` reaches the
       launcher without importing PenguinCore/config/engine.
-- [ ] Make launch-mode selection explicit. `--use-global-opencode` should
-      bypass local source preference, and a future env/flag should choose
-      source, built dist, sidecar, or global binary deliberately.
-- [ ] Move terminal background-color probing after first paint or cap its wait
+- [x] Make `--use-global-opencode` bypass local source preference.
+- [ ] Make launch-mode selection fully explicit with a future env/flag that
+      chooses source, built dist, sidecar, or global binary deliberately.
+- [x] Move terminal background-color probing after first paint or cap its wait
       more aggressively.
-- [ ] Audit whether Penguin web-backed mode can defer or skip OpenCode worker
+- [x] Audit whether Penguin web-backed mode can defer or skip OpenCode worker
       initialization until a feature actually needs it.
-- [ ] Add lightweight startup timing instrumentation around Python launcher,
+- [x] Add lightweight startup timing instrumentation around Python launcher,
       Bun/binary spawn, first render, and Penguin bootstrap completion.
+- [ ] Investigate Bun/source-mode module load cost before `thread.handler.start`;
+      this is now the largest remaining measured pre-render startup segment.
+
+Progress - 2026-06-08:
+
+- First fix lazy-loads `penguin.__init__` core/config/engine/agent exports and
+  `penguin.cli.__init__` CLI exports so the TUI launcher import no longer pays
+  for `PenguinCore`, tool manager, IPython/notebook helpers, or Rich/Typer CLI
+  setup.
+- Local timing improved from roughly `2.1s` to `0.28-0.45s` for
+  `uv run python -c 'import penguin.cli.opencode_launcher'`, and from roughly
+  `2.1s` to `0.54s` for `uv run penguin-tui --help`.
+- `--use-global-opencode` now prefers the global `opencode` binary before
+  considering local Bun/source execution.
+
+Progress - 2026-06-09:
+
+- Added env-gated startup profiling via `PENGUIN_TUI_PROFILE=1` /
+  `OPENCODE_TUI_PROFILE=1` across the Python launcher, TUI thread handler,
+  first render path, theme initialization, and Penguin bootstrap.
+- Penguin `SyncProvider` now starts in `partial` mode so first paint is not
+  blocked by `/config`, `/provider`, `/session`, `/lsp`, `/vcs`, or related
+  bootstrap fetches. `LocalProvider` now tolerates the temporarily empty agent
+  list during that early render.
+- Capped Penguin-mode terminal background-color probing at `150ms` instead of
+  allowing the full `1000ms` timeout on terminals that do not answer the color
+  query.
+- Deferred the OpenCode worker creation in Penguin web-backed mode until the
+  delayed upgrade check or reload/shutdown path needs it.
+- Live profile against local Penguin web on `127.0.0.1:8080`:
+  - launcher reaches Bun spawn at about `255ms`
+  - Bun/source mode reaches `thread.handler.start` at about `2.54s`
+  - terminal color probing now adds about `156ms`
+  - first render starts at about `2.69s`
+- Current conclusion: the original 10s blank was partly a readiness gate, but
+  the largest remaining cold-start target is Bun/source-mode module loading
+  before the TUI thread handler. A built/sidecar/global runtime path is likely
+  the next meaningful optimization after this surgical pass.
 
 ### 7. Testing and verification
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -39,11 +39,14 @@ import open from "open"
 import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { exitSession } from "./util/exit"
+import { profileStartup } from "./util/startup-profile"
 
 const PENGUIN_DOCS_URL = "https://penguin-rho.vercel.app"
 const OPENCODE_DOCS_URL = "https://opencode.ai/docs"
+const TERMINAL_BACKGROUND_TIMEOUT_MS = 1000
+const PENGUIN_TERMINAL_BACKGROUND_TIMEOUT_MS = 150
 
-async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
+async function getTerminalBackgroundColor(timeoutMs = TERMINAL_BACKGROUND_TIMEOUT_MS): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
   if (!process.stdin.isTTY) return "dark"
 
@@ -99,7 +102,7 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
     timeout = setTimeout(() => {
       cleanup()
       resolve("dark")
-    }, 1000)
+    }, timeoutMs)
   })
 }
 
@@ -117,12 +120,21 @@ export function tui(input: {
 }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
-    const mode = await getTerminalBackgroundColor()
+    profileStartup("tui.start", { penguin: input.penguin })
+    const terminalColorStart = Date.now()
+    const terminalColorTimeout = input.penguin ? PENGUIN_TERMINAL_BACKGROUND_TIMEOUT_MS : TERMINAL_BACKGROUND_TIMEOUT_MS
+    const mode = await getTerminalBackgroundColor(terminalColorTimeout)
+    profileStartup("terminal_background.done", {
+      duration_ms: Date.now() - terminalColorStart,
+      timeout_ms: terminalColorTimeout,
+      mode,
+    })
     const onExit = async () => {
       await input.onExit?.()
       resolve()
     }
 
+    profileStartup("render.start")
     render(
       () => {
         return (
@@ -187,6 +199,7 @@ export function tui(input: {
         },
       },
     )
+    profileStartup("render.returned")
   })
 }
 

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -47,6 +47,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         const first = agents()[0]
         if (first) setAgentStore("current", first.name)
       })
+      const fallbackAgent = createMemo<Agent>(() => ({
+        name: agentStore.current,
+        mode: "primary",
+        permission: [],
+        options: {},
+      }))
       const { theme } = useTheme()
       const colors = createMemo(() => [
         theme.secondary,
@@ -64,7 +70,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return (
             agents().find((x) => x.name === agentStore.current) ??
             agents()[0] ??
-            ({ name: agentStore.current } as Agent)
+            fallbackAgent()
           )
         },
         set(name: string) {

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -12,6 +12,7 @@ import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
+import type { Agent } from "@opencode-ai/sdk/v2"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -38,7 +39,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const [agentStore, setAgentStore] = createStore<{
         current: string
       }>({
-        current: agents()[0].name,
+        current: "build",
+      })
+      createEffect(() => {
+        const current = agents().find((x) => x.name === agentStore.current)
+        if (current) return
+        const first = agents()[0]
+        if (first) setAgentStore("current", first.name)
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -54,7 +61,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current)!
+          return (
+            agents().find((x) => x.name === agentStore.current) ??
+            agents()[0] ??
+            ({ name: agentStore.current } as Agent)
+          )
         },
         set(name: string) {
           if (!agents().some((x) => x.name === name))
@@ -66,6 +77,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setAgentStore("current", name)
         },
         move(direction: 1 | -1) {
+          if (!agents().length) return
           batch(() => {
             let next = agents().findIndex((x) => x.name === agentStore.current) + direction
             if (next < 0) next = agents().length - 1

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -49,10 +49,13 @@ import {
   shouldIgnorePenguinScopedEvent,
 } from "./sync-scope"
 import { expandSessionSearchResults, removeSessionRecord, upsertSessionRecord } from "../util/session-family"
+import { profileStartup } from "../util/startup-profile"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
   init: () => {
+    const sdk = useSDK()
+    const route = useRoute()
     const [store, setStore] = createStore<{
       status: "loading" | "partial" | "complete"
       provider: Provider[]
@@ -105,7 +108,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       },
       provider_auth: {},
       config: {},
-      status: "loading",
+      status: sdk.penguin ? "partial" : "loading",
       agent: [],
       permission: {},
       question: {},
@@ -126,9 +129,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
     })
-
-    const sdk = useSDK()
-    const route = useRoute()
     const fullSyncedSessions = new Set<string>()
 
     const sessionIndex = (sessionID: string) => store.session.findIndex((item) => item.id === sessionID)
@@ -528,9 +528,29 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     async function bootstrap(refreshActive = false) {
       console.log("bootstrapping")
+      profileStartup("sync.bootstrap.start", {
+        penguin: sdk.penguin,
+        refreshActive,
+      })
       if (sdk.penguin) {
         fullSyncedSessions.clear()
         const directory = store.path.directory || sdk.directory || process.cwd()
+        const timed = async <T,>(label: string, promise: Promise<T>) => {
+          const start = Date.now()
+          try {
+            const result = await promise
+            profileStartup(`sync.bootstrap.${label}.done`, {
+              duration_ms: Date.now() - start,
+            })
+            return result
+          } catch (error) {
+            profileStartup(`sync.bootstrap.${label}.error`, {
+              duration_ms: Date.now() - start,
+              error: error instanceof Error ? error.message : String(error),
+            })
+            throw error
+          }
+        }
         const sessionsUrl = iife(() => {
           const url = new URL("/session", sdk.url)
           url.searchParams.set("directory", directory)
@@ -539,40 +559,59 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
         const [providersData, providerListData, configData, providerAuthData, sessionsData, roster] = await Promise.all(
           [
-            fetchBootstrapJson({
-              fetch: sdk.fetch,
-              path: new URL("/config/providers", sdk.url),
-              endpoint: "/config/providers",
-              fallback: undefined,
-            }),
-            fetchBootstrapJson({
-              fetch: sdk.fetch,
-              path: new URL("/provider", sdk.url),
-              endpoint: "/provider",
-              fallback: undefined,
-            }),
-            fetchBootstrapJson({
-              fetch: sdk.fetch,
-              path: new URL("/config", sdk.url),
-              endpoint: "/config",
-              fallback: undefined,
-            }),
-            fetchBootstrapJson({
-              fetch: sdk.fetch,
-              path: new URL("/provider/auth", sdk.url),
-              endpoint: "/provider/auth",
-              fallback: undefined,
-            }),
-            sdk.fetch(sessionsUrl)
-              .then((res) => (res.ok ? res.json() : undefined))
-              .then((data) => (Array.isArray(data) ? data : []))
-              .catch(() => []),
-            sdk.fetch(new URL("/api/v1/agents", sdk.url))
-              .then((res) => (res.ok ? res.json() : undefined))
-              .then((data) => (Array.isArray(data) ? data : []))
-              .catch(() => []),
+            timed(
+              "config_providers",
+              fetchBootstrapJson({
+                fetch: sdk.fetch,
+                path: new URL("/config/providers", sdk.url),
+                endpoint: "/config/providers",
+                fallback: undefined,
+              }),
+            ),
+            timed(
+              "provider",
+              fetchBootstrapJson({
+                fetch: sdk.fetch,
+                path: new URL("/provider", sdk.url),
+                endpoint: "/provider",
+                fallback: undefined,
+              }),
+            ),
+            timed(
+              "config",
+              fetchBootstrapJson({
+                fetch: sdk.fetch,
+                path: new URL("/config", sdk.url),
+                endpoint: "/config",
+                fallback: undefined,
+              }),
+            ),
+            timed(
+              "provider_auth",
+              fetchBootstrapJson({
+                fetch: sdk.fetch,
+                path: new URL("/provider/auth", sdk.url),
+                endpoint: "/provider/auth",
+                fallback: undefined,
+              }),
+            ),
+            timed(
+              "sessions",
+              sdk.fetch(sessionsUrl)
+                .then((res) => (res.ok ? res.json() : undefined))
+                .then((data) => (Array.isArray(data) ? data : []))
+                .catch(() => []),
+            ),
+            timed(
+              "agents",
+              sdk.fetch(new URL("/api/v1/agents", sdk.url))
+                .then((res) => (res.ok ? res.json() : undefined))
+                .then((data) => (Array.isArray(data) ? data : []))
+                .catch(() => []),
+            ),
           ],
         )
+        const mapStart = Date.now()
         const bootstrapState = mapPenguinBootstrap({
           baseUrl: sdk.url,
           configData,
@@ -582,6 +621,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           providersData,
           roster: Array.isArray(roster) ? roster : [],
           sessions: Array.isArray(sessionsData) ? sessionsData : [],
+        })
+        profileStartup("sync.bootstrap.map.done", {
+          duration_ms: Date.now() - mapStart,
         })
         batch(() => {
           setStore("provider", reconcile(bootstrapState.provider))
@@ -597,6 +639,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           setStore("path", reconcile(bootstrapState.path))
           setStore("status", "complete")
         })
+        profileStartup("sync.bootstrap.primary_store.done")
 
         const systemUrl = (pathname: string) => {
           const url = new URL(pathname, sdk.url)
@@ -605,30 +648,42 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         await Promise.all([
-          fetchBootstrapJson({
-            fetch: sdk.fetch,
-            path: systemUrl("/lsp"),
-            endpoint: "/lsp",
-            fallback: [] as LspStatus[],
-          }),
-          fetchBootstrapJson({
-            fetch: sdk.fetch,
-            path: systemUrl("/formatter"),
-            endpoint: "/formatter",
-            fallback: [] as FormatterStatus[],
-          }),
-          fetchBootstrapJson({
-            fetch: sdk.fetch,
-            path: systemUrl("/vcs"),
-            endpoint: "/vcs",
-            fallback: undefined,
-          }),
-          fetchBootstrapJson({
-            fetch: sdk.fetch,
-            path: systemUrl("/path"),
-            endpoint: "/path",
-            fallback: undefined,
-          }),
+          timed(
+            "lsp",
+            fetchBootstrapJson({
+              fetch: sdk.fetch,
+              path: systemUrl("/lsp"),
+              endpoint: "/lsp",
+              fallback: [] as LspStatus[],
+            }),
+          ),
+          timed(
+            "formatter",
+            fetchBootstrapJson({
+              fetch: sdk.fetch,
+              path: systemUrl("/formatter"),
+              endpoint: "/formatter",
+              fallback: [] as FormatterStatus[],
+            }),
+          ),
+          timed(
+            "vcs",
+            fetchBootstrapJson({
+              fetch: sdk.fetch,
+              path: systemUrl("/vcs"),
+              endpoint: "/vcs",
+              fallback: undefined,
+            }),
+          ),
+          timed(
+            "path",
+            fetchBootstrapJson({
+              fetch: sdk.fetch,
+              path: systemUrl("/path"),
+              endpoint: "/path",
+              fallback: undefined,
+            }),
+          ),
         ]).then((result) => {
           const lsp = result[0]
           const formatter = result[1]
@@ -641,10 +696,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             if (path) setStore("path", reconcile(path))
           })
         })
+        profileStartup("sync.bootstrap.system_store.done")
         const activeSessionID = route.data.type === "session" ? route.data.sessionID : undefined
         if (activeSessionID && (refreshActive || store.session.some((item) => item.id === activeSessionID))) {
+          const hydrateStart = Date.now()
           await syncSessionSnapshot(activeSessionID, true)
+          profileStartup("sync.bootstrap.active_session.done", {
+            duration_ms: Date.now() - hydrateStart,
+            sessionID: activeSessionID,
+          })
         }
+        profileStartup("sync.bootstrap.done")
         return
       }
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -51,6 +51,7 @@ import { createStore, produce } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { useSDK } from "./sdk"
+import { profileStartup } from "../util/startup-profile"
 
 type ThemeColors = {
   primary: RGBA
@@ -314,9 +315,21 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     })
 
     function init() {
+      profileStartup("theme.init.start", {
+        active: store.active,
+        mode: store.mode,
+      })
+      if (store.active !== "system" && store.themes[store.active]) {
+        setStore("ready", true)
+      }
       resolveSystemTheme()
+      const customThemeStart = Date.now()
       getCustomThemes()
         .then((custom) => {
+          profileStartup("theme.custom_themes.done", {
+            duration_ms: Date.now() - customThemeStart,
+            count: Object.keys(custom).length,
+          })
           setStore(
             produce((draft) => {
               Object.assign(draft.themes, custom)
@@ -324,6 +337,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           )
         })
         .catch(() => {
+          profileStartup("theme.custom_themes.error", {
+            duration_ms: Date.now() - customThemeStart,
+          })
           setStore("active", defaultTheme)
         })
         .finally(() => {
@@ -336,13 +352,16 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     onMount(init)
 
     function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
+      const paletteStart = Date.now()
       renderer
         .getPalette({
           size: 16,
         })
         .then((colors) => {
-          console.log(colors.palette)
+          profileStartup("theme.palette.done", {
+            duration_ms: Date.now() - paletteStart,
+            palette_colors: colors.palette.length,
+          })
           if (!colors.palette[0]) {
             if (store.active === "system") {
               setStore(

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -9,6 +9,7 @@ import { Log } from "@/util/log"
 import { withNetworkOptions } from "@/cli/network"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
+import { profileStartup } from "./util/startup-profile"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -77,32 +78,60 @@ export const TuiThreadCommand = cmd({
         describe: "penguin web server url",
       }),
   handler: async (args) => {
+    profileStartup("thread.handler.start", {
+      has_project: Boolean(args.project),
+      has_prompt: Boolean(args.prompt),
+      has_session: Boolean(args.session),
+    })
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
+    const cwdStart = Date.now()
     const baseCwd = process.env.PWD ?? process.cwd()
     const cwd = args.project ? path.resolve(baseCwd, args.project) : baseCwd
+    profileStartup("thread.cwd.done", {
+      duration_ms: Date.now() - cwdStart,
+      cwd,
+    })
     const localWorker = new URL("./worker.ts", import.meta.url)
     const distWorker = new URL("./cli/cmd/tui/worker.js", import.meta.url)
+    const workerPathStart = Date.now()
     const workerPath = await iife(async () => {
       if (typeof OPENCODE_WORKER_PATH !== "undefined") return OPENCODE_WORKER_PATH
       if (await Bun.file(distWorker).exists()) return distWorker
       return localWorker
     })
+    profileStartup("thread.worker_path.done", {
+      duration_ms: Date.now() - workerPathStart,
+      worker_path: String(workerPath),
+    })
     try {
+      const chdirStart = Date.now()
       process.chdir(cwd)
+      profileStartup("thread.chdir.done", {
+        duration_ms: Date.now() - chdirStart,
+      })
     } catch (e) {
       UI.error("Failed to change directory to " + cwd)
       return
     }
 
-    const worker = new Worker(workerPath, {
-      env: Object.fromEntries(
-        Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-      ),
-    })
-    worker.onerror = (e) => {
-      Log.Default.error(e)
+    let client: RpcClient | undefined
+    function ensureClient() {
+      if (client) return client
+      const workerStart = Date.now()
+      const worker = new Worker(workerPath, {
+        env: Object.fromEntries(
+          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        ),
+      })
+      worker.onerror = (e) => {
+        Log.Default.error(e)
+      }
+      client = Rpc.client<typeof rpc>(worker)
+      profileStartup("thread.worker.spawn.done", {
+        duration_ms: Date.now() - workerStart,
+      })
+      return client
     }
-    const client = Rpc.client<typeof rpc>(worker)
     process.on("uncaughtException", (e) => {
       Log.Default.error(e)
     })
@@ -110,13 +139,19 @@ export const TuiThreadCommand = cmd({
       Log.Default.error(e)
     })
     process.on("SIGUSR2", async () => {
-      await client.call("reload", undefined)
+      await ensureClient().call("reload", undefined)
     })
 
+    const promptStart = Date.now()
     const prompt = await iife(async () => {
       const piped = !process.stdin.isTTY ? await Bun.stdin.text() : undefined
       if (!args.prompt) return piped
       return piped ? piped + "\n" + args.prompt : args.prompt
+    })
+    profileStartup("thread.prompt.done", {
+      duration_ms: Date.now() - promptStart,
+      stdin_tty: process.stdin.isTTY,
+      has_prompt: Boolean(prompt),
     })
 
     const base = args.url ?? process.env.PENGUIN_WEB_URL ?? "http://127.0.0.1:9000"
@@ -125,6 +160,10 @@ export const TuiThreadCommand = cmd({
     const customFetch = undefined
     const events = undefined
 
+    profileStartup("thread.tui.call", {
+      url,
+      has_session: Boolean(sessionID),
+    })
     const tuiPromise = tui({
       url,
       directory: cwd,
@@ -140,12 +179,12 @@ export const TuiThreadCommand = cmd({
         prompt,
       },
       onExit: async () => {
-        await client.call("shutdown", undefined)
+        await client?.call("shutdown", undefined)
       },
     })
 
     setTimeout(() => {
-      client.call("checkUpgrade", { directory: cwd }).catch(() => {})
+      ensureClient().call("checkUpgrade", { directory: cwd }).catch(() => {})
     }, 1000)
 
     await tuiPromise

--- a/penguin-tui/packages/opencode/src/cli/cmd/tui/util/startup-profile.ts
+++ b/penguin-tui/packages/opencode/src/cli/cmd/tui/util/startup-profile.ts
@@ -1,0 +1,12 @@
+const STARTUP_PROFILE =
+  process.env.PENGUIN_TUI_PROFILE === "1" ||
+  process.env.OPENCODE_TUI_PROFILE === "1"
+
+export function profileStartup(label: string, details: Record<string, unknown> = {}) {
+  if (!STARTUP_PROFILE) return
+  console.log("[penguin-tui startup]", {
+    label,
+    ms: Math.round(performance.now()),
+    ...details,
+  })
+}

--- a/penguin/__init__.py
+++ b/penguin/__init__.py
@@ -52,48 +52,11 @@ package_dir = os.path.dirname(os.path.abspath(__file__))
 if package_dir not in sys.path:
     sys.path.insert(0, package_dir)
 
-# Core exports - main public API
-from .core import PenguinCore
-from .config import config
-from .engine import Engine, EngineSettings
-
 # ---------------------------------------------------------------------------
 # Agent exports – simplified high-level wrapper
 # ---------------------------------------------------------------------------
 
-import warnings
-
 from ._version import __author__, __email__, __license__, __version__
-
-# The canonical package layout places ``penguin.agent`` as a *sibling* package
-# of this sub-package (``penguin.penguin``).  A simple relative import is all
-# that is required – tinkering with ``sys.path`` is both fragile and can mask
-# genuine packaging errors.
-
-try:
-    # NOTE: ``from ..agent`` resolves to the top-level ``penguin.agent`` because
-    # ``penguin.penguin`` lives one level below the root package.
-    from ..agent import PenguinAgent  # type: ignore
-except ImportError as exc:  # pragma: no cover – only trips in broken installs
-    # Emit a *single* runtime warning instead of writing directly to stderr so
-    # that callers retain full control over visibility (e.g. ``-W error``).
-    warnings.warn(
-        "PenguinAgent could not be imported – the agent module is missing. "
-        "Most high-level conveniences will be unavailable.\n"
-        f"Underlying error: {exc}",
-        category=ImportWarning,
-        stacklevel=2,
-    )
-
-    class PenguinAgent:  # pylint: disable=too-few-public-methods
-        """Placeholder that raises a helpful error when instantiated."""
-
-        def __init__(self, *_, **__):
-            raise ImportError(
-                "PenguinAgent is unavailable – the 'penguin.agent' sub-package "
-                "could not be imported. Please check your installation or "
-                "ensure optional dependencies are installed."
-            )
 
 # Project management exports - lazy load to avoid import overhead
 # from .project import ProjectManager, Project, Task
@@ -175,6 +138,60 @@ def __getattr__(name):
     """Lazy loading for optional exports to avoid import overhead."""
     if name in _optional_exports:
         return _optional_exports[name]
+
+    if name == "PenguinCore":
+        from .core import PenguinCore
+
+        _optional_exports["PenguinCore"] = PenguinCore
+        return PenguinCore
+
+    if name == "config":
+        from .config import config
+
+        _optional_exports["config"] = config
+        return config
+
+    if name in {"Engine", "EngineSettings"}:
+        from .engine import Engine, EngineSettings
+
+        _optional_exports.update(
+            {
+                "Engine": Engine,
+                "EngineSettings": EngineSettings,
+            }
+        )
+        return _optional_exports[name]
+
+    if name == "PenguinAgent":
+        try:
+            from .agent import PenguinAgent
+
+            _optional_exports["PenguinAgent"] = PenguinAgent
+            return PenguinAgent
+        except ImportError as exc:  # pragma: no cover - broken installs only
+            import warnings
+
+            warnings.warn(
+                "PenguinAgent could not be imported – the agent module is "
+                "missing. Most high-level conveniences will be unavailable.\n"
+                f"Underlying error: {exc}",
+                category=ImportWarning,
+                stacklevel=2,
+            )
+
+            class PenguinAgent:  # pylint: disable=too-few-public-methods
+                """Placeholder that raises a helpful error when instantiated."""
+
+                def __init__(self, *_, **__):
+                    raise ImportError(
+                        "PenguinAgent is unavailable – the 'penguin.agent' "
+                        "sub-package could not be imported. Please check your "
+                        "installation or ensure optional dependencies are "
+                        "installed."
+                    )
+
+            _optional_exports["PenguinAgent"] = PenguinAgent
+            return PenguinAgent
     
     # Try to load project management exports
     if name in ['ProjectManager', 'Project', 'Task']:

--- a/penguin/cli/__init__.py
+++ b/penguin/cli/__init__.py
@@ -47,35 +47,7 @@ def get_cli_app():
     return _cli_app
 
 
-# Try to expose CLI components
-try:
-    from .cli import app as cli_app
-    # Note: individual command modules don't exist yet, so we'll skip those imports for now
-    
-    __all__ = [
-        "cli_app",
-        "get_cli_app",
-        "PenguinCLI"
-    ]
-    
-    # Import PenguinCLI class if available
-    try:
-        from .cli import PenguinCLI
-    except ImportError:
-        # PenguinCLI class might not be available in all setups
-        pass
-    
-except ImportError:
-    # CLI dependencies not available (minimal install)
-    __all__ = ["get_cli_app"]
-
-
-
-# Import journal commands to register them
-try:
-    from .journal_commands import journal_command
-except ImportError:
-    pass  # journal commands might not be available
+__all__ = ["cli_app", "get_cli_app", "journal_command", "PenguinCLI"]
 
 class PenguinCLI:
     """Main CLI interface class for programmatic access."""
@@ -94,4 +66,24 @@ class PenguinCLI:
             args = []
         # This would integrate with typer's testing functionality
         # For now, it's a placeholder
-        return self.app(args) 
+        return self.app(args)
+
+
+def __getattr__(name: str) -> object:
+    """Lazy-load optional CLI exports."""
+    if name == "cli_app":
+        app = get_cli_app()
+        if app is None:
+            raise AttributeError(
+                "CLI dependencies not available. Install with: pip install penguin-ai"
+            )
+        return app
+
+    if name == "journal_command":
+        try:
+            from .journal_commands import journal_command
+        except ImportError as exc:
+            raise AttributeError("journal_command is unavailable") from exc
+        return journal_command
+
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/penguin/cli/opencode_launcher.py
+++ b/penguin/cli/opencode_launcher.py
@@ -39,6 +39,25 @@ DEFAULT_TUI_RELEASE_API_ROOT = "https://api.github.com/repos/Maximooch/penguin/r
 DEFAULT_TUI_RELEASE_URL = f"{DEFAULT_TUI_RELEASE_API_ROOT}/latest"
 DEFAULT_WEB_URL = f"http://127.0.0.1:{DEFAULT_WEB_PORT}"
 _URL_MODE_CAP_CACHE: dict[str, bool] = {}
+_STARTUP_PROFILE_START = time.perf_counter()
+
+
+def _profile_startup(label: str, **details: Any) -> None:
+    """Emit env-gated launcher startup timing for TUI profiling."""
+    if (
+        os.getenv("PENGUIN_TUI_PROFILE") != "1"
+        and os.getenv("OPENCODE_TUI_PROFILE") != "1"
+    ):
+        return
+    payload = {
+        "label": label,
+        "ms": round((time.perf_counter() - _STARTUP_PROFILE_START) * 1000),
+        **details,
+    }
+    print(
+        f"[penguin-tui launcher] {json.dumps(payload, sort_keys=True)}",
+        file=sys.stderr,
+    )
 
 
 def _normalize_base_url(raw_url: str) -> str:
@@ -771,6 +790,8 @@ def _build_opencode_command(
         project_dir: Target project directory for the TUI session.
         base_url: Penguin web base URL.
         extra_args: Additional args passed through to OpenCode CLI.
+        use_global_opencode: Prefer the global `opencode` binary over local
+            source checkout execution.
 
     Returns:
         Tuple of command argv and optional cwd for the child process.
@@ -780,10 +801,25 @@ def _build_opencode_command(
     """
     extra = list(extra_args)
     has_url_arg = "--url" in extra
+    global_error = ""
+
+    if use_global_opencode:
+        opencode_bin = shutil.which("opencode")
+        if opencode_bin:
+            cmd = _build_binary_tui_command(
+                binary=opencode_bin,
+                project_dir=project_dir,
+                base_url=base_url,
+                extra_args=extra,
+                has_url_arg=has_url_arg,
+                require_url_mode=False,
+            )
+            return cmd, None
+        global_error = " Global 'opencode' binary was not found."
 
     bun_bin = shutil.which("bun")
     local_dir = _find_local_opencode_dir()
-    if bun_bin and local_dir is not None:
+    if not use_global_opencode and bun_bin and local_dir is not None:
         cmd = [
             bun_bin,
             "run",
@@ -810,25 +846,12 @@ def _build_opencode_command(
     except RuntimeError as exc:
         sidecar_error = str(exc)
 
-    if use_global_opencode:
-        opencode_bin = shutil.which("opencode")
-        if opencode_bin:
-            cmd = _build_binary_tui_command(
-                binary=opencode_bin,
-                project_dir=project_dir,
-                base_url=base_url,
-                extra_args=extra,
-                has_url_arg=has_url_arg,
-                require_url_mode=False,
-            )
-            return cmd, None
-
     raise RuntimeError(
         "Penguin TUI runtime is not available. Install or upgrade with "
         "'pip install -U penguin-ai'. For development, set "
         "PENGUIN_OPENCODE_DIR to your local 'penguin-tui/packages/opencode' "
         "path, or use --use-global-opencode with an installed 'opencode' binary. "
-        f"Sidecar bootstrap error: {sidecar_error}"
+        f"{global_error} Sidecar bootstrap error: {sidecar_error}"
     )
 
 
@@ -906,7 +929,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     Returns:
         Process exit code.
     """
+    _profile_startup("launcher.start")
+    parse_start = time.perf_counter()
     args, extra_args = _parse_args(argv)
+    _profile_startup(
+        "launcher.args.done",
+        duration_ms=round((time.perf_counter() - parse_start) * 1000),
+        extra_args=len(extra_args),
+    )
 
     try:
         base_url = _normalize_base_url(args.url)
@@ -930,8 +960,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Force it to the requested target project when launched via uvx/tool shims.
     env["PWD"] = str(project_dir)
 
+    health_start = time.perf_counter()
     server_running = _is_server_running(base_url)
+    _profile_startup(
+        "launcher.health.done",
+        duration_ms=round((time.perf_counter() - health_start) * 1000),
+        server_running=server_running,
+    )
+    auth_start = time.perf_counter()
     _prepare_local_auth_env(base_url, env, server_running=server_running)
+    _profile_startup(
+        "launcher.auth_env.done",
+        duration_ms=round((time.perf_counter() - auth_start) * 1000),
+    )
 
     server_proc: subprocess.Popen[str] | None = None
     cleanup_registered = False
@@ -974,14 +1015,26 @@ def main(argv: Sequence[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
+    cache_auth_start = time.perf_counter()
     _sync_local_auth_env_from_cache(base_url, env)
+    _profile_startup(
+        "launcher.auth_cache.done",
+        duration_ms=round((time.perf_counter() - cache_auth_start) * 1000),
+    )
 
     try:
+        command_start = time.perf_counter()
         opencode_cmd, opencode_cwd = _build_opencode_command(
             project_dir,
             base_url,
             extra_args,
             use_global_opencode=args.use_global_opencode,
+        )
+        _profile_startup(
+            "launcher.command.done",
+            duration_ms=round((time.perf_counter() - command_start) * 1000),
+            executable=Path(opencode_cmd[0]).name if opencode_cmd else "",
+            cwd=str(opencode_cwd) if opencode_cwd is not None else None,
         )
     except RuntimeError as exc:
         if cleanup_registered:
@@ -990,7 +1043,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
+        _profile_startup("launcher.spawn.start")
         result = subprocess.run(opencode_cmd, cwd=opencode_cwd, env=env)
+        _profile_startup("launcher.spawn.done", returncode=result.returncode)
         return result.returncode
     except KeyboardInterrupt:
         return 130

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -209,6 +209,41 @@ def test_build_command_uses_global_attach_mode_when_requested(
     ]
 
 
+def test_build_command_uses_global_before_local_source_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    local_source = tmp_path / "opencode"
+    global_bin = "/usr/local/bin/opencode"
+
+    monkeypatch.setattr(
+        opencode_launcher, "_find_local_opencode_dir", lambda: local_source
+    )
+    monkeypatch.setattr(
+        opencode_launcher.shutil,
+        "which",
+        lambda name: {
+            "bun": "/usr/local/bin/bun",
+            "opencode": global_bin,
+        }.get(name),
+    )
+    monkeypatch.setattr(
+        opencode_launcher, "_binary_supports_url_mode", lambda binary: True
+    )
+
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        [],
+        use_global_opencode=True,
+    )
+
+    assert cwd is None
+    assert cmd == [global_bin, str(project_dir), "--url", "http://127.0.0.1:9000"]
+
+
 def test_build_command_error_surfaces_sidecar_bootstrap_detail(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Reduces perceived Penguin TUI startup time by removing unnecessary work from the first-render path and adding targeted startup profiling.

## Changes

- Lazy-load Penguin package and CLI exports so the TUI launcher avoids importing core/config/engine paths before launch.
- Start Penguin sync bootstrap in partial mode so first paint is not blocked by provider/session/system fetches.
- Tolerate an initially empty agent list during early render.
- Cap Penguin terminal background probing to avoid a one-second pre-render wait.
- Defer OpenCode worker creation until reload/upgrade/shutdown paths need it.
- Add env-gated startup profiling for launcher, thread, render, theme, and bootstrap timing.
- Update the Phase 6.5 plan with measurements and remaining optimization targets.

## Validation

- `bun run typecheck`
- `git diff --check`
- `uv run ruff check penguin/cli/opencode_launcher.py tests/test_opencode_launcher.py`
- `uv run pytest -q tests/test_opencode_launcher.py tests/test_package_exports.py::TestCoreExports::test_core_classes_importable tests/test_package_exports.py::TestCoreExports::test_config_importable tests/test_package_exports.py::TestWebExports::test_cli_classes_importable_when_available tests/test_package_exports.py::TestAllExports::test_all_exports_importable`

## Notes

Manual profiling with `PENGUIN_TUI_PROFILE=1` now shows first render around ~2s locally, with the largest remaining cost in Bun/source-mode module loading before `thread.handler.start`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-gated startup profiling for TUI launch and internal milestones (enable via env var).
  * Added a regression test ensuring global OpenCode is preferred when requested.

* **Performance**
  * Reduced cold-start cost via lazy-loading and deferred worker initialization in web-backed mode.
  * Made terminal background-color detection timeout configurable for different modes.

* **Reliability**
  * Improved agent selection/fallbacks and more robust lazy-loading of core CLI exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->