### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+0.9.0 — 2026-07-07
+------------------
+
+Highlights
+- **ACBRA core-runtime decomposition closed**: `PenguinCore` is now a thin compatibility/orchestration facade over focused `penguin.core_runtime` modules for startup, model/runtime handling, streaming, action mapping, RunMode events, checkpoints, diagnostics, OpenCode bridging, token usage, and agent lifecycle helpers.
+- **Durable runtime event ledger**: Added persisted runtime-event recording plus canonical runtime-event envelope projection so web/TUI clients can consume normalized, replayable state instead of ad hoc event shapes.
+- **Penguin TUI upstream campaign closed through Phase 10**: Stabilized OpenCode-compatible event frames, prompt/session compatibility, notification controls, backend command registry foundations, provider/model catalog state, and session hydration state.
+- **TUI reliability hardening**: Improved paste handling, prompt context handling, malformed tool input, inline tool errors, live assistant turn ordering, running-state submit blocking, model selection, session lists, usage telemetry, and startup performance.
+- **Operational logging**: Added per-run web server log files with configurable directory/file controls.
+
+Added
+- Durable runtime event ledger and canonical runtime event envelope projection.
+- Runtime event projection docs and backend/TUI contract updates for the upstream TUI path.
+- TUI desktop/terminal notification policy controls.
+- Backend command registry foundations for the OpenCode-compatible TUI backend.
+- Session model hydration state and provider model catalog state for TUI consumers.
+- Per-run `penguin-web` server log files under the Penguin workspace by default.
+
+Changed
+- Refactored core runtime boundaries into focused `penguin.core_runtime` modules while preserving public compatibility paths.
+- Moved OpenCode event emission toward service-layer ownership and normalized event frames.
+- Improved startup behavior by decoupling catalog/session hydration work from critical path execution.
+- Improved model/provider selection and session compatibility edges across Penguin web/TUI surfaces.
+
+Fixed
+- TUI review hardening issues around paste handling, prompt context handling, malformed tool input, inline tool errors, duplicate/blank session handling, session list depth, usage telemetry, model selection, and assistant turn ordering.
+- Runtime event envelope blockers and compatibility gaps for downstream web/TUI consumers.
+- Exposure of multi-agent tools to Responses-style provider flows.
+- OpenAI OAuth environment refresh after callback and OpenRouter model catalog entries without valid context length.
+
 0.7.0 — 2026-04-27
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,15 @@ Read more:
 
 ## Version Highlights
 
+### v0.9.0
+
+- Completed the ACBRA core-runtime decomposition campaign: `PenguinCore` is now a thin compatibility/orchestration facade over focused `penguin.core_runtime` modules.
+- Added a durable runtime event ledger and canonical runtime-event envelope projection for web/TUI clients, giving downstream surfaces replayable and normalized runtime state.
+- Closed the Penguin TUI upstream-adoption campaign through Phase 10, including stronger OpenCode-compatible event frames, prompt/session compatibility, notification controls, backend command registry foundations, provider/model catalog state, and session hydration state.
+- Hardened the TUI around prompt context handling, paste handling, malformed tool input, inline tool errors, live assistant turn ordering, running-state submit blocking, model selection, session lists, usage telemetry, and startup performance.
+- Expanded multi-agent/tool exposure for Responses-style providers and improved runtime compatibility edges across sessions, web, and TUI surfaces.
+- Added per-run web server file logging with configurable log directory/file controls for easier operational debugging.
+
 ### v0.8.1
 
 - Fixed Python 3.9 import compatibility for MCP configuration by avoiding a runtime PEP 604 union type alias.

--- a/docs/docs/usage/cli_commands.md
+++ b/docs/docs/usage/cli_commands.md
@@ -1,4 +1,4 @@
-# Penguin CLI – Command Reference (v0.6.x)
+# Penguin CLI – Command Reference (v0.9.x)
 
 Penguin now exposes multiple terminal entrypoints on top of the same runtime:
 

--- a/docs/docs/usage/project_management.md
+++ b/docs/docs/usage/project_management.md
@@ -1,6 +1,6 @@
 # Project Management
 
-Penguin v0.6.x introduces a powerful SQLite-backed project management system that provides robust task tracking, hierarchical organization, and integration with Penguin's runtime workflow. This guide covers all aspects of managing projects and tasks in Penguin.
+Penguin includes a SQLite-backed project management system that provides robust task tracking, hierarchical organization, and integration with Penguin's runtime workflow. This guide covers all aspects of managing projects and tasks in Penguin.
 
 ## Overview
 

--- a/docs/docs/usage/web_interface.md
+++ b/docs/docs/usage/web_interface.md
@@ -1,4 +1,4 @@
-# Web Interface / API Server Guide (v0.6.x)
+# Web Interface / API Server Guide (v0.9.x)
 
 Penguin ships with a **FastAPI-based HTTP server** that exposes chat, projects, tasks, SSE/WS streaming, uploads, and integration routes. That server is also the backend surface used by the OpenCode-derived terminal UI in `penguin-tui/`.
 

--- a/penguin/_version.py
+++ b/penguin/_version.py
@@ -2,7 +2,7 @@
 
 __all__ = ["__author__", "__email__", "__license__", "__version__"]
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 __author__ = "Maximus Putnam"
 __email__ = "MaximusPutnam@gmail.com"
 __license__ = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguin-ai"
-version = "0.8.1"
+version = "0.9.0"
 description = "Penguin: A modular, extensible AI coding agent and software engineer with its own execution environment."
 readme = "README.md"
 requires-python = ">=3.9,<3.13"


### PR DESCRIPTION
## Summary
- Bump Penguin package metadata to 0.9.0
- Add 0.9.0 README highlights and changelog entry
- Refresh stale docs labels from v0.6.x to v0.9.x/current wording

## Verification
- python -m pytest tests/test_mcp_phase1.py tests/test_tool_runtime_records.py tests/test_web_server.py -q
- python -m build --sdist --wheel

Co-authored-by: penguin-agent[bot] <penguin-agent[bot]@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable runtime event logging and a normalized event format for web and TUI users.
  * Improved TUI reliability and session handling, with stronger input and startup behavior.
  * Expanded multi-agent tool availability across runtime workflows.
  * Added per-run application log files with configurable output options.

* **Bug Fixes**
  * Fixed several TUI consistency, compatibility, and telemetry issues.
  * Resolved OAuth and context-length related problems.

* **Documentation**
  * Updated release notes and user guides for the new 0.9.0 version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->