### PR TITLE
fix: harden GPT-5.6 reasoning metadata handling

### DIFF
--- a/context/tasks/cli-acbra-testing-refactor.md
+++ b/context/tasks/cli-acbra-testing-refactor.md
@@ -1,0 +1,665 @@
+# CLI ACBRA Testing And Refactor Campaign
+
+## Purpose
+
+Turn `penguin/cli/cli.py` from a high-risk startup, command, and interactive
+shell god file into a small composition and registration layer by applying the
+same repeatable ACBRA loop used for the core-runtime campaign:
+
+1. **Audit** current behavior, responsibilities, invariants, and failure modes.
+2. **Characterize** behavior that must not regress.
+3. **Build** the testing pyramid for the selected CLI slice.
+4. **Refactor** behind the new test boundary.
+5. **Assault** the extracted boundary with property, fault-injection, ordering,
+   and replay checks where they are useful.
+
+This document is intentionally scoped to the Python CLI implementation under
+`penguin/cli/`, with `penguin/cli/cli.py` as the primary decomposition target.
+It is not a CLI redesign plan and it is not permission to rewrite the file in
+one pass.
+
+## Why This Exists
+
+`penguin/cli/cli.py` is currently far beyond the intended boundary for a CLI
+entrypoint. It owns or coordinates:
+
+- import timing and startup diagnostics
+- configuration compatibility and model/runtime projection
+- global core construction
+- workspace and environment normalization
+- direct-prompt, interactive, session, and RunMode dispatch
+- Typer command registration for config, permissions, skills, MCP, agents,
+  projects, tasks, coordination, profiling, and chat
+- the legacy interactive `PenguinCLI` shell
+- display, streaming, reasoning, interrupt, and input behavior
+
+This creates predictable failure modes:
+
+- model and configuration intent is reconstructed differently by different
+  entry paths
+- a model override can accidentally inherit capabilities from the configured
+  source model
+- explicit and inferred configuration values are difficult to distinguish
+  after projection through dictionaries
+- command behavior and command registration are too coupled to test cleanly
+- fixes in one surface can destabilize direct prompt, interactive, RunMode, or
+  command-group startup
+- review-driven local patches reinforce the god file instead of removing the
+  source of the defects
+
+The goal is not to make a perfectly polished 5,000-line CLI. The goal is to
+extract tested services until `cli.py` primarily registers commands, parses
+top-level options, and delegates to focused startup and command modules.
+
+## Relationship To Existing Plans
+
+This campaign depends on:
+
+- `context/tasks/testing-pyramid.md`
+- `context/tasks/cli-refactor-and-bootstrap-audit.md`
+- `context/tasks/cli-surface-audit.md`
+- `context/tasks/project-bootstrap-workflow.md`
+- `context/process/blueprint.template.md` for the ITUV lifecycle
+
+Historical input:
+
+- `context/archive/plans/refactoring_python_cli_plan.md`
+  - useful for prior display, streaming, event, class, and command extraction
+    ideas
+  - stale line counts and assumptions must be re-audited before use
+- `context/archive/plans/penguin_cli_refactor_plan.md`
+  - primarily concerns the retired TypeScript/Ink CLI and should not drive this
+    Python campaign
+
+The user-facing follow-up is:
+
+- `context/tasks/cli-interface-ergonomics-plan.md`
+
+That ergonomics plan should follow structural stabilization rather than drive
+the decomposition. Command naming, discoverability, defaults, and workflow
+polish are easier and safer once startup, configuration, rendering, and command
+execution have explicit owners. Correctness blockers may still be fixed before
+the refactor, but broad UX work should not be mixed into extraction PRs.
+
+## Relationship To The Core ACBRA Campaign
+
+This campaign follows the protocol established by
+`context/tasks/core-acbra-testing-refactor.md`:
+
+- characterize before moving behavior
+- extract one responsibility at a time
+- preserve compatibility at the old public boundary
+- use deterministic fake dependencies before live-provider checks
+- report coverage and assurance by extracted slice, not only by global test
+  percentage
+
+The CLI has a different risk profile from `PenguinCore`. Its highest risks are
+startup ordering, environment mutation, configuration provenance, command
+dispatch, terminal state, and duplicated user-facing behavior.
+
+## ITUV Gate
+
+Every ACBRA slice must pass ITUV before it is complete:
+
+- **IMPLEMENT**: changes are limited to one selected responsibility and its
+  delegation boundary.
+- **TEST**: characterization, unit, contract, and integration tests for that
+  responsibility pass.
+- **USE**: at least one real local CLI recipe exercises the normal installed or
+  `uv run` surface.
+- **VERIFY**: acceptance criteria, preserved behavior, and residual risks are
+  recorded from test and usage evidence.
+
+Live providers are not the default proof of correctness. Prefer monkeypatched
+configuration loaders, fake cores, fake provider clients, Typer test runners,
+temporary workspaces, and deterministic event streams. A live provider smoke
+may supplement the evidence when the slice specifically concerns provider
+startup, but it must not replace hermetic tests.
+
+## Current Baseline To Capture
+
+Before the first extraction PR, record:
+
+```bash
+wc -l penguin/cli/cli.py
+rg -n "^def |^async def |^class |^    def |^    async def " penguin/cli/cli.py
+git status --short
+uv run pytest -q \
+  tests/test_cli_entrypoint_dispatcher.py \
+  tests/test_cli_integration.py \
+  tests/test_cli_surface_audit_regressions.py \
+  tests/cli
+```
+
+Known baseline on July 9, 2026:
+
+- `penguin/cli/cli.py` is 5,213 lines.
+- model/reasoning projection helpers live directly in `cli.py` around the
+  global initialization path.
+- `_initialize_core_components_globally(...)` remains a high-risk composition
+  function used by many commands.
+- the interactive `PenguinCLI` class begins late in the file and still owns
+  terminal/display behavior despite existing manager classes.
+- CLI-focused tests exist across `tests/cli/`,
+  `tests/test_cli_entrypoint_dispatcher.py`, `tests/test_cli_integration.py`,
+  and `tests/test_cli_surface_audit_regressions.py`.
+
+The baseline must also list known dirty worktree files so unrelated user work
+is not reverted or committed during the campaign.
+
+## CLI Invariants
+
+These invariants matter more than raw line reduction.
+
+### Startup And Composition
+
+- import-time behavior remains lazy enough that `penguin --help` is fast and
+  does not initialize providers unnecessarily
+- root, workspace, and environment normalization happen once in a documented
+  order
+- configuration is loaded once per intended startup lifecycle
+- global compatibility state is assigned only after construction succeeds
+- partial startup failure preserves the original exception and does not leave
+  misleading half-initialized globals
+- direct prompt, interactive chat, RunMode, and command groups resolve the same
+  target runtime semantics unless their contracts intentionally differ
+
+### Model And Reasoning Configuration
+
+- the target model is resolved before model-derived capabilities are inferred
+- `--model` never inherits capabilities from the configured source model
+- explicit user choices outrank provider defaults and inferred values
+- explicit `false`, explicit effort, and explicit token budget remain distinct
+  from unset values
+- explicit token-budget provenance is independent of reasoning-enabled
+  provenance
+- native/OpenRouter/Anthropic reasoning styles retain their correct request
+  configuration
+- configuration projection and reconstruction round-trip without silently
+  changing intent
+
+### Workspace And Project Semantics
+
+- execution root, Penguin workspace, and project workspace remain distinct
+- command options either work as documented or fail clearly
+- project/task selection is deterministic and ambiguous names fail closed
+- project and task commands delegate business logic rather than duplicating it
+  in command bodies
+
+### Command Dispatch
+
+- Typer decorators and public command names remain stable during extraction
+  unless a separate ergonomics PR intentionally changes them
+- sync command wrappers invoke their async implementation exactly once
+- command failures map to stable exit codes and actionable messages
+- JSON or machine-readable output remains free of incidental Rich output
+- command registration does not import or initialize unrelated heavy systems
+
+### Interactive Shell And Streaming
+
+- streamed content, reasoning, tool calls, and tool results remain ordered
+- interrupt and cancellation restore terminal state and release active work
+- empty or tool-only turns do not create misleading blank assistant output
+- event handling and rendering do not persist or mutate business state
+- session selection and continuation preserve the intended workspace and
+  conversation scope
+
+### Compatibility
+
+- `penguin`, `penguin --help`, `penguin .`, direct-prompt modes, and supported
+  command groups keep their current external contracts
+- extracted modules do not introduce import cycles or package-source tests
+- CLI code remains a consumer of core/web/project services, not a second
+  implementation of their business rules
+
+## Slice Plan
+
+Work in bounded campaigns. Do not combine multiple high-risk slices merely to
+reduce the line count faster.
+
+### Slice 1: Model Startup And Configuration Projection
+
+Candidate extraction target:
+
+- `penguin/cli/model_runtime.py`
+
+Move or replace:
+
+- `_project_reasoning_config`
+- `_resolve_cli_reasoning_config`
+- model dictionary normalization inside
+  `_initialize_core_components_globally(...)`
+- target-model selection and model-override handling
+- construction of the final `ModelConfig`
+
+The extracted API should accept explicit inputs and return a complete
+`ModelConfig` or a typed construction result. It must not depend on private
+`ModelConfig` flags from the CLI boundary. If configuration provenance is part
+of the contract, represent it with an explicit input schema or first-class
+factory API.
+
+Required characterization matrix:
+
+- same model versus `--model` override
+- reasoning-capable versus non-reasoning target
+- `reasoning_enabled`: true / false / unset
+- effort: valid / invalid / unset
+- max-token budget: explicit / inferred / unset
+- source and target across OpenAI, Anthropic, and OpenRouter styles
+- qualified and unqualified model IDs
+- static configuration versus provider-catalog metadata
+
+Known regressions to capture before extraction:
+
+- configured `gpt-4o` plus `--model gpt-5.6-sol` must recompute GPT-5.6
+  capabilities instead of inheriting `supports_reasoning=False`
+- configured GPT-5.6 plus `--model gpt-4o` must not carry GPT-5.6 capabilities
+  into the target
+- an explicit `reasoning_max_tokens: 8000` must not become an inferred 2000
+  token budget merely because `enabled` was omitted
+
+Acceptance:
+
+- `cli.py` does not project or reconstruct reasoning/model capability fields
+- target-model resolution happens before capability inference
+- a table-driven test matrix proves explicit and inferred configuration
+  precedence
+- `_initialize_core_components_globally(...)` delegates model construction to
+  the extracted module
+
+### Slice 2: Startup And Dependency Composition
+
+Candidate extraction target:
+
+- `penguin/cli/bootstrap.py`
+
+Move or wrap:
+
+- `_initialize_core_components_globally(...)`
+- config loading and compatibility conversion
+- workspace-aware `PenguinCore` construction
+- global compatibility assignment
+- startup progress and failure reporting boundaries
+
+Required tests:
+
+- successful construction with fake config/core factories
+- config-load failure, provider failure, and partial-construction cleanup
+- repeated initialization behavior
+- workspace override and model override propagation
+- direct prompt and interactive startup parity
+- no provider initialization for `--help` and other metadata-only commands
+
+Acceptance:
+
+- `cli.py` delegates startup to a focused bootstrap service
+- bootstrap returns an explicit result instead of mutating many globals during
+  intermediate phases
+- compatibility globals are assigned in one small adapter after success
+
+### Slice 3: Environment, Root, And Workspace Normalization
+
+Candidate extraction target:
+
+- `penguin/cli/environment.py`
+
+Move or wrap:
+
+- `_set_cli_workspace_path`
+- `_preconfigure_cli_environment`
+- execution-root normalization
+- environment variable projection used only by CLI startup
+
+Required tests:
+
+- relative, absolute, missing, and symlinked paths
+- explicit workspace versus current-directory defaults
+- repeated calls and pre-existing environment variables
+- project workspace remains distinct from execution root
+- platform-specific path behavior where relevant
+
+Acceptance:
+
+- path/environment mutation is centralized and documented
+- tests prove idempotence or explicitly document non-idempotent behavior
+- command implementations no longer improvise workspace normalization
+
+### Slice 4: Command Execution Services
+
+Candidate extraction targets:
+
+- `penguin/cli/commands/project.py`
+- `penguin/cli/commands/task.py`
+- `penguin/cli/commands/agent.py`
+- `penguin/cli/commands/config.py`
+- additional domain modules only when their boundaries are proven
+
+Keep Typer registration thin. Extract command execution functions that accept
+typed inputs and services, then return structured outcomes for rendering.
+
+Required tests:
+
+- public command names/options remain registered
+- command services are unit tested without Typer or terminal state
+- Typer contract tests cover parsing, exit codes, and output projection
+- ambiguous selectors and service failures remain explicit
+
+Acceptance:
+
+- command bodies in `cli.py` are registration/delegation only
+- project/task/agent business logic is not duplicated between CLI and backend
+  services
+- command output is rendered from structured results
+
+### Slice 5: RunMode And Direct-Prompt Dispatch
+
+Candidate extraction target:
+
+- `penguin/cli/run_dispatch.py`
+
+Move or wrap:
+
+- `_run_penguin_direct_prompt`
+- `_handle_run_mode`
+- `_handle_session_management`
+- top-level mode-selection decisions from `main_entry(...)`
+
+Required tests:
+
+- precedence among direct prompt, session management, RunMode, and interactive
+  mode
+- `--run`, `--247`, and `--continuous` dispatch contracts
+- cancellation, non-terminal outcomes, and structured output
+- invalid option combinations fail before core execution
+
+Acceptance:
+
+- `main_entry(...)` parses options and delegates to one dispatch policy
+- RunMode lifecycle truth remains owned by runtime services
+- CLI does not reinterpret pending-review, clarification, or blocked outcomes
+
+### Slice 6: Rendering And Output Policy
+
+Candidate extraction targets:
+
+- existing `penguin/cli/renderer.py` and manager classes where suitable
+- a focused output-policy adapter for plain, Rich, and JSON output
+
+Move or consolidate:
+
+- duplicated message and status rendering
+- command result formatting
+- reasoning and code-block display helpers
+- machine-readable output policy
+
+Required tests:
+
+- golden or snapshot-like tests for stable structured fragments
+- ANSI/no-ANSI behavior
+- JSON output contains no incidental terminal decoration
+- errors and warnings use consistent streams and exit behavior
+
+Acceptance:
+
+- rendering consumes outcomes and events; it does not perform domain actions
+- duplicate formatting logic is removed only after parity tests pass
+- interactive and command output share helpers where their contracts match
+
+### Slice 7: Interactive Shell And Streaming Lifecycle
+
+Candidate extraction targets:
+
+- `penguin/cli/interactive.py`
+- existing `DisplayManager`, `StreamingManager`, `SessionManager`, and
+  `EventManager` boundaries after re-audit
+
+Move or delegate:
+
+- `PenguinCLI.chat_loop`
+- interrupt and cancellation handling
+- streaming finalization and terminal restoration
+- session continuation and interactive input coordination
+- residual display methods that belong to existing managers
+
+Required tests:
+
+- deterministic event-stream replay
+- cancellation during content, reasoning, and tool execution
+- tool-only and empty-turn finalization
+- session switch/continue behavior
+- terminal state cleanup after exceptions
+- fault injection from renderer, event manager, and core process calls
+
+Acceptance:
+
+- the interactive shell is a coordinator over focused managers
+- terminal state has explicit lifecycle ownership
+- the legacy `PenguinCLI` class is small enough to audit or replaced by a
+  focused interactive application object
+
+### Slice 8: Registration And Compatibility Facade
+
+Candidate end state:
+
+- `penguin/cli/cli.py` contains Typer app/group registration, compatibility
+  imports, and small delegation wrappers
+
+Required tests:
+
+- package entry points resolve
+- `penguin --help` and command-group help work from an installed wheel
+- public command names, options, and aliases match the frozen contract
+- deprecated compatibility shims warn or delegate intentionally
+
+Acceptance:
+
+- `cli.py` is no longer the owner of configuration, runtime startup, rendering,
+  or domain command policy
+- file size is a consequence of clean ownership, not the primary metric
+
+## Testing Pyramid For Each Slice
+
+### Layer 0: Static Hygiene
+
+```bash
+uv run python -m compileall penguin/cli
+uv run ruff check <touched files>
+uv run ruff format --check <touched files>
+git diff --check
+```
+
+Broader legacy lint debt should be reported, not silently mixed into a focused
+extraction PR.
+
+### Layer 1: Unit
+
+Target pure projection, parsing, selection, rendering, and dispatch helpers.
+Avoid constructing a real `PenguinCore` for decisions that do not require it.
+
+### Layer 2: Property
+
+Use Hypothesis where input combinations are broad:
+
+- model/provider IDs and overrides
+- tri-state reasoning fields and explicit-value precedence
+- root/workspace path normalization
+- command selector and status normalization
+- output mode combinations
+
+### Layer 3: State Machine
+
+Use state-machine tests for:
+
+- startup: uninitialized -> initializing -> ready/failed
+- interactive lifecycle: idle -> requesting -> streaming/tooling -> idle
+- interrupt/cancel/finalize transitions
+- session select/switch/continue behavior
+
+### Layer 4: Contract
+
+Freeze:
+
+- command names, arguments, options, and exit codes
+- startup/model projection semantics
+- structured command outcomes
+- JSON output shapes
+- event-to-terminal rendering contracts where public
+
+### Layer 5: Hermetic Integration
+
+Use:
+
+- `typer.testing.CliRunner`
+- fake config loaders and core factories
+- fake providers and event buses
+- temporary workspaces and credential stores
+- deterministic async command services
+
+No test in this layer should require a fixed port, real OAuth credentials, or a
+live model.
+
+### Layer 6: Installed-Artifact Smoke
+
+Build and install the wheel into a clean environment, then verify:
+
+```bash
+penguin --help
+penguin config --help
+penguin project --help
+penguin task --help
+```
+
+Add the narrowest useful direct-prompt or fake-provider recipe for the slice.
+
+### Layer 7: Live Smoke
+
+Opt-in only. Appropriate candidates:
+
+- one direct prompt through a configured provider
+- one interactive streamed turn
+- one model override when the slice changes provider/model startup
+
+Live checks supplement deterministic coverage and should record the exact
+model, provider, date, and result.
+
+### Layer 8: Fuzz And Fault Injection
+
+Candidates:
+
+- malformed configuration dictionaries
+- command argument combinations
+- terminal interruption timing
+- partial startup failures
+- event ordering and missing optional fields
+
+### Layer 9: Mutation
+
+Use only after extraction on small deterministic modules:
+
+- model override precedence
+- explicit/unset configuration decisions
+- command dispatch precedence
+- workspace selection and ambiguous identifier branches
+
+## Default Verification Commands
+
+Start targeted, then broaden:
+
+```bash
+uv run pytest -q tests/cli
+uv run pytest -q \
+  tests/test_cli_entrypoint_dispatcher.py \
+  tests/test_cli_integration.py \
+  tests/test_cli_surface_audit_regressions.py
+uv run pytest -q tests -m "not live and not e2e and not slow"
+```
+
+For startup or packaging slices, also run the applicable release-runbook smoke
+checks from `context/process/release-runbook.md`.
+
+## PR Discipline
+
+- one extraction slice per PR unless a shared characterization boundary already
+  proves the combined move
+- characterize first; do not move and redesign behavior simultaneously
+- preserve Typer decorators until command execution is safely behind services
+- avoid drive-by formatting of the 5,000-line file
+- do not add new business logic to `cli.py` during the campaign unless it is a
+  temporary compatibility shim with a deletion task
+- every PR records lines moved, lines deleted, tests added, and residual risks
+- commit unrelated user files neither accidentally nor “for convenience”
+
+## ACBRA Checklist
+
+For each slice:
+
+- [ ] Audit responsibilities, call sites, globals, and side effects.
+- [ ] Capture the current command/startup contract with characterization tests.
+- [ ] Write invariants and explicit non-goals for the slice.
+- [ ] Add unit tests for local decisions.
+- [ ] Add property tests where configuration/input combinations are broad.
+- [ ] Add state-machine tests where lifecycle or terminal state matters.
+- [ ] Add contract tests for public command and output behavior.
+- [ ] Refactor behind passing tests.
+- [ ] Run the normal CLI recipe through `uv run` or an installed artifact.
+- [ ] Run targeted and broader offline suites.
+- [ ] Add fault injection or mutation checks if the extracted boundary is
+      critical and deterministic.
+- [ ] Record residual risks and the next slice.
+
+## Definition Of Done
+
+Short term:
+
+- model startup/projection behavior is extracted and characterized
+- model overrides recompute capabilities from the target model
+- explicit reasoning effort and token-budget provenance survive startup
+- CLI correctness fixes stop depending on private `ModelConfig` flags
+
+Medium term:
+
+- startup/composition, environment normalization, command execution, dispatch,
+  and rendering have focused owners
+- command bodies are thin registration/delegation wrappers
+- interactive lifecycle behavior has replay and fault-injection coverage
+- CLI-focused coverage reports are available per extracted subsystem
+
+Long term:
+
+- `penguin/cli/cli.py` is small enough to audit as an entrypoint and
+  compatibility facade
+- adding or changing a command no longer requires navigating unrelated model,
+  streaming, and interactive-shell logic
+- the ergonomics plan can proceed on stable service boundaries rather than
+  adding more policy to the god file
+- future agents can apply the CLI ACBRA protocol as a repeatable campaign rather
+  than restarting decomposition from an archived plan
+
+## Follow-Up: CLI Ergonomics
+
+After the relevant structural boundaries are stable, resume
+`context/tasks/cli-interface-ergonomics-plan.md` for:
+
+- clearer command semantics and discoverability
+- improved project/workspace/root UX
+- higher-level project bootstrap workflows
+- command naming and default-policy cleanup
+- CLI/web/library workflow alignment
+
+Do not treat this ordering as a blanket blocker on user-facing fixes. Fix
+truthfulness and release blockers when they occur. The rule is narrower:
+**do not use ergonomics work as justification to add substantial new policy to
+`cli.py` while its responsibilities are being extracted.**
+
+## Open Questions
+
+- Should model/runtime startup extraction live under `penguin/cli/` or reuse a
+  provider-neutral factory under `penguin/core_runtime/`?
+- Should explicit configuration provenance become a public `ModelConfig`
+  construction contract instead of CLI-owned projection metadata?
+- Which legacy interactive `PenguinCLI` responsibilities still belong in the
+  Python CLI now that Penguin TUI is the primary interactive surface?
+- Which command groups should remain compatibility-only after the ergonomics
+  campaign?
+- What maximum size or dependency-count guard would prevent `cli.py` from
+  becoming a god file again without encouraging artificial module splitting?

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -424,6 +424,68 @@ def _ensure_config_compatible(config_data: Any) -> Any:
     return config_data
 
 
+def _project_reasoning_config(model_config: ModelConfig) -> dict[str, Any]:
+    """Project reasoning fields without converting implicit state to explicit off."""
+
+    reasoning_enabled_explicit = bool(
+        getattr(model_config, "_reasoning_enabled_explicit", False)
+    )
+    reasoning_effort_explicit = bool(
+        getattr(model_config, "_reasoning_effort_explicit", False)
+    )
+    return {
+        "reasoning_enabled": (
+            model_config.reasoning_enabled
+            if reasoning_enabled_explicit
+            else None
+        ),
+        "reasoning_effort": (
+            model_config.reasoning_effort if reasoning_effort_explicit else None
+        ),
+        "reasoning_max_tokens": (
+            model_config.reasoning_max_tokens
+            if reasoning_enabled_explicit
+            else None
+        ),
+        "reasoning_exclude": model_config.reasoning_exclude,
+        "supports_reasoning": model_config.supports_reasoning,
+        "supported_reasoning_levels": model_config.supported_reasoning_levels,
+    }
+
+
+def _resolve_cli_reasoning_config(model_dict: dict[str, Any]) -> dict[str, Any]:
+    """Resolve flat or nested CLI reasoning configuration without inventing values."""
+
+    nested = model_dict.get("reasoning")
+    reasoning = nested if isinstance(nested, dict) else {}
+    if "enabled" in reasoning:
+        reasoning_enabled: bool | None = bool(reasoning.get("enabled"))
+    elif "reasoning_enabled" in model_dict:
+        configured_enabled = model_dict.get("reasoning_enabled")
+        reasoning_enabled = (
+            None if configured_enabled is None else bool(configured_enabled)
+        )
+    else:
+        reasoning_enabled = None
+    reasoning_effort = reasoning.get(
+        "effort", model_dict.get("reasoning_effort")
+    )
+    return {
+        "reasoning_enabled": reasoning_enabled,
+        "reasoning_effort": reasoning_effort,
+        "reasoning_max_tokens": reasoning.get(
+            "max_tokens", model_dict.get("reasoning_max_tokens")
+        ),
+        "reasoning_exclude": bool(
+            reasoning.get("exclude", model_dict.get("reasoning_exclude", False))
+        ),
+        "supports_reasoning": model_dict.get("supports_reasoning"),
+        "supported_reasoning_levels": model_dict.get(
+            "supported_reasoning_levels"
+        ),
+    }
+
+
 async def _initialize_core_components_globally(
     model_override: Optional[str] = None,
     workspace_override: Optional[Path] = None,
@@ -496,6 +558,7 @@ async def _initialize_core_components_globally(
                 "vision_enabled": getattr(_model_cfg, "vision_enabled", False),
                 "max_output_tokens": getattr(_model_cfg, "max_output_tokens", None),
                 "context_window": getattr(_model_cfg, "max_context_window_tokens", None),
+                **_project_reasoning_config(_model_cfg),
             }
         else:
             model_dict = {}
@@ -531,6 +594,7 @@ async def _initialize_core_components_globally(
         model_dict = {}
         api_base = None
 
+    reasoning_config = _resolve_cli_reasoning_config(model_dict)
     _model_config = ModelConfig(
         model=model_override or model_dict.get("default", DEFAULT_MODEL),
         provider=model_dict.get("provider", DEFAULT_PROVIDER),
@@ -538,45 +602,22 @@ async def _initialize_core_components_globally(
         client_preference=model_dict.get("client_preference", "openrouter"),
         streaming_enabled=streaming_enabled,
         vision_enabled=model_dict.get("vision_enabled", False),
-        max_output_tokens=model_dict.get("max_output_tokens", model_dict.get("max_tokens", 8000)),
+        max_output_tokens=model_dict.get(
+            "max_output_tokens", model_dict.get("max_tokens", 8000)
+        ),
         max_context_window_tokens=model_dict.get(
             "max_context_window_tokens",
             model_dict.get("context_window"),
         ),
         temperature=model_dict.get("temperature", 0.7),
-        # Reasoning configuration (supports both legacy flat keys and nested `reasoning:` block)
-        reasoning_enabled=(
-            bool(
-                model_dict.get("reasoning", {}).get(
-                    "enabled", model_dict.get("reasoning_enabled", False)
-                )
-            )
-            if isinstance(model_dict.get("reasoning"), dict)
-            else bool(model_dict.get("reasoning_enabled", False))
-        ),
-        reasoning_effort=(
-            model_dict.get("reasoning", {}).get(
-                "effort", model_dict.get("reasoning_effort")
-            )
-            if isinstance(model_dict.get("reasoning"), dict)
-            else model_dict.get("reasoning_effort")
-        ),
-        reasoning_max_tokens=(
-            model_dict.get("reasoning", {}).get(
-                "max_tokens", model_dict.get("reasoning_max_tokens")
-            )
-            if isinstance(model_dict.get("reasoning"), dict)
-            else model_dict.get("reasoning_max_tokens")
-        ),
-        reasoning_exclude=(
-            bool(
-                model_dict.get("reasoning", {}).get(
-                    "exclude", model_dict.get("reasoning_exclude", False)
-                )
-            )
-            if isinstance(model_dict.get("reasoning"), dict)
-            else bool(model_dict.get("reasoning_exclude", False))
-        ),
+        reasoning_enabled=reasoning_config["reasoning_enabled"],
+        reasoning_effort=reasoning_config["reasoning_effort"],
+        reasoning_max_tokens=reasoning_config["reasoning_max_tokens"],
+        reasoning_exclude=reasoning_config["reasoning_exclude"],
+        supports_reasoning=reasoning_config["supports_reasoning"],
+        supported_reasoning_levels=reasoning_config[
+            "supported_reasoning_levels"
+        ],
         service_tier=model_dict.get("service_tier"),
     )
 

--- a/penguin/llm/adapters/anthropic.py
+++ b/penguin/llm/adapters/anthropic.py
@@ -24,6 +24,7 @@ from ..contracts import (
 )
 from ..model_config import ModelConfig
 from ..provider_transform import build_llm_error, normalize_finish_reason
+from ..reasoning_variants import anthropic_reasoning_efforts
 
 from penguin.constants import get_default_max_output_tokens
 
@@ -254,6 +255,7 @@ class AnthropicAdapter(BaseAdapter):
                 getattr(self.model_config, "reasoning_enabled", False)
                 or self.model_config.get_reasoning_config()
             ),
+            reasoning_efforts=anthropic_reasoning_efforts(self.model_config.model),
             vision=self.supports_vision(),
             max_context_tokens=getattr(
                 self.model_config,

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -2843,7 +2843,8 @@ class OpenAIAdapter(BaseAdapter):
             return reasoning_config
 
         prepared = dict(reasoning_config)
-        if prepared.get("effort") == "ultra":
+        effort = prepared.get("effort")
+        if isinstance(effort, str) and effort.strip().lower() == "ultra":
             prepared["effort"] = "max"
 
         if bool(getattr(self.model_config, "reasoning_exclude", False)):

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -44,6 +44,10 @@ from ..provider_transform import (
     normalize_openai_responses_tool_choice,
     normalize_openai_responses_tools,
 )
+from ..reasoning_variants import (
+    openai_reasoning_efforts,
+    reasoning_efforts_from_metadata,
+)
 from .base import BaseAdapter
 
 logger = logging.getLogger(__name__)
@@ -592,6 +596,12 @@ class OpenAIAdapter(BaseAdapter):
             reasoning=bool(
                 getattr(self.model_config, "reasoning_enabled", False)
                 or self.model_config.get_reasoning_config()
+            ),
+            reasoning_efforts=(
+                reasoning_efforts_from_metadata(
+                    getattr(self.model_config, "supported_reasoning_levels", None)
+                )
+                or openai_reasoning_efforts(self.model_config.model)
             ),
             vision=self.supports_vision(),
             resumable=True,

--- a/penguin/llm/adapters/openai.py
+++ b/penguin/llm/adapters/openai.py
@@ -588,6 +588,9 @@ class OpenAIAdapter(BaseAdapter):
     def get_capabilities(self) -> LLMProviderCapabilities:
         """Return OpenAI/Responses capability metadata."""
 
+        configured_reasoning_levels = getattr(
+            self.model_config, "supported_reasoning_levels", None
+        )
         return LLMProviderCapabilities(
             provider=self.provider,
             model=str(getattr(self.model_config, "model", "") or ""),
@@ -598,10 +601,9 @@ class OpenAIAdapter(BaseAdapter):
                 or self.model_config.get_reasoning_config()
             ),
             reasoning_efforts=(
-                reasoning_efforts_from_metadata(
-                    getattr(self.model_config, "supported_reasoning_levels", None)
-                )
-                or openai_reasoning_efforts(self.model_config.model)
+                reasoning_efforts_from_metadata(configured_reasoning_levels)
+                if configured_reasoning_levels is not None
+                else openai_reasoning_efforts(self.model_config.model)
             ),
             vision=self.supports_vision(),
             resumable=True,

--- a/penguin/llm/contracts.py
+++ b/penguin/llm/contracts.py
@@ -104,7 +104,7 @@ class LLMProviderCapabilities:
     prompt_cache: bool = False
     resumable: bool = False
     background: bool = False
-    reasoning_efforts: tuple[str, ...] = ()
+    reasoning_efforts: Optional[tuple[str, ...]] = None
     max_context_tokens: Optional[int] = None
     max_output_tokens: Optional[int] = None
     provider_data: Dict[str, Any] = field(default_factory=dict)
@@ -122,7 +122,11 @@ class LLMProviderCapabilities:
             "prompt_cache": self.prompt_cache,
             "resumable": self.resumable,
             "background": self.background,
-            "reasoning_efforts": list(self.reasoning_efforts),
+            "reasoning_efforts": (
+                list(self.reasoning_efforts)
+                if self.reasoning_efforts is not None
+                else None
+            ),
             "max_context_tokens": self.max_context_tokens,
             "max_output_tokens": self.max_output_tokens,
             "provider_data": dict(self.provider_data or {}),

--- a/penguin/llm/contracts.py
+++ b/penguin/llm/contracts.py
@@ -104,6 +104,7 @@ class LLMProviderCapabilities:
     prompt_cache: bool = False
     resumable: bool = False
     background: bool = False
+    reasoning_efforts: tuple[str, ...] = ()
     max_context_tokens: Optional[int] = None
     max_output_tokens: Optional[int] = None
     provider_data: Dict[str, Any] = field(default_factory=dict)
@@ -121,6 +122,7 @@ class LLMProviderCapabilities:
             "prompt_cache": self.prompt_cache,
             "resumable": self.resumable,
             "background": self.background,
+            "reasoning_efforts": list(self.reasoning_efforts),
             "max_context_tokens": self.max_context_tokens,
             "max_output_tokens": self.max_output_tokens,
             "provider_data": dict(self.provider_data or {}),

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -4,16 +4,15 @@ import logging
 import os
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
+from penguin.constants import get_default_max_history_tokens
 from penguin.llm.reasoning_variants import (
     reasoning_effort_from_metadata,
     reasoning_efforts_from_metadata,
 )
-
-from penguin.constants import get_default_max_history_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -78,17 +77,23 @@ class ModelConfig:
     service_tier: Optional[Literal["auto", "default", "flex", "priority"]] = None
 
     # Reasoning tokens support
-    reasoning_enabled: bool = False
+    reasoning_enabled: Optional[bool] = None
     reasoning_effort: Optional[str] = None
     reasoning_max_tokens: Optional[int] = None
     reasoning_exclude: bool = False
     supports_reasoning: Optional[bool] = None
     supported_reasoning_levels: Optional[list[str]] = None
+    _reasoning_enabled_explicit: bool = field(init=False, repr=False, default=False)
+    _reasoning_effort_explicit: bool = field(init=False, repr=False, default=False)
 
     # OpenRouter debug mode - echoes upstream request body (development only)
     debug_upstream: bool = False
 
     def __post_init__(self):
+        self._reasoning_enabled_explicit = self.reasoning_enabled is not None
+        self._reasoning_effort_explicit = self.reasoning_effort is not None
+        if self.reasoning_enabled is None:
+            self.reasoning_enabled = False
         self.service_tier = normalize_openai_service_tier(self.service_tier)
 
         if self.api_key is None and self.provider:
@@ -136,7 +141,11 @@ class ModelConfig:
             self.supports_reasoning = self._detect_reasoning_support()
 
         # Set default reasoning configuration for reasoning-capable models
-        if self.supports_reasoning and not self.reasoning_enabled:
+        if (
+            self.supports_reasoning
+            and not self.reasoning_enabled
+            and not self._reasoning_enabled_explicit
+        ):
             # Only auto-enable if user hasn't explicitly configured reasoning
             if (
                 self.reasoning_effort is None
@@ -318,7 +327,13 @@ class ModelConfig:
             default_model = os.getenv("PENGUIN_MODEL", "claude-3-5-sonnet-20240620")
 
         # Parse reasoning configuration from environment
-        reasoning_enabled = os.getenv("PENGUIN_REASONING_ENABLED", "").lower() == "true"
+        raw_reasoning_enabled = os.getenv("PENGUIN_REASONING_ENABLED")
+        reasoning_enabled = (
+            raw_reasoning_enabled.strip().lower() == "true"
+            if isinstance(raw_reasoning_enabled, str)
+            and raw_reasoning_enabled.strip()
+            else None
+        )
         raw_reasoning_effort = os.getenv("PENGUIN_REASONING_EFFORT")
         reasoning_effort = (
             raw_reasoning_effort.strip().lower()
@@ -481,8 +496,10 @@ class ModelConfig:
             reasoning_enabled = bool(model_specific.get("reasoning_enabled"))
         elif "enabled" in reasoning_config:
             reasoning_enabled = bool(reasoning_config.get("enabled"))
+        elif supported_reasoning_levels:
+            reasoning_enabled = True
         else:
-            reasoning_enabled = bool(supported_reasoning_levels)
+            reasoning_enabled = None
 
         # Build ModelConfig with model-specific settings
         return cls(

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -448,6 +448,41 @@ class ModelConfig:
             if supported_reasoning_levels
             else None
         )
+        if supported_reasoning_levels:
+            supported_reasoning_set = set(supported_reasoning_levels)
+            if (
+                configured_reasoning_effort
+                and configured_reasoning_effort not in supported_reasoning_set
+            ):
+                logger.warning(
+                    "Ignoring unsupported configured reasoning effort %r for model %s; "
+                    "supported=%s fallback=%r",
+                    configured_reasoning_effort,
+                    model_name,
+                    list(supported_reasoning_levels),
+                    fallback_reasoning_effort,
+                )
+                configured_reasoning_effort = None
+            if (
+                default_reasoning_effort
+                and default_reasoning_effort not in supported_reasoning_set
+            ):
+                logger.warning(
+                    "Ignoring unsupported default reasoning effort %r for model %s; "
+                    "supported=%s fallback=%r",
+                    default_reasoning_effort,
+                    model_name,
+                    list(supported_reasoning_levels),
+                    fallback_reasoning_effort,
+                )
+                default_reasoning_effort = None
+
+        if "reasoning_enabled" in model_specific:
+            reasoning_enabled = bool(model_specific.get("reasoning_enabled"))
+        elif "enabled" in reasoning_config:
+            reasoning_enabled = bool(reasoning_config.get("enabled"))
+        else:
+            reasoning_enabled = bool(supported_reasoning_levels)
 
         # Build ModelConfig with model-specific settings
         return cls(
@@ -495,11 +530,7 @@ class ModelConfig:
                 if os.getenv("PENGUIN_MAX_HISTORY_TOKENS")
                 else None
             ),
-            reasoning_enabled=bool(
-                model_specific.get("reasoning_enabled")
-                or reasoning_config.get("enabled", False)
-                or supported_reasoning_levels
-            ),
+            reasoning_enabled=reasoning_enabled,
             reasoning_effort=(
                 configured_reasoning_effort
                 or default_reasoning_effort

--- a/penguin/llm/reasoning_variants.py
+++ b/penguin/llm/reasoning_variants.py
@@ -12,7 +12,8 @@ from typing import Any
 _WIDELY_SUPPORTED_EFFORTS = ("low", "medium", "high")
 _OPENAI_GPT51_EFFORTS = ("none", "low", "medium", "high")
 _OPENAI_FULL_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh")
-_OPENAI_GPT56_PLUS_EFFORTS = _OPENAI_FULL_EFFORTS + ("max",)
+_OPENAI_GPT56_EFFORTS = ("none", "low", "medium", "high", "xhigh", "max")
+_OPENAI_FUTURE_EFFORTS = (*_OPENAI_FULL_EFFORTS, "max")
 _ANTHROPIC_STANDARD_EFFORTS = ("low", "medium", "high")
 _ANTHROPIC_MAX_EFFORTS = ("low", "medium", "high", "max")
 
@@ -59,11 +60,13 @@ def openai_reasoning_efforts(model_id: str) -> tuple[str, ...]:
     if re.search(r"gpt-5(?:-[0-9]+)?-pro", key):
         return ("high",)
 
-    if re.search(r"gpt-5-(?:[6-9]|[1-9][0-9])", key) or re.search(
-        r"gpt-[6-9](?:-|$)",
-        key,
+    if re.search(r"gpt-5-6(?:-|$)", key):
+        return _OPENAI_GPT56_EFFORTS
+
+    if re.search(r"gpt-5-(?:[7-9]|[1-9][0-9])", key) or re.search(
+        r"gpt-[6-9](?:-|$)", key
     ):
-        return _OPENAI_GPT56_PLUS_EFFORTS
+        return _OPENAI_FUTURE_EFFORTS
 
     if re.search(r"gpt-5-(?:[2-9]|[1-9][0-9])", key):
         return _OPENAI_FULL_EFFORTS

--- a/penguin/llm/reasoning_variants.py
+++ b/penguin/llm/reasoning_variants.py
@@ -65,10 +65,7 @@ def openai_reasoning_efforts(model_id: str) -> tuple[str, ...]:
     ):
         return _OPENAI_GPT56_PLUS_EFFORTS
 
-    if re.search(r"gpt-5-(?:[2-9]|[1-9][0-9])", key) or re.search(
-        r"gpt-[6-9](?:-|$)",
-        key,
-    ):
+    if re.search(r"gpt-5-(?:[2-9]|[1-9][0-9])", key):
         return _OPENAI_FULL_EFFORTS
 
     if "gpt-5-1" in key:

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -53,6 +53,41 @@ _REASONING_EFFORT_VARIANTS = {
     "ultra",
 }
 _REASONING_MAX_VARIANTS = {"max"}
+
+
+class UnsupportedReasoningVariantError(ValueError):
+    """Raised when a requested reasoning variant is unsupported by a model."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        model: str,
+        variant: str,
+        supported: tuple[str, ...],
+    ) -> None:
+        self.provider = provider
+        self.model = model
+        self.variant = variant
+        self.supported = supported
+        super().__init__(
+            f"Reasoning variant '{variant}' is not supported by "
+            f"{provider or 'provider'}/{model or 'model'}"
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a client-safe structured error payload."""
+
+        return {
+            "code": "unsupported_reasoning_variant",
+            "message": str(self),
+            "provider": self.provider or None,
+            "model": self.model or None,
+            "variant": self.variant,
+            "supported": list(self.supported),
+        }
+
+
 _REASONING_DISABLE_VARIANTS = {"off"}
 _NATIVE_RESPONSE_COMPLETION_TOOLS = {"finish_response"}
 logger = logging.getLogger(__name__)
@@ -1187,7 +1222,10 @@ def build_reasoning_fallback_note(
 
 
 def apply_reasoning_variant_override(
-    model_config: Any, variant: Optional[str]
+    model_config: Any,
+    variant: Optional[str],
+    *,
+    supported_efforts: Any = None,
 ) -> Optional[Dict[str, Any]]:
     """Apply a temporary reasoning variant override to a model config."""
 
@@ -1217,23 +1255,23 @@ def apply_reasoning_variant_override(
     provider_id = str(getattr(model_config, "provider", "") or "").strip().lower()
     model_id = str(getattr(model_config, "model", "") or "").strip()
 
-    if provider_id in {"openai", "anthropic"}:
-        if provider_id == "anthropic" and value not in {
-            "low",
-            "medium",
-            "high",
-            "max",
-        }:
-            return None
-
-        metadata_variants = reasoning_efforts_from_metadata(
-            getattr(model_config, "supported_reasoning_levels", None)
-        )
-        supported_native_variants = set(
-            metadata_variants or native_reasoning_efforts(provider_id, model_id)
-        )
+    metadata_variants = reasoning_efforts_from_metadata(
+        getattr(model_config, "supported_reasoning_levels", None)
+    )
+    capability_variants = reasoning_efforts_from_metadata(supported_efforts)
+    supported_native_variants = tuple(
+        capability_variants
+        or metadata_variants
+        or native_reasoning_efforts(provider_id, model_id)
+    )
+    if supported_native_variants:
         if value not in supported_native_variants:
-            return None
+            raise UnsupportedReasoningVariantError(
+                provider=provider_id,
+                model=model_id,
+                variant=value,
+                supported=supported_native_variants,
+            )
 
         model_config.reasoning_enabled = True
         model_config.reasoning_effort = value

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -1255,16 +1255,21 @@ def apply_reasoning_variant_override(
     provider_id = str(getattr(model_config, "provider", "") or "").strip().lower()
     model_id = str(getattr(model_config, "model", "") or "").strip()
 
-    metadata_variants = reasoning_efforts_from_metadata(
-        getattr(model_config, "supported_reasoning_levels", None)
+    raw_metadata_variants = getattr(
+        model_config, "supported_reasoning_levels", None
     )
+    metadata_variants = reasoning_efforts_from_metadata(raw_metadata_variants)
     capability_variants = reasoning_efforts_from_metadata(supported_efforts)
-    supported_native_variants = tuple(
-        capability_variants
-        or metadata_variants
-        or native_reasoning_efforts(provider_id, model_id)
-    )
-    if supported_native_variants:
+    capability_declared = supported_efforts is not None
+    metadata_declared = raw_metadata_variants is not None
+    if capability_declared:
+        supported_native_variants = capability_variants
+    elif metadata_declared:
+        supported_native_variants = metadata_variants
+    else:
+        supported_native_variants = native_reasoning_efforts(provider_id, model_id)
+
+    if capability_declared or metadata_declared or supported_native_variants:
         if value not in supported_native_variants:
             raise UnsupportedReasoningVariantError(
                 provider=provider_id,

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -1218,6 +1218,14 @@ def apply_reasoning_variant_override(
     model_id = str(getattr(model_config, "model", "") or "").strip()
 
     if provider_id in {"openai", "anthropic"}:
+        if provider_id == "anthropic" and value not in {
+            "low",
+            "medium",
+            "high",
+            "max",
+        }:
+            return None
+
         metadata_variants = reasoning_efforts_from_metadata(
             getattr(model_config, "supported_reasoning_levels", None)
         )

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -39,6 +39,7 @@ from penguin.config import WORKSPACE_PATH
 from penguin.core import PenguinCore
 from penguin.llm.model_config import normalize_openai_service_tier
 from penguin.llm.runtime import (
+    UnsupportedReasoningVariantError,
     apply_reasoning_variant_override as apply_llm_reasoning_variant_override,
     build_reasoning_debug_snapshot as build_llm_reasoning_debug_snapshot,
     build_reasoning_visibility_note as build_llm_reasoning_visibility_note,
@@ -124,6 +125,7 @@ from penguin.web.services.opencode_provider import (
     remove_provider_auth_record,
     set_provider_auth_record,
 )
+from penguin.web.services.provider_catalog import codex_oauth_cached_provider_models
 from penguin.web.services.mcp import (
     close_mcp as close_mcp_service,
     get_mcp_status as get_mcp_status_service,
@@ -1042,10 +1044,17 @@ def _apply_reasoning_variant_override(
     variant: Optional[str],
     *,
     model_config: Optional[Any] = None,
+    api_client: Optional[Any] = None,
 ) -> Optional[Dict[str, Any]]:
+    supported_efforts: Any = None
+    capabilities_getter = getattr(api_client, "get_provider_capabilities", None)
+    if callable(capabilities_getter):
+        capabilities = capabilities_getter()
+        supported_efforts = getattr(capabilities, "reasoning_efforts", None)
     return apply_llm_reasoning_variant_override(
         model_config or getattr(core, "model_config", None),
         variant,
+        supported_efforts=supported_efforts,
     )
 
 
@@ -1148,10 +1157,14 @@ async def _resolve_request_runtime_for_model(
     requested = requested_model.strip() if isinstance(requested_model, str) else ""
     resolver = getattr(core, "resolve_request_runtime", None)
     if callable(resolver):
-        return await resolver(requested or None)
+        model_config, api_client = await resolver(requested or None)
+        _apply_cached_provider_model_metadata(model_config)
+        return model_config, api_client
 
     if not requested:
-        return getattr(core, "model_config", None), None
+        model_config = getattr(core, "model_config", None)
+        _apply_cached_provider_model_metadata(model_config)
+        return model_config, None
 
     current_model = (
         core.get_current_model() if hasattr(core, "get_current_model") else None
@@ -1170,7 +1183,9 @@ async def _resolve_request_runtime_for_model(
     )
 
     if requested in {current_raw, current_qualified}:
-        return getattr(core, "model_config", None), None
+        model_config = getattr(core, "model_config", None)
+        _apply_cached_provider_model_metadata(model_config)
+        return model_config, None
 
     candidates: list[str] = [requested]
     if "/" in requested:
@@ -1193,7 +1208,9 @@ async def _resolve_request_runtime_for_model(
     for candidate in candidates:
         loaded = await loader(candidate)
         if loaded:
-            return getattr(core, "model_config", None), None
+            model_config = getattr(core, "model_config", None)
+            _apply_cached_provider_model_metadata(model_config)
+            return model_config, None
         reason = getattr(core, "_last_model_load_error", None)
         if isinstance(reason, str) and reason.strip():
             last_reason = reason.strip()
@@ -1209,6 +1226,38 @@ async def _resolve_request_runtime_for_model(
     if last_reason:
         detail = f"{detail}: {last_reason}"
     raise ValueError(detail)
+
+
+def _apply_cached_provider_model_metadata(model_config: Any) -> None:
+    """Apply cached OAuth catalog metadata to a request-scoped model config."""
+
+    if model_config is None:
+        return
+    provider_id = str(getattr(model_config, "provider", "") or "").strip().lower()
+    if provider_id != "openai":
+        return
+    model_id = str(getattr(model_config, "model", "") or "").strip()
+    if model_id.startswith("openai/"):
+        model_id = model_id.split("/", 1)[1]
+    auth_record = get_provider_auth_records().get("openai")
+    metadata = (
+        codex_oauth_cached_provider_models(auth_record)
+        .get("openai", {})
+        .get(model_id)
+    )
+    if not isinstance(metadata, dict):
+        return
+    levels = metadata.get("supported_reasoning_levels")
+    if isinstance(levels, (list, tuple)):
+        model_config.supported_reasoning_levels = list(levels)
+        model_config.supports_reasoning = bool(levels)
+        default_effort = metadata.get("default_reasoning_level")
+        if (
+            bool(getattr(model_config, "reasoning_enabled", False))
+            and isinstance(default_effort, str)
+            and default_effort in levels
+        ):
+            model_config.reasoning_effort = default_effort
 
 
 def _resolve_context_file_path(
@@ -4136,11 +4185,15 @@ async def handle_chat_message(
 
             stream_cb = _rest_stream_cb
 
-        reasoning_variant_snapshot = _apply_reasoning_variant_override(
-            core,
-            request.variant,
-            model_config=request_model_config,
-        )
+        try:
+            reasoning_variant_snapshot = _apply_reasoning_variant_override(
+                core,
+                request.variant,
+                model_config=request_model_config,
+                api_client=request_api_client,
+            )
+        except UnsupportedReasoningVariantError as exc:
+            raise HTTPException(status_code=400, detail=exc.to_dict()) from exc
         await _persist_session_model_selection(
             core,
             request_session_id,
@@ -4697,6 +4750,7 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                     core,
                     variant if isinstance(variant, str) else None,
                     model_config=request_model_config,
+                    api_client=request_api_client,
                 )
                 await _persist_session_model_selection(
                     core,
@@ -4865,6 +4919,11 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                         f"Client disconnected before complete event could be sent: {e}"
                     )
 
+            except UnsupportedReasoningVariantError as process_err:
+                await websocket.send_json(
+                    {"event": "error", "data": process_err.to_dict()}
+                )
+                continue
             except WebSocketDisconnect as disconnect_err:
                 # Client disconnected during processing - this is normal
                 logger.info(

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -125,7 +125,7 @@ from penguin.web.services.opencode_provider import (
     remove_provider_auth_record,
     set_provider_auth_record,
 )
-from penguin.web.services.provider_catalog import codex_oauth_cached_provider_models
+from penguin.web.services.provider_catalog import apply_cached_codex_model_metadata
 from penguin.web.services.mcp import (
     close_mcp as close_mcp_service,
     get_mcp_status as get_mcp_status_service,
@@ -1158,12 +1158,12 @@ async def _resolve_request_runtime_for_model(
     resolver = getattr(core, "resolve_request_runtime", None)
     if callable(resolver):
         model_config, api_client = await resolver(requested or None)
-        _apply_cached_provider_model_metadata(model_config)
+        apply_cached_codex_model_metadata(model_config)
         return model_config, api_client
 
     if not requested:
         model_config = getattr(core, "model_config", None)
-        _apply_cached_provider_model_metadata(model_config)
+        apply_cached_codex_model_metadata(model_config)
         return model_config, None
 
     current_model = (
@@ -1184,7 +1184,7 @@ async def _resolve_request_runtime_for_model(
 
     if requested in {current_raw, current_qualified}:
         model_config = getattr(core, "model_config", None)
-        _apply_cached_provider_model_metadata(model_config)
+        apply_cached_codex_model_metadata(model_config)
         return model_config, None
 
     candidates: list[str] = [requested]
@@ -1209,7 +1209,7 @@ async def _resolve_request_runtime_for_model(
         loaded = await loader(candidate)
         if loaded:
             model_config = getattr(core, "model_config", None)
-            _apply_cached_provider_model_metadata(model_config)
+            apply_cached_codex_model_metadata(model_config)
             return model_config, None
         reason = getattr(core, "_last_model_load_error", None)
         if isinstance(reason, str) and reason.strip():
@@ -1226,38 +1226,6 @@ async def _resolve_request_runtime_for_model(
     if last_reason:
         detail = f"{detail}: {last_reason}"
     raise ValueError(detail)
-
-
-def _apply_cached_provider_model_metadata(model_config: Any) -> None:
-    """Apply cached OAuth catalog metadata to a request-scoped model config."""
-
-    if model_config is None:
-        return
-    provider_id = str(getattr(model_config, "provider", "") or "").strip().lower()
-    if provider_id != "openai":
-        return
-    model_id = str(getattr(model_config, "model", "") or "").strip()
-    if model_id.startswith("openai/"):
-        model_id = model_id.split("/", 1)[1]
-    auth_record = get_provider_auth_records().get("openai")
-    metadata = (
-        codex_oauth_cached_provider_models(auth_record)
-        .get("openai", {})
-        .get(model_id)
-    )
-    if not isinstance(metadata, dict):
-        return
-    levels = metadata.get("supported_reasoning_levels")
-    if isinstance(levels, (list, tuple)):
-        model_config.supported_reasoning_levels = list(levels)
-        model_config.supports_reasoning = bool(levels)
-        default_effort = metadata.get("default_reasoning_level")
-        if (
-            bool(getattr(model_config, "reasoning_enabled", False))
-            and isinstance(default_effort, str)
-            and default_effort in levels
-        ):
-            model_config.reasoning_effort = default_effort
 
 
 def _resolve_context_file_path(

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import httpx
 
+from penguin.web.services.provider_credentials import get_provider_credentials
 from penguin.web.services.reasoning_variants import (
     reasoning_effort_from_metadata,
     reasoning_efforts_from_metadata,
@@ -284,7 +285,9 @@ def _openai_codex_cache_key(credential_record: dict[str, Any] | None) -> str | N
 
     account_id = credential_record.get("accountId")
     account_key = account_id.strip() if isinstance(account_id, str) else ""
-    return f"{access[-12:]}:{account_key}"
+    if account_key:
+        return f"account:{account_key}"
+    return f"token:{access[-12:]}"
 
 
 def codex_oauth_cached_provider_models(
@@ -307,6 +310,83 @@ def codex_oauth_cached_provider_models(
         }
 
     return {"openai": models} if models else {}
+
+
+def apply_cached_codex_model_metadata(model_config: Any) -> None:
+    """Hydrate an OpenAI model config from cached Codex OAuth metadata."""
+
+    if model_config is None:
+        return
+    provider_id = str(getattr(model_config, "provider", "") or "").strip().lower()
+    if provider_id != "openai":
+        return
+    model_id = str(getattr(model_config, "model", "") or "").strip()
+    if model_id.startswith("openai/"):
+        model_id = model_id.split("/", 1)[1]
+    auth_record = get_provider_credentials().get("openai")
+    metadata = (
+        codex_oauth_cached_provider_models(auth_record)
+        .get("openai", {})
+        .get(model_id)
+    )
+    if not isinstance(metadata, dict):
+        return
+
+    raw_levels = metadata.get("supported_reasoning_levels")
+    if not isinstance(raw_levels, (list, tuple)):
+        return
+    levels = reasoning_efforts_from_metadata(raw_levels)
+    model_config.supported_reasoning_levels = list(levels)
+    model_config.supports_reasoning = bool(levels)
+    if not levels:
+        return
+    reasoning_enabled_explicit = _model_config_field_was_explicit(
+        model_config,
+        "reasoning_enabled",
+        "_reasoning_enabled_explicit",
+    )
+    if reasoning_enabled_explicit and not bool(
+        getattr(model_config, "reasoning_enabled", False)
+    ):
+        return
+
+    current_effort = reasoning_effort_from_metadata(
+        getattr(model_config, "reasoning_effort", None)
+    )
+    if (
+        _model_config_field_was_explicit(
+            model_config,
+            "reasoning_effort",
+            "_reasoning_effort_explicit",
+        )
+        and current_effort in levels
+    ):
+        return
+    default_effort = reasoning_effort_from_metadata(
+        metadata.get("default_reasoning_level")
+    )
+    if (
+        bool(getattr(model_config, "reasoning_enabled", False))
+        and default_effort in levels
+    ):
+        model_config.reasoning_effort = default_effort
+
+
+def _model_config_field_was_explicit(
+    model_config: Any,
+    field_name: str,
+    marker_name: str,
+) -> bool:
+    """Return whether a reasoning field was explicitly configured."""
+
+    marker = getattr(model_config, marker_name, None)
+    if marker is not None:
+        return bool(marker)
+    try:
+        values = vars(model_config)
+    except TypeError:
+        values = {}
+    return field_name in values
 
 
 def codex_oauth_provider_models(

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -6,6 +6,7 @@ payload shapes. They derive provider/model data from Penguin runtime state.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from threading import RLock
@@ -18,6 +19,8 @@ from penguin.web.services.reasoning_variants import (
     reasoning_effort_from_metadata,
     reasoning_efforts_from_metadata,
 )
+
+logger = logging.getLogger(__name__)
 
 _PROVIDER_METADATA: dict[str, dict[str, Any]] = {
     "openai": {
@@ -365,11 +368,23 @@ def apply_cached_codex_model_metadata(model_config: Any) -> None:
     default_effort = reasoning_effort_from_metadata(
         metadata.get("default_reasoning_level")
     )
-    if (
-        bool(getattr(model_config, "reasoning_enabled", False))
-        and default_effort in levels
-    ):
+    if not bool(getattr(model_config, "reasoning_enabled", False)):
+        return
+    if default_effort in levels:
         model_config.reasoning_effort = default_effort
+        return
+
+    fallback_effort = levels[(len(levels) - 1) // 2]
+    if current_effort not in levels:
+        logger.warning(
+            "Replacing unsupported reasoning effort %r for model %s with %r; "
+            "supported=%s",
+            current_effort,
+            model_id,
+            fallback_effort,
+            list(levels),
+        )
+        model_config.reasoning_effort = fallback_effort
 
 
 def _model_config_field_was_explicit(

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -271,9 +271,6 @@ def _openai_codex_model_input_modalities(raw_value: Any) -> list[str]:
     ]
 
 
-def _openai_codex_model_reasoning_enabled(raw_value: Any) -> bool:
-    return bool(reasoning_efforts_from_metadata(raw_value))
-
 # TODO: Look into this later, could be an issue.
 def _openai_codex_cache_key(credential_record: dict[str, Any] | None) -> str | None:
     if not isinstance(credential_record, dict):
@@ -391,9 +388,7 @@ def codex_oauth_provider_models(
         supported_reasoning_levels = reasoning_efforts_from_metadata(
             item.get("supported_reasoning_levels")
         )
-        reasoning_enabled = _openai_codex_model_reasoning_enabled(
-            supported_reasoning_levels
-        )
+        reasoning_enabled = bool(supported_reasoning_levels)
         default_reasoning_level = reasoning_effort_from_metadata(
             item.get("default_reasoning_level")
         )

--- a/tests/api/test_concurrent_session_isolation.py
+++ b/tests/api/test_concurrent_session_isolation.py
@@ -9,13 +9,18 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from fastapi import HTTPException
+from starlette.websockets import WebSocketDisconnect
 
-from penguin.system.execution_context import ExecutionContext, execution_context_scope
-from penguin.system.execution_context import get_current_execution_context
 from penguin.llm.model_config import ModelConfig
 from penguin.llm.openrouter_gateway import OpenRouterGateway
+from penguin.system.execution_context import (
+    ExecutionContext,
+    execution_context_scope,
+    get_current_execution_context,
+)
 from penguin.tools.tool_manager import ToolManager
-from penguin.web.routes import MessageRequest, handle_chat_message
+from penguin.web.routes import MessageRequest, handle_chat_message, stream_chat
 
 
 def _dummy_log_error(exc: Exception, context: str = "") -> None:
@@ -375,6 +380,158 @@ async def test_rest_chat_variant_emits_outbound_reasoning_payload(
     assert core.model_config.reasoning_effort is None
     assert core.model_config.reasoning_max_tokens is None
     assert core.model_config.supports_reasoning is False
+
+
+@pytest.mark.asyncio
+async def test_rest_chat_rejects_variant_before_session_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsupported reasoning variant returns 400 before persistence or execution."""
+
+    repo = tmp_path / "chat_repo_variant_rejection"
+    repo.mkdir()
+    persisted: list[tuple[Any, ...]] = []
+
+    class _Core:
+        def __init__(self) -> None:
+            self.runtime_config = SimpleNamespace(
+                workspace_root=str(tmp_path),
+                project_root=str(tmp_path),
+                active_root=str(tmp_path),
+            )
+            self._opencode_session_directories: dict[str, str] = {}
+            self.model_config = ModelConfig(
+                model="claude-sonnet-4-6",
+                provider="anthropic",
+                client_preference="native",
+                reasoning_enabled=False,
+            )
+
+        async def resolve_request_runtime(self, _model_id: str | None):
+            api_client = SimpleNamespace(
+                get_provider_capabilities=lambda: SimpleNamespace(
+                    reasoning_efforts=("low", "medium", "high")
+                )
+            )
+            return self.model_config, api_client
+
+        async def process(self, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError(f"process should not run: {kwargs}")
+
+    async def _fake_persist(*args: Any, **kwargs: Any) -> None:
+        persisted.append((*args, kwargs))
+
+    monkeypatch.setattr(
+        "penguin.web.routes._persist_session_model_selection",
+        _fake_persist,
+    )
+    request = MessageRequest(
+        text="ping",
+        session_id="session_variant_rejection",
+        directory=str(repo),
+        streaming=False,
+    )
+    setattr(request, "variant", "ultra")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handle_chat_message(request, core=cast(Any, _Core()))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["code"] == "unsupported_reasoning_variant"
+    assert persisted == []
+
+
+@pytest.mark.asyncio
+async def test_websocket_chat_rejects_variant_before_session_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """WebSocket variant errors are structured and skip persistence and execution."""
+
+    persisted: list[tuple[Any, ...]] = []
+
+    class _WebSocket:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+            self.client_state = SimpleNamespace(name="CONNECTED")
+            self._received = False
+
+        async def accept(self) -> None:
+            return None
+
+        async def receive_json(self) -> dict[str, Any]:
+            if self._received:
+                raise WebSocketDisconnect()
+            self._received = True
+            return {"text": "ping", "variant": "ultra"}
+
+        async def send_json(self, payload: dict[str, Any]) -> None:
+            self.events.append(payload)
+
+    class _EventBus:
+        def subscribe(self, *_args: Any) -> None:
+            return None
+
+        def unsubscribe(self, *_args: Any) -> None:
+            return None
+
+    class _Core:
+        def __init__(self) -> None:
+            self.runtime_config = SimpleNamespace(
+                workspace_root=str(tmp_path),
+                project_root=str(tmp_path),
+                active_root=str(tmp_path),
+            )
+            self._opencode_session_directories: dict[str, str] = {}
+            self.model_config = ModelConfig(
+                model="claude-sonnet-4-6",
+                provider="anthropic",
+                client_preference="native",
+                reasoning_enabled=False,
+            )
+
+        async def resolve_request_runtime(self, _model_id: str | None):
+            api_client = SimpleNamespace(
+                get_provider_capabilities=lambda: SimpleNamespace(
+                    reasoning_efforts=("low", "medium", "high")
+                )
+            )
+            return self.model_config, api_client
+
+        async def process(self, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError(f"process should not run: {kwargs}")
+
+    async def _noop_async(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _fake_persist(*args: Any, **kwargs: Any) -> None:
+        persisted.append((*args, kwargs))
+
+    monkeypatch.setattr("penguin.web.routes.require_websocket_auth", _noop_async)
+    monkeypatch.setattr(
+        "penguin.web.routes._setup_approval_websocket_callbacks", lambda: None
+    )
+    monkeypatch.setattr(
+        "penguin.web.routes._setup_question_event_callbacks", lambda: None
+    )
+    monkeypatch.setattr(
+        "penguin.web.routes._persist_session_agent_mode", _noop_async
+    )
+    monkeypatch.setattr(
+        "penguin.web.routes._persist_session_model_selection", _fake_persist
+    )
+    monkeypatch.setattr(
+        "penguin.web.routes.CLIEventBus.get_sync", lambda: _EventBus()
+    )
+    websocket = _WebSocket()
+
+    await stream_chat(cast(Any, websocket), core=cast(Any, _Core()))
+
+    assert websocket.events[0] == {"event": "start", "data": {}}
+    assert websocket.events[1]["event"] == "error"
+    assert websocket.events[1]["data"]["code"] == "unsupported_reasoning_variant"
+    assert persisted == []
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_reasoning_variant_overrides.py
+++ b/tests/api/test_reasoning_variant_overrides.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -10,10 +11,11 @@ from penguin.llm.adapters.openai import OpenAIAdapter
 from penguin.llm.model_config import ModelConfig
 from penguin.llm.runtime import UnsupportedReasoningVariantError
 from penguin.web.routes import (
-    _apply_cached_provider_model_metadata,
     _apply_reasoning_variant_override,
     _restore_reasoning_variant_override,
 )
+from penguin.web.services import provider_catalog
+from penguin.web.services.provider_catalog import apply_cached_codex_model_metadata
 
 
 def _core_with_model_config(
@@ -129,6 +131,128 @@ def test_anthropic_metadata_variant_rejects_ultra() -> None:
     assert core.model_config.reasoning_effort is None
 
 
+def test_authoritative_empty_capabilities_reject_reasoning_variants() -> None:
+    """An explicitly empty adapter capability prevents heuristic fallback."""
+
+    core = _core_with_model_config("anthropic", "claude-3-7-sonnet")
+    api_client = SimpleNamespace(
+        get_provider_capabilities=lambda: SimpleNamespace(reasoning_efforts=())
+    )
+
+    with pytest.raises(UnsupportedReasoningVariantError):
+        _apply_reasoning_variant_override(core, "ultra", api_client=api_client)
+
+    assert core.model_config.reasoning_enabled is False
+    assert core.model_config.reasoning_effort is None
+
+
+def test_codex_catalog_cache_survives_oauth_token_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable account identity preserves cached metadata across token refresh."""
+
+    initial = {
+        "type": "oauth",
+        "access": "old-token-aaaaaaaaaaaa",
+        "accountId": "account-stable",
+    }
+    monkeypatch.setitem(
+        provider_catalog._OPENAI_CODEX_MODELS_CACHE,
+        "fetched_at",
+        time.time(),
+    )
+    monkeypatch.setitem(
+        provider_catalog._OPENAI_CODEX_MODELS_CACHE,
+        "cache_key",
+        provider_catalog._openai_codex_cache_key(initial),
+    )
+    monkeypatch.setitem(
+        provider_catalog._OPENAI_CODEX_MODELS_CACHE,
+        "models",
+        {"gpt-5.6-sol": {"reasoning_enabled": True}},
+    )
+    rotated = dict(initial, access="new-token-bbbbbbbbbbbb")
+
+    cached = provider_catalog.codex_oauth_cached_provider_models(rotated)
+
+    assert "gpt-5.6-sol" in cached["openai"]
+
+
+def test_cached_metadata_preserves_explicit_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog hydration does not re-enable explicitly disabled reasoning."""
+
+    _patch_cached_codex_metadata(monkeypatch)
+    model_config = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=False,
+    )
+
+    apply_cached_codex_model_metadata(model_config)
+
+    assert model_config.reasoning_enabled is False
+    assert model_config.reasoning_effort is None
+    assert model_config.get_reasoning_config() is None
+
+
+def test_cached_metadata_preserves_supported_explicit_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catalog defaults do not replace an explicit supported effort."""
+
+    _patch_cached_codex_metadata(monkeypatch)
+    model_config = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=True,
+        reasoning_effort="high",
+    )
+
+    apply_cached_codex_model_metadata(model_config)
+
+    assert model_config.reasoning_effort == "high"
+    assert model_config.get_reasoning_config() == {"effort": "high"}
+
+
+def _patch_cached_codex_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install deterministic Codex metadata for hydration tests."""
+
+    oauth_record = {
+        "type": "oauth",
+        "access": "oauth-test-token",
+        "accountId": "account-test",
+    }
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider_credentials",
+        lambda: {"openai": oauth_record},
+    )
+    monkeypatch.setattr(
+        provider_catalog,
+        "codex_oauth_cached_provider_models",
+        lambda _record: {
+            "openai": {
+                "gpt-5.6-sol": {
+                    "supported_reasoning_levels": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max",
+                        "ultra",
+                    ],
+                    "default_reasoning_level": "low",
+                }
+            }
+        },
+    )
+
+
 @pytest.mark.asyncio
 async def test_cached_codex_ultra_reaches_openai_safe_prepared_request(
     monkeypatch: pytest.MonkeyPatch,
@@ -141,11 +265,11 @@ async def test_cached_codex_ultra_reaches_openai_safe_prepared_request(
         "accountId": "account-test",
     }
     monkeypatch.setattr(
-        "penguin.web.routes.get_provider_auth_records",
+        "penguin.web.services.provider_catalog.get_provider_credentials",
         lambda: {"openai": oauth_record},
     )
     monkeypatch.setattr(
-        "penguin.web.routes.codex_oauth_cached_provider_models",
+        "penguin.web.services.provider_catalog.codex_oauth_cached_provider_models",
         lambda _record: {
             "openai": {
                 "gpt-5.6-sol": {
@@ -177,7 +301,7 @@ async def test_cached_codex_ultra_reaches_openai_safe_prepared_request(
     api_client = SimpleNamespace(get_provider_capabilities=adapter.get_capabilities)
     core = SimpleNamespace(model_config=model_config)
 
-    _apply_cached_provider_model_metadata(model_config)
+    apply_cached_codex_model_metadata(model_config)
     snapshot = _apply_reasoning_variant_override(
         core,
         "ultra",

--- a/tests/api/test_reasoning_variant_overrides.py
+++ b/tests/api/test_reasoning_variant_overrides.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
+from penguin.llm.adapters.openai import OpenAIAdapter
+from penguin.llm.model_config import ModelConfig
+from penguin.llm.runtime import UnsupportedReasoningVariantError
 from penguin.web.routes import (
+    _apply_cached_provider_model_metadata,
     _apply_reasoning_variant_override,
     _restore_reasoning_variant_override,
 )
@@ -29,17 +35,21 @@ def _core_with_model_config(
 
 
 def test_openai_native_variant_rejects_unsupported_effort() -> None:
+    """Unsupported native OpenAI efforts raise a structured error."""
+
     core = _core_with_model_config("openai", "gpt-5.1")
 
-    snapshot = _apply_reasoning_variant_override(core, "xhigh")
+    with pytest.raises(UnsupportedReasoningVariantError):
+        _apply_reasoning_variant_override(core, "xhigh")
 
-    assert snapshot is None
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
     assert core.model_config.reasoning_max_tokens is None
 
 
 def test_openai_metadata_variant_allows_ultra_when_advertised() -> None:
+    """Advertised Codex Ultra metadata enables an Ultra request override."""
+
     core = _core_with_model_config(
         "openai",
         "gpt-5.6-sol",
@@ -55,15 +65,17 @@ def test_openai_metadata_variant_allows_ultra_when_advertised() -> None:
 
 
 def test_openai_metadata_variant_rejects_ultra_when_not_advertised() -> None:
+    """Unadvertised Ultra variants raise a structured validation error."""
+
     core = _core_with_model_config(
         "openai",
         "gpt-5.6-luna",
         ["low", "medium", "high", "max"],
     )
 
-    snapshot = _apply_reasoning_variant_override(core, "ultra")
+    with pytest.raises(UnsupportedReasoningVariantError):
+        _apply_reasoning_variant_override(core, "ultra")
 
-    assert snapshot is None
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
 
@@ -85,24 +97,99 @@ def test_anthropic_native_variant_allows_max_for_opus_46() -> None:
 
 
 def test_anthropic_native_variant_rejects_max_for_sonnet_46() -> None:
+    """Unsupported native Anthropic Max raises a structured error."""
+
     core = _core_with_model_config("anthropic", "claude-sonnet-4-6")
 
-    snapshot = _apply_reasoning_variant_override(core, "max")
+    with pytest.raises(UnsupportedReasoningVariantError):
+        _apply_reasoning_variant_override(core, "max")
 
-    assert snapshot is None
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
 
 
 def test_anthropic_metadata_variant_rejects_ultra() -> None:
+    """Anthropic adapter capabilities reject Ultra despite bad metadata."""
+
     core = _core_with_model_config(
         "anthropic",
         "claude-opus-4-6",
         ["low", "medium", "high", "max", "ultra"],
     )
 
-    snapshot = _apply_reasoning_variant_override(core, "ultra")
+    api_client = SimpleNamespace(
+        get_provider_capabilities=lambda: SimpleNamespace(
+            reasoning_efforts=("low", "medium", "high", "max")
+        )
+    )
+    with pytest.raises(UnsupportedReasoningVariantError):
+        _apply_reasoning_variant_override(core, "ultra", api_client=api_client)
 
-    assert snapshot is None
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
+
+
+@pytest.mark.asyncio
+async def test_cached_codex_ultra_reaches_openai_safe_prepared_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached Codex metadata survives runtime validation and request preparation."""
+
+    oauth_record = {
+        "type": "oauth",
+        "access": "oauth-test-token",
+        "accountId": "account-test",
+    }
+    monkeypatch.setattr(
+        "penguin.web.routes.get_provider_auth_records",
+        lambda: {"openai": oauth_record},
+    )
+    monkeypatch.setattr(
+        "penguin.web.routes.codex_oauth_cached_provider_models",
+        lambda _record: {
+            "openai": {
+                "gpt-5.6-sol": {
+                    "supported_reasoning_levels": [
+                        "none",
+                        "low",
+                        "medium",
+                        "high",
+                        "xhigh",
+                        "max",
+                        "ultra",
+                    ],
+                    "default_reasoning_level": "low",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "penguin.llm.adapters.openai.get_provider_credential",
+        lambda _provider_id: oauth_record,
+    )
+    model_config = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        api_key="oauth-test-token",
+    )
+    adapter = OpenAIAdapter(model_config)
+    api_client = SimpleNamespace(get_provider_capabilities=adapter.get_capabilities)
+    core = SimpleNamespace(model_config=model_config)
+
+    _apply_cached_provider_model_metadata(model_config)
+    snapshot = _apply_reasoning_variant_override(
+        core,
+        "ultra",
+        model_config=model_config,
+        api_client=api_client,
+    )
+    prepared = await adapter.prepare_request(
+        [{"role": "user", "content": "ping"}],
+        stream=False,
+    )
+
+    assert isinstance(snapshot, dict)
+    assert model_config.supported_reasoning_levels[-1] == "ultra"
+    assert prepared.route == "openai.codex_oauth.responses"
+    assert prepared.body["reasoning"]["effort"] == "max"

--- a/tests/api/test_reasoning_variant_overrides.py
+++ b/tests/api/test_reasoning_variant_overrides.py
@@ -92,3 +92,17 @@ def test_anthropic_native_variant_rejects_max_for_sonnet_46() -> None:
     assert snapshot is None
     assert core.model_config.reasoning_enabled is False
     assert core.model_config.reasoning_effort is None
+
+
+def test_anthropic_metadata_variant_rejects_ultra() -> None:
+    core = _core_with_model_config(
+        "anthropic",
+        "claude-opus-4-6",
+        ["low", "medium", "high", "max", "ultra"],
+    )
+
+    snapshot = _apply_reasoning_variant_override(core, "ultra")
+
+    assert snapshot is None
+    assert core.model_config.reasoning_enabled is False
+    assert core.model_config.reasoning_effort is None

--- a/tests/api/test_reasoning_variant_overrides.py
+++ b/tests/api/test_reasoning_variant_overrides.py
@@ -218,7 +218,33 @@ def test_cached_metadata_preserves_supported_explicit_effort(
     assert model_config.get_reasoning_config() == {"effort": "high"}
 
 
-def _patch_cached_codex_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("catalog_default", [None, "bogus"])
+def test_cached_metadata_replaces_unsupported_effort_without_valid_default(
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_default: str | None,
+) -> None:
+    """Unsupported efforts fall back even when catalog default is unusable."""
+
+    _patch_cached_codex_metadata(monkeypatch, catalog_default=catalog_default)
+    model_config = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=True,
+        reasoning_effort="minimal",
+    )
+
+    apply_cached_codex_model_metadata(model_config)
+
+    assert model_config.reasoning_effort == "high"
+    assert model_config.get_reasoning_config() == {"effort": "high"}
+
+
+def _patch_cached_codex_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    catalog_default: str | None = "low",
+) -> None:
     """Install deterministic Codex metadata for hydration tests."""
 
     oauth_record = {
@@ -246,7 +272,11 @@ def _patch_cached_codex_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
                         "max",
                         "ultra",
                     ],
-                    "default_reasoning_level": "low",
+                    **(
+                        {"default_reasoning_level": catalog_default}
+                        if catalog_default is not None
+                        else {}
+                    ),
                 }
             }
         },

--- a/tests/api/test_reasoning_variants_service.py
+++ b/tests/api/test_reasoning_variants_service.py
@@ -27,9 +27,10 @@ def test_openai_gpt_51_limits_reasoning_efforts() -> None:
 
 
 def test_openai_gpt_56_exposes_max_effort() -> None:
+    """GPT-5.6 exposes the documented effort set without minimal."""
+
     assert native_reasoning_efforts("openai", "gpt-5.6-sol") == (
         "none",
-        "minimal",
         "low",
         "medium",
         "high",
@@ -39,6 +40,8 @@ def test_openai_gpt_56_exposes_max_effort() -> None:
 
 
 def test_openai_gpt_6_exposes_future_reasoning_efforts() -> None:
+    """Future GPT generations retain the conservative fallback effort set."""
+
     assert native_reasoning_efforts("openai", "gpt-6") == (
         "none",
         "minimal",

--- a/tests/api/test_reasoning_variants_service.py
+++ b/tests/api/test_reasoning_variants_service.py
@@ -38,6 +38,18 @@ def test_openai_gpt_56_exposes_max_effort() -> None:
     )
 
 
+def test_openai_gpt_6_exposes_future_reasoning_efforts() -> None:
+    assert native_reasoning_efforts("openai", "gpt-6") == (
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    )
+
+
 def test_openai_gpt_5_pro_is_high_only() -> None:
     assert native_reasoning_efforts("openai", "gpt-5-pro") == ("high",)
 

--- a/tests/cli/test_reasoning_projection.py
+++ b/tests/cli/test_reasoning_projection.py
@@ -1,0 +1,77 @@
+"""Regression tests for reasoning configuration projection in the primary CLI."""
+
+from penguin.cli.cli import (
+    _project_reasoning_config,
+    _resolve_cli_reasoning_config,
+)
+from penguin.llm.model_config import ModelConfig
+
+
+def _rebuild_reasoning_config(source: ModelConfig) -> ModelConfig:
+    """Rebuild a model config through the primary CLI projection path."""
+
+    projected = _resolve_cli_reasoning_config(_project_reasoning_config(source))
+    return ModelConfig(
+        model=source.model,
+        provider=source.provider,
+        client_preference=source.client_preference,
+        reasoning_enabled=projected["reasoning_enabled"],
+        reasoning_effort=projected["reasoning_effort"],
+        reasoning_max_tokens=projected["reasoning_max_tokens"],
+        reasoning_exclude=projected["reasoning_exclude"],
+        supports_reasoning=projected["supports_reasoning"],
+        supported_reasoning_levels=projected["supported_reasoning_levels"],
+    )
+
+
+def test_cli_reasoning_projection_preserves_implicit_defaults() -> None:
+    """CLI reconstruction keeps implicit GPT reasoning enabled and non-explicit."""
+
+    source = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+    )
+
+    rebuilt = _rebuild_reasoning_config(source)
+
+    assert rebuilt.reasoning_enabled is True
+    assert rebuilt.reasoning_effort == "medium"
+    assert rebuilt._reasoning_enabled_explicit is False
+    assert rebuilt._reasoning_effort_explicit is False
+
+
+def test_cli_reasoning_projection_preserves_explicit_effort() -> None:
+    """CLI reconstruction keeps explicitly configured reasoning effort."""
+
+    source = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=True,
+        reasoning_effort="high",
+    )
+
+    rebuilt = _rebuild_reasoning_config(source)
+
+    assert rebuilt.reasoning_enabled is True
+    assert rebuilt.reasoning_effort == "high"
+    assert rebuilt._reasoning_enabled_explicit is True
+    assert rebuilt._reasoning_effort_explicit is True
+
+
+def test_cli_reasoning_projection_preserves_explicit_opt_out() -> None:
+    """CLI reconstruction keeps an explicit reasoning opt-out disabled."""
+
+    source = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=False,
+    )
+
+    rebuilt = _rebuild_reasoning_config(source)
+
+    assert rebuilt.reasoning_enabled is False
+    assert rebuilt.reasoning_effort is None
+    assert rebuilt._reasoning_enabled_explicit is True

--- a/tests/llm/test_model_config_reasoning.py
+++ b/tests/llm/test_model_config_reasoning.py
@@ -98,6 +98,8 @@ def test_codex_model_metadata_falls_back_to_middle_supported_effort() -> None:
 
 
 def test_codex_model_metadata_rejects_unsupported_efforts() -> None:
+    """Unsupported configured and default efforts fall back to metadata."""
+
     config = ModelConfig.for_model(
         model_name="openai/gpt-5.6-luna",
         provider="openai",
@@ -121,6 +123,8 @@ def test_codex_model_metadata_rejects_unsupported_efforts() -> None:
 
 
 def test_explicit_reasoning_opt_out_wins_over_supported_metadata() -> None:
+    """An explicit reasoning opt-out wins over inferred catalog support."""
+
     config = ModelConfig.for_model(
         model_name="openai/gpt-5.6-sol",
         provider="openai",

--- a/tests/llm/test_model_config_reasoning.py
+++ b/tests/llm/test_model_config_reasoning.py
@@ -95,3 +95,51 @@ def test_codex_model_metadata_falls_back_to_middle_supported_effort() -> None:
     )
 
     assert config.get_reasoning_config() == {"effort": "medium"}
+
+
+def test_codex_model_metadata_rejects_unsupported_efforts() -> None:
+    config = ModelConfig.for_model(
+        model_name="openai/gpt-5.6-luna",
+        provider="openai",
+        model_configs={
+            "openai/gpt-5.6-luna": {
+                "provider": "openai",
+                "model": "gpt-5.6-luna",
+                "reasoning": {"effort": "ultra"},
+                "default_reasoning_level": "xhigh",
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                    {"effort": "max"},
+                ],
+            }
+        },
+    )
+
+    assert config.get_reasoning_config() == {"effort": "medium"}
+
+
+def test_explicit_reasoning_opt_out_wins_over_supported_metadata() -> None:
+    config = ModelConfig.for_model(
+        model_name="openai/gpt-5.6-sol",
+        provider="openai",
+        model_configs={
+            "openai/gpt-5.6-sol": {
+                "provider": "openai",
+                "model": "gpt-5.6-sol",
+                "reasoning_enabled": False,
+                "default_reasoning_level": "low",
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                ],
+            }
+        },
+    )
+
+    assert config.reasoning_enabled is False
+    assert config.supports_reasoning is True
+    assert config.supported_reasoning_levels == ["low", "medium", "high"]
+    assert config.get_reasoning_config() is None

--- a/tests/llm/test_model_config_reasoning.py
+++ b/tests/llm/test_model_config_reasoning.py
@@ -147,3 +147,17 @@ def test_explicit_reasoning_opt_out_wins_over_supported_metadata() -> None:
     assert config.supports_reasoning is True
     assert config.supported_reasoning_levels == ["low", "medium", "high"]
     assert config.get_reasoning_config() is None
+
+
+def test_direct_explicit_reasoning_opt_out_is_not_auto_enabled() -> None:
+    """Direct construction preserves an explicit False reasoning setting."""
+
+    config = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+        reasoning_enabled=False,
+    )
+
+    assert config.reasoning_enabled is False
+    assert config.get_reasoning_config() is None

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -17,6 +17,8 @@ def _image_payload_magic(data_uri: str) -> bytes:
 
 
 def test_prepare_reasoning_config_maps_ultra_to_openai_max() -> None:
+    """Ultra metadata is converted to the OpenAI wire-level Max effort."""
+
     adapter = OpenAIAdapter(
         ModelConfig(
             model="gpt-5.6-sol",
@@ -28,13 +30,15 @@ def test_prepare_reasoning_config_maps_ultra_to_openai_max() -> None:
         )
     )
 
-    assert adapter._prepare_reasoning_config(  # noqa: SLF001
+    assert adapter._prepare_reasoning_config(
         {"effort": "ultra"},
         stream=True,
     ) == {"effort": "max", "summary": "auto"}
 
 
 def test_prepare_reasoning_config_maps_mixed_case_ultra_to_openai_max() -> None:
+    """Direct mixed-case Ultra config is normalized to OpenAI-safe Max."""
+
     adapter = OpenAIAdapter(
         ModelConfig(
             model="gpt-5.6-sol",
@@ -46,7 +50,7 @@ def test_prepare_reasoning_config_maps_mixed_case_ultra_to_openai_max() -> None:
         )
     )
 
-    assert adapter._prepare_reasoning_config(  # noqa: SLF001
+    assert adapter._prepare_reasoning_config(
         {"effort": " Ultra "},
         stream=True,
     ) == {"effort": "max", "summary": "auto"}

--- a/tests/test_openai_adapter_streaming.py
+++ b/tests/test_openai_adapter_streaming.py
@@ -34,6 +34,24 @@ def test_prepare_reasoning_config_maps_ultra_to_openai_max() -> None:
     ) == {"effort": "max", "summary": "auto"}
 
 
+def test_prepare_reasoning_config_maps_mixed_case_ultra_to_openai_max() -> None:
+    adapter = OpenAIAdapter(
+        ModelConfig(
+            model="gpt-5.6-sol",
+            provider="openai",
+            client_preference="native",
+            api_key="sk-test",
+            reasoning_enabled=True,
+            reasoning_effort="Ultra",
+        )
+    )
+
+    assert adapter._prepare_reasoning_config(  # noqa: SLF001
+        {"effort": " Ultra "},
+        stream=True,
+    ) == {"effort": "max", "summary": "auto"}
+
+
 @dataclass(frozen=True)
 class _DummyStreamEvent:
     """Minimal stream event shape used by OpenAIAdapter streaming."""


### PR DESCRIPTION
## Summary
- normalize mixed-case/whitespace  before mapping it to OpenAI wire 
- validate configured and default reasoning efforts against advertised model metadata
- preserve explicit  even when reasoning levels are advertised
- reject Anthropic  overrides before the adapter can silently drop them
- remove redundant GPT-6 regex and Codex reasoning-enabled helper

## CodeRabbit triage
### Fixed (signal)
- case-sensitive OpenAI Ultra mapping
- unsupported configured/default metadata effort selection
- explicit reasoning opt-out being overridden
- Anthropic Ultra accepted then silently omitted

### Cleanup applied
- overlapping GPT-6 regex
- redundant catalog helper

### Skipped (noise)
- Google-style docstrings for two tiny metadata normalizers
- Google-style docstring for private 

These docstring requests do not affect correctness, public API behavior, or maintainability enough to justify extra diff.

## Validation
- Python compile checks passed for all touched modules/tests
- 50 targeted provider/reasoning tests passed
-  passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-aware reasoning effort metadata across providers, enabling stricter override validation.
  * When an unsupported reasoning variant is requested, requests now return clear client-facing errors (REST 400; WebSocket error events).

* **Bug Fixes**
  * Improved OpenAI “ultra” normalization and reasoning-effort mapping for newer GPT model ranges.
  * Hardening and precedence fixes for reasoning enablement/configuration, including better fallbacks when efforts aren’t supported.

* **Chores**
  * Expanded regression tests for reasoning capability detection, override rejection, streaming error behavior, and CLI reasoning projection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->