### PR TITLE
feat: add per-run web server file logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Commands
 - If port `9000` is already occupied by a running Penguin backend/TUI session, use a different non-reserved local port for testing or verification, e.g. `8080` or `9010`.
 - Per `docs/docs/usage/web_interface.md`, port `9000` is the documented/default Penguin web server port, so treat it as the primary runtime port and avoid stealing it for ad hoc verification when a real backend is already running.
 - Current runtime truth: `penguin-web` host/port selection is reliably controlled by env vars (`HOST` / `PORT`). Do not assume `penguin-web --host ... --port ...` works until that path is explicitly fixed and verified.
+- `penguin-web` writes one rotating `.txt` server log per run to `{PENGUIN_WORKSPACE:-~/penguin_workspace}/server-logs/penguin-web-<timestamp>-<pid>.txt` by default. Use `PENGUIN_WEB_LOG_DIR` to move the directory, `PENGUIN_WEB_LOG_FILE` to force a single file, or `PENGUIN_WEB_LOG_ENABLED=false` to disable.
 
 Style and Conventions
 - Follow .cursorrules at repo root. Key points: PEP 8, explicit > implicit, single responsibility, comprehensive type annotations, Google-style docstrings, robust exception handling, logging.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ Other entrypoints:
 - `penguin-cli` - headless CLI for automation and scripts
 - `penguin-web` - FastAPI server for web/API usage
 
+### Web Server Logs
+
+`penguin-web` writes one server log file per web server run by default:
+
+```text
+{PENGUIN_WORKSPACE:-~/penguin_workspace}/server-logs/penguin-web-<timestamp>-<pid>.txt
+```
+
+The log file includes Penguin startup/application logs plus Uvicorn error and access
+logs, with per-file rotation enabled. Override the directory, force a specific file,
+or disable this behavior with:
+
+```bash
+export PENGUIN_WEB_LOG_DIR="/path/to/server-logs"
+export PENGUIN_WEB_LOG_FILE="/path/to/logs.txt"
+export PENGUIN_WEB_LOG_ENABLED=false
+```
+
 ## What You Get
 
 - Coding workflow tools: file reads/writes/diffs, shell commands, test execution, search,

--- a/penguin/web/server.py
+++ b/penguin/web/server.py
@@ -8,8 +8,11 @@ import argparse
 import logging
 import os
 import sys
+from datetime import datetime, timezone
 from ipaddress import ip_address
-from typing import Optional, Sequence
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Optional, Sequence
 from urllib.parse import quote
 
 from penguin.constants import DEFAULT_WEB_PORT
@@ -19,6 +22,169 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_HOST = "127.0.0.1"
 LOCAL_ONLY_HOSTS = {"127.0.0.1", "localhost", "::1"}
+SERVER_LOG_DIRNAME = "server-logs"
+SERVER_LOG_FILENAME_PREFIX = "penguin-web"
+SERVER_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+SERVER_LOG_HANDLER_FLAG = "_penguin_web_server_file_handler"
+
+
+def _coerce_int_env(name: str, default: int) -> int:
+    """Return a positive integer environment value or a safe default."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    return value if value > 0 else default
+
+
+def _web_server_file_logging_enabled() -> bool:
+    """Return whether web server file logging should be configured."""
+    value = os.environ.get("PENGUIN_WEB_LOG_ENABLED", "true").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _new_server_log_filename() -> str:
+    """Return a unique text filename for one web server process run."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{SERVER_LOG_FILENAME_PREFIX}-{timestamp}-{os.getpid()}.txt"
+
+
+def _resolve_server_log_path() -> Path:
+    """Resolve the managed web server log file path."""
+    override = os.environ.get("PENGUIN_WEB_LOG_FILE", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+
+    directory_override = os.environ.get("PENGUIN_WEB_LOG_DIR", "").strip()
+    if directory_override:
+        return (
+            Path(directory_override).expanduser().resolve()
+            / _new_server_log_filename()
+        )
+
+    from penguin.config import get_workspace_root
+
+    return (
+        get_workspace_root().expanduser().resolve()
+        / SERVER_LOG_DIRNAME
+        / _new_server_log_filename()
+    )
+
+
+def _attach_startup_file_handler(log_path: Path, log_level: int) -> None:
+    """Attach an idempotent startup file handler before uvicorn takes over."""
+    root_logger = logging.getLogger()
+    root_logger.setLevel(min(root_logger.level or log_level, log_level))
+
+    for handler in list(root_logger.handlers):
+        if not getattr(handler, SERVER_LOG_HANDLER_FLAG, False):
+            continue
+        if Path(getattr(handler, "baseFilename", "")) == log_path:
+            handler.setLevel(log_level)
+            return
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    handler = RotatingFileHandler(
+        log_path,
+        maxBytes=_coerce_int_env("PENGUIN_WEB_LOG_MAX_BYTES", 5 * 1024 * 1024),
+        backupCount=_coerce_int_env("PENGUIN_WEB_LOG_BACKUP_COUNT", 3),
+        encoding="utf-8",
+    )
+    handler.setLevel(log_level)
+    handler.setFormatter(logging.Formatter(SERVER_LOG_FORMAT))
+    setattr(handler, SERVER_LOG_HANDLER_FLAG, True)
+    root_logger.addHandler(handler)
+
+
+def _build_uvicorn_log_config(log_path: Path, log_level: str) -> dict[str, Any]:
+    """Build uvicorn logging config that preserves console output and adds a file."""
+    max_bytes = _coerce_int_env("PENGUIN_WEB_LOG_MAX_BYTES", 5 * 1024 * 1024)
+    backup_count = _coerce_int_env("PENGUIN_WEB_LOG_BACKUP_COUNT", 3)
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "()": "uvicorn.logging.DefaultFormatter",
+                "fmt": "%(levelprefix)s %(message)s",
+                "use_colors": None,
+            },
+            "access": {
+                "()": "uvicorn.logging.AccessFormatter",
+                "fmt": (
+                    '%(levelprefix)s %(client_addr)s - "%(request_line)s" '
+                    "%(status_code)s"
+                ),
+            },
+            "file": {
+                "format": SERVER_LOG_FORMAT,
+            },
+        },
+        "handlers": {
+            "default": {
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+            "access": {
+                "formatter": "access",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+            "file": {
+                "formatter": "file",
+                "class": "logging.handlers.RotatingFileHandler",
+                "filename": str(log_path),
+                "maxBytes": max_bytes,
+                "backupCount": backup_count,
+                "encoding": "utf-8",
+            },
+        },
+        "loggers": {
+            "uvicorn": {
+                "handlers": ["default", "file"],
+                "level": log_level.upper(),
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": log_level.upper(),
+            },
+            "uvicorn.access": {
+                "handlers": ["access", "file"],
+                "level": log_level.upper(),
+                "propagate": False,
+            },
+        },
+        "root": {
+            "handlers": ["file"],
+            "level": log_level.upper(),
+        },
+    }
+
+
+def _configure_server_file_logging(log_level: str) -> Optional[dict[str, Any]]:
+    """Configure managed web server file logging and return uvicorn config."""
+    if not _web_server_file_logging_enabled():
+        return None
+
+    try:
+        log_path = _resolve_server_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        numeric_level = logging.getLevelName(log_level.upper())
+        if not isinstance(numeric_level, int):
+            numeric_level = logging.INFO
+        _attach_startup_file_handler(log_path, numeric_level)
+    except OSError as exc:
+        logger.warning("Failed to configure Penguin web server file logging: %s", exc)
+        return None
+
+    logger.info("Penguin web server logs writing to %s", log_path)
+    return _build_uvicorn_log_config(log_path, log_level)
 
 
 def _is_local_host(host: str) -> bool:
@@ -54,7 +220,8 @@ def validate_startup_security(host: str) -> None:
 
     raise RuntimeError(
         "Refusing to bind Penguin web server to a non-local host with auth disabled. "
-        "Remove PENGUIN_AUTH_ENABLED=false, switch to HOST=127.0.0.1 for local-only use, "
+        "Remove PENGUIN_AUTH_ENABLED=false, switch to HOST=127.0.0.1 "
+        "for local-only use, "
         "or explicitly override with PENGUIN_ALLOW_INSECURE_NO_AUTH=true."
     )
 
@@ -100,7 +267,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _resolve_runtime_settings(argv: Optional[Sequence[str]] = None) -> tuple[str, int, bool]:
+def _resolve_runtime_settings(
+    argv: Optional[Sequence[str]] = None,
+) -> tuple[str, int, bool]:
     """Resolve host/port/debug from CLI args first, then env vars."""
     parser = _build_arg_parser()
     args = parser.parse_args(list(argv) if argv is not None else [])
@@ -130,27 +299,33 @@ def _print_no_auth_warning(host: str, port: int) -> None:
     display_host = _display_host(host)
     if _is_local_host(host):
         print(
-            "\033[93mWarning: Penguin local web auth is explicitly disabled for this session.\033[0m"
+            "\033[93mWarning: Penguin local web auth is explicitly disabled "
+            "for this session.\033[0m"
         )
         print(
-            f"\033[93mThis instance is reachable at http://{display_host}:{port} without authentication.\033[0m"
+            f"\033[93mThis instance is reachable at "
+            f"http://{display_host}:{port} without authentication.\033[0m"
         )
         print(
             "\033[93mProtected local startup is the default: uv run penguin-web\033[0m"
         )
         print(
-            "\033[93mTo keep auth disabled intentionally: PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
+            "\033[93mTo keep auth disabled intentionally: "
+            "PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
         )
         return
 
     print(
-        "\033[91mWarning: Penguin is exposed on a non-local host without authentication.\033[0m"
+        "\033[91mWarning: Penguin is exposed on a non-local host "
+        "without authentication.\033[0m"
     )
     print(
-        "\033[91mThis is only allowed because PENGUIN_ALLOW_INSECURE_NO_AUTH=true is set.\033[0m"
+        "\033[91mThis is only allowed because "
+        "PENGUIN_ALLOW_INSECURE_NO_AUTH=true is set.\033[0m"
     )
     print(
-        "\033[93mSafer options: remove PENGUIN_AUTH_ENABLED=false or switch back to HOST=127.0.0.1.\033[0m\n"
+        "\033[93mSafer options: remove PENGUIN_AUTH_ENABLED=false "
+        "or switch back to HOST=127.0.0.1.\033[0m\n"
     )
 
 
@@ -175,22 +350,28 @@ def _print_local_auth_bootstrap_banner(host: str, port: int) -> None:
                 port,
                 exc,
             )
-        bootstrap_url = f"http://{display_host}:{port}/authorize#local_token={quote(startup_token, safe='')}"
+        encoded_token = quote(startup_token, safe="")
+        bootstrap_url = (
+            f"http://{display_host}:{port}/authorize#local_token={encoded_token}"
+        )
         print(
-            "\033[93mBrowser/dashboard only: open this local authorization URL once for this browser.\033[0m"
+            "\033[93mBrowser/dashboard only: open this local authorization "
+            "URL once for this browser.\033[0m"
         )
         print(f"\033[93m  {bootstrap_url}\033[0m")
         print(f"\033[93mStartup token (debug fallback): {startup_token}\033[0m")
     else:
         print(
-            "\033[93mBrowser/dashboard: authorize with a configured API key at /api/v1/auth/session if needed.\033[0m"
+            "\033[93mBrowser/dashboard: authorize with a configured API key "
+            "at /api/v1/auth/session if needed.\033[0m"
         )
     print("\033[93mTUI/CLI: local Penguin sessions authenticate automatically.\033[0m")
     print(
         "\033[93mCI/headless: use PENGUIN_API_KEYS with X-API-Key header auth.\033[0m"
     )
     print(
-        "\033[93mTo explicitly run local-only without auth: PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
+        "\033[93mTo explicitly run local-only without auth: "
+        "PENGUIN_AUTH_ENABLED=false uv run penguin-web\033[0m\n"
     )
 
 
@@ -205,6 +386,8 @@ def main(argv: Optional[Sequence[str]] = None):
 
     try:
         host, port, debug = _resolve_runtime_settings(argv)
+        log_level = "debug" if debug else "info"
+        log_config = _configure_server_file_logging(log_level)
         app = None
         validate_startup_security(host)
         if debug:
@@ -227,7 +410,8 @@ def main(argv: Optional[Sequence[str]] = None):
             "penguin.web.server:create_app_factory",
             host=host,
             port=port,
-            log_level="debug",
+            log_level=log_level,
+            log_config=log_config,
             reload=True,
             factory=True,
         )
@@ -236,7 +420,14 @@ def main(argv: Optional[Sequence[str]] = None):
     if app is None:
         return 1
 
-    uvicorn.run(app, host=host, port=port, log_level="info", reload=False)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        log_config=log_config,
+        reload=False,
+    )
 
     return 0
 
@@ -258,20 +449,31 @@ def start_server(
             "Web dependencies not available. Install with: pip install penguin-ai[web]"
         ) from exc
 
+    log_level = "debug" if debug else "info"
+    log_config = _configure_server_file_logging(log_level)
     validate_startup_security(host)
+
     if debug:
         uvicorn.run(
             "penguin.web.server:create_app_factory",
             host=host,
             port=port,
-            log_level="debug",
+            log_level=log_level,
+            log_config=log_config,
             reload=True,
             factory=True,
         )
         return
 
     app = create_app_factory()
-    uvicorn.run(app, host=host, port=port, log_level="info", reload=False)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=log_level,
+        log_config=log_config,
+        reload=False,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,8 +1,21 @@
+import logging
 import sys
 import types
-import logging
+
+import pytest
 
 from penguin.web import server
+
+
+@pytest.fixture(autouse=True)
+def disable_web_file_logging(monkeypatch):
+    monkeypatch.setenv("PENGUIN_WEB_LOG_ENABLED", "false")
+    yield
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        if getattr(handler, server.SERVER_LOG_HANDLER_FLAG, False):
+            root_logger.removeHandler(handler)
+            handler.close()
 
 
 def test_resolve_runtime_settings_prefers_cli_args(monkeypatch):
@@ -31,6 +44,59 @@ def test_resolve_runtime_settings_uses_env_fallback(monkeypatch):
     assert debug is True
 
 
+def test_resolve_server_log_path_defaults_to_workspace(monkeypatch, tmp_path):
+    monkeypatch.delenv("PENGUIN_WEB_LOG_FILE", raising=False)
+    monkeypatch.delenv("PENGUIN_WEB_LOG_DIR", raising=False)
+    monkeypatch.setenv("PENGUIN_WORKSPACE", str(tmp_path))
+
+    log_path = server._resolve_server_log_path()
+
+    assert log_path.parent == tmp_path / "server-logs"
+    assert log_path.name.startswith("penguin-web-")
+    assert log_path.suffix == ".txt"
+
+
+def test_resolve_server_log_path_uses_log_dir_override(monkeypatch, tmp_path):
+    monkeypatch.delenv("PENGUIN_WEB_LOG_FILE", raising=False)
+    monkeypatch.setenv("PENGUIN_WEB_LOG_DIR", str(tmp_path / "runs"))
+
+    log_path = server._resolve_server_log_path()
+
+    assert log_path.parent == tmp_path / "runs"
+    assert log_path.name.startswith("penguin-web-")
+    assert log_path.suffix == ".txt"
+
+
+def test_resolve_server_log_path_file_override_stays_exact(monkeypatch, tmp_path):
+    log_file = tmp_path / "custom" / "logs.txt"
+    monkeypatch.setenv("PENGUIN_WEB_LOG_FILE", str(log_file))
+    monkeypatch.setenv("PENGUIN_WEB_LOG_DIR", str(tmp_path / "ignored"))
+
+    assert server._resolve_server_log_path() == log_file.resolve()
+
+
+def test_configure_server_file_logging_can_be_disabled():
+    assert server._configure_server_file_logging("info") is None
+
+
+def test_configure_server_file_logging_creates_uvicorn_log_config(
+    monkeypatch, tmp_path
+):
+    log_dir = tmp_path / "server-logs"
+    monkeypatch.setenv("PENGUIN_WEB_LOG_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_WEB_LOG_DIR", str(log_dir))
+
+    log_config = server._configure_server_file_logging("info")
+
+    assert log_config is not None
+    log_file = next(log_dir.glob("penguin-web-*.txt"))
+    assert log_file.exists()
+    assert log_file.parent.exists()
+    assert "Penguin web server logs writing to" in log_file.read_text()
+    assert log_config["handlers"]["file"]["filename"] == str(log_file.resolve())
+    assert "file" in log_config["loggers"]["uvicorn.access"]["handlers"]
+
+
 def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     calls = []
 
@@ -52,6 +118,7 @@ def test_main_debug_uses_reload_safe_import_string(monkeypatch, capsys):
     assert calls[0][1]["reload"] is True
     assert calls[0][1]["factory"] is True
     assert calls[0][1]["port"] == 8080
+    assert calls[0][1]["log_config"] is None
 
 
 def test_main_defaults_to_localhost_without_auth(monkeypatch, capsys):
@@ -76,16 +143,18 @@ def test_main_defaults_to_localhost_without_auth(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "http://127.0.0.1:9000" in output
     assert "Penguin local web auth is enabled." in output
-    assert (
-        "Browser/dashboard only: open this local authorization URL once for this browser."
-        in output
+    local_auth_message = (
+        "Browser/dashboard only: open this local authorization URL once "
+        "for this browser."
     )
+    assert local_auth_message in output
     assert "TUI/CLI: local Penguin sessions authenticate automatically." in output
     assert "CI/headless: use PENGUIN_API_KEYS with X-API-Key header auth." in output
     assert "PENGUIN_AUTH_ENABLED=false uv run penguin-web" in output
     assert calls[0][0][0] is app
     assert calls[0][1]["host"] == "127.0.0.1"
     assert calls[0][1]["port"] == 9000
+    assert calls[0][1]["log_config"] is None
 
 
 def test_main_explicit_false_prints_unsecured_warning(monkeypatch, capsys):
@@ -135,10 +204,11 @@ def test_main_prints_startup_token_when_auth_bootstrap_enabled(monkeypatch, caps
 
     output = capsys.readouterr().out
     assert "Penguin local web auth is enabled." in output
-    assert (
-        "Browser/dashboard only: open this local authorization URL once for this browser."
-        in output
+    local_auth_message = (
+        "Browser/dashboard only: open this local authorization URL once "
+        "for this browser."
     )
+    assert local_auth_message in output
     assert "http://127.0.0.1:9000/authorize#local_token=" in output
     assert "Startup token (debug fallback):" in output
     assert "TUI/CLI: local Penguin sessions authenticate automatically." in output
@@ -232,6 +302,7 @@ def test_start_server_non_debug_uses_app_instance(monkeypatch):
     assert calls[0][1]["host"] == "127.0.0.1"
     assert calls[0][1]["port"] == 9000
     assert calls[0][1]["reload"] is False
+    assert calls[0][1]["log_config"] is None
 
 
 def test_start_server_defaults_to_localhost(monkeypatch):


### PR DESCRIPTION
## Summary
- write penguin-web startup/application logs plus Uvicorn error/access logs to per-run workspace text files
- default to `{workspace}/server-logs/penguin-web-<timestamp>-<pid>.txt`
- add `PENGUIN_WEB_LOG_DIR`, `PENGUIN_WEB_LOG_FILE`, and `PENGUIN_WEB_LOG_ENABLED=false` controls
- document behavior in README/AGENTS and add focused tests

## Verification
- `pytest -q tests/test_web_server.py`
- `ruff check penguin/web/server.py tests/test_web_server.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional web server log files with per-run rotation and configurable output location.
  * Support added for changing the log directory, setting a specific log file path, or turning file logging off.

* **Bug Fixes**
  * Improved startup guidance for local and non-local access.
  * Debug authorization links now handle tokens safely in the browser URL.

* **Documentation**
  * Updated the README and operator guidance with logging details and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->