### PR TITLE
feat(tui): add canonical runtime event envelope projection

### DIFF
--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -1912,7 +1912,8 @@ Phase 11 goals:
 Phase 11 implementation notes:
 
 - Backend-owned event envelope lives in
-  `penguin/web/services/runtime_events.py`.
+  `penguin/system/runtime_events.py` so runtime/core imports stay independent of
+  the web/ASGI stack.
 - Runtime events use schema version `penguin.runtime_event.v1` and contain:
   `id`, `schema_version`, `type`, `category`, `source`, `subject`, `time`,
   `stream_id`, `sequence`, `scope`, `correlation`, `actor`, `privacy`,
@@ -1943,6 +1944,10 @@ Phase 11 implementation notes:
 - SSE keeps a bounded in-memory compatibility replay window for current
   reconnect/dedupe behavior. A durable emit-time event ledger is Phase 11.5; do
   not build Phase 12 consumers on the bounded SSE buffer.
+- The current `server.replay_gap` frame is a temporary compatibility signal for
+  bounded-buffer misses. It is intentionally not a durable runtime-event cursor;
+  future TUI/Link consumers should treat it as a full-resync trigger unless the
+  Phase 11.5 ledger replaces it with a real replay cursor.
 - Current CWM events should be modeled as token/context-window telemetry. Do
   not describe current CWM behavior as compaction; it trims by category priority
   and recency.
@@ -2007,12 +2012,22 @@ Phase 11.5 test requirements:
 
 Implementation notes:
 
-- Prefer a small service module under `penguin/web/services` or a runtime event
-  storage package instead of adding ledger behavior to routes.
+- Prefer a small runtime event storage package or service module that consumes
+  `penguin/system/runtime_events.py` instead of adding ledger behavior to routes.
 - SSE should remain a projection/subscription layer. It should not own durable
   event truth.
 - The first ledger can be local/deterministic and modest. The important contract
   is append-only, ordered, replayable, redacted `RuntimeEvent` records.
+- Move the current bounded SSE replay helpers, queued-live-event dedupe bridge,
+  replay-gap payload shaping, and queue/backpressure policy out of
+  `penguin/web/sse_events.py` as part of the ledger work. The route module should
+  subscribe, filter/project, and frame events only.
+- Decide whether replay-gap notifications should omit synthetic SSE ids, carry a
+  newest ledger cursor, or be replaced by ledger-backed replay responses before
+  any client consumes `server.replay_gap` as more than a resync signal.
+- Keep `server.connected` / `server.replay_gap` classified as transport signals
+  in the ledger design instead of relying on the current default
+  `session_lifecycle` fallback.
 
 ### 12. Post-envelope TUI and runtime feature follow-ups
 

--- a/penguin/core.py
+++ b/penguin/core.py
@@ -208,7 +208,7 @@ from penguin.utils.profiling import (
     profile_startup_phase,
     profiler,
 )
-from penguin.web.services.runtime_events import wrap_opencode_event
+from penguin.system.runtime_events import redact_runtime_payload, wrap_opencode_event
 
 try:
     from penguin.system.message_bus import MessageBus, ProtocolMessage
@@ -6515,8 +6515,7 @@ class PenguinCore:
         if not session_id or session_id == "unknown":
             return
 
-        public_event = wrap_opencode_event(event_type, properties)
-        public_properties = public_event.get("properties")
+        public_properties, _redacted_fields = redact_runtime_payload(properties)
         if isinstance(public_properties, dict):
             properties = dict(public_properties)
 

--- a/penguin/system/runtime_events.py
+++ b/penguin/system/runtime_events.py
@@ -44,6 +44,15 @@ _SECRET_KEY_NAMES = {
     "secret_key",
     "token",
 }
+# Standalone credential markers: a key is a secret wherever one of these appears
+# as a segment (db_password, webhook_secret, proxy_authorization). Safe against
+# token telemetry, whose keys never contain these words (unlike "token", which
+# must stay pair-matched so token_usage / input_tokens stay visible).
+_SECRET_KEY_SEGMENTS = {
+    "authorization",
+    "password",
+    "secret",
+}
 _SEQUENCE_LOCK = threading.Lock()
 _SEQUENCE_COUNTERS: dict[str, itertools.count[int]] = {}
 
@@ -487,19 +496,23 @@ def _is_secret_key(key: str) -> bool:
     if not segments:
         return False
 
-    key_tokens = {"key", "keys"}
-    if "api" in segments and key_tokens.intersection(segments):
-        return True
-    if "secret" in segments and key_tokens.intersection(segments):
-        return True
-    if "private" in segments and key_tokens.intersection(segments):
+    # Standalone markers (password/secret/authorization) redact wherever present.
+    if any(segment in _SECRET_KEY_SEGMENTS for segment in segments):
         return True
 
+    # "<x> key(s)" style names (api_key, openai_api_key, private_keys).
+    key_tokens = {"key", "keys"}
+    if key_tokens.intersection(segments) and (
+        "api" in segments or "private" in segments
+    ):
+        return True
+
+    # "<x> token" credential pairs. Pair-matched (not a bare "token" marker) so
+    # token telemetry like token_usage / input_tokens stays visible.
     credential_pairs = {
         ("access", "token"),
         ("auth", "token"),
         ("bearer", "token"),
-        ("client", "secret"),
         ("id", "token"),
         ("refresh", "token"),
         ("session", "token"),

--- a/penguin/tui_adapter/part_events.py
+++ b/penguin/tui_adapter/part_events.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Tuple
 
-from penguin.web.services.runtime_events import wrap_opencode_event
+from penguin.system.runtime_events import wrap_opencode_event
 
 
 class PartType(Enum):

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -60,7 +60,7 @@ from penguin.web.services.configuration import (
 from penguin.web.services.command_registry import list_opencode_commands
 from penguin.web.services.notification_settings import notification_settings_payload
 from penguin.web.services.opencode_events import schedule_opencode_event
-from penguin.web.services.runtime_events import wrap_opencode_event
+from penguin.system.runtime_events import wrap_opencode_event
 from penguin.web.services.conversations import (
     create_conversation_payload,
     get_conversation_payload,

--- a/penguin/web/services/opencode_events.py
+++ b/penguin/web/services/opencode_events.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from penguin.web.services.runtime_events import (
+from penguin.system.runtime_events import (
     opencode_payload_from_runtime_event,
     runtime_event_from_opencode,
     wrap_opencode_event,

--- a/penguin/web/services/system_status.py
+++ b/penguin/web/services/system_status.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from penguin.config import WORKSPACE_PATH
-from penguin.web.services.runtime_events import wrap_opencode_event
+from penguin.system.runtime_events import wrap_opencode_event
 
 logger = logging.getLogger(__name__)
 _LAST_BRANCH_KEYS: dict[str, str] = {}

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -27,8 +27,12 @@ router = APIRouter()
 _REPLAY_BUFFER_ATTR = "_opencode_sse_replay_v1"
 # Bounded compatibility buffer until Phase 11.5 lands the durable runtime event
 # ledger. It covers short reconnects only; gaps are surfaced to clients instead
-# of being silently ignored.
+# of being silently ignored. Do not treat this route-local memory as durable
+# event truth; the ledger should own replay, retention, drop logging, and policy.
 _MAX_REPLAY_EVENTS = 1000
+# Temporary per-connection delivery limits for the compatibility SSE projection.
+# Phase 11.5 should promote these to named policy/config values with metrics for
+# slow-client drops once the ledger can remain the source of replay truth.
 _SSE_QUEUE_MAX_EVENTS = 1000
 _SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
 
@@ -97,6 +101,9 @@ async def events_sse(
 
     async def event_generator() -> AsyncIterator[str]:
         queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=_SSE_QUEUE_MAX_EVENTS)
+        # Reconnect-only dedupe bridge: events can arrive after subscription but
+        # before replay drains. The set is intentionally per connection and
+        # should disappear when Phase 11.5 moves replay/dedupe to the ledger.
         queued_live_event_ids: set[str] = set()
         event_order = 0
 
@@ -222,7 +229,8 @@ async def events_sse(
                 if isinstance(event_id, str):
                     queued_live_event_ids.add(event_id)
             except asyncio.QueueFull:
-                # Drop event if queue is full (client is slow)
+                # Drop event if queue is full (client is slow). Phase 11.5 should
+                # add ledger-backed recovery plus logging/metrics for this path.
                 pass
 
         # Subscribe to events
@@ -298,6 +306,9 @@ async def events_sse(
 
 
 def _replay_buffer(core: Any) -> list[dict[str, Any]]:
+    # Phase 11 bridge only: keep the compatibility buffer attached to the shared
+    # core so reconnects can replay across SSE connections. Move this behind a
+    # ledger/service boundary when durable runtime events land in Phase 11.5.
     existing = getattr(core, _REPLAY_BUFFER_ATTR, None)
     if isinstance(existing, list):
         return existing
@@ -330,6 +341,10 @@ def _replay_events_after(
 
 
 def _replay_gap_event(core: Any, last_event_id: str) -> dict[str, Any]:
+    # Temporary transport signal, not durable runtime truth. Current EventSource
+    # clients may resume from this synthetic frame's SSE id and receive another
+    # gap; the eventual TUI/Link consumer should treat it as a full-resync signal
+    # unless Phase 11.5 changes the frame to carry a real ledger resume cursor.
     buffer = _replay_buffer(core)
     oldest_id = buffer[0].get("id") if buffer else None
     newest_id = buffer[-1].get("id") if buffer else None

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -25,7 +25,12 @@ if TYPE_CHECKING:
 
 router = APIRouter()
 _REPLAY_BUFFER_ATTR = "_opencode_sse_replay_v1"
+# Bounded compatibility buffer until Phase 11.5 lands the durable runtime event
+# ledger. It covers short reconnects only; gaps are surfaced to clients instead
+# of being silently ignored.
 _MAX_REPLAY_EVENTS = 1000
+_SSE_QUEUE_MAX_EVENTS = 1000
+_SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
 
 # Global reference to core instance (set by app.py)
 _core_instance: Optional["PenguinCore"] = None
@@ -72,7 +77,13 @@ async def events_sse(
     effective_session_id = session_id or conversation_id
     effective_agent_id = agent_id
     effective_directory = normalize_directory(directory)
-    effective_last_event_id = last_event_id or last_event_id_header
+    effective_last_event_id = (
+        last_event_id
+        if isinstance(last_event_id, str) and last_event_id
+        else last_event_id_header
+        if isinstance(last_event_id_header, str) and last_event_id_header
+        else None
+    )
 
     if effective_session_id and directory:
         session_dirs = getattr(core, "_opencode_session_directories", None)
@@ -85,7 +96,8 @@ async def events_sse(
             session_dirs[effective_session_id] = resolved
 
     async def event_generator() -> AsyncIterator[str]:
-        queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=1000)
+        queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=_SSE_QUEUE_MAX_EVENTS)
+        queued_live_event_ids: set[str] = set()
         event_order = 0
 
         def next_event(data: dict[str, Any]) -> dict[str, Any] | None:
@@ -206,6 +218,9 @@ async def events_sse(
             try:
                 _remember_replay_event(core, normalized)
                 queue.put_nowait(normalized)
+                event_id = normalized.get("id")
+                if isinstance(event_id, str):
+                    queued_live_event_ids.add(event_id)
             except asyncio.QueueFull:
                 # Drop event if queue is full (client is slow)
                 pass
@@ -228,7 +243,20 @@ async def events_sse(
                 yield sse_event_frame(normalized_connected)
 
             if effective_last_event_id:
-                for event in _replay_events_after(core, effective_last_event_id):
+                replay_found, replay_events = _replay_events_after(
+                    core,
+                    effective_last_event_id,
+                )
+                if not replay_found:
+                    gap_event = next_event(
+                        _replay_gap_event(core, effective_last_event_id)
+                    )
+                    if gap_event and event_allowed(gap_event):
+                        yield sse_event_frame(gap_event)
+                for event in replay_events:
+                    event_id = event.get("id")
+                    if isinstance(event_id, str) and event_id in queued_live_event_ids:
+                        continue
                     if event_allowed(event):
                         yield sse_event_frame(event)
 
@@ -236,7 +264,13 @@ async def events_sse(
             while True:
                 try:
                     # Wait for event with timeout for keepalive
-                    event = await asyncio.wait_for(queue.get(), timeout=300.0)
+                    event = await asyncio.wait_for(
+                        queue.get(),
+                        timeout=_SSE_KEEPALIVE_TIMEOUT_SECONDS,
+                    )
+                    event_id = event.get("id")
+                    if isinstance(event_id, str):
+                        queued_live_event_ids.discard(event_id)
                     yield sse_event_frame(event)
                 except asyncio.TimeoutError:
                     # Send keepalive comment
@@ -284,12 +318,30 @@ def _remember_replay_event(core: Any, event: dict[str, Any]) -> None:
         del buffer[: len(buffer) - _MAX_REPLAY_EVENTS]
 
 
-def _replay_events_after(core: Any, last_event_id: str) -> list[dict[str, Any]]:
+def _replay_events_after(
+    core: Any,
+    last_event_id: str,
+) -> tuple[bool, list[dict[str, Any]]]:
     buffer = _replay_buffer(core)
     for index, event in enumerate(buffer):
         if event.get("id") == last_event_id:
-            return buffer[index + 1 :]
-    return []
+            return True, buffer[index + 1 :]
+    return False, []
+
+
+def _replay_gap_event(core: Any, last_event_id: str) -> dict[str, Any]:
+    buffer = _replay_buffer(core)
+    oldest_id = buffer[0].get("id") if buffer else None
+    newest_id = buffer[-1].get("id") if buffer else None
+    return {
+        "type": "server.replay_gap",
+        "properties": {
+            "lastEventID": last_event_id,
+            "oldestEventID": oldest_id if isinstance(oldest_id, str) else None,
+            "newestEventID": newest_id if isinstance(newest_id, str) else None,
+            "reason": "last_event_id_not_available",
+        },
+    }
 
 
 @router.get("/api/v1/health")

--- a/tests/api/test_opencode_events_service.py
+++ b/tests/api/test_opencode_events_service.py
@@ -17,7 +17,7 @@ from penguin.web.services.opencode_events import (
     schedule_opencode_event,
     sse_event_frame,
 )
-from penguin.web.services.runtime_events import reset_runtime_event_sequences
+from penguin.system.runtime_events import reset_runtime_event_sequences
 
 
 def test_normalize_opencode_event_adds_id_time_order_and_correlation(tmp_path):

--- a/tests/api/test_runtime_events_service.py
+++ b/tests/api/test_runtime_events_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from penguin.web.services.runtime_events import (
+from penguin.system.runtime_events import (
     RUNTIME_EVENT_CATEGORIES,
     RUNTIME_EVENT_SCHEMA_VERSION,
     build_runtime_event,
@@ -83,6 +83,49 @@ def test_runtime_event_redacts_public_payload_secrets() -> None:
     assert event["payload"]["nested"]["client_secret"] == "[redacted]"
     assert event["payload"]["nested"]["private_key"] == "[redacted]"
     assert event["payload"]["nested"]["secret_key"] == "[redacted]"
+
+
+def test_runtime_event_redacts_suffix_style_credentials() -> None:
+    # Regression: password/secret/authorization credential names whose sensitive
+    # word is a non-trailing or prefixed segment must still be redacted, without
+    # touching token telemetry whose keys never contain those words.
+    reset_runtime_event_sequences()
+
+    event = build_runtime_event(
+        event_type="provider.auth.updated",
+        payload={
+            "sessionID": "ses_1",
+            "db_password": "hunter2",
+            "webhook_secret": "whsec_live",
+            "proxy_authorization": "Bearer xyz",
+            "oauth_client_secret": "cs_live",
+            "nested": {"admin_password": "root"},
+            # Telemetry that must remain visible.
+            "tokens": 12,
+            "token_usage": {"input_tokens": 3, "output_tokens": 9},
+            "input_tokens": 3,
+        },
+    )
+
+    payload = event["payload"]
+    assert payload["db_password"] == "[redacted]"
+    assert payload["webhook_secret"] == "[redacted]"
+    assert payload["proxy_authorization"] == "[redacted]"
+    assert payload["oauth_client_secret"] == "[redacted]"
+    assert payload["nested"]["admin_password"] == "[redacted]"
+
+    assert payload["tokens"] == 12
+    assert payload["token_usage"] == {"input_tokens": 3, "output_tokens": 9}
+    assert payload["input_tokens"] == 3
+
+    assert event["privacy"]["classification"] == "sensitive"
+    assert set(event["privacy"]["redacted_fields"]) == {
+        "db_password",
+        "webhook_secret",
+        "proxy_authorization",
+        "oauth_client_secret",
+        "nested.admin_password",
+    }
 
 
 def test_runtime_event_preserves_token_usage_telemetry() -> None:

--- a/tests/api/test_sse_and_status_scoping.py
+++ b/tests/api/test_sse_and_status_scoping.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from penguin.web.services.runtime_events import reset_runtime_event_sequences
+from penguin.system.runtime_events import reset_runtime_event_sequences
 from penguin.web.services.system_status import get_path_info
 from penguin.web.sse_events import events_sse, set_core_instance
 
@@ -174,6 +174,172 @@ async def test_sse_replays_buffered_events_after_last_event_id(tmp_path: Path):
     )
     assert replayed["id"] == second_event["id"]
     assert replayed["properties"]["id"] == "msg_2"
+
+    await replay_stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_reports_replay_gap_for_evicted_last_event_id(tmp_path: Path):
+    reset_runtime_event_sequences()
+    event_bus = _EventBus()
+    runtime = SimpleNamespace(
+        workspace_root=str(tmp_path),
+        project_root=str(tmp_path),
+        active_root=str(tmp_path),
+    )
+    core = SimpleNamespace(
+        event_bus=event_bus,
+        runtime_config=runtime,
+        _opencode_session_directories={},
+    )
+    set_core_instance(core)
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+    )
+    stream = response.body_iterator
+    _ = _parse_sse(await stream.__anext__())
+
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_1",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_2",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+
+    first_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    second_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    await stream.aclose()
+
+    core._opencode_sse_replay_v1 = [second_event]
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+        last_event_id=first_event["id"],
+    )
+    replay_stream = response.body_iterator
+
+    _ = _parse_sse(await replay_stream.__anext__())
+    gap = _parse_sse(await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25))
+    assert gap["type"] == "server.replay_gap"
+    assert gap["properties"]["lastEventID"] == first_event["id"]
+    assert gap["properties"]["oldestEventID"] == second_event["id"]
+    assert gap["properties"]["newestEventID"] == second_event["id"]
+    assert gap["properties"]["reason"] == "last_event_id_not_available"
+
+    await replay_stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_reconnect_does_not_duplicate_live_event_already_in_replay(
+    tmp_path: Path,
+):
+    reset_runtime_event_sequences()
+    event_bus = _EventBus()
+    runtime = SimpleNamespace(
+        workspace_root=str(tmp_path),
+        project_root=str(tmp_path),
+        active_root=str(tmp_path),
+    )
+    core = SimpleNamespace(
+        event_bus=event_bus,
+        runtime_config=runtime,
+        _opencode_session_directories={},
+    )
+    set_core_instance(core)
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+    )
+    stream = response.body_iterator
+    _ = _parse_sse(await stream.__anext__())
+
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_1",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_2",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+
+    first_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    second_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    await stream.aclose()
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+        last_event_id=first_event["id"],
+    )
+    replay_stream = response.body_iterator
+    _ = _parse_sse(await replay_stream.__anext__())
+
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "runtime_event": {
+                "id": second_event["id"],
+                "type": second_event["type"],
+                "payload": second_event["properties"],
+                "sequence": second_event["order"],
+                "time": second_event["time"],
+            },
+            "type": second_event["type"],
+            "properties": second_event["properties"],
+        },
+    )
+
+    delivered = _parse_sse(
+        await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25)
+    )
+    assert delivered["id"] == second_event["id"]
+    try:
+        duplicate = await asyncio.wait_for(replay_stream.__anext__(), timeout=0.05)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        duplicate = None
+    if duplicate is not None:
+        assert _parse_sse(duplicate)["id"] != second_event["id"]
 
     await replay_stream.aclose()
 


### PR DESCRIPTION
## Summary

Adds Phase 11’s canonical runtime event envelope foundation for Penguin/TUI integration.

This introduces a web-free `penguin.system.runtime_events` envelope layer, wraps existing OpenCode-compatible events through the canonical shape, preserves the public TUI SSE stream contract, and hardens replay/order behavior enough for Phase 11 before the durable event ledger work in Phase 11.5.

## Changes

- Add `penguin.runtime_event.v1` envelope construction and redaction.
- Move runtime event logic into `penguin.system.runtime_events` so `penguin.core` does not import the web/ASGI stack.
- Project canonical runtime events into OpenCode-compatible `{ id, order, time, type, properties }` SSE payloads.
- Preserve SSE `id:` parsing on the TUI client.
- Keep token/CWM telemetry visible while redacting credential-shaped fields.
- Use unique runtime event IDs for public SSE/replay identity.
- Add replay gap signaling when `last_event_id` has been evicted from the bounded in-memory buffer.
- Avoid duplicate delivery when replay and live events race during reconnect.
- Avoid bumping runtime sequence counters in transcript persistence paths that only need redaction.

## Notes

This PR intentionally does not implement the durable runtime event ledger. That is Phase 11.5 and should replace the bounded in-memory SSE buffer as the source of replay truth.

## Validation

- `uv run --group dev pytest tests -q`
  - `1622 passed, 3 skipped, 103 deselected`
- Focused runtime/SSE tests
  - `29 passed`
- `bun test test/tui/penguin-event-stream.test.ts test/cli/tui/notification-policy.test.ts`
  - `13 passed`
- `uv run --group dev ruff check --select F401,F821 ...`
- `uv run --group dev ruff format --check ...`
- `python -m compileall ...`
- `git diff --check`

## Import Check

- `import penguin.system.runtime_events` does not load FastAPI.
- `import penguin.core` does not load FastAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event streaming reconnect behavior, including clearer handling when older events are no longer available.
* **Bug Fixes**
  * Reduced duplicate events during stream replay after reconnects.
  * Expanded sensitive-data redaction so more credential-like fields are hidden automatically.
  * Kept token usage and telemetry fields visible while still protecting secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->