### PR TITLE
feat: add GPT-5.6 Codex reasoning support

### DIFF
--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -2843,6 +2843,9 @@ class OpenAIAdapter(BaseAdapter):
             return reasoning_config
 
         prepared = dict(reasoning_config)
+        if prepared.get("effort") == "ultra":
+            prepared["effort"] = "max"
+
         if bool(getattr(self.model_config, "reasoning_exclude", False)):
             return prepared
 

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -8,6 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
+from penguin.llm.reasoning_variants import (
+    reasoning_effort_from_metadata,
+    reasoning_efforts_from_metadata,
+)
+
 from penguin.constants import get_default_max_history_tokens
 
 logger = logging.getLogger(__name__)
@@ -74,12 +79,11 @@ class ModelConfig:
 
     # Reasoning tokens support
     reasoning_enabled: bool = False
-    reasoning_effort: Optional[
-        Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
-    ] = None
+    reasoning_effort: Optional[str] = None
     reasoning_max_tokens: Optional[int] = None
     reasoning_exclude: bool = False
     supports_reasoning: Optional[bool] = None
+    supported_reasoning_levels: Optional[list[str]] = None
 
     # OpenRouter debug mode - echoes upstream request body (development only)
     debug_upstream: bool = False
@@ -331,6 +335,7 @@ class ModelConfig:
             "high",
             "xhigh",
             "max",
+            "ultra",
         }
 
         max_output_env = os.getenv("PENGUIN_MAX_OUTPUT_TOKENS") or os.getenv(
@@ -425,6 +430,25 @@ class ModelConfig:
                 "openrouter" if provider == "openrouter" else "native",
             )
 
+        reasoning_config = model_specific.get("reasoning")
+        if not isinstance(reasoning_config, dict):
+            reasoning_config = {}
+
+        supported_reasoning_levels = reasoning_efforts_from_metadata(
+            model_specific.get("supported_reasoning_levels")
+        )
+        configured_reasoning_effort = reasoning_effort_from_metadata(
+            reasoning_config.get("effort")
+        )
+        default_reasoning_effort = reasoning_effort_from_metadata(
+            model_specific.get("default_reasoning_level")
+        )
+        fallback_reasoning_effort = (
+            supported_reasoning_levels[(len(supported_reasoning_levels) - 1) // 2]
+            if supported_reasoning_levels
+            else None
+        )
+
         # Build ModelConfig with model-specific settings
         return cls(
             model=model_name,
@@ -471,18 +495,20 @@ class ModelConfig:
                 if os.getenv("PENGUIN_MAX_HISTORY_TOKENS")
                 else None
             ),
-            reasoning_enabled=model_specific.get("reasoning", {}).get("enabled", False)
-            if isinstance(model_specific.get("reasoning"), dict)
-            else False,
-            reasoning_effort=model_specific.get("reasoning", {}).get("effort")
-            if isinstance(model_specific.get("reasoning"), dict)
-            else None,
-            reasoning_max_tokens=model_specific.get("reasoning", {}).get("max_tokens")
-            if isinstance(model_specific.get("reasoning"), dict)
-            else None,
-            reasoning_exclude=model_specific.get("reasoning", {}).get("exclude", False)
-            if isinstance(model_specific.get("reasoning"), dict)
-            else False,
+            reasoning_enabled=bool(
+                model_specific.get("reasoning_enabled")
+                or reasoning_config.get("enabled", False)
+                or supported_reasoning_levels
+            ),
+            reasoning_effort=(
+                configured_reasoning_effort
+                or default_reasoning_effort
+                or fallback_reasoning_effort
+            ),
+            reasoning_max_tokens=reasoning_config.get("max_tokens"),
+            reasoning_exclude=bool(reasoning_config.get("exclude", False)),
+            supports_reasoning=True if supported_reasoning_levels else None,
+            supported_reasoning_levels=list(supported_reasoning_levels) or None,
             service_tier=normalize_openai_service_tier(
                 model_specific.get("service_tier")
                 or os.getenv("PENGUIN_OPENAI_SERVICE_TIER")

--- a/penguin/llm/reasoning_variants.py
+++ b/penguin/llm/reasoning_variants.py
@@ -12,6 +12,7 @@ from typing import Any
 _WIDELY_SUPPORTED_EFFORTS = ("low", "medium", "high")
 _OPENAI_GPT51_EFFORTS = ("none", "low", "medium", "high")
 _OPENAI_FULL_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
+_OPENAI_GPT56_PLUS_EFFORTS = _OPENAI_FULL_EFFORTS + ("max",)
 _ANTHROPIC_STANDARD_EFFORTS = ("low", "medium", "high")
 _ANTHROPIC_MAX_EFFORTS = ("low", "medium", "high", "max")
 
@@ -23,6 +24,32 @@ def _normalized_model_key(model_id: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value).strip("-")
 
 
+def reasoning_effort_from_metadata(raw_value: Any) -> str | None:
+    """Return a normalized reasoning effort from provider model metadata."""
+
+    value = raw_value.get("effort") if isinstance(raw_value, dict) else raw_value
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def reasoning_efforts_from_metadata(raw_value: Any) -> tuple[str, ...]:
+    """Return ordered, de-duplicated reasoning efforts from provider metadata."""
+
+    if not isinstance(raw_value, (list, tuple)):
+        return ()
+
+    efforts: list[str] = []
+    seen: set[str] = set()
+    for item in raw_value:
+        effort = reasoning_effort_from_metadata(item)
+        if effort and effort not in seen:
+            seen.add(effort)
+            efforts.append(effort)
+    return tuple(efforts)
+
+
 def openai_reasoning_efforts(model_id: str) -> tuple[str, ...]:
     """Return conservative OpenAI effort variants for a model id."""
     key = _normalized_model_key(model_id)
@@ -31,6 +58,12 @@ def openai_reasoning_efforts(model_id: str) -> tuple[str, ...]:
 
     if re.search(r"gpt-5(?:-[0-9]+)?-pro", key):
         return ("high",)
+
+    if re.search(r"gpt-5-(?:[6-9]|[1-9][0-9])", key) or re.search(
+        r"gpt-[6-9](?:-|$)",
+        key,
+    ):
+        return _OPENAI_GPT56_PLUS_EFFORTS
 
     if re.search(r"gpt-5-(?:[2-9]|[1-9][0-9])", key) or re.search(
         r"gpt-[6-9](?:-|$)",
@@ -91,4 +124,6 @@ __all__ = [
     "native_reasoning_efforts",
     "native_reasoning_variants",
     "openai_reasoning_efforts",
+    "reasoning_effort_from_metadata",
+    "reasoning_efforts_from_metadata",
 ]

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -38,9 +38,20 @@ from .provider_transform import (
     normalize_openai_responses_tool_choice,
     normalize_openai_responses_tools,
 )
-from .reasoning_variants import native_reasoning_efforts
+from .reasoning_variants import (
+    native_reasoning_efforts,
+    reasoning_efforts_from_metadata,
+)
 
-_REASONING_EFFORT_VARIANTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
+_REASONING_EFFORT_VARIANTS = {
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "ultra",
+}
 _REASONING_MAX_VARIANTS = {"max"}
 _REASONING_DISABLE_VARIANTS = {"off"}
 _NATIVE_RESPONSE_COMPLETION_TOOLS = {"finish_response"}
@@ -1207,7 +1218,12 @@ def apply_reasoning_variant_override(
     model_id = str(getattr(model_config, "model", "") or "").strip()
 
     if provider_id in {"openai", "anthropic"}:
-        supported_native_variants = set(native_reasoning_efforts(provider_id, model_id))
+        metadata_variants = reasoning_efforts_from_metadata(
+            getattr(model_config, "supported_reasoning_levels", None)
+        )
+        supported_native_variants = set(
+            metadata_variants or native_reasoning_efforts(provider_id, model_id)
+        )
         if value not in supported_native_variants:
             return None
 

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -1021,7 +1021,15 @@ class MessageRequest(BaseModel):
     parts: Optional[List[Dict[str, Any]]] = None
 
 
-_REASONING_EFFORT_VARIANTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
+_REASONING_EFFORT_VARIANTS = {
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "ultra",
+}
 _REASONING_MAX_VARIANTS = {"max"}
 _REASONING_DISABLE_VARIANTS = {"off"}
 _INLINE_FILE_REFERENCE_PATTERN = re.compile(

--- a/penguin/web/services/opencode_provider.py
+++ b/penguin/web/services/opencode_provider.py
@@ -48,6 +48,7 @@ from penguin.web.services.provider_credentials import (
 from penguin.web.services.reasoning_variants import (
     native_reasoning_efforts,
     native_reasoning_variants,
+    reasoning_efforts_from_metadata,
 )
 
 # Compatibility export used by existing tests/patch points.
@@ -207,9 +208,19 @@ def _model_variants_payload(
     provider_id: str,
     model_id: str,
     reasoning_enabled: bool,
+    conf: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]] | None:
     if not reasoning_enabled:
         return None
+
+    metadata_efforts = reasoning_efforts_from_metadata(
+        conf.get("supported_reasoning_levels") if isinstance(conf, dict) else None
+    )
+    if metadata_efforts:
+        return {
+            effort: {"reasoning": {"effort": effort}}
+            for effort in metadata_efforts
+        }
 
     provider_value = provider_id.strip().lower()
 
@@ -579,7 +590,7 @@ def _config_model_payload(
             isinstance(conf.get("reasoning"), dict) and conf["reasoning"].get("enabled")
         )
     )
-    variants = _model_variants_payload(provider_id, model_id, True)
+    variants = _model_variants_payload(provider_id, model_id, True, conf)
     reasoning_supported = reasoning_enabled or bool(variants)
     name = conf.get("name") or conf.get("model") or model_id
     release_date = conf.get("release_date")
@@ -643,7 +654,7 @@ def _provider_list_model_payload(
             isinstance(conf.get("reasoning"), dict) and conf["reasoning"].get("enabled")
         )
     )
-    variants = _model_variants_payload(provider_id, model_id, True)
+    variants = _model_variants_payload(provider_id, model_id, True, conf)
     reasoning_supported = reasoning_enabled or bool(variants)
     release_date = conf.get("release_date")
     if not isinstance(release_date, str) or not release_date.strip():

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -13,6 +13,11 @@ from typing import Any
 
 import httpx
 
+from penguin.web.services.reasoning_variants import (
+    reasoning_effort_from_metadata,
+    reasoning_efforts_from_metadata,
+)
+
 _PROVIDER_METADATA: dict[str, dict[str, Any]] = {
     "openai": {
         "name": "OpenAI",
@@ -267,9 +272,7 @@ def _openai_codex_model_input_modalities(raw_value: Any) -> list[str]:
 
 
 def _openai_codex_model_reasoning_enabled(raw_value: Any) -> bool:
-    if not isinstance(raw_value, list):
-        return False
-    return any(isinstance(item, dict) and item.get("effort") for item in raw_value)
+    return bool(reasoning_efforts_from_metadata(raw_value))
 
 # TODO: Look into this later, could be an issue.
 def _openai_codex_cache_key(credential_record: dict[str, Any] | None) -> str | None:
@@ -385,8 +388,14 @@ def codex_oauth_provider_models(
         input_modalities = _openai_codex_model_input_modalities(
             item.get("input_modalities")
         )
-        reasoning_enabled = _openai_codex_model_reasoning_enabled(
+        supported_reasoning_levels = reasoning_efforts_from_metadata(
             item.get("supported_reasoning_levels")
+        )
+        reasoning_enabled = _openai_codex_model_reasoning_enabled(
+            supported_reasoning_levels
+        )
+        default_reasoning_level = reasoning_effort_from_metadata(
+            item.get("default_reasoning_level")
         )
         priority = item.get("priority")
 
@@ -401,6 +410,14 @@ def codex_oauth_provider_models(
             "reasoning_enabled": reasoning_enabled,
             "source": "codex",
         }
+        if supported_reasoning_levels:
+            conf["supported_reasoning_levels"] = list(supported_reasoning_levels)
+        if default_reasoning_level:
+            conf["default_reasoning_level"] = default_reasoning_level
+        if isinstance(item.get("supports_reasoning_summaries"), bool):
+            conf["supports_reasoning_summaries"] = item[
+                "supports_reasoning_summaries"
+            ]
         if isinstance(priority, int):
             conf["priority"] = priority
         discovered[model_id] = conf

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -735,6 +735,41 @@ async def test_openai_oauth_catalog_replaces_static_openai_models(
             return {
                 "models": [
                     {
+                        "slug": "gpt-5.6-sol",
+                        "display_name": "GPT-5.6-Sol",
+                        "visibility": "list",
+                        "priority": 0,
+                        "context_window": 400000,
+                        "max_context_window": 1000000,
+                        "input_modalities": ["text", "image"],
+                        "default_reasoning_level": "low",
+                        "supported_reasoning_levels": [
+                            {"effort": "low"},
+                            {"effort": "medium"},
+                            {"effort": "high"},
+                            {"effort": "xhigh"},
+                            {"effort": "max"},
+                            {"effort": "ultra"},
+                        ],
+                        "supports_reasoning_summaries": True,
+                    },
+                    {
+                        "slug": "gpt-5.6-luna",
+                        "display_name": "GPT-5.6-Luna",
+                        "visibility": "list",
+                        "priority": 3,
+                        "context_window": 400000,
+                        "max_context_window": 1000000,
+                        "input_modalities": ["text", "image"],
+                        "default_reasoning_level": "medium",
+                        "supported_reasoning_levels": [
+                            {"effort": "low"},
+                            {"effort": "medium"},
+                            {"effort": "high"},
+                            {"effort": "max"},
+                        ],
+                    },
+                    {
                         "slug": "gpt-5.5",
                         "display_name": "GPT-5.5",
                         "visibility": "list",
@@ -825,26 +860,45 @@ async def test_openai_oauth_catalog_replaces_static_openai_models(
     )
 
     assert list(openai["models"].keys()) == [
+        "gpt-5.6-sol",
         "gpt-5.5",
         "gpt-5.4",
+        "gpt-5.6-luna",
         "gpt-5.3-codex",
     ]
     assert "gpt-5" not in openai["models"]
     assert "codex-auto-review" not in openai["models"]
-    assert providers_payload["default"]["openai"] == "gpt-5.5"
-    assert openai["models"]["gpt-5.5"]["capabilities"]["attachment"] is True
-    assert openai["models"]["gpt-5.5"]["capabilities"]["reasoning"] is True
+    assert providers_payload["default"]["openai"] == "gpt-5.6-sol"
+    assert openai["models"]["gpt-5.6-sol"]["capabilities"]["attachment"] is True
+    assert openai["models"]["gpt-5.6-sol"]["capabilities"]["reasoning"] is True
+    assert set(openai["models"]["gpt-5.6-sol"]["variants"].keys()) == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert set(openai["models"]["gpt-5.6-luna"]["variants"].keys()) == {
+        "low",
+        "medium",
+        "high",
+        "max",
+    }
+    assert set(openai["models"]["gpt-5.5"]["variants"].keys()) == {"xhigh"}
 
     provider_payload = await opencode_provider_list(core=typed_core)
     openai_provider = next(
         item for item in provider_payload["all"] if item["id"] == "openai"
     )
     assert list(openai_provider["models"].keys()) == [
+        "gpt-5.6-sol",
         "gpt-5.5",
         "gpt-5.4",
+        "gpt-5.6-luna",
         "gpt-5.3-codex",
     ]
-    assert provider_payload["default"]["openai"] == "gpt-5.5"
+    assert provider_payload["default"]["openai"] == "gpt-5.6-sol"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_reasoning_variant_overrides.py
+++ b/tests/api/test_reasoning_variant_overrides.py
@@ -10,11 +10,16 @@ from penguin.web.routes import (
 )
 
 
-def _core_with_model_config(provider: str, model: str) -> SimpleNamespace:
+def _core_with_model_config(
+    provider: str,
+    model: str,
+    supported_reasoning_levels: list[str] | None = None,
+) -> SimpleNamespace:
     return SimpleNamespace(
         model_config=SimpleNamespace(
             provider=provider,
             model=model,
+            supported_reasoning_levels=supported_reasoning_levels,
             reasoning_enabled=False,
             reasoning_effort=None,
             reasoning_max_tokens=None,
@@ -32,6 +37,35 @@ def test_openai_native_variant_rejects_unsupported_effort() -> None:
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
     assert core.model_config.reasoning_max_tokens is None
+
+
+def test_openai_metadata_variant_allows_ultra_when_advertised() -> None:
+    core = _core_with_model_config(
+        "openai",
+        "gpt-5.6-sol",
+        ["low", "medium", "high", "xhigh", "max", "ultra"],
+    )
+
+    snapshot = _apply_reasoning_variant_override(core, "ultra")
+
+    assert isinstance(snapshot, dict)
+    assert core.model_config.reasoning_enabled is True
+    assert core.model_config.reasoning_effort == "ultra"
+    assert core.model_config.reasoning_max_tokens is None
+
+
+def test_openai_metadata_variant_rejects_ultra_when_not_advertised() -> None:
+    core = _core_with_model_config(
+        "openai",
+        "gpt-5.6-luna",
+        ["low", "medium", "high", "max"],
+    )
+
+    snapshot = _apply_reasoning_variant_override(core, "ultra")
+
+    assert snapshot is None
+    assert core.model_config.reasoning_enabled is False
+    assert core.model_config.reasoning_effort is None
 
 
 def test_anthropic_native_variant_allows_max_for_opus_46() -> None:

--- a/tests/api/test_reasoning_variants_service.py
+++ b/tests/api/test_reasoning_variants_service.py
@@ -1,6 +1,9 @@
 """Unit tests for provider-aware reasoning variant resolution."""
 
-from penguin.web.services.reasoning_variants import native_reasoning_efforts
+from penguin.web.services.reasoning_variants import (
+    native_reasoning_efforts,
+    reasoning_efforts_from_metadata,
+)
 
 
 def test_openai_gpt_54_uses_full_reasoning_effort_surface() -> None:
@@ -23,6 +26,18 @@ def test_openai_gpt_51_limits_reasoning_efforts() -> None:
     )
 
 
+def test_openai_gpt_56_exposes_max_effort() -> None:
+    assert native_reasoning_efforts("openai", "gpt-5.6-sol") == (
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    )
+
+
 def test_openai_gpt_5_pro_is_high_only() -> None:
     assert native_reasoning_efforts("openai", "gpt-5-pro") == ("high",)
 
@@ -38,3 +53,15 @@ def test_anthropic_opus_46_supports_max_effort() -> None:
 
 def test_anthropic_non_effort_model_returns_no_variants() -> None:
     assert native_reasoning_efforts("anthropic", "claude-3-7-sonnet") == ()
+
+
+def test_reasoning_metadata_preserves_custom_efforts_in_order() -> None:
+    assert reasoning_efforts_from_metadata(
+        [
+            {"effort": "Low"},
+            {"effort": "ULTRA"},
+            {"effort": "low"},
+            "max",
+            {"description": "missing effort"},
+        ]
+    ) == ("low", "ultra", "max")

--- a/tests/llm/test_model_config_reasoning.py
+++ b/tests/llm/test_model_config_reasoning.py
@@ -41,3 +41,57 @@ def test_explicit_reasoning_effort_overrides_support_detection() -> None:
     )
 
     assert config.get_reasoning_config() == {"effort": "xhigh"}
+
+
+def test_codex_model_metadata_sets_supported_reasoning_default() -> None:
+    config = ModelConfig.for_model(
+        model_name="openai/gpt-5.6-sol",
+        provider="openai",
+        model_configs={
+            "openai/gpt-5.6-sol": {
+                "provider": "openai",
+                "model": "gpt-5.6-sol",
+                "reasoning_enabled": True,
+                "default_reasoning_level": "low",
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                    {"effort": "xhigh"},
+                    {"effort": "max"},
+                    {"effort": "ultra"},
+                ],
+            }
+        },
+    )
+
+    assert config.supported_reasoning_levels == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
+    assert config.get_reasoning_config() == {"effort": "low"}
+
+
+def test_codex_model_metadata_falls_back_to_middle_supported_effort() -> None:
+    config = ModelConfig.for_model(
+        model_name="openai/gpt-5.6-luna",
+        provider="openai",
+        model_configs={
+            "openai/gpt-5.6-luna": {
+                "provider": "openai",
+                "model": "gpt-5.6-luna",
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                    {"effort": "max"},
+                ],
+            }
+        },
+    )
+
+    assert config.get_reasoning_config() == {"effort": "medium"}

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -16,6 +16,24 @@ def _image_payload_magic(data_uri: str) -> bytes:
     return base64.b64decode(data_uri.split(",", 1)[1])[:3]
 
 
+def test_prepare_reasoning_config_maps_ultra_to_openai_max() -> None:
+    adapter = OpenAIAdapter(
+        ModelConfig(
+            model="gpt-5.6-sol",
+            provider="openai",
+            client_preference="native",
+            api_key="sk-test",
+            reasoning_enabled=True,
+            reasoning_effort="ultra",
+        )
+    )
+
+    assert adapter._prepare_reasoning_config(  # noqa: SLF001
+        {"effort": "ultra"},
+        stream=True,
+    ) == {"effort": "max", "summary": "auto"}
+
+
 @dataclass(frozen=True)
 class _DummyStreamEvent:
     """Minimal stream event shape used by OpenAIAdapter streaming."""


### PR DESCRIPTION
## Summary
- preserve Codex OAuth model reasoning metadata (, )
- expose metadata-driven OpenCode/OpenAI variants, including / only when advertised
- map  to OpenAI wire , matching Codex behavior, without faking Codex multi-agent orchestration
- add targeted provider/runtime/adapter tests for GPT-5.6 Sol/Luna metadata handling

## Validation
- 
- ...........................................                              [100%]
=============================== warnings summary ===============================
penguin/agent/schema.py:132
  /Users/maximusputnam/Code/Penguin/penguin/penguin/agent/schema.py:132: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    @validator("tools", always=True)

penguin/agent/schema.py:65
  /Users/maximusputnam/Code/Penguin/penguin/penguin/agent/schema.py:65: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class AgentConfig(BaseModel):

tests/api/test_opencode_provider_routes.py::test_openrouter_catalog_expands_provider_payloads
tests/api/test_opencode_provider_routes.py::test_auth_set_and_remove_round_trip
tests/api/test_opencode_provider_routes.py::test_api_v1_aliases_match_opencode_routes
tests/api/test_opencode_provider_routes.py::test_http_route_wiring_for_config_provider_auth
  /Users/maximusputnam/Code/Penguin/penguin/penguin/web/services/provider_credentials.py:116: UserWarning: Provider credentials loaded from legacy plaintext JSON store. Prefer environment variables for headless/server deployments; plaintext persistence is deprecated.
    _warn_legacy_store_usage(path)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
43 passed, 6 warnings in 1.33s

## Notes
- Ruff was not available in the local venv ().
-  was already dirty and is intentionally not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new reasoning effort option, **“ultra”**, across supported model workflows.
  * Provider and model metadata can now surface supported reasoning levels more accurately, improving available option lists.

* **Bug Fixes**
  * Reasoning settings now map **“ultra”** to the correct OpenAI-compatible value when sending requests.
  * Reasoning overrides are now validated against each model’s advertised capabilities, reducing invalid option selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->