### PR TITLE
feat: add durable runtime event ledger

### DIFF
--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -1967,67 +1967,109 @@ Verification expectations:
 
 ### 11.5. Add the durable runtime event ledger
 
-Phase 11.5 should land after the canonical `RuntimeEvent` envelope and before
-Phase 12 UI/runtime feature work. The point is infrastructure, not dashboards:
-make event history durable, replayable, and privacy-safe so diff review,
-multi-agent progress, richer notifications, observability, analytics, and Link
-projection all consume the same source of truth.
+Phase 11.5 lands after the canonical `RuntimeEvent` envelope and before Phase 12
+UI/runtime feature work. The point is infrastructure, not dashboards: make event
+history durable, replayable, and privacy-safe so diff review, multi-agent
+progress, richer notifications, observability, analytics, and Link projection can
+later consume one source of truth.
 
 Phase 11.5 goals:
 
-- [ ] Add an append-only event store for redacted public `RuntimeEvent` records.
-- [ ] Persist stable ordering by `stream_id`, `sequence`, and insertion order.
-- [ ] Move replay recording to event emission time instead of per-SSE-connection
+- [x] Add an append-only event store for redacted public `RuntimeEvent` records.
+- [x] Persist stable ordering by `stream_id`, `sequence`, and insertion order.
+- [x] Move replay recording to event emission time instead of per-SSE-connection
       handlers, then filter/project at subscription time.
-- [ ] Support SSE resume/replay from `Last-Event-ID` and `last_event_id` using
+- [x] Support SSE resume/replay from `Last-Event-ID` and `last_event_id` using
       the ledger, not only the bounded in-memory SSE buffer.
-- [ ] Preserve `RuntimeEvent.id` as replay identity and keep message, part,
+- [x] Preserve `RuntimeEvent.id` as replay identity and keep message, part,
       question, tool, token-usage, and other domain IDs as entity IDs.
-- [ ] Add retention controls: max events, max age, max storage size, and a clear
+- [x] Add retention controls: max events, max age, max storage size, and a clear
       cleanup policy.
-- [ ] Define slow-client/backpressure behavior: if an SSE queue drops an event,
+- [x] Define slow-client/backpressure behavior: if an SSE queue drops an event,
       the ledger still remains the truth for reconnect/replay.
-- [ ] Promote SSE replay/queue/keepalive constants into named policy/config
+- [x] Promote SSE replay/queue/keepalive constants into named policy/config
       values with comments about memory limits, reconnect horizon, slow-client
       behavior, and eventual logging/metrics for dropped events.
 - [ ] Move runtime sequence assignment out of process-global hidden counters and
       into the durable ledger/buffer once that storage layer exists.
-- [ ] Keep the privacy boundary strict: the default ledger stores only redacted
+- [x] Keep the privacy boundary strict: the default ledger stores only redacted
       public envelopes. Raw/private payload capture is out of scope unless a
       separate, explicitly protected diagnostic store is designed.
-- [ ] Keep analytics dashboards, metrics UIs, and observability products out of
+- [x] Keep analytics dashboards, metrics UIs, and observability products out of
       this phase. Phase 11.5 only makes the ledger reliable.
+
+Phase 11.5 implementation notes:
+
+- Added `penguin/system/runtime_event_ledger.py`, a SQLite-backed append-only
+  ledger for redacted public `RuntimeEvent` envelopes. The default path is
+  `${WORKSPACE_PATH}/runtime_events/runtime_events.db`, overrideable with
+  `PENGUIN_RUNTIME_EVENT_LEDGER_PATH`.
+- Persisted rows include the full redacted public envelope plus indexed columns
+  for event id, stream id, sequence, type, category, event time, insertion time,
+  session/conversation/agent/task/run/project ids, directory, privacy
+  classification, redaction flag, payload JSON, and projection JSON.
+- The stored envelope includes `id`, `schema_version`, `type`, `category`,
+  `source`, `subject`, `time`, `stream_id`, `sequence`, `scope`, `correlation`,
+  `actor`, `privacy`, `payload`, and `projections`. Credential-like fields are
+  redacted before persistence; token/context-window telemetry remains visible.
+- `RuntimeEvent.id` is the replay identity. Message, part, question, tool,
+  token-usage, and other domain ids remain entity ids inside `payload`, `scope`,
+  or `projections`.
+- `penguin/web/sse_events.py` no longer owns a route-local replay buffer. It
+  installs one core-level EventBus recorder that persists `opencode_event`
+  payloads at emission time, then replays from the ledger and projects back to
+  the current OpenCode-compatible SSE shape at subscription time.
+- The SSE live queue is delivery-only. If the queue fills for a slow client, the
+  live frame may be dropped for that connection, but the event remains in the
+  ledger and can be recovered on reconnect with `Last-Event-ID`.
+- `server.connected` and `server.replay_gap` remain transport signals and are
+  not treated as durable runtime truth. `server.replay_gap` carries
+  `lastEventID`, `oldestEventID`, `newestEventID`, and
+  `reason="last_event_id_not_available"`; clients should still treat it as a
+  full-resync/hydration signal, not as a domain event.
+
+Retention behavior:
+
+- Defaults: `PENGUIN_RUNTIME_EVENT_LEDGER_MAX_EVENTS=100000`,
+  `PENGUIN_RUNTIME_EVENT_LEDGER_MAX_AGE_DAYS=14`,
+  `PENGUIN_RUNTIME_EVENT_LEDGER_MAX_BYTES=268435456`, and
+  `PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS=60`.
+- Max-events cleanup deletes the oldest rows beyond the configured event count.
+- Max-age cleanup deletes rows whose event timestamp is older than the cutoff.
+- Max-size cleanup is a soft cap: it deletes oldest rows toward a low-water mark
+  and asks SQLite for incremental vacuum. SQLite may reuse freed pages instead
+  of immediately shrinking the file, so this is an operational cap, not a hard
+  write failure.
+- If a client resumes from an event id that retention has deleted, the SSE layer
+  emits `server.replay_gap` and the client should do a full session resync.
+- Retention only prunes replay/observability event history. It does not delete
+  sessions, messages, checkpoints, task records, conversation metadata, or tool
+  artifacts.
 
 Phase 11.5 test requirements:
 
-- [ ] Restart/reconnect replay from persisted events.
-- [ ] Duplicate suppression by `RuntimeEvent.id` without dropping repeated
+- [x] Restart/reconnect replay from persisted events.
+- [x] Duplicate suppression by `RuntimeEvent.id` without dropping repeated
       deltas for the same message part.
-- [ ] Wrong-session, wrong-agent, and wrong-directory filtering at replay time.
-- [ ] Partial stream replay and stream completion ordering.
+- [x] Wrong-session, wrong-agent, and wrong-directory filtering at replay time.
+- [x] Partial stream replay and stream completion ordering.
 - [ ] Tool call/result adjacency, including native tool-call replay boundaries.
-- [ ] Token/CWM telemetry survives redaction and replay.
-- [ ] Queue backpressure does not lose ledger truth.
-- [ ] Retention cleanup preserves ordering and never exposes raw secrets.
+- [x] Token/CWM telemetry survives redaction and replay.
+- [x] Queue backpressure does not lose ledger truth.
+- [x] Retention cleanup preserves ordering and never exposes raw secrets.
 
-Implementation notes:
+Deferred follow-ups:
 
-- Prefer a small runtime event storage package or service module that consumes
-  `penguin/system/runtime_events.py` instead of adding ledger behavior to routes.
-- SSE should remain a projection/subscription layer. It should not own durable
-  event truth.
-- The first ledger can be local/deterministic and modest. The important contract
-  is append-only, ordered, replayable, redacted `RuntimeEvent` records.
-- Move the current bounded SSE replay helpers, queued-live-event dedupe bridge,
-  replay-gap payload shaping, and queue/backpressure policy out of
-  `penguin/web/sse_events.py` as part of the ledger work. The route module should
-  subscribe, filter/project, and frame events only.
-- Decide whether replay-gap notifications should omit synthetic SSE ids, carry a
-  newest ledger cursor, or be replaced by ledger-backed replay responses before
-  any client consumes `server.replay_gap` as more than a resync signal.
-- Keep `server.connected` / `server.replay_gap` classified as transport signals
-  in the ledger design instead of relying on the current default
-  `session_lifecycle` fallback.
+- Move runtime sequence assignment out of process-global hidden counters and into
+  the durable ledger or a ledger-backed sequence allocator. Phase 11.5 preserves
+  the Phase 11 sequence behavior while making emission-time persistence durable.
+- Add focused native tool-call/tool-result adjacency replay fixtures before UI
+  consumers rely on ledger replay for full tool timelines.
+- Add logging/metrics for slow-client queue drops, retention cleanup volume,
+  replay gaps, and ledger write failures.
+- Keep analytics dashboards, metrics UIs, Link projection endpoints, and
+  observability products out of this phase. The ledger is now reliable enough to
+  support them later, but they should be separate product/API work.
 
 ### 12. Post-envelope TUI and runtime feature follow-ups
 

--- a/context/tasks/penguin-tui-upstream.md
+++ b/context/tasks/penguin-tui-upstream.md
@@ -2004,10 +2004,12 @@ Phase 11.5 implementation notes:
   ledger for redacted public `RuntimeEvent` envelopes. The default path is
   `${WORKSPACE_PATH}/runtime_events/runtime_events.db`, overrideable with
   `PENGUIN_RUNTIME_EVENT_LEDGER_PATH`.
-- Persisted rows include the full redacted public envelope plus indexed columns
+- Persisted rows include the full redacted public envelope plus stored columns
   for event id, stream id, sequence, type, category, event time, insertion time,
   session/conversation/agent/task/run/project ids, directory, privacy
-  classification, redaction flag, payload JSON, and projection JSON.
+  classification, redaction flag, payload JSON, and projection JSON. The SQLite
+  schema adds secondary indexes only for `(stream_id, sequence)`,
+  `(session_id, agent_id, directory)`, and `event_time`.
 - The stored envelope includes `id`, `schema_version`, `type`, `category`,
   `source`, `subject`, `time`, `stream_id`, `sequence`, `scope`, `correlation`,
   `actor`, `privacy`, `payload`, and `projections`. Credential-like fields are

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -281,12 +281,18 @@ class RuntimeEventLedger:
         last_event_id: str,
         *,
         limit: int | None = None,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        directory: str | None = None,
     ) -> ReplayResult:
         """Return events after ``last_event_id`` in durable insertion order.
 
         Args:
             last_event_id: RuntimeEvent id supplied by a reconnecting client.
             limit: Optional maximum number of events to return.
+            session_id: Optional session scope for replay filtering.
+            agent_id: Optional agent scope for replay filtering.
+            directory: Optional directory scope for replay filtering.
 
         Returns:
             ReplayResult with retained events after the cursor, or a gap result
@@ -307,17 +313,27 @@ class RuntimeEventLedger:
                 if cursor_row is None:
                     return ReplayResult(found=False, events=[], **bounds)
 
+                clauses = ["rowid > ?"]
+                params: list[Any] = [cursor_row["rowid"]]
+                if session_id:
+                    clauses.append("(session_id = ? OR session_id IS NULL)")
+                    params.append(session_id)
+                if agent_id:
+                    clauses.append("(agent_id = ? OR agent_id IS NULL)")
+                    params.append(agent_id)
+                if directory:
+                    clauses.append("(directory = ? OR directory IS NULL)")
+                    params.append(directory)
+
                 sql = """
                     SELECT event_json
                     FROM runtime_events
-                    WHERE rowid > ?
+                    WHERE {where_clause}
                     ORDER BY rowid ASC
-                """
+                """.format(where_clause=" AND ".join(clauses))
                 if limit is not None and limit > 0:
                     sql += " LIMIT ?"
-                    params = (cursor_row["rowid"], limit)
-                else:
-                    params = (cursor_row["rowid"],)
+                    params.append(limit)
                 rows = conn.execute(sql, params).fetchall()
                 return ReplayResult(
                     found=True,
@@ -454,27 +470,34 @@ class RuntimeEventLedger:
         if current_size <= max_bytes:
             return
 
-        low_water = int(max_bytes * 0.9)
-        while current_size > low_water:
-            count = conn.execute(
-                "SELECT COUNT(*) AS count FROM runtime_events"
-            ).fetchone()["count"]
-            if int(count) <= 0:
-                break
-            batch = max(1, min(1000, int(count) // 10 or 1))
-            conn.execute(
-                """
-                DELETE FROM runtime_events
-                WHERE rowid IN (
-                    SELECT rowid FROM runtime_events ORDER BY rowid ASC LIMIT ?
-                )
-                """,
-                (batch,),
+        count = conn.execute(
+            "SELECT COUNT(*) AS count FROM runtime_events"
+        ).fetchone()["count"]
+        retained_count = int(count)
+        if retained_count <= 1:
+            self._incremental_vacuum(conn)
+            return
+
+        low_water = max(1, int(max_bytes * 0.9))
+        estimated_bytes_per_row = max(1, current_size // retained_count)
+        target_count = max(1, low_water // estimated_bytes_per_row)
+        if target_count >= retained_count:
+            target_count = retained_count - 1
+        delete_count = max(1, retained_count - target_count)
+        delete_count = min(delete_count, retained_count - 1)
+        conn.execute(
+            """
+            DELETE FROM runtime_events
+            WHERE rowid IN (
+                SELECT rowid FROM runtime_events ORDER BY rowid ASC LIMIT ?
             )
-            conn.commit()
-            current_size = self._database_size_bytes(conn)
-            if int(count) <= batch:
-                break
+            """,
+            (delete_count,),
+        )
+        conn.commit()
+        self._incremental_vacuum(conn)
+
+    def _incremental_vacuum(self, conn: sqlite3.Connection) -> None:
         try:
             conn.execute("PRAGMA incremental_vacuum")
         except sqlite3.DatabaseError:
@@ -492,10 +515,13 @@ class RuntimeEventLedger:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self.path), timeout=30.0)
         conn.row_factory = sqlite3.Row
+        auto_vacuum = conn.execute("PRAGMA auto_vacuum").fetchone()[0]
+        if int(auto_vacuum) != 2:
+            conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+            conn.execute("VACUUM")
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=30000")
         conn.execute("PRAGMA foreign_keys=ON")
-        conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
         return conn
 
     def _ensure_schema(self, conn: sqlite3.Connection) -> None:

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -460,6 +460,12 @@ class RuntimeEventLedger:
         max_bytes = self.policy.max_bytes
         if max_bytes is None or max_bytes <= 0:
             return
+
+        # WAL bytes are included in the soft cap. Checkpoint first so a large
+        # sidecar does not make the row-pruning estimate over-delete retained
+        # replay history when truncating the WAL would be enough.
+        conn.commit()
+        self._checkpoint_wal(conn)
         current_size = self._database_size_bytes(conn)
         if current_size <= max_bytes:
             return
@@ -489,7 +495,16 @@ class RuntimeEventLedger:
             (delete_count,),
         )
         conn.commit()
+        self._checkpoint_wal(conn)
         self._incremental_vacuum(conn)
+        conn.commit()
+        self._checkpoint_wal(conn)
+
+    def _checkpoint_wal(self, conn: sqlite3.Connection) -> None:
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except sqlite3.DatabaseError:
+            pass
 
     def _incremental_vacuum(self, conn: sqlite3.Connection) -> None:
         try:

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -181,58 +181,64 @@ class RuntimeEventLedger:
 
         with self._lock:
             conn = self._thread_connection()
-            self._ensure_schema(conn)
-            before_changes = conn.total_changes
-            conn.execute(
-                """
-                INSERT OR IGNORE INTO runtime_events (
-                    event_id,
-                    stream_id,
-                    sequence,
-                    event_type,
-                    category,
-                    event_time,
-                    inserted_at,
-                    session_id,
-                    conversation_id,
-                    agent_id,
-                    task_id,
-                    run_id,
-                    project_id,
-                    directory,
-                    privacy_classification,
-                    redacted,
-                    payload_json,
-                    projection_json,
-                    event_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    event_id,
-                    _string_or_none(event.get("stream_id")) or "global",
-                    _positive_int_or_zero(event.get("sequence")),
-                    _string_or_none(event.get("type")) or "unknown",
-                    _string_or_none(event.get("category")) or "session_lifecycle",
-                    _positive_int_or_zero(event.get("time")),
-                    int(time.time() * 1000),
-                    _string_or_none(scope.get("session_id")),
-                    _string_or_none(scope.get("conversation_id")),
-                    _string_or_none(scope.get("agent_id")),
-                    _string_or_none(scope.get("task_id")),
-                    _string_or_none(scope.get("run_id")),
-                    _string_or_none(scope.get("project_id")),
-                    _string_or_none(scope.get("directory")),
-                    _string_or_none(privacy.get("classification")) or "public",
-                    1 if privacy.get("redacted") else 0,
-                    _json_dump(payload if isinstance(payload, Mapping) else {}),
-                    _json_dump(projections if isinstance(projections, Mapping) else {}),
-                    _json_dump(dict(event)),
-                ),
-            )
-            conn.commit()
-            inserted = conn.total_changes > before_changes
-            self.cleanup_if_due(conn=conn)
-            return inserted
+            try:
+                self._ensure_schema(conn)
+                before_changes = conn.total_changes
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO runtime_events (
+                        event_id,
+                        stream_id,
+                        sequence,
+                        event_type,
+                        category,
+                        event_time,
+                        inserted_at,
+                        session_id,
+                        conversation_id,
+                        agent_id,
+                        task_id,
+                        run_id,
+                        project_id,
+                        directory,
+                        privacy_classification,
+                        redacted,
+                        payload_json,
+                        projection_json,
+                        event_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event_id,
+                        _string_or_none(event.get("stream_id")) or "global",
+                        _positive_int_or_zero(event.get("sequence")),
+                        _string_or_none(event.get("type")) or "unknown",
+                        _string_or_none(event.get("category")) or "session_lifecycle",
+                        _positive_int_or_zero(event.get("time")),
+                        int(time.time() * 1000),
+                        _string_or_none(scope.get("session_id")),
+                        _string_or_none(scope.get("conversation_id")),
+                        _string_or_none(scope.get("agent_id")),
+                        _string_or_none(scope.get("task_id")),
+                        _string_or_none(scope.get("run_id")),
+                        _string_or_none(scope.get("project_id")),
+                        _string_or_none(scope.get("directory")),
+                        _string_or_none(privacy.get("classification")) or "public",
+                        1 if privacy.get("redacted") else 0,
+                        _json_dump(payload if isinstance(payload, Mapping) else {}),
+                        _json_dump(
+                            projections if isinstance(projections, Mapping) else {}
+                        ),
+                        _json_dump(dict(event)),
+                    ),
+                )
+                inserted = conn.total_changes > before_changes
+                self.cleanup_if_due(conn=conn)
+                conn.commit()
+                return inserted
+            except Exception:
+                conn.rollback()
+                raise
 
     def extend(self, events: Iterable[Mapping[str, Any]]) -> int:
         """Persist multiple redacted public RuntimeEvent envelopes.
@@ -465,7 +471,8 @@ class RuntimeEventLedger:
         # sidecar does not make the row-pruning estimate over-delete retained
         # replay history when truncating the WAL would be enough.
         conn.commit()
-        self._checkpoint_wal(conn)
+        if not self._checkpoint_wal(conn):
+            return
         current_size = self._database_size_bytes(conn)
         if current_size <= max_bytes:
             return
@@ -495,16 +502,20 @@ class RuntimeEventLedger:
             (delete_count,),
         )
         conn.commit()
-        self._checkpoint_wal(conn)
+        if not self._checkpoint_wal(conn):
+            return
         self._incremental_vacuum(conn)
         conn.commit()
         self._checkpoint_wal(conn)
 
-    def _checkpoint_wal(self, conn: sqlite3.Connection) -> None:
+    def _checkpoint_wal(self, conn: sqlite3.Connection) -> bool:
         try:
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
         except sqlite3.DatabaseError:
-            pass
+            return False
+        if row is None:
+            return False
+        return int(row[0]) == 0
 
     def _incremental_vacuum(self, conn: sqlite3.Connection) -> None:
         try:

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -1,0 +1,526 @@
+"""Durable storage for public runtime event envelopes.
+
+The ledger stores redacted public ``RuntimeEvent`` records for replay and
+runtime observability. It is intentionally not the conversation transcript or a
+private diagnostics store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+from penguin.config import WORKSPACE_PATH
+from penguin.system.runtime_events import RUNTIME_EVENT_SCHEMA_VERSION
+
+DEFAULT_LEDGER_MAX_EVENTS = 100_000
+DEFAULT_LEDGER_MAX_AGE_DAYS = 14
+DEFAULT_LEDGER_MAX_BYTES = 256 * 1024 * 1024
+DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS = 60.0
+_RUNTIME_EVENT_LEDGER_ATTR = "_runtime_event_ledger_v1"
+
+
+@dataclass(frozen=True)
+class RuntimeEventLedgerPolicy:
+    """Retention and cleanup policy for the runtime event ledger."""
+
+    max_events: int = DEFAULT_LEDGER_MAX_EVENTS
+    max_age_seconds: Optional[int] = DEFAULT_LEDGER_MAX_AGE_DAYS * 24 * 60 * 60
+    max_bytes: Optional[int] = DEFAULT_LEDGER_MAX_BYTES
+    cleanup_interval_seconds: float = DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Ledger replay lookup result."""
+
+    found: bool
+    events: list[dict[str, Any]]
+    oldest_event_id: Optional[str] = None
+    newest_event_id: Optional[str] = None
+
+
+def default_ledger_path() -> Path:
+    """Return the default on-disk SQLite path for runtime events."""
+    override = os.getenv("PENGUIN_RUNTIME_EVENT_LEDGER_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path(WORKSPACE_PATH).expanduser() / "runtime_events" / "runtime_events.db"
+
+
+def policy_from_env() -> RuntimeEventLedgerPolicy:
+    """Build a ledger policy from environment variables."""
+    return RuntimeEventLedgerPolicy(
+        max_events=_env_int(
+            "PENGUIN_RUNTIME_EVENT_LEDGER_MAX_EVENTS",
+            DEFAULT_LEDGER_MAX_EVENTS,
+        ),
+        max_age_seconds=_env_age_seconds(
+            "PENGUIN_RUNTIME_EVENT_LEDGER_MAX_AGE_DAYS",
+            DEFAULT_LEDGER_MAX_AGE_DAYS,
+        ),
+        max_bytes=_env_optional_int(
+            "PENGUIN_RUNTIME_EVENT_LEDGER_MAX_BYTES",
+            DEFAULT_LEDGER_MAX_BYTES,
+        ),
+        cleanup_interval_seconds=float(
+            _env_optional_int(
+                "PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS",
+                int(DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS),
+            )
+            or 0
+        ),
+    )
+
+
+def get_runtime_event_ledger(core: Optional[Any] = None) -> "RuntimeEventLedger":
+    """Return the shared runtime event ledger for a core object or process."""
+    if core is not None:
+        existing = getattr(core, _RUNTIME_EVENT_LEDGER_ATTR, None)
+        if isinstance(existing, RuntimeEventLedger):
+            return existing
+        ledger = RuntimeEventLedger(default_ledger_path(), policy=policy_from_env())
+        setattr(core, _RUNTIME_EVENT_LEDGER_ATTR, ledger)
+        return ledger
+
+    global _PROCESS_LEDGER
+    if _PROCESS_LEDGER is None:
+        _PROCESS_LEDGER = RuntimeEventLedger(default_ledger_path(), policy=policy_from_env())
+    return _PROCESS_LEDGER
+
+
+class RuntimeEventLedger:
+    """SQLite-backed append-only ledger for public runtime events."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        policy: Optional[RuntimeEventLedgerPolicy] = None,
+    ) -> None:
+        self.path = Path(path).expanduser()
+        self.policy = policy or RuntimeEventLedgerPolicy()
+        self._lock = threading.RLock()
+        self._last_cleanup = 0.0
+        self._initialized = False
+
+    def append(self, event: Mapping[str, Any]) -> bool:
+        """Persist an event envelope if it has not already been stored."""
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            return False
+        if not _looks_like_public_runtime_event(event):
+            return False
+
+        scope = event.get("scope")
+        if not isinstance(scope, Mapping):
+            scope = {}
+        privacy = event.get("privacy")
+        if not isinstance(privacy, Mapping):
+            privacy = {}
+        payload = event.get("payload")
+        projections = event.get("projections")
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                before_changes = conn.total_changes
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO runtime_events (
+                        event_id,
+                        stream_id,
+                        sequence,
+                        event_type,
+                        category,
+                        event_time,
+                        inserted_at,
+                        session_id,
+                        conversation_id,
+                        agent_id,
+                        task_id,
+                        run_id,
+                        project_id,
+                        directory,
+                        privacy_classification,
+                        redacted,
+                        payload_json,
+                        projection_json,
+                        event_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event_id,
+                        _string_or_none(event.get("stream_id")) or "global",
+                        _positive_int_or_zero(event.get("sequence")),
+                        _string_or_none(event.get("type")) or "unknown",
+                        _string_or_none(event.get("category")) or "session_lifecycle",
+                        _positive_int_or_zero(event.get("time")),
+                        int(time.time() * 1000),
+                        _string_or_none(scope.get("session_id")),
+                        _string_or_none(scope.get("conversation_id")),
+                        _string_or_none(scope.get("agent_id")),
+                        _string_or_none(scope.get("task_id")),
+                        _string_or_none(scope.get("run_id")),
+                        _string_or_none(scope.get("project_id")),
+                        _string_or_none(scope.get("directory")),
+                        _string_or_none(privacy.get("classification")) or "public",
+                        1 if privacy.get("redacted") else 0,
+                        _json_dump(payload if isinstance(payload, Mapping) else {}),
+                        _json_dump(
+                            projections if isinstance(projections, Mapping) else {}
+                        ),
+                        _json_dump(dict(event)),
+                    ),
+                )
+                conn.commit()
+                inserted = conn.total_changes > before_changes
+                self.cleanup_if_due(conn=conn)
+                return inserted
+            finally:
+                conn.close()
+
+    def extend(self, events: Iterable[Mapping[str, Any]]) -> int:
+        """Persist multiple events and return the number of accepted rows."""
+        accepted = 0
+        for event in events:
+            if self.append(event):
+                accepted += 1
+        return accepted
+
+    def contains(self, event_id: str) -> bool:
+        """Return whether an event id exists in the ledger."""
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                row = conn.execute(
+                    "SELECT 1 FROM runtime_events WHERE event_id = ? LIMIT 1",
+                    (event_id,),
+                ).fetchone()
+                return row is not None
+            finally:
+                conn.close()
+
+    def replay_after(
+        self,
+        last_event_id: str,
+        *,
+        limit: Optional[int] = None,
+    ) -> ReplayResult:
+        """Return events after ``last_event_id`` in durable insertion order."""
+        if not isinstance(last_event_id, str) or not last_event_id:
+            return ReplayResult(found=False, events=[], **self.bounds())
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                cursor_row = conn.execute(
+                    "SELECT rowid FROM runtime_events WHERE event_id = ? LIMIT 1",
+                    (last_event_id,),
+                ).fetchone()
+                bounds = self.bounds(conn=conn)
+                if cursor_row is None:
+                    return ReplayResult(found=False, events=[], **bounds)
+
+                sql = """
+                    SELECT event_json
+                    FROM runtime_events
+                    WHERE rowid > ?
+                    ORDER BY rowid ASC
+                """
+                if limit is not None and limit > 0:
+                    sql += " LIMIT ?"
+                    params = (cursor_row["rowid"], limit)
+                else:
+                    params = (cursor_row["rowid"],)
+                rows = conn.execute(sql, params).fetchall()
+                return ReplayResult(
+                    found=True,
+                    events=[_json_load(row["event_json"]) for row in rows],
+                    **bounds,
+                )
+            finally:
+                conn.close()
+
+    def newest(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """Return the newest events in insertion order."""
+        with self._lock:
+            conn = self._connect()
+            try:
+                self._ensure_schema(conn)
+                rows = conn.execute(
+                    """
+                    SELECT event_json
+                    FROM runtime_events
+                    ORDER BY rowid DESC
+                    LIMIT ?
+                    """,
+                    (max(limit, 0),),
+                ).fetchall()
+                return [_json_load(row["event_json"]) for row in reversed(rows)]
+            finally:
+                conn.close()
+
+    def bounds(self, *, conn: Optional[sqlite3.Connection] = None) -> dict[str, Optional[str]]:
+        """Return oldest/newest event ids currently retained."""
+        owns_connection = conn is None
+        if conn is None:
+            conn = self._connect()
+        try:
+            self._ensure_schema(conn)
+            oldest = conn.execute(
+                "SELECT event_id FROM runtime_events ORDER BY rowid ASC LIMIT 1"
+            ).fetchone()
+            newest = conn.execute(
+                "SELECT event_id FROM runtime_events ORDER BY rowid DESC LIMIT 1"
+            ).fetchone()
+            return {
+                "oldest_event_id": oldest["event_id"] if oldest else None,
+                "newest_event_id": newest["event_id"] if newest else None,
+            }
+        finally:
+            if owns_connection:
+                conn.close()
+
+    def cleanup_if_due(self, *, conn: Optional[sqlite3.Connection] = None) -> None:
+        """Run throttled retention cleanup."""
+        now = time.monotonic()
+        if (
+            self.policy.cleanup_interval_seconds > 0
+            and now - self._last_cleanup < self.policy.cleanup_interval_seconds
+        ):
+            return
+        self.cleanup(conn=conn)
+        self._last_cleanup = now
+
+    def cleanup(self, *, conn: Optional[sqlite3.Connection] = None) -> None:
+        """Apply max-events, max-age, and soft max-size retention rules."""
+        owns_connection = conn is None
+        if conn is None:
+            conn = self._connect()
+        try:
+            self._ensure_schema(conn)
+            self._cleanup_by_age(conn)
+            self._cleanup_by_count(conn)
+            self._cleanup_by_size(conn)
+            conn.commit()
+        finally:
+            if owns_connection:
+                conn.close()
+
+    def _cleanup_by_age(self, conn: sqlite3.Connection) -> None:
+        if self.policy.max_age_seconds is None or self.policy.max_age_seconds <= 0:
+            return
+        cutoff_ms = int((time.time() - self.policy.max_age_seconds) * 1000)
+        conn.execute("DELETE FROM runtime_events WHERE event_time < ?", (cutoff_ms,))
+
+    def _cleanup_by_count(self, conn: sqlite3.Connection) -> None:
+        if self.policy.max_events <= 0:
+            conn.execute("DELETE FROM runtime_events")
+            return
+        count = conn.execute("SELECT COUNT(*) AS count FROM runtime_events").fetchone()[
+            "count"
+        ]
+        overflow = int(count) - self.policy.max_events
+        if overflow <= 0:
+            return
+        conn.execute(
+            """
+            DELETE FROM runtime_events
+            WHERE rowid IN (
+                SELECT rowid FROM runtime_events ORDER BY rowid ASC LIMIT ?
+            )
+            """,
+            (overflow,),
+        )
+
+    def _cleanup_by_size(self, conn: sqlite3.Connection) -> None:
+        max_bytes = self.policy.max_bytes
+        if max_bytes is None or max_bytes <= 0:
+            return
+        current_size = self._database_size_bytes(conn)
+        if current_size <= max_bytes:
+            return
+
+        low_water = int(max_bytes * 0.9)
+        while current_size > low_water:
+            count = conn.execute(
+                "SELECT COUNT(*) AS count FROM runtime_events"
+            ).fetchone()["count"]
+            if int(count) <= 0:
+                break
+            batch = max(1, min(1000, int(count) // 10 or 1))
+            conn.execute(
+                """
+                DELETE FROM runtime_events
+                WHERE rowid IN (
+                    SELECT rowid FROM runtime_events ORDER BY rowid ASC LIMIT ?
+                )
+                """,
+                (batch,),
+            )
+            conn.commit()
+            current_size = self._database_size_bytes(conn)
+            if int(count) <= batch:
+                break
+        try:
+            conn.execute("PRAGMA incremental_vacuum")
+        except sqlite3.DatabaseError:
+            pass
+
+    def _database_size_bytes(self, conn: sqlite3.Connection) -> int:
+        page_count = conn.execute("PRAGMA page_count").fetchone()[0]
+        page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+        return int(page_count) * int(page_size)
+
+    def _connect(self) -> sqlite3.Connection:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.path), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        if self._initialized:
+            return
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runtime_events (
+                event_id TEXT PRIMARY KEY,
+                stream_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                category TEXT NOT NULL,
+                event_time INTEGER NOT NULL,
+                inserted_at INTEGER NOT NULL,
+                session_id TEXT,
+                conversation_id TEXT,
+                agent_id TEXT,
+                task_id TEXT,
+                run_id TEXT,
+                project_id TEXT,
+                directory TEXT,
+                privacy_classification TEXT,
+                redacted INTEGER NOT NULL DEFAULT 0,
+                payload_json TEXT NOT NULL,
+                projection_json TEXT NOT NULL,
+                event_json TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_runtime_events_stream_sequence
+            ON runtime_events(stream_id, sequence)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_runtime_events_scope
+            ON runtime_events(session_id, agent_id, directory)
+            """
+        )
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_runtime_events_time
+            ON runtime_events(event_time)
+            """
+        )
+        conn.commit()
+        self._initialized = True
+
+
+_PROCESS_LEDGER: Optional[RuntimeEventLedger] = None
+
+
+def _looks_like_public_runtime_event(event: Mapping[str, Any]) -> bool:
+    schema = event.get("schema_version")
+    if schema != RUNTIME_EVENT_SCHEMA_VERSION:
+        return False
+    event_type = event.get("type")
+    event_id = event.get("id")
+    payload = event.get("payload")
+    return (
+        isinstance(event_type, str)
+        and bool(event_type)
+        and isinstance(event_id, str)
+        and bool(event_id)
+        and isinstance(payload, Mapping)
+    )
+
+
+def _json_dump(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _json_load(value: str) -> dict[str, Any]:
+    loaded = json.loads(value)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
+
+
+def _positive_int_or_zero(value: Any) -> int:
+    return value if isinstance(value, int) and value > 0 else 0
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_optional_int(name: str, default: Optional[int]) -> Optional[int]:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    if raw.lower() in {"none", "off", "disabled", "0"}:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_age_seconds(name: str, default_days: int) -> Optional[int]:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default_days * 24 * 60 * 60
+    if raw.lower() in {"none", "off", "disabled", "0"}:
+        return None
+    try:
+        return int(raw) * 24 * 60 * 60
+    except ValueError:
+        return default_days * 24 * 60 * 60
+
+
+__all__ = [
+    "DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS",
+    "DEFAULT_LEDGER_MAX_AGE_DAYS",
+    "DEFAULT_LEDGER_MAX_BYTES",
+    "DEFAULT_LEDGER_MAX_EVENTS",
+    "ReplayResult",
+    "RuntimeEventLedger",
+    "RuntimeEventLedgerPolicy",
+    "default_ledger_path",
+    "get_runtime_event_ledger",
+    "policy_from_env",
+]

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -8,6 +8,7 @@ private diagnostics store.
 from __future__ import annotations
 
 import json
+import math
 import os
 import sqlite3
 import threading
@@ -97,12 +98,9 @@ def policy_from_env() -> RuntimeEventLedgerPolicy:
             "PENGUIN_RUNTIME_EVENT_LEDGER_MAX_BYTES",
             DEFAULT_LEDGER_MAX_BYTES,
         ),
-        cleanup_interval_seconds=float(
-            _env_optional_int(
-                "PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS",
-                int(DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS),
-            )
-            or 0
+        cleanup_interval_seconds=_env_cleanup_interval_seconds(
+            "PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS",
+            DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS,
         ),
     )
 
@@ -152,6 +150,7 @@ class RuntimeEventLedger:
         self.path = Path(path).expanduser()
         self.policy = policy or RuntimeEventLedgerPolicy()
         self._lock = threading.RLock()
+        self._local = threading.local()
         self._last_cleanup = 0.0
         self._initialized = False
 
@@ -181,64 +180,59 @@ class RuntimeEventLedger:
         projections = event.get("projections")
 
         with self._lock:
-            conn = self._connect()
-            try:
-                self._ensure_schema(conn)
-                before_changes = conn.total_changes
-                conn.execute(
-                    """
-                    INSERT OR IGNORE INTO runtime_events (
-                        event_id,
-                        stream_id,
-                        sequence,
-                        event_type,
-                        category,
-                        event_time,
-                        inserted_at,
-                        session_id,
-                        conversation_id,
-                        agent_id,
-                        task_id,
-                        run_id,
-                        project_id,
-                        directory,
-                        privacy_classification,
-                        redacted,
-                        payload_json,
-                        projection_json,
-                        event_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        event_id,
-                        _string_or_none(event.get("stream_id")) or "global",
-                        _positive_int_or_zero(event.get("sequence")),
-                        _string_or_none(event.get("type")) or "unknown",
-                        _string_or_none(event.get("category")) or "session_lifecycle",
-                        _positive_int_or_zero(event.get("time")),
-                        int(time.time() * 1000),
-                        _string_or_none(scope.get("session_id")),
-                        _string_or_none(scope.get("conversation_id")),
-                        _string_or_none(scope.get("agent_id")),
-                        _string_or_none(scope.get("task_id")),
-                        _string_or_none(scope.get("run_id")),
-                        _string_or_none(scope.get("project_id")),
-                        _string_or_none(scope.get("directory")),
-                        _string_or_none(privacy.get("classification")) or "public",
-                        1 if privacy.get("redacted") else 0,
-                        _json_dump(payload if isinstance(payload, Mapping) else {}),
-                        _json_dump(
-                            projections if isinstance(projections, Mapping) else {}
-                        ),
-                        _json_dump(dict(event)),
-                    ),
-                )
-                conn.commit()
-                inserted = conn.total_changes > before_changes
-                self.cleanup_if_due(conn=conn)
-                return inserted
-            finally:
-                conn.close()
+            conn = self._thread_connection()
+            self._ensure_schema(conn)
+            before_changes = conn.total_changes
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO runtime_events (
+                    event_id,
+                    stream_id,
+                    sequence,
+                    event_type,
+                    category,
+                    event_time,
+                    inserted_at,
+                    session_id,
+                    conversation_id,
+                    agent_id,
+                    task_id,
+                    run_id,
+                    project_id,
+                    directory,
+                    privacy_classification,
+                    redacted,
+                    payload_json,
+                    projection_json,
+                    event_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    _string_or_none(event.get("stream_id")) or "global",
+                    _positive_int_or_zero(event.get("sequence")),
+                    _string_or_none(event.get("type")) or "unknown",
+                    _string_or_none(event.get("category")) or "session_lifecycle",
+                    _positive_int_or_zero(event.get("time")),
+                    int(time.time() * 1000),
+                    _string_or_none(scope.get("session_id")),
+                    _string_or_none(scope.get("conversation_id")),
+                    _string_or_none(scope.get("agent_id")),
+                    _string_or_none(scope.get("task_id")),
+                    _string_or_none(scope.get("run_id")),
+                    _string_or_none(scope.get("project_id")),
+                    _string_or_none(scope.get("directory")),
+                    _string_or_none(privacy.get("classification")) or "public",
+                    1 if privacy.get("redacted") else 0,
+                    _json_dump(payload if isinstance(payload, Mapping) else {}),
+                    _json_dump(projections if isinstance(projections, Mapping) else {}),
+                    _json_dump(dict(event)),
+                ),
+            )
+            conn.commit()
+            inserted = conn.total_changes > before_changes
+            self.cleanup_if_due(conn=conn)
+            return inserted
 
     def extend(self, events: Iterable[Mapping[str, Any]]) -> int:
         """Persist multiple redacted public RuntimeEvent envelopes.
@@ -511,6 +505,18 @@ class RuntimeEventLedger:
         wal_size = _path_size(self.path.with_name(f"{self.path.name}-wal"))
         return max(logical_size, file_size) + wal_size
 
+    def _thread_connection(self) -> sqlite3.Connection:
+        conn = getattr(self._local, "connection", None)
+        if isinstance(conn, sqlite3.Connection):
+            try:
+                conn.execute("SELECT 1")
+                return conn
+            except sqlite3.Error:
+                pass
+        conn = self._connect()
+        self._local.connection = conn
+        return conn
+
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self.path), timeout=30.0)
@@ -659,6 +665,19 @@ def _env_optional_int(name: str, default: int | None) -> int | None:
         return int(raw)
     except ValueError:
         return default
+
+
+def _env_cleanup_interval_seconds(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    if raw.lower() in {"none", "off", "disabled", "0"}:
+        return math.inf
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else math.inf
 
 
 def _env_age_seconds(name: str, default_days: int) -> int | None:

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -17,7 +17,10 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from penguin.config import WORKSPACE_PATH
-from penguin.system.runtime_events import RUNTIME_EVENT_SCHEMA_VERSION
+from penguin.system.runtime_events import (
+    RUNTIME_EVENT_SCHEMA_VERSION,
+    redact_runtime_payload,
+)
 
 DEFAULT_LEDGER_MAX_EVENTS = 100_000
 DEFAULT_LEDGER_MAX_AGE_DAYS = 14
@@ -28,7 +31,15 @@ _RUNTIME_EVENT_LEDGER_ATTR = "_runtime_event_ledger_v1"
 
 @dataclass(frozen=True)
 class RuntimeEventLedgerPolicy:
-    """Retention and cleanup policy for the runtime event ledger."""
+    """Retention and cleanup policy for the runtime event ledger.
+
+    Attributes:
+        max_events: Maximum retained event rows before oldest-row cleanup.
+        max_age_seconds: Optional event-age retention window in seconds.
+        max_bytes: Optional soft on-disk size limit for the SQLite database and
+            WAL sidecar.
+        cleanup_interval_seconds: Minimum seconds between automatic cleanups.
+    """
 
     max_events: int = DEFAULT_LEDGER_MAX_EVENTS
     max_age_seconds: int | None = DEFAULT_LEDGER_MAX_AGE_DAYS * 24 * 60 * 60
@@ -38,7 +49,14 @@ class RuntimeEventLedgerPolicy:
 
 @dataclass(frozen=True)
 class ReplayResult:
-    """Ledger replay lookup result."""
+    """Ledger replay lookup result.
+
+    Attributes:
+        found: Whether the replay cursor was present in retained ledger rows.
+        events: RuntimeEvent envelopes retained after the replay cursor.
+        oldest_event_id: Oldest currently retained RuntimeEvent id, if any.
+        newest_event_id: Newest currently retained RuntimeEvent id, if any.
+    """
 
     found: bool
     events: list[dict[str, Any]]
@@ -47,7 +65,12 @@ class ReplayResult:
 
 
 def default_ledger_path() -> Path:
-    """Return the default on-disk SQLite path for runtime events."""
+    """Return the default on-disk SQLite path for runtime events.
+
+    Returns:
+        Configured ledger path from ``PENGUIN_RUNTIME_EVENT_LEDGER_PATH`` or
+        the default path under ``WORKSPACE_PATH/runtime_events``.
+    """
     override = os.getenv("PENGUIN_RUNTIME_EVENT_LEDGER_PATH")
     if override:
         return Path(override).expanduser()
@@ -55,7 +78,12 @@ def default_ledger_path() -> Path:
 
 
 def policy_from_env() -> RuntimeEventLedgerPolicy:
-    """Build a ledger policy from environment variables."""
+    """Build a ledger policy from environment variables.
+
+    Returns:
+        RuntimeEventLedgerPolicy populated from ``PENGUIN_RUNTIME_EVENT_*``
+        settings, with defaults for missing or malformed values.
+    """
     return RuntimeEventLedgerPolicy(
         max_events=_env_int(
             "PENGUIN_RUNTIME_EVENT_LEDGER_MAX_EVENTS",
@@ -80,7 +108,16 @@ def policy_from_env() -> RuntimeEventLedgerPolicy:
 
 
 def get_runtime_event_ledger(core: Any | None = None) -> RuntimeEventLedger:
-    """Return the shared runtime event ledger for a core object or process."""
+    """Return the shared runtime event ledger.
+
+    Args:
+        core: Optional Penguin core object that should own an isolated ledger
+            instance for this process.
+
+    Returns:
+        RuntimeEventLedger attached to ``core`` when provided, otherwise the
+        process-level ledger.
+    """
     if core is not None:
         existing = getattr(core, _RUNTIME_EVENT_LEDGER_ATTR, None)
         if isinstance(existing, RuntimeEventLedger):
@@ -99,7 +136,12 @@ def get_runtime_event_ledger(core: Any | None = None) -> RuntimeEventLedger:
 
 
 class RuntimeEventLedger:
-    """SQLite-backed append-only ledger for public runtime events."""
+    """SQLite-backed append-only ledger for public runtime events.
+
+    The ledger stores only already-redacted public RuntimeEvent envelopes. It
+    provides durable replay and bounded retention for SSE/client reconnects; it
+    is not the private transcript or diagnostics store.
+    """
 
     def __init__(
         self,
@@ -114,7 +156,15 @@ class RuntimeEventLedger:
         self._initialized = False
 
     def append(self, event: Mapping[str, Any]) -> bool:
-        """Persist an event envelope if it has not already been stored."""
+        """Persist a redacted public RuntimeEvent envelope.
+
+        Args:
+            event: Candidate RuntimeEvent envelope.
+
+        Returns:
+            True when a new row was inserted. False when the event is invalid,
+            unsafe to persist, or already present.
+        """
         event_id = event.get("id")
         if not isinstance(event_id, str) or not event_id:
             return False
@@ -191,7 +241,14 @@ class RuntimeEventLedger:
                 conn.close()
 
     def extend(self, events: Iterable[Mapping[str, Any]]) -> int:
-        """Persist multiple events and return the number of accepted rows."""
+        """Persist multiple redacted public RuntimeEvent envelopes.
+
+        Args:
+            events: Iterable of candidate RuntimeEvent envelopes.
+
+        Returns:
+            Number of rows inserted into the ledger.
+        """
         accepted = 0
         for event in events:
             if self.append(event):
@@ -199,7 +256,14 @@ class RuntimeEventLedger:
         return accepted
 
     def contains(self, event_id: str) -> bool:
-        """Return whether an event id exists in the ledger."""
+        """Return whether an event id exists in the ledger.
+
+        Args:
+            event_id: RuntimeEvent id to look up.
+
+        Returns:
+            True when the event id is currently retained.
+        """
         with self._lock:
             conn = self._connect()
             try:
@@ -218,7 +282,16 @@ class RuntimeEventLedger:
         *,
         limit: int | None = None,
     ) -> ReplayResult:
-        """Return events after ``last_event_id`` in durable insertion order."""
+        """Return events after ``last_event_id`` in durable insertion order.
+
+        Args:
+            last_event_id: RuntimeEvent id supplied by a reconnecting client.
+            limit: Optional maximum number of events to return.
+
+        Returns:
+            ReplayResult with retained events after the cursor, or a gap result
+            when the cursor is no longer retained.
+        """
         if not isinstance(last_event_id, str) or not last_event_id:
             return ReplayResult(found=False, events=[], **self.bounds())
 
@@ -255,7 +328,15 @@ class RuntimeEventLedger:
                 conn.close()
 
     def newest(self, *, limit: int = 100) -> list[dict[str, Any]]:
-        """Return the newest events in insertion order."""
+        """Return newest retained events in insertion order.
+
+        Args:
+            limit: Maximum number of events to return.
+
+        Returns:
+            Retained RuntimeEvent envelopes ordered oldest-to-newest within the
+            selected newest slice.
+        """
         with self._lock:
             conn = self._connect()
             try:
@@ -278,7 +359,14 @@ class RuntimeEventLedger:
         *,
         conn: sqlite3.Connection | None = None,
     ) -> dict[str, str | None]:
-        """Return oldest/newest event ids currently retained."""
+        """Return oldest and newest retained event ids.
+
+        Args:
+            conn: Optional existing SQLite connection to reuse.
+
+        Returns:
+            Mapping with ``oldest_event_id`` and ``newest_event_id`` values.
+        """
         owns_connection = conn is None
         if conn is None:
             conn = self._connect()
@@ -299,7 +387,11 @@ class RuntimeEventLedger:
                 conn.close()
 
     def cleanup_if_due(self, *, conn: sqlite3.Connection | None = None) -> None:
-        """Run throttled retention cleanup."""
+        """Run throttled retention cleanup when the policy interval has elapsed.
+
+        Args:
+            conn: Optional existing SQLite connection to reuse.
+        """
         now = time.monotonic()
         if (
             self.policy.cleanup_interval_seconds > 0
@@ -310,7 +402,11 @@ class RuntimeEventLedger:
         self._last_cleanup = now
 
     def cleanup(self, *, conn: sqlite3.Connection | None = None) -> None:
-        """Apply max-events, max-age, and soft max-size retention rules."""
+        """Apply max-events, max-age, and soft max-size retention rules.
+
+        Args:
+            conn: Optional existing SQLite connection to reuse.
+        """
         owns_connection = conn is None
         if conn is None:
             conn = self._connect()
@@ -387,7 +483,10 @@ class RuntimeEventLedger:
     def _database_size_bytes(self, conn: sqlite3.Connection) -> int:
         page_count = conn.execute("PRAGMA page_count").fetchone()[0]
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
-        return int(page_count) * int(page_size)
+        logical_size = int(page_count) * int(page_size)
+        file_size = self.path.stat().st_size if self.path.exists() else 0
+        wal_size = _path_size(self.path.with_name(f"{self.path.name}-wal"))
+        return max(logical_size, file_size) + wal_size
 
     def _connect(self) -> sqlite3.Connection:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -459,13 +558,42 @@ def _looks_like_public_runtime_event(event: Mapping[str, Any]) -> bool:
     event_type = event.get("type")
     event_id = event.get("id")
     payload = event.get("payload")
-    return (
+    privacy = event.get("privacy")
+    if not (
         isinstance(event_type, str)
         and bool(event_type)
         and isinstance(event_id, str)
         and bool(event_id)
         and isinstance(payload, Mapping)
-    )
+        and isinstance(privacy, Mapping)
+    ):
+        return False
+
+    classification = privacy.get("classification")
+    redacted = privacy.get("redacted")
+    redacted_fields = privacy.get("redacted_fields")
+    event_is_safely_redacted = _value_is_already_redacted(event)
+    if classification == "public" and redacted is False:
+        return event_is_safely_redacted
+    if (
+        classification == "sensitive"
+        and redacted is True
+        and isinstance(redacted_fields, list)
+    ):
+        return event_is_safely_redacted
+    return False
+
+
+def _value_is_already_redacted(value: Mapping[str, Any]) -> bool:
+    redacted_value, _redacted_fields = redact_runtime_payload(dict(value))
+    return _json_dump(redacted_value) == _json_dump(value)
+
+
+def _path_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
 
 
 def _json_dump(value: Any) -> str:

--- a/penguin/system/runtime_event_ledger.py
+++ b/penguin/system/runtime_event_ledger.py
@@ -14,7 +14,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping
 
 from penguin.config import WORKSPACE_PATH
 from penguin.system.runtime_events import RUNTIME_EVENT_SCHEMA_VERSION
@@ -31,8 +31,8 @@ class RuntimeEventLedgerPolicy:
     """Retention and cleanup policy for the runtime event ledger."""
 
     max_events: int = DEFAULT_LEDGER_MAX_EVENTS
-    max_age_seconds: Optional[int] = DEFAULT_LEDGER_MAX_AGE_DAYS * 24 * 60 * 60
-    max_bytes: Optional[int] = DEFAULT_LEDGER_MAX_BYTES
+    max_age_seconds: int | None = DEFAULT_LEDGER_MAX_AGE_DAYS * 24 * 60 * 60
+    max_bytes: int | None = DEFAULT_LEDGER_MAX_BYTES
     cleanup_interval_seconds: float = DEFAULT_LEDGER_CLEANUP_INTERVAL_SECONDS
 
 
@@ -42,8 +42,8 @@ class ReplayResult:
 
     found: bool
     events: list[dict[str, Any]]
-    oldest_event_id: Optional[str] = None
-    newest_event_id: Optional[str] = None
+    oldest_event_id: str | None = None
+    newest_event_id: str | None = None
 
 
 def default_ledger_path() -> Path:
@@ -79,7 +79,7 @@ def policy_from_env() -> RuntimeEventLedgerPolicy:
     )
 
 
-def get_runtime_event_ledger(core: Optional[Any] = None) -> "RuntimeEventLedger":
+def get_runtime_event_ledger(core: Any | None = None) -> RuntimeEventLedger:
     """Return the shared runtime event ledger for a core object or process."""
     if core is not None:
         existing = getattr(core, _RUNTIME_EVENT_LEDGER_ATTR, None)
@@ -91,7 +91,10 @@ def get_runtime_event_ledger(core: Optional[Any] = None) -> "RuntimeEventLedger"
 
     global _PROCESS_LEDGER
     if _PROCESS_LEDGER is None:
-        _PROCESS_LEDGER = RuntimeEventLedger(default_ledger_path(), policy=policy_from_env())
+        _PROCESS_LEDGER = RuntimeEventLedger(
+            default_ledger_path(),
+            policy=policy_from_env(),
+        )
     return _PROCESS_LEDGER
 
 
@@ -102,7 +105,7 @@ class RuntimeEventLedger:
         self,
         path: str | Path,
         *,
-        policy: Optional[RuntimeEventLedgerPolicy] = None,
+        policy: RuntimeEventLedgerPolicy | None = None,
     ) -> None:
         self.path = Path(path).expanduser()
         self.policy = policy or RuntimeEventLedgerPolicy()
@@ -213,7 +216,7 @@ class RuntimeEventLedger:
         self,
         last_event_id: str,
         *,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> ReplayResult:
         """Return events after ``last_event_id`` in durable insertion order."""
         if not isinstance(last_event_id, str) or not last_event_id:
@@ -270,7 +273,11 @@ class RuntimeEventLedger:
             finally:
                 conn.close()
 
-    def bounds(self, *, conn: Optional[sqlite3.Connection] = None) -> dict[str, Optional[str]]:
+    def bounds(
+        self,
+        *,
+        conn: sqlite3.Connection | None = None,
+    ) -> dict[str, str | None]:
         """Return oldest/newest event ids currently retained."""
         owns_connection = conn is None
         if conn is None:
@@ -291,7 +298,7 @@ class RuntimeEventLedger:
             if owns_connection:
                 conn.close()
 
-    def cleanup_if_due(self, *, conn: Optional[sqlite3.Connection] = None) -> None:
+    def cleanup_if_due(self, *, conn: sqlite3.Connection | None = None) -> None:
         """Run throttled retention cleanup."""
         now = time.monotonic()
         if (
@@ -302,7 +309,7 @@ class RuntimeEventLedger:
         self.cleanup(conn=conn)
         self._last_cleanup = now
 
-    def cleanup(self, *, conn: Optional[sqlite3.Connection] = None) -> None:
+    def cleanup(self, *, conn: sqlite3.Connection | None = None) -> None:
         """Apply max-events, max-age, and soft max-size retention rules."""
         owns_connection = conn is None
         if conn is None:
@@ -442,7 +449,7 @@ class RuntimeEventLedger:
         self._initialized = True
 
 
-_PROCESS_LEDGER: Optional[RuntimeEventLedger] = None
+_PROCESS_LEDGER: RuntimeEventLedger | None = None
 
 
 def _looks_like_public_runtime_event(event: Mapping[str, Any]) -> bool:
@@ -470,7 +477,7 @@ def _json_load(value: str) -> dict[str, Any]:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def _string_or_none(value: Any) -> Optional[str]:
+def _string_or_none(value: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
@@ -488,7 +495,7 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _env_optional_int(name: str, default: Optional[int]) -> Optional[int]:
+def _env_optional_int(name: str, default: int | None) -> int | None:
     raw = os.getenv(name)
     if raw is None or raw == "":
         return default
@@ -500,7 +507,7 @@ def _env_optional_int(name: str, default: Optional[int]) -> Optional[int]:
         return default
 
 
-def _env_age_seconds(name: str, default_days: int) -> Optional[int]:
+def _env_age_seconds(name: str, default_days: int) -> int | None:
     raw = os.getenv(name)
     if raw is None or raw == "":
         return default_days * 24 * 60 * 60

--- a/penguin/web/services/opencode_events.py
+++ b/penguin/web/services/opencode_events.py
@@ -176,6 +176,29 @@ def sse_event_frame(event: dict[str, Any]) -> str:
     return f"{prefix}data: {json.dumps(event)}\n\n"
 
 
+def record_opencode_event(core: Any, data: dict[str, Any]) -> dict[str, Any] | None:
+    """Persist an OpenCode event's RuntimeEvent envelope and return it."""
+    runtime_event = runtime_event_from_opencode(data)
+    if runtime_event is None:
+        return None
+
+    from penguin.system.runtime_event_ledger import get_runtime_event_ledger
+
+    get_runtime_event_ledger(core).append(runtime_event)
+
+    # Mutate the shared EventBus payload so downstream live subscribers use the
+    # same event identity and ordering that was persisted at emission time.
+    data["runtime_event"] = runtime_event
+    projected = opencode_payload_from_runtime_event(runtime_event)
+    data["id"] = projected.get("id")
+    data["time"] = projected.get("time")
+    data["order"] = projected.get("order")
+    projected_properties = projected.get("properties")
+    if isinstance(projected_properties, dict):
+        data["properties"] = projected_properties
+    return runtime_event
+
+
 async def emit_opencode_event(
     core: Any,
     event_type: str,

--- a/penguin/web/services/opencode_events.py
+++ b/penguin/web/services/opencode_events.py
@@ -191,6 +191,9 @@ def record_opencode_event(core: Any, data: dict[str, Any]) -> dict[str, Any] | N
     data["runtime_event"] = runtime_event
     projected = opencode_payload_from_runtime_event(runtime_event)
     data["id"] = projected.get("id")
+    projected_type = projected.get("type")
+    if isinstance(projected_type, str) and projected_type:
+        data["type"] = projected_type
     data["time"] = projected.get("time")
     data["order"] = projected.get("order")
     projected_properties = projected.get("properties")

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -262,10 +262,14 @@ async def events_sse(
             if effective_last_event_id:
                 replay_cursor = effective_last_event_id
                 while True:
-                    replay = _replay_events_after(
+                    replay = await asyncio.to_thread(
+                        _replay_events_after,
                         core,
                         replay_cursor,
                         limit=_SSE_REPLAY_PAGE_SIZE,
+                        session_id=effective_session_id,
+                        agent_id=effective_agent_id,
+                        directory=effective_directory,
                     )
                     if not replay.found:
                         gap_event = next_event(
@@ -364,10 +368,24 @@ def _install_runtime_event_ledger_recorder(core: Any) -> None:
     setattr(core, _LEDGER_RECORDER_ATTR, ledger_handler)
 
 
-def _replay_events_after(core: Any, last_event_id: str, *, limit: int):
+def _replay_events_after(
+    core: Any,
+    last_event_id: str,
+    *,
+    limit: int,
+    session_id: str | None = None,
+    agent_id: str | None = None,
+    directory: str | None = None,
+):
     from penguin.system.runtime_event_ledger import get_runtime_event_ledger
 
-    return get_runtime_event_ledger(core).replay_after(last_event_id, limit=limit)
+    return get_runtime_event_ledger(core).replay_after(
+        last_event_id,
+        limit=limit,
+        session_id=session_id,
+        agent_id=agent_id,
+        directory=directory,
+    )
 
 
 def _replay_gap_event(

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -69,7 +69,7 @@ async def events_sse(
     directory: str | None = Query(None, description="Workspace directory"),
     last_event_id: str | None = Query(
         None,
-        description="Replay buffered events after this SSE id",
+        description="Replay durable ledger events after this SSE id",
     ),
     last_event_id_header: str | None = Header(None, alias="Last-Event-ID"),
 ):
@@ -115,7 +115,7 @@ async def events_sse(
         delivered_event_order: deque[str] = deque()
         event_order = 0
 
-        def mark_delivered(event_id: Any) -> None:
+        def mark_delivered(event_id: object) -> None:
             if not isinstance(event_id, str) or not event_id:
                 return
             if event_id in delivered_event_ids:
@@ -287,7 +287,7 @@ async def events_sse(
                     if not replay.found:
                         gap_event = next_event(
                             _replay_gap_event(
-                                effective_last_event_id,
+                                replay_cursor,
                                 oldest_event_id=replay.oldest_event_id,
                                 newest_event_id=replay.newest_event_id,
                             )

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -4,12 +4,15 @@ Provides Server-Sent Events endpoint that streams OpenCode-compatible
 message/part events to the TUI client.
 """
 
+from __future__ import annotations
+
 import asyncio
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
 
 from fastapi import APIRouter, Header, Query
 from fastapi.responses import StreamingResponse
 
+from penguin.system.runtime_events import opencode_payload_from_runtime_event
 from penguin.web.services.opencode_events import (
     GLOBAL_STATUS_EVENTS,
     directory_matches,
@@ -17,6 +20,7 @@ from penguin.web.services.opencode_events import (
     extract_event_session,
     normalize_directory,
     normalize_opencode_event,
+    record_opencode_event,
     sse_event_frame,
 )
 
@@ -24,15 +28,11 @@ if TYPE_CHECKING:
     from penguin.core import PenguinCore
 
 router = APIRouter()
-_REPLAY_BUFFER_ATTR = "_opencode_sse_replay_v1"
-# Bounded compatibility buffer until Phase 11.5 lands the durable runtime event
-# ledger. It covers short reconnects only; gaps are surfaced to clients instead
-# of being silently ignored. Do not treat this route-local memory as durable
-# event truth; the ledger should own replay, retention, drop logging, and policy.
-_MAX_REPLAY_EVENTS = 1000
-# Temporary per-connection delivery limits for the compatibility SSE projection.
-# Phase 11.5 should promote these to named policy/config values with metrics for
-# slow-client drops once the ledger can remain the source of replay truth.
+_LEDGER_RECORDER_ATTR = "_runtime_event_ledger_recorder_v1"
+# Per-connection delivery limits for the compatibility SSE projection. The
+# durable runtime event ledger owns replay truth; this queue only buffers live
+# delivery for a connected client. Slow-client drops are recoverable by
+# reconnecting with Last-Event-ID.
 _SSE_QUEUE_MAX_EVENTS = 1000
 _SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
 
@@ -44,6 +44,7 @@ def set_core_instance(core: "PenguinCore"):
     """Set the core instance for dependency injection."""
     global _core_instance
     _core_instance = core
+    _install_runtime_event_ledger_recorder(core)
 
 
 def get_core_instance() -> "PenguinCore":
@@ -102,9 +103,10 @@ async def events_sse(
     async def event_generator() -> AsyncIterator[str]:
         queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=_SSE_QUEUE_MAX_EVENTS)
         # Reconnect-only dedupe bridge: events can arrive after subscription but
-        # before replay drains. The set is intentionally per connection and
-        # should disappear when Phase 11.5 moves replay/dedupe to the ledger.
+        # before replay drains. The set is intentionally per connection; durable
+        # replay identity comes from the runtime event ledger.
         queued_live_event_ids: set[str] = set()
+        delivered_event_ids: set[str] = set()
         event_order = 0
 
         def next_event(data: dict[str, Any]) -> dict[str, Any] | None:
@@ -222,15 +224,19 @@ async def events_sse(
             if not event_allowed(normalized):
                 return
 
+            normalized_id = normalized.get("id")
+            if isinstance(normalized_id, str) and normalized_id in delivered_event_ids:
+                return
+
             try:
-                _remember_replay_event(core, normalized)
                 queue.put_nowait(normalized)
                 event_id = normalized.get("id")
                 if isinstance(event_id, str):
                     queued_live_event_ids.add(event_id)
             except asyncio.QueueFull:
-                # Drop event if queue is full (client is slow). Phase 11.5 should
-                # add ledger-backed recovery plus logging/metrics for this path.
+                # Drop only this live delivery. The runtime event ledger already
+                # recorded the event at emission time, so reconnect/replay remains
+                # authoritative for slow clients.
                 pass
 
         # Subscribe to events
@@ -251,21 +257,25 @@ async def events_sse(
                 yield sse_event_frame(normalized_connected)
 
             if effective_last_event_id:
-                replay_found, replay_events = _replay_events_after(
-                    core,
-                    effective_last_event_id,
-                )
-                if not replay_found:
+                replay = _replay_events_after(core, effective_last_event_id)
+                if not replay.found:
                     gap_event = next_event(
-                        _replay_gap_event(core, effective_last_event_id)
+                        _replay_gap_event(
+                            effective_last_event_id,
+                            oldest_event_id=replay.oldest_event_id,
+                            newest_event_id=replay.newest_event_id,
+                        )
                     )
                     if gap_event and event_allowed(gap_event):
                         yield sse_event_frame(gap_event)
-                for event in replay_events:
+                for runtime_event in replay.events:
+                    event = opencode_payload_from_runtime_event(runtime_event)
                     event_id = event.get("id")
                     if isinstance(event_id, str) and event_id in queued_live_event_ids:
                         continue
                     if event_allowed(event):
+                        if isinstance(event_id, str):
+                            delivered_event_ids.add(event_id)
                         yield sse_event_frame(event)
 
             # Stream events
@@ -279,6 +289,7 @@ async def events_sse(
                     event_id = event.get("id")
                     if isinstance(event_id, str):
                         queued_live_event_ids.discard(event_id)
+                        delivered_event_ids.add(event_id)
                     yield sse_event_frame(event)
                 except asyncio.TimeoutError:
                     # Send keepalive comment
@@ -305,55 +316,47 @@ async def events_sse(
     )
 
 
-def _replay_buffer(core: Any) -> list[dict[str, Any]]:
-    # Phase 11 bridge only: keep the compatibility buffer attached to the shared
-    # core so reconnects can replay across SSE connections. Move this behind a
-    # ledger/service boundary when durable runtime events land in Phase 11.5.
-    existing = getattr(core, _REPLAY_BUFFER_ATTR, None)
-    if isinstance(existing, list):
-        return existing
-    buffer: list[dict[str, Any]] = []
-    setattr(core, _REPLAY_BUFFER_ATTR, buffer)
-    return buffer
-
-
-def _remember_replay_event(core: Any, event: dict[str, Any]) -> None:
-    event_id = event.get("id")
-    if not isinstance(event_id, str) or not event_id:
+def _install_runtime_event_ledger_recorder(core: Any) -> None:
+    """Install one emission-time ledger recorder on the core EventBus."""
+    if getattr(core, _LEDGER_RECORDER_ATTR, None) is not None:
         return
-    buffer = _replay_buffer(core)
-    if any(item.get("id") == event_id for item in buffer):
+    event_bus = getattr(core, "event_bus", None)
+    subscribe = getattr(event_bus, "subscribe", None)
+    if not callable(subscribe):
         return
-    buffer.append(event)
-    if len(buffer) > _MAX_REPLAY_EVENTS:
-        del buffer[: len(buffer) - _MAX_REPLAY_EVENTS]
+
+    def ledger_handler(event_type: str, data: Any) -> None:
+        if event_type != "opencode_event" or not isinstance(data, dict):
+            return
+        try:
+            record_opencode_event(core, data)
+        except Exception:
+            # Ledger failures must not interrupt live TUI streaming. The client can
+            # still receive the live frame; replay will surface a gap if needed.
+            pass
+
+    subscribe("opencode_event", ledger_handler)
+    setattr(core, _LEDGER_RECORDER_ATTR, ledger_handler)
 
 
-def _replay_events_after(
-    core: Any,
+def _replay_events_after(core: Any, last_event_id: str):
+    from penguin.system.runtime_event_ledger import get_runtime_event_ledger
+
+    return get_runtime_event_ledger(core).replay_after(last_event_id)
+
+
+def _replay_gap_event(
     last_event_id: str,
-) -> tuple[bool, list[dict[str, Any]]]:
-    buffer = _replay_buffer(core)
-    for index, event in enumerate(buffer):
-        if event.get("id") == last_event_id:
-            return True, buffer[index + 1 :]
-    return False, []
-
-
-def _replay_gap_event(core: Any, last_event_id: str) -> dict[str, Any]:
-    # Temporary transport signal, not durable runtime truth. Current EventSource
-    # clients may resume from this synthetic frame's SSE id and receive another
-    # gap; the eventual TUI/Link consumer should treat it as a full-resync signal
-    # unless Phase 11.5 changes the frame to carry a real ledger resume cursor.
-    buffer = _replay_buffer(core)
-    oldest_id = buffer[0].get("id") if buffer else None
-    newest_id = buffer[-1].get("id") if buffer else None
+    *,
+    oldest_event_id: str | None = None,
+    newest_event_id: str | None = None,
+) -> dict[str, Any]:
     return {
         "type": "server.replay_gap",
         "properties": {
             "lastEventID": last_event_id,
-            "oldestEventID": oldest_id if isinstance(oldest_id, str) else None,
-            "newestEventID": newest_id if isinstance(newest_id, str) else None,
+            "oldestEventID": oldest_event_id,
+            "newestEventID": newest_event_id,
             "reason": "last_event_id_not_available",
         },
     }

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -7,6 +7,7 @@ message/part events to the TUI client.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import APIRouter, Header, Query
@@ -27,6 +28,7 @@ from penguin.web.services.opencode_events import (
 if TYPE_CHECKING:
     from penguin.core import PenguinCore
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 _LEDGER_RECORDER_ATTR = "_runtime_event_ledger_recorder_v1"
 # Per-connection delivery limits for the compatibility SSE projection. The
@@ -34,6 +36,7 @@ _LEDGER_RECORDER_ATTR = "_runtime_event_ledger_recorder_v1"
 # delivery for a connected client. Slow-client drops are recoverable by
 # reconnecting with Last-Event-ID.
 _SSE_QUEUE_MAX_EVENTS = 1000
+_SSE_REPLAY_PAGE_SIZE = 1000
 _SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
 
 # Global reference to core instance (set by app.py)
@@ -257,26 +260,45 @@ async def events_sse(
                 yield sse_event_frame(normalized_connected)
 
             if effective_last_event_id:
-                replay = _replay_events_after(core, effective_last_event_id)
-                if not replay.found:
-                    gap_event = next_event(
-                        _replay_gap_event(
-                            effective_last_event_id,
-                            oldest_event_id=replay.oldest_event_id,
-                            newest_event_id=replay.newest_event_id,
-                        )
+                replay_cursor = effective_last_event_id
+                while True:
+                    replay = _replay_events_after(
+                        core,
+                        replay_cursor,
+                        limit=_SSE_REPLAY_PAGE_SIZE,
                     )
-                    if gap_event and event_allowed(gap_event):
-                        yield sse_event_frame(gap_event)
-                for runtime_event in replay.events:
-                    event = opencode_payload_from_runtime_event(runtime_event)
-                    event_id = event.get("id")
-                    if isinstance(event_id, str) and event_id in queued_live_event_ids:
-                        continue
-                    if event_allowed(event):
-                        if isinstance(event_id, str):
-                            delivered_event_ids.add(event_id)
-                        yield sse_event_frame(event)
+                    if not replay.found:
+                        gap_event = next_event(
+                            _replay_gap_event(
+                                effective_last_event_id,
+                                oldest_event_id=replay.oldest_event_id,
+                                newest_event_id=replay.newest_event_id,
+                            )
+                        )
+                        if gap_event and event_allowed(gap_event):
+                            yield sse_event_frame(gap_event)
+                        break
+                    if not replay.events:
+                        break
+                    for runtime_event in replay.events:
+                        event = opencode_payload_from_runtime_event(runtime_event)
+                        event_id = event.get("id")
+                        if (
+                            isinstance(event_id, str)
+                            and event_id in queued_live_event_ids
+                        ):
+                            continue
+                        if event_allowed(event):
+                            if isinstance(event_id, str):
+                                delivered_event_ids.add(event_id)
+                            yield sse_event_frame(event)
+                    next_cursor = replay.events[-1].get("id")
+                    if (
+                        len(replay.events) < _SSE_REPLAY_PAGE_SIZE
+                        or not isinstance(next_cursor, str)
+                    ):
+                        break
+                    replay_cursor = next_cursor
 
             # Stream events
             while True:
@@ -333,16 +355,19 @@ def _install_runtime_event_ledger_recorder(core: Any) -> None:
         except Exception:
             # Ledger failures must not interrupt live TUI streaming. The client can
             # still receive the live frame; replay will surface a gap if needed.
-            pass
+            logger.debug(
+                "Failed to record OpenCode event in runtime ledger",
+                exc_info=True,
+            )
 
     subscribe("opencode_event", ledger_handler)
     setattr(core, _LEDGER_RECORDER_ATTR, ledger_handler)
 
 
-def _replay_events_after(core: Any, last_event_id: str):
+def _replay_events_after(core: Any, last_event_id: str, *, limit: int):
     from penguin.system.runtime_event_ledger import get_runtime_event_ledger
 
-    return get_runtime_event_ledger(core).replay_after(last_event_id)
+    return get_runtime_event_ledger(core).replay_after(last_event_id, limit=limit)
 
 
 def _replay_gap_event(

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import APIRouter, Header, Query
@@ -38,6 +39,7 @@ _LEDGER_RECORDER_ATTR = "_runtime_event_ledger_recorder_v1"
 _SSE_QUEUE_MAX_EVENTS = 1000
 _SSE_REPLAY_PAGE_SIZE = 1000
 _SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
+_SSE_DEDUPE_MAX_EVENTS = 1000
 
 # Global reference to core instance (set by app.py)
 _core_instance: PenguinCore | None = None
@@ -110,7 +112,18 @@ async def events_sse(
         # replay identity comes from the runtime event ledger.
         queued_live_event_ids: set[str] = set()
         delivered_event_ids: set[str] = set()
+        delivered_event_order: deque[str] = deque()
         event_order = 0
+
+        def mark_delivered(event_id: Any) -> None:
+            if not isinstance(event_id, str) or not event_id:
+                return
+            if event_id in delivered_event_ids:
+                return
+            delivered_event_ids.add(event_id)
+            delivered_event_order.append(event_id)
+            while len(delivered_event_order) > _SSE_DEDUPE_MAX_EVENTS:
+                delivered_event_ids.discard(delivered_event_order.popleft())
 
         def next_event(data: dict[str, Any]) -> dict[str, Any] | None:
             nonlocal event_order
@@ -294,7 +307,7 @@ async def events_sse(
                             continue
                         if event_allowed(event):
                             if isinstance(event_id, str):
-                                delivered_event_ids.add(event_id)
+                                mark_delivered(event_id)
                             yield sse_event_frame(event)
                     next_cursor = replay.events[-1].get("id")
                     if (
@@ -315,7 +328,7 @@ async def events_sse(
                     event_id = event.get("id")
                     if isinstance(event_id, str):
                         queued_live_event_ids.discard(event_id)
-                        delivered_event_ids.add(event_id)
+                        mark_delivered(event_id)
                     yield sse_event_frame(event)
                 except asyncio.TimeoutError:
                     # Send keepalive comment

--- a/penguin/web/sse_events.py
+++ b/penguin/web/sse_events.py
@@ -7,7 +7,7 @@ message/part events to the TUI client.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import APIRouter, Header, Query
 from fastapi.responses import StreamingResponse
@@ -37,17 +37,17 @@ _SSE_QUEUE_MAX_EVENTS = 1000
 _SSE_KEEPALIVE_TIMEOUT_SECONDS = 300.0
 
 # Global reference to core instance (set by app.py)
-_core_instance: Optional["PenguinCore"] = None
+_core_instance: PenguinCore | None = None
 
 
-def set_core_instance(core: "PenguinCore"):
+def set_core_instance(core: PenguinCore):
     """Set the core instance for dependency injection."""
     global _core_instance
     _core_instance = core
     _install_runtime_event_ledger_recorder(core)
 
 
-def get_core_instance() -> "PenguinCore":
+def get_core_instance() -> PenguinCore:
     """Get the core instance."""
     if _core_instance is None:
         raise RuntimeError("Core instance not set - call set_core_instance() first")
@@ -56,17 +56,17 @@ def get_core_instance() -> "PenguinCore":
 
 @router.get("/api/v1/events/sse")
 async def events_sse(
-    session_id: Optional[str] = Query(None, description="Filter to specific session"),
-    conversation_id: Optional[str] = Query(
+    session_id: str | None = Query(None, description="Filter to specific session"),
+    conversation_id: str | None = Query(
         None, description="Alias for session_id (API compatibility)"
     ),
-    agent_id: Optional[str] = Query(None, description="Filter to specific agent"),
-    directory: Optional[str] = Query(None, description="Workspace directory"),
-    last_event_id: Optional[str] = Query(
+    agent_id: str | None = Query(None, description="Filter to specific agent"),
+    directory: str | None = Query(None, description="Workspace directory"),
+    last_event_id: str | None = Query(
         None,
         description="Replay buffered events after this SSE id",
     ),
-    last_event_id_header: Optional[str] = Header(None, alias="Last-Event-ID"),
+    last_event_id_header: str | None = Header(None, alias="Last-Event-ID"),
 ):
     """
     SSE stream of OpenCode-compatible events.

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -8,10 +8,10 @@ import sqlite3
 import time
 from typing import TYPE_CHECKING, Any, Mapping
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 from penguin.system.runtime_event_ledger import (
     RuntimeEventLedger,
@@ -205,7 +205,6 @@ def test_ledger_max_events_cleanup_removes_oldest_rows(tmp_path: Path) -> None:
 
 
 
-
 def test_policy_from_env_disables_auto_cleanup_for_off_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -257,6 +256,81 @@ def test_ledger_max_bytes_cleanup_removes_oldest_rows(
     assert replay.found is True
     assert [event["id"] for event in replay.events] == [events[3]["id"]]
 
+
+
+def test_append_rolls_back_thread_connection_after_cleanup_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    first = _event("ses_1", 1)
+    second = _event("ses_1", 2)
+
+    def fail_cleanup(*, conn: sqlite3.Connection | None = None) -> None:
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(ledger, "cleanup_if_due", fail_cleanup)
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        ledger.append(first)
+
+    monkeypatch.setattr(ledger, "cleanup_if_due", lambda *, conn=None: None)
+    assert ledger.append(second) is True
+    assert [event["id"] for event in ledger.newest(limit=10)] == [second["id"]]
+
+
+def test_ledger_checkpoint_below_size_cap_does_not_prune_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path, max_bytes=2_500)
+    checkpointed = False
+
+    def fake_size(
+        self: RuntimeEventLedger,
+        conn: sqlite3.Connection,
+    ) -> int:
+        return 1_000 if checkpointed else 4_000
+
+    def fake_checkpoint(
+        self: RuntimeEventLedger,
+        conn: sqlite3.Connection,
+    ) -> bool:
+        nonlocal checkpointed
+        checkpointed = True
+        return True
+
+    monkeypatch.setattr(RuntimeEventLedger, "_database_size_bytes", fake_size)
+    monkeypatch.setattr(RuntimeEventLedger, "_checkpoint_wal", fake_checkpoint)
+    events = [_event("ses_1", index) for index in range(1, 4)]
+
+    assert ledger.extend(events) == 3
+    assert checkpointed is True
+    assert [event["id"] for event in ledger.newest(limit=10)] == [
+        event["id"] for event in events
+    ]
+
+
+def test_ledger_failed_checkpoint_skips_size_pruning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path, max_bytes=2_500)
+
+    monkeypatch.setattr(
+        RuntimeEventLedger,
+        "_database_size_bytes",
+        lambda self, conn: 4_000,
+    )
+    monkeypatch.setattr(RuntimeEventLedger, "_checkpoint_wal", lambda self, conn: False)
+    events = [_event("ses_1", index) for index in range(1, 4)]
+
+    assert ledger.extend(events) == 3
+    assert [event["id"] for event in ledger.newest(limit=10)] == [
+        event["id"] for event in events
+    ]
 
 def test_ledger_connect_enables_incremental_auto_vacuum(tmp_path: Path) -> None:
     reset_runtime_event_sequences()

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import copy
 import sqlite3
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -19,13 +20,19 @@ from penguin.system.runtime_events import (
 )
 
 
-def _ledger(tmp_path: Path, **policy_kwargs) -> RuntimeEventLedger:
+def _ledger(
+    tmp_path: Path,
+    *,
+    max_events: int = 100,
+    max_age_seconds: int | None = None,
+    max_bytes: int | None = None,
+    cleanup_interval_seconds: float = 0,
+) -> RuntimeEventLedger:
     policy = RuntimeEventLedgerPolicy(
-        max_events=policy_kwargs.pop("max_events", 100),
-        max_age_seconds=policy_kwargs.pop("max_age_seconds", None),
-        max_bytes=policy_kwargs.pop("max_bytes", None),
-        cleanup_interval_seconds=policy_kwargs.pop("cleanup_interval_seconds", 0),
-        **policy_kwargs,
+        max_events=max_events,
+        max_age_seconds=max_age_seconds,
+        max_bytes=max_bytes,
+        cleanup_interval_seconds=cleanup_interval_seconds,
     )
     return RuntimeEventLedger(tmp_path / "runtime_events.db", policy=policy)
 
@@ -35,10 +42,10 @@ def _event(
     index: int,
     *,
     event_type: str = "message.updated",
-    payload_extra: dict | None = None,
+    payload_extra: Mapping[str, Any] | None = None,
     time_ms: int | None = None,
-) -> dict:
-    payload = {
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "id": f"msg_{index}",
         "sessionID": session_id,
         "role": "assistant",
@@ -147,6 +154,59 @@ def test_ledger_max_age_cleanup_removes_old_events(tmp_path: Path) -> None:
     assert [event["id"] for event in retained] == [fresh_event["id"]]
 
 
+def test_ledger_max_bytes_cleanup_removes_oldest_rows(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path, max_bytes=2_500)
+
+    def fake_size(
+        self: RuntimeEventLedger,
+        conn: sqlite3.Connection,
+    ) -> int:
+        count = conn.execute("SELECT COUNT(*) AS count FROM runtime_events").fetchone()[
+            "count"
+        ]
+        return int(count) * 1_000
+
+    monkeypatch.setattr(RuntimeEventLedger, "_database_size_bytes", fake_size)
+    events = [_event("ses_1", index) for index in range(1, 5)]
+
+    assert ledger.extend(events) == 4
+
+    retained = ledger.newest(limit=10)
+    assert [event["id"] for event in retained] == [events[2]["id"], events[3]["id"]]
+    replay = ledger.replay_after(events[2]["id"])
+    assert replay.found is True
+    assert [event["id"] for event in replay.events] == [events[3]["id"]]
+
+
+def test_ledger_database_size_includes_wal_sidecar(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    assert ledger.append(_event("ses_1", 1)) is True
+
+    def fake_path_size(path: Path) -> int:
+        return 1_234 if path.name.endswith("-wal") else 0
+
+    monkeypatch.setattr(
+        "penguin.system.runtime_event_ledger._path_size",
+        fake_path_size,
+    )
+    conn = ledger._connect()
+    try:
+        page_count = conn.execute("PRAGMA page_count").fetchone()[0]
+        page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+        logical_size = int(page_count) * int(page_size)
+        assert ledger._database_size_bytes(conn) >= logical_size + 1_234
+    finally:
+        conn.close()
+
+
 def test_ledger_persists_only_redacted_public_payload(tmp_path: Path) -> None:
     reset_runtime_event_sequences()
     ledger = _ledger(tmp_path)
@@ -167,9 +227,38 @@ def test_ledger_persists_only_redacted_public_payload(tmp_path: Path) -> None:
     assert stored["privacy"]["redacted"] is True
 
     conn = sqlite3.connect(str(tmp_path / "runtime_events.db"))
+    conn.row_factory = sqlite3.Row
     try:
-        raw = conn.execute("SELECT event_json FROM runtime_events").fetchone()[0]
+        row = conn.execute(
+            "SELECT payload_json, projection_json, event_json FROM runtime_events"
+        ).fetchone()
     finally:
         conn.close()
-    assert "sk-secret" not in raw
-    assert "[redacted]" in raw
+
+    assert row is not None
+    for column in ("payload_json", "projection_json", "event_json"):
+        assert "sk-secret" not in row[column]
+    assert "[redacted]" in row["payload_json"]
+    assert "[redacted]" in row["event_json"]
+
+
+def test_ledger_rejects_unredacted_runtime_event_fields(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    event = build_runtime_event(
+        event_type="provider.auth.updated",
+        payload={"sessionID": "ses_1", "api_key": "sk-secret"},
+    )
+    unsafe_payload = copy.deepcopy(event)
+    unsafe_payload["payload"]["api_key"] = "sk-secret"
+    unsafe_payload["privacy"] = {
+        "classification": "public",
+        "redacted": False,
+        "redacted_fields": [],
+    }
+    unsafe_projection = copy.deepcopy(event)
+    unsafe_projection["projections"] = {"opencode": {"api_key": "sk-secret"}}
+
+    assert ledger.append(unsafe_payload) is False
+    assert ledger.append(unsafe_projection) is False
+    assert ledger.newest(limit=10) == []

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -1,0 +1,172 @@
+"""Tests for durable RuntimeEvent ledger storage."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from penguin.system.runtime_event_ledger import (
+    RuntimeEventLedger,
+    RuntimeEventLedgerPolicy,
+)
+from penguin.system.runtime_events import (
+    build_runtime_event,
+    reset_runtime_event_sequences,
+)
+
+
+def _ledger(tmp_path: Path, **policy_kwargs) -> RuntimeEventLedger:
+    policy = RuntimeEventLedgerPolicy(
+        max_events=policy_kwargs.pop("max_events", 100),
+        max_age_seconds=policy_kwargs.pop("max_age_seconds", None),
+        max_bytes=policy_kwargs.pop("max_bytes", None),
+        cleanup_interval_seconds=policy_kwargs.pop("cleanup_interval_seconds", 0),
+        **policy_kwargs,
+    )
+    return RuntimeEventLedger(tmp_path / "runtime_events.db", policy=policy)
+
+
+def _event(
+    session_id: str,
+    index: int,
+    *,
+    event_type: str = "message.updated",
+    payload_extra: dict | None = None,
+    time_ms: int | None = None,
+) -> dict:
+    payload = {
+        "id": f"msg_{index}",
+        "sessionID": session_id,
+        "role": "assistant",
+    }
+    if payload_extra:
+        payload.update(payload_extra)
+    return build_runtime_event(
+        event_type=event_type,
+        payload=payload,
+        sequence=index,
+        time_ms=time_ms or 1_000 + index,
+    )
+
+
+def test_ledger_appends_and_replays_after_last_event_id(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    first = _event("ses_1", 1)
+    second = _event("ses_1", 2)
+
+    assert ledger.append(first) is True
+    assert ledger.append(second) is True
+
+    replay = ledger.replay_after(first["id"])
+
+    assert replay.found is True
+    assert [event["id"] for event in replay.events] == [second["id"]]
+    assert replay.oldest_event_id == first["id"]
+    assert replay.newest_event_id == second["id"]
+
+
+def test_ledger_suppresses_duplicate_runtime_event_ids(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    event = _event("ses_1", 1)
+
+    assert ledger.append(event) is True
+    assert ledger.append(event) is False
+
+    assert [item["id"] for item in ledger.newest(limit=10)] == [event["id"]]
+
+
+def test_ledger_keeps_repeated_part_deltas_as_distinct_events(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    first = _event(
+        "ses_1",
+        1,
+        event_type="message.part.updated",
+        payload_extra={
+            "part": {
+                "id": "part_1",
+                "messageID": "msg_1",
+                "sessionID": "ses_1",
+                "type": "text",
+            },
+            "delta": "Hel",
+        },
+    )
+    second = _event(
+        "ses_1",
+        2,
+        event_type="message.part.updated",
+        payload_extra={
+            "part": {
+                "id": "part_1",
+                "messageID": "msg_1",
+                "sessionID": "ses_1",
+                "type": "text",
+            },
+            "delta": "lo",
+        },
+    )
+
+    assert ledger.extend([first, second]) == 2
+
+    newest = ledger.newest(limit=10)
+    assert [event["payload"]["delta"] for event in newest] == ["Hel", "lo"]
+    assert newest[0]["id"] != newest[1]["id"]
+
+
+def test_ledger_max_events_cleanup_removes_oldest_rows(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path, max_events=2)
+    events = [_event("ses_1", index) for index in range(1, 4)]
+
+    assert ledger.extend(events) == 3
+
+    retained = ledger.newest(limit=10)
+    assert [event["id"] for event in retained] == [events[1]["id"], events[2]["id"]]
+    replay = ledger.replay_after(events[0]["id"])
+    assert replay.found is False
+    assert replay.oldest_event_id == events[1]["id"]
+    assert replay.newest_event_id == events[2]["id"]
+
+
+def test_ledger_max_age_cleanup_removes_old_events(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path, max_age_seconds=60)
+    old_event = _event("ses_1", 1, time_ms=int((time.time() - 120) * 1000))
+    fresh_event = _event("ses_1", 2, time_ms=int(time.time() * 1000))
+
+    assert ledger.extend([old_event, fresh_event]) == 2
+
+    retained = ledger.newest(limit=10)
+    assert [event["id"] for event in retained] == [fresh_event["id"]]
+
+
+def test_ledger_persists_only_redacted_public_payload(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    event = build_runtime_event(
+        event_type="provider.auth.updated",
+        payload={
+            "sessionID": "ses_1",
+            "api_key": "sk-secret",
+            "tokens": 42,
+        },
+    )
+
+    assert ledger.append(event) is True
+
+    stored = ledger.newest(limit=1)[0]
+    assert stored["payload"]["api_key"] == "[redacted]"
+    assert stored["payload"]["tokens"] == 42
+    assert stored["privacy"]["redacted"] is True
+
+    conn = sqlite3.connect(str(tmp_path / "runtime_events.db"))
+    try:
+        raw = conn.execute("SELECT event_json FROM runtime_events").fetchone()[0]
+    finally:
+        conn.close()
+    assert "sk-secret" not in raw
+    assert "[redacted]" in raw

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import copy
+import math
 import sqlite3
 import time
 from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 from penguin.system.runtime_event_ledger import (
     RuntimeEventLedger,
@@ -199,6 +202,20 @@ def test_ledger_max_events_cleanup_removes_oldest_rows(tmp_path: Path) -> None:
     assert replay.found is False
     assert replay.oldest_event_id == events[1]["id"]
     assert replay.newest_event_id == events[2]["id"]
+
+
+
+
+def test_policy_from_env_disables_auto_cleanup_for_off_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from penguin.system.runtime_event_ledger import policy_from_env
+
+    monkeypatch.setenv("PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS", "0")
+    assert math.isinf(policy_from_env().cleanup_interval_seconds)
+
+    monkeypatch.setenv("PENGUIN_RUNTIME_EVENT_LEDGER_CLEANUP_INTERVAL_SECONDS", "off")
+    assert math.isinf(policy_from_env().cleanup_interval_seconds)
 
 
 def test_ledger_max_age_cleanup_removes_old_events(tmp_path: Path) -> None:

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from penguin.system.runtime_event_ledger import (
     RuntimeEventLedger,

--- a/tests/api/test_runtime_event_ledger.py
+++ b/tests/api/test_runtime_event_ledger.py
@@ -127,6 +127,65 @@ def test_ledger_keeps_repeated_part_deltas_as_distinct_events(tmp_path: Path) ->
     assert newest[0]["id"] != newest[1]["id"]
 
 
+def test_ledger_replay_filters_session_agent_and_directory(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+    directory_one = str(tmp_path / "one")
+    directory_two = str(tmp_path / "two")
+    first = build_runtime_event(
+        event_type="message.updated",
+        payload={"id": "msg_1", "role": "assistant"},
+        scope={
+            "session_id": "ses_1",
+            "agent_id": "agent_a",
+            "directory": directory_one,
+        },
+        sequence=1,
+    )
+    wrong_agent = build_runtime_event(
+        event_type="message.updated",
+        payload={"id": "msg_2", "role": "assistant"},
+        scope={
+            "session_id": "ses_1",
+            "agent_id": "agent_b",
+            "directory": directory_one,
+        },
+        sequence=2,
+    )
+    wrong_directory = build_runtime_event(
+        event_type="message.updated",
+        payload={"id": "msg_3", "role": "assistant"},
+        scope={
+            "session_id": "ses_1",
+            "agent_id": "agent_a",
+            "directory": directory_two,
+        },
+        sequence=3,
+    )
+    retained = build_runtime_event(
+        event_type="message.updated",
+        payload={"id": "msg_4", "role": "assistant"},
+        scope={
+            "session_id": "ses_1",
+            "agent_id": "agent_a",
+            "directory": directory_one,
+        },
+        sequence=4,
+    )
+
+    assert ledger.extend([first, wrong_agent, wrong_directory, retained]) == 4
+
+    replay = ledger.replay_after(
+        first["id"],
+        session_id="ses_1",
+        agent_id="agent_a",
+        directory=directory_one,
+    )
+
+    assert replay.found is True
+    assert [event["id"] for event in replay.events] == [retained["id"]]
+
+
 def test_ledger_max_events_cleanup_removes_oldest_rows(tmp_path: Path) -> None:
     reset_runtime_event_sequences()
     ledger = _ledger(tmp_path, max_events=2)
@@ -180,6 +239,19 @@ def test_ledger_max_bytes_cleanup_removes_oldest_rows(
     replay = ledger.replay_after(events[2]["id"])
     assert replay.found is True
     assert [event["id"] for event in replay.events] == [events[3]["id"]]
+
+
+def test_ledger_connect_enables_incremental_auto_vacuum(tmp_path: Path) -> None:
+    reset_runtime_event_sequences()
+    ledger = _ledger(tmp_path)
+
+    assert ledger.append(_event("ses_1", 1)) is True
+
+    conn = sqlite3.connect(str(tmp_path / "runtime_events.db"))
+    try:
+        assert conn.execute("PRAGMA auto_vacuum").fetchone()[0] == 2
+    finally:
+        conn.close()
 
 
 def test_ledger_database_size_includes_wal_sidecar(

--- a/tests/api/test_sse_and_status_scoping.py
+++ b/tests/api/test_sse_and_status_scoping.py
@@ -503,9 +503,11 @@ async def test_sse_live_queue_drop_does_not_lose_ledger_truth(
     assert first_event["properties"]["id"] == "msg_1"
     await stream.aclose()
 
-    assert [
-        event["payload"]["id"] for event in core._runtime_event_ledger_v1.newest(limit=10)
-    ] == ["msg_1", "msg_2"]
+    retained_payload_ids = [
+        event["payload"]["id"]
+        for event in core._runtime_event_ledger_v1.newest(limit=10)
+    ]
+    assert retained_payload_ids == ["msg_1", "msg_2"]
 
     response = await events_sse(
         session_id="session_one",

--- a/tests/api/test_sse_and_status_scoping.py
+++ b/tests/api/test_sse_and_status_scoping.py
@@ -9,9 +9,25 @@ from types import SimpleNamespace
 
 import pytest
 
+from penguin.system.runtime_event_ledger import (
+    RuntimeEventLedger,
+    RuntimeEventLedgerPolicy,
+)
 from penguin.system.runtime_events import reset_runtime_event_sequences
 from penguin.web.services.system_status import get_path_info
 from penguin.web.sse_events import events_sse, set_core_instance
+
+
+def _install_test_ledger(core, tmp_path: Path, *, max_events: int = 100) -> None:
+    core._runtime_event_ledger_v1 = RuntimeEventLedger(
+        tmp_path / f"runtime-events-{id(core)}.db",
+        policy=RuntimeEventLedgerPolicy(
+            max_events=max_events,
+            max_age_seconds=None,
+            max_bytes=None,
+            cleanup_interval_seconds=0,
+        ),
+    )
 
 
 class _EventBus:
@@ -54,6 +70,7 @@ async def test_sse_scopes_session_events_and_allows_global_status_events(
         runtime_config=runtime,
         _opencode_session_directories={},
     )
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(
@@ -120,6 +137,7 @@ async def test_sse_replays_buffered_events_after_last_event_id(tmp_path: Path):
         runtime_config=runtime,
         _opencode_session_directories={},
     )
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(
@@ -192,6 +210,7 @@ async def test_sse_reports_replay_gap_for_evicted_last_event_id(tmp_path: Path):
         runtime_config=runtime,
         _opencode_session_directories={},
     )
+    _install_test_ledger(core, tmp_path, max_events=1)
     set_core_instance(core)
 
     response = await events_sse(
@@ -230,7 +249,6 @@ async def test_sse_reports_replay_gap_for_evicted_last_event_id(tmp_path: Path):
     second_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
     await stream.aclose()
 
-    core._opencode_sse_replay_v1 = [second_event]
     response = await events_sse(
         session_id="session_one",
         conversation_id=None,
@@ -267,6 +285,7 @@ async def test_sse_reconnect_does_not_duplicate_live_event_already_in_replay(
         runtime_config=runtime,
         _opencode_session_directories={},
     )
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(
@@ -314,6 +333,10 @@ async def test_sse_reconnect_does_not_duplicate_live_event_already_in_replay(
     )
     replay_stream = response.body_iterator
     _ = _parse_sse(await replay_stream.__anext__())
+    replayed = _parse_sse(
+        await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25)
+    )
+    assert replayed["id"] == second_event["id"]
 
     await event_bus.emit(
         "opencode_event",
@@ -330,10 +353,6 @@ async def test_sse_reconnect_does_not_duplicate_live_event_already_in_replay(
         },
     )
 
-    delivered = _parse_sse(
-        await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25)
-    )
-    assert delivered["id"] == second_event["id"]
     try:
         duplicate = await asyncio.wait_for(replay_stream.__anext__(), timeout=0.05)
     except (asyncio.TimeoutError, StopAsyncIteration):
@@ -341,6 +360,167 @@ async def test_sse_reconnect_does_not_duplicate_live_event_already_in_replay(
     if duplicate is not None:
         assert _parse_sse(duplicate)["id"] != second_event["id"]
 
+    await replay_stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_replay_filters_wrong_session_events(tmp_path: Path):
+    reset_runtime_event_sequences()
+    event_bus = _EventBus()
+    runtime = SimpleNamespace(
+        workspace_root=str(tmp_path),
+        project_root=str(tmp_path),
+        active_root=str(tmp_path),
+    )
+    core = SimpleNamespace(
+        event_bus=event_bus,
+        runtime_config=runtime,
+        _opencode_session_directories={},
+    )
+    _install_test_ledger(core, tmp_path)
+    set_core_instance(core)
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+    )
+    stream = response.body_iterator
+    _ = _parse_sse(await stream.__anext__())
+
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_1",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+    first_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_other",
+                "sessionID": "session_other",
+                "role": "assistant",
+            },
+        },
+    )
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_2",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+    second_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    await stream.aclose()
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+        last_event_id=first_event["id"],
+    )
+    replay_stream = response.body_iterator
+    _ = _parse_sse(await replay_stream.__anext__())
+    replayed = _parse_sse(
+        await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25)
+    )
+
+    assert replayed["id"] == second_event["id"]
+    assert replayed["properties"]["id"] == "msg_2"
+    await replay_stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_live_queue_drop_does_not_lose_ledger_truth(
+    tmp_path: Path,
+    monkeypatch,
+):
+    reset_runtime_event_sequences()
+    event_bus = _EventBus()
+    runtime = SimpleNamespace(
+        workspace_root=str(tmp_path),
+        project_root=str(tmp_path),
+        active_root=str(tmp_path),
+    )
+    core = SimpleNamespace(
+        event_bus=event_bus,
+        runtime_config=runtime,
+        _opencode_session_directories={},
+    )
+    _install_test_ledger(core, tmp_path)
+    set_core_instance(core)
+
+    import penguin.web.sse_events as sse_events
+
+    monkeypatch.setattr(sse_events, "_SSE_QUEUE_MAX_EVENTS", 1)
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+    )
+    stream = response.body_iterator
+    _ = _parse_sse(await stream.__anext__())
+
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_1",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+    await event_bus.emit(
+        "opencode_event",
+        {
+            "type": "message.updated",
+            "properties": {
+                "id": "msg_2",
+                "sessionID": "session_one",
+                "role": "assistant",
+            },
+        },
+    )
+
+    first_event = _parse_sse(await asyncio.wait_for(stream.__anext__(), timeout=0.25))
+    assert first_event["properties"]["id"] == "msg_1"
+    await stream.aclose()
+
+    assert [
+        event["payload"]["id"] for event in core._runtime_event_ledger_v1.newest(limit=10)
+    ] == ["msg_1", "msg_2"]
+
+    response = await events_sse(
+        session_id="session_one",
+        conversation_id=None,
+        agent_id=None,
+        directory=str(tmp_path),
+        last_event_id=first_event["id"],
+    )
+    replay_stream = response.body_iterator
+    _ = _parse_sse(await replay_stream.__anext__())
+    replayed = _parse_sse(
+        await asyncio.wait_for(replay_stream.__anext__(), timeout=0.25)
+    )
+
+    assert replayed["properties"]["id"] == "msg_2"
     await replay_stream.aclose()
 
 
@@ -389,6 +569,7 @@ async def test_sse_streams_clarification_session_status_events(tmp_path: Path):
     core._opencode_session_directories = {}
     core._current_conversation_id = "session_one"
     core.conversation_manager = SimpleNamespace(current_agent_id="default")
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(
@@ -441,6 +622,7 @@ async def test_sse_streams_time_limit_session_status_events(tmp_path: Path):
     core._opencode_session_directories = {}
     core._current_conversation_id = "session_one"
     core.conversation_manager = SimpleNamespace(current_agent_id="default")
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(
@@ -492,6 +674,7 @@ async def test_sse_streams_idle_no_ready_task_status_events(tmp_path: Path):
     core._opencode_session_directories = {}
     core._current_conversation_id = "session_one"
     core.conversation_manager = SimpleNamespace(current_agent_id="default")
+    _install_test_ledger(core, tmp_path)
     set_core_instance(core)
 
     response = await events_sse(

--- a/tests/api/test_sse_and_status_scoping.py
+++ b/tests/api/test_sse_and_status_scoping.py
@@ -266,6 +266,12 @@ async def test_sse_reports_replay_gap_for_evicted_last_event_id(tmp_path: Path):
     assert gap["properties"]["newestEventID"] == second_event["id"]
     assert gap["properties"]["reason"] == "last_event_id_not_available"
 
+    try:
+        extra = await asyncio.wait_for(replay_stream.__anext__(), timeout=0.05)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        extra = None
+    assert extra is None
+
     await replay_stream.aclose()
 
 


### PR DESCRIPTION
## Summary
- Add a SQLite-backed durable RuntimeEvent ledger for redacted public event envelopes.
- Record OpenCode-projected runtime events at EventBus emission time and replay SSE reconnects from the ledger instead of the route-local buffer.
- Keep SSE live queues as delivery-only; slow-client drops remain recoverable through Last-Event-ID replay.
- Update the Phase 11.5 plan with stored event contents, retention behavior, completed items, and deferred follow-ups.

## Verification
- uv run pytest tests/api/test_runtime_event_ledger.py tests/api/test_runtime_events_service.py tests/api/test_sse_and_status_scoping.py tests/api/test_opencode_events_service.py -q
- uv run python -m py_compile penguin/system/runtime_event_ledger.py penguin/web/sse_events.py penguin/web/services/opencode_events.py tests/api/test_runtime_event_ledger.py tests/api/test_sse_and_status_scoping.py
- uv run ruff check penguin/system/runtime_event_ledger.py penguin/web/sse_events.py penguin/web/services/opencode_events.py tests/api/test_runtime_event_ledger.py tests/api/test_sse_and_status_scoping.py
- git diff --check

## Notes
- Retention defaults are 100k events, 14 days, 256 MiB soft DB cap, and 60s cleanup throttle.
- Ledger pruning only removes replay/observability history; sessions, messages, checkpoints, tasks, and artifacts are unaffected.
- Runtime sequence allocation and native tool-call adjacency fixtures remain explicit follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a durable, replayable runtime event ledger with configurable retention.
  * Updated the live event stream to use ledger-backed replay (including reconnect handling and `replay_gap` when older events are evicted).
  * Improved OpenCode event ingestion to persist and expose consistent runtime event metadata.
* **Bug Fixes**
  * Reduced duplicate event delivery across replay/live and during reconnects.
  * Ensured correct history replay even when the live stream queue drops messages; strengthened redaction guarantees for sensitive content.
* **Tests**
  * Expanded coverage for ledger replay/scoping/retention and SSE replay-gap behavior, including queue-drop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->