### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+0.9.1 — 2026-07-09
+------------------
+
+Highlights
+- **GPT-5.6 day-one compatibility**: Added OpenAI/Codex catalog support for GPT-5.6 Sol, Terra, and Luna when advertised and provisioned for the authenticated account.
+- **Metadata-driven reasoning**: Preserved provider-advertised reasoning levels through model selection and request execution, including OpenAI-safe `ultra` to `max` request mapping.
+- **Reasoning contract hardening**: Added provider-capability validation and explicit REST/WebSocket rejection for unsupported reasoning variants before persistence or execution.
+- **CLI refactor campaign**: Added a dedicated ACBRA plan for decomposing CLI startup, model configuration, command services, rendering, and interactive lifecycle behavior before broader ergonomics work.
+
+Added
+- Dynamic GPT-5.6 Codex model and reasoning-level discovery for authenticated OpenAI accounts.
+- Request-level reasoning variant validation against provider capabilities and cached catalog metadata.
+- `context/tasks/cli-acbra-testing-refactor.md` as the characterization-first Python CLI decomposition campaign.
+
+Changed
+- Carried Codex reasoning metadata into request-scoped model configuration rather than relying only on static model configuration.
+- Used stable OpenAI account identity for cached Codex catalog metadata so OAuth token rotation does not discard model capabilities.
+- Preserved explicit reasoning opt-outs and supported configured efforts when applying catalog defaults.
+
+Fixed
+- Unsupported reasoning variants being silently ignored, persisted, or forwarded through incompatible provider paths.
+- GPT-5.6 reasoning effort exposure so the non-catalog fallback uses the documented `none`, `low`, `medium`, `high`, `xhigh`, and `max` levels.
+- CLI startup reconstruction losing implicit or explicit reasoning configuration for the configured model.
+
+Known preview note
+- GPT-5.6 availability is controlled by OpenAI's staged rollout. A model may briefly appear in the account catalog before its execution backend is provisioned; Penguin forwards the documented model ID and surfaces the upstream error.
+
 0.9.0 — 2026-07-07
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ Read more:
 
 ## Version Highlights
 
+### v0.9.1
+
+- Added day-one GPT-5.6 support through Penguin's OpenAI/Codex OAuth catalog path, including Sol, Terra, and Luna when advertised and provisioned for the authenticated account.
+- Preserved model-specific reasoning metadata through request execution and mapped Codex `ultra` mode to the OpenAI-safe `max` wire effort.
+- Rejected unsupported reasoning variants before REST/WebSocket requests can persist or execute them.
+- Preserved explicit reasoning opt-outs and supported configured efforts across catalog hydration and OAuth token refreshes.
+- Added a dedicated CLI ACBRA decomposition campaign, with broader CLI ergonomics work sequenced after structural stabilization.
+
 ### v0.9.0
 
 - Completed the ACBRA core-runtime decomposition campaign: `PenguinCore` is now a thin compatibility/orchestration facade over focused `penguin.core_runtime` modules.

--- a/penguin/_version.py
+++ b/penguin/_version.py
@@ -2,7 +2,7 @@
 
 __all__ = ["__author__", "__email__", "__license__", "__version__"]
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __author__ = "Maximus Putnam"
 __email__ = "MaximusPutnam@gmail.com"
 __license__ = "AGPL-3.0-or-later"

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -222,6 +222,7 @@ else:
     from prompt_toolkit.styles import Style  # type: ignore
     from prompt_toolkit.formatted_text import HTML  # type: ignore
 
+from penguin._version import __version__
 from penguin.cli.interface import PenguinInterface
 from penguin.config import (
     DEFAULT_MODEL,
@@ -1253,8 +1254,7 @@ def main_entry(
     Penguin AI Assistant - Your command-line AI companion.
     """
     if version:
-        # TODO: Get version dynamically, e.g., from importlib.metadata or a __version__ string
-        console.print("Penguin AI Assistant v0.1.0 (Placeholder Version)")
+        console.print(f"Penguin {__version__}")
         raise typer.Exit()
 
     # Preconfigure environment for root/project overrides so that even

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "penguin-ai"
-version = "0.9.0"
+version = "0.9.1"
 description = "Penguin: A modular, extensible AI coding agent and software engineer with its own execution environment."
 readme = "README.md"
 requires-python = ">=3.9,<3.13"

--- a/tests/cli/test_version_output.py
+++ b/tests/cli/test_version_output.py
@@ -1,0 +1,15 @@
+"""CLI version output regression tests."""
+
+from click.testing import CliRunner
+from typer.main import get_command
+
+from penguin._version import __version__
+from penguin.cli.cli import app
+
+
+def test_cli_version_matches_package_version() -> None:
+    """Report the package version instead of a stale placeholder."""
+    result = CliRunner().invoke(get_command(app), ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == f"Penguin {__version__}"


### PR DESCRIPTION
## Summary
- bump Penguin package metadata from `0.9.0` to `0.9.1`
- document GPT-5.6 Sol/Terra/Luna catalog support and rollout caveat
- document metadata-driven reasoning and provider validation hardening
- replace the stale CLI `--version` placeholder with the package version

## Validation
- `65 passed` across version, entrypoint, package export, public surface, and launcher tests
- `python -m build --wheel --sdist`
- clean virtualenv install from `penguin_ai-0.9.1-py3-none-any.whl`
- `penguin --version` and `penguin-cli --version` both report `Penguin 0.9.1`
- wheel and sdist metadata verified
- `git diff --check`

## Release note
GPT-5.6 access is controlled by OpenAI's staged rollout. A model may briefly be advertised before its execution backend is provisioned; Penguin forwards the documented model ID and surfaces the upstream error.
