### PR TITLE
feat: add Link execution profiles

### DIFF
--- a/docs/docs/api_reference/api_server.md
+++ b/docs/docs/api_reference/api_server.md
@@ -170,6 +170,8 @@ Process a chat message with optional conversation support, multi-modal capabilit
   "context_files": ["path/to/file1.py", "path/to/file2.py"],
   "streaming": true,
   "max_iterations": 20,
+  "execution_profile": "research",
+  "tools_enabled": true,
   "image_paths": ["/path/to/image.png"],
   "include_reasoning": false
 }
@@ -186,6 +188,12 @@ Process a chat message with optional conversation support, multi-modal capabilit
 - `streaming` (optional): Accepted for compatibility; REST `/chat/message` returns final payloads (use WebSocket endpoint for token streaming)
 - `max_iterations` (optional): An explicit reasoning-iteration limit. When
   omitted, Penguin does not impose a local iteration ceiling.
+- `execution_profile` (optional): Per-request behavior profile. `agent` is the
+  default full-capability profile; `chat` always disables tools and uses a
+  compact direct-answer prompt; `research` limits tools to the read-only
+  research allowlist.
+- `tools_enabled` (optional): Restrict tools for an `agent` or `research` turn.
+  It cannot enable tools for the `chat` profile.
 - `image_paths` (optional): List of image paths for vision models
 - `include_reasoning` (optional): Include reasoning content in response
 

--- a/penguin/core_runtime/process_engine.py
+++ b/penguin/core_runtime/process_engine.py
@@ -100,8 +100,19 @@ async def run_engine_process(
     request_session_id: str | None,
     scoped_conversation_id: str | None,
     trace_log_info: Any,
+    tools_enabled: bool = True,
+    allowed_tool_names: list[str] | None = None,
+    include_web_search: bool = True,
 ) -> Any:
     """Dispatch a process request through the configured Engine."""
+    profile_kwargs: dict[str, Any] = {}
+    if not (tools_enabled and allowed_tool_names is None and include_web_search):
+        profile_kwargs = {
+            "tools_enabled": tools_enabled,
+            "allowed_tool_names": allowed_tool_names,
+            "include_web_search": include_web_search,
+        }
+
     if multi_step:
         is_formal_task = bool(context and context.get("task_mode", False))
         _trace_engine_process(
@@ -124,6 +135,7 @@ async def run_engine_process(
                 agent_id=agent_id,
                 api_client_override=api_client_override,
                 model_config_override=model_config_override,
+                **profile_kwargs,
             )
 
         return await owner.engine.run_response(
@@ -135,6 +147,7 @@ async def run_engine_process(
             agent_id=agent_id,
             api_client_override=api_client_override,
             model_config_override=model_config_override,
+            **profile_kwargs,
         )
 
     return await owner.engine.run_single_turn(
@@ -145,4 +158,5 @@ async def run_engine_process(
         agent_id=agent_id,
         api_client_override=api_client_override,
         model_config_override=model_config_override,
+        **profile_kwargs,
     )

--- a/penguin/core_runtime/process_facade.py
+++ b/penguin/core_runtime/process_facade.py
@@ -104,6 +104,9 @@ class ProcessCoreFacade:
         multi_step: bool = True,
         api_client_override: APIClient | None = None,
         model_config_override: ModelConfig | None = None,
+        tools_enabled: bool = True,
+        allowed_tool_names: list[str] | None = None,
+        include_web_search: bool = True,
     ) -> dict[str, Any]:
         """Process a message through Penguin."""
         return await core_process_runtime.process_with_retry(
@@ -119,6 +122,9 @@ class ProcessCoreFacade:
             multi_step=multi_step,
             api_client_override=api_client_override,
             model_config_override=model_config_override,
+            tools_enabled=tools_enabled,
+            allowed_tool_names=allowed_tool_names,
+            include_web_search=include_web_search,
             log=logger,
             trace_log_info=_trace_log_info,
             log_error_fn=log_error,

--- a/penguin/core_runtime/process_runtime.py
+++ b/penguin/core_runtime/process_runtime.py
@@ -74,6 +74,9 @@ async def process_with_retry(
     trace_log_info: Callable[..., None],
     log_error_fn: Callable[..., None],
     retry_sleep: Callable[[float], Awaitable[None]] | None = None,
+    tools_enabled: bool = True,
+    allowed_tool_names: list[str] | None = None,
+    include_web_search: bool = True,
 ) -> dict[str, Any] | BaseException:
     """Process a user request with the public retry policy applied."""
     retrying = _process_retrying(sleep=retry_sleep)
@@ -91,6 +94,9 @@ async def process_with_retry(
         multi_step=multi_step,
         api_client_override=api_client_override,
         model_config_override=model_config_override,
+        tools_enabled=tools_enabled,
+        allowed_tool_names=allowed_tool_names,
+        include_web_search=include_web_search,
         log=log,
         trace_log_info=trace_log_info,
         log_error_fn=log_error_fn,
@@ -114,6 +120,9 @@ async def process(
     log: logging.Logger,
     trace_log_info: Callable[..., None],
     log_error_fn: Callable[..., None],
+    tools_enabled: bool = True,
+    allowed_tool_names: list[str] | None = None,
+    include_web_search: bool = True,
 ) -> dict[str, Any]:
     """Process a user request through PenguinCore-owned collaborators."""
 
@@ -235,6 +244,9 @@ async def process(
                 agent_id=agent_id,
                 api_client_override=api_client_override,
                 model_config_override=model_config_override,
+                tools_enabled=tools_enabled,
+                allowed_tool_names=allowed_tool_names,
+                include_web_search=include_web_search,
                 conversation_manager=conversation_manager,
                 execution_context=execution_context,
                 request_session_id=request_session_id,

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -288,6 +288,12 @@ class LoopConfig:
     # Optional billed-token ceiling for this loop invocation.
     token_budget: Optional[int] = None
 
+    # Per-request execution profile controls. These remain on the loop config
+    # so task-mode runs cannot accidentally bypass a chat/research profile.
+    tools_enabled: bool = True
+    allowed_tool_names: Optional[List[str]] = None
+    include_web_search: bool = True
+
 
 @dataclass
 class LoopState:
@@ -1694,10 +1700,12 @@ class Engine:
 
                 # Execute LLM step
                 response_data = await self._llm_step(
-                    tools_enabled=True,
+                    tools_enabled=config.tools_enabled,
                     streaming=config.streaming,
                     stream_callback=config.stream_callback,
                     agent_id=self.current_agent_id,
+                    allowed_tool_names=config.allowed_tool_names,
+                    include_web_search=config.include_web_search,
                 )
 
                 last_response = response_data.get("assistant_response", "")
@@ -1864,10 +1872,14 @@ class Engine:
                     )
                     break
 
-                if not iteration_results and self._queue_malformed_action_repair_note(
-                    cm,
-                    last_response,
-                    mode=config.mode,
+                if (
+                    config.tools_enabled
+                    and not iteration_results
+                    and self._queue_malformed_action_repair_note(
+                        cm,
+                        last_response,
+                        mode=config.mode,
+                    )
                 ):
                     await self._save_conversation(cm, async_save=config.async_save)
                     if config.message_callback:
@@ -2109,6 +2121,8 @@ class Engine:
         *,
         image_paths: Optional[List[str]] = None,
         tools_enabled: bool = True,
+        allowed_tool_names: Optional[List[str]] = None,
+        include_web_search: bool = True,
         streaming: Optional[bool] = None,
         stream_callback: Optional[Callable[[str], None]] = None,
         agent_id: Optional[str] = None,
@@ -2144,6 +2158,8 @@ class Engine:
                 streaming=streaming,
                 stream_callback=stream_callback,
                 agent_id=self.current_agent_id,
+                allowed_tool_names=allowed_tool_names,
+                include_web_search=include_web_search,
             )
             return response_data
         finally:
@@ -2166,6 +2182,9 @@ class Engine:
         agent_role: Optional[str] = None,
         api_client_override: Optional[Any] = None,
         model_config_override: Optional[Any] = None,
+        tools_enabled: bool = True,
+        allowed_tool_names: Optional[List[str]] = None,
+        include_web_search: bool = True,
     ) -> Dict[str, Any]:
         """
         Multi-step conversational loop for natural conversation flow.
@@ -2249,10 +2268,12 @@ class Engine:
 
                 # Execute LLM step with streaming support
                 response_data = await self._llm_step(
-                    tools_enabled=True,
+                    tools_enabled=tools_enabled,
                     streaming=streaming_flag,
                     stream_callback=stream_callback,
                     agent_id=self.current_agent_id,
+                    allowed_tool_names=allowed_tool_names,
+                    include_web_search=include_web_search,
                 )
 
                 last_response = response_data.get("assistant_response", "")
@@ -2320,10 +2341,14 @@ class Engine:
                         f"[LOOP DEBUG] Response contains 'finish_response' text but wasn't parsed as action. Response preview: {last_response[:100]}..."
                     )
 
-                if not iteration_results and self._queue_malformed_action_repair_note(
-                    cm,
-                    last_response,
-                    mode="response",
+                if (
+                    tools_enabled
+                    and not iteration_results
+                    and self._queue_malformed_action_repair_note(
+                        cm,
+                        last_response,
+                        mode="response",
+                    )
                 ):
                     await self._save_conversation(cm, async_save=True)
                     continue
@@ -2409,6 +2434,10 @@ class Engine:
         api_client_override: Optional[Any] = None,
         model_config_override: Optional[Any] = None,
         token_budget: Optional[int] = None,
+
+        tools_enabled: bool = True,
+        allowed_tool_names: Optional[List[str]] = None,
+        include_web_search: bool = True,
     ) -> Dict[str, Any]:
         """Run a task-oriented reasoning loop using the shared iteration engine.
 
@@ -2595,6 +2624,9 @@ class Engine:
                 ),
                 default_completion_status="iterations_exceeded",
                 token_budget=token_budget,
+                tools_enabled=tools_enabled,
+                allowed_tool_names=allowed_tool_names,
+                include_web_search=include_web_search,
             )
 
             result = await self._iteration_loop(cm, config, max_iters)
@@ -2698,7 +2730,13 @@ class Engine:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _prepare_responses_tools(self, tool_manager) -> Dict[str, Any]:
+    def _prepare_responses_tools(
+        self,
+        tool_manager,
+        *,
+        allowed_names: Optional[Sequence[str]] = None,
+        include_web_search: bool = True,
+    ) -> Dict[str, Any]:
         """Prepare Responses API tools payload if enabled.
 
         Returns:
@@ -2708,6 +2746,8 @@ class Engine:
             return prepare_responses_tool_kwargs(
                 self._get_runtime_model_config(),
                 tool_manager,
+                allowed_names=allowed_names,
+                include_web_search=include_web_search,
             )
         except Exception as exc:
             logger.debug("Failed to prepare Responses tools: %s", exc)
@@ -3023,6 +3063,7 @@ class Engine:
         api_client: APIClient,
         tool_manager,
         cm: ConversationManager,
+        allowed_tool_names: Optional[Sequence[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Handle all pending Responses API tool calls.
 
@@ -3075,6 +3116,7 @@ class Engine:
             persist_image_artifacts=lambda action_result: (
                 self._persist_tool_image_artifacts(cm, action_result)
             ),
+            allowed_tool_names=allowed_tool_names,
         )
 
     def _persist_record(
@@ -3432,6 +3474,7 @@ class Engine:
         cm: ConversationManager,
         action_executor: ActionExecutor,
         assistant_response: str,
+        allowed_tool_names: Optional[Sequence[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Parse and execute CodeAct actions from assistant response.
 
@@ -3463,6 +3506,21 @@ class Engine:
             )
             for tool_call in tool_calls_from_codeact_actions(actions)
         ]
+        if allowed_tool_names is not None:
+            allowed = {name.strip() for name in allowed_tool_names if name.strip()}
+            blocked = [
+                tool_call.name
+                for tool_call in tool_calls
+                if tool_call.name not in allowed
+            ]
+            if blocked:
+                logger.warning(
+                    "Skipping ActionXML tool calls outside this execution profile: %s",
+                    blocked,
+                )
+            tool_calls = [
+                tool_call for tool_call in tool_calls if tool_call.name in allowed
+            ]
         logger.debug(
             "[AUTO-CONTINUE FIX] Parsed %s actions from response", len(tool_calls)
         )
@@ -3594,6 +3652,8 @@ class Engine:
         streaming: Optional[bool] = None,
         stream_callback: Optional[Callable[[str], None]] = None,
         agent_id: Optional[str] = None,
+        allowed_tool_names: Optional[Sequence[str]] = None,
+        include_web_search: bool = True,
     ) -> Dict[str, Any]:
         """Execute a single LLM step: call model, handle tool calls, execute actions.
 
@@ -3652,9 +3712,20 @@ class Engine:
             agent_id=agent_id,
         )
 
-        # Step 1: Prepare Responses API tools if enabled
+        # Step 1: Prepare Responses API tools only for profiles that permit
+        # them. A no-tool chat request must not send schemas at all.
         llm_step_started = time.perf_counter()
-        extra_kwargs = self._prepare_responses_tools(tool_manager)
+        tool_profile_kwargs: Dict[str, Any] = {}
+        if allowed_tool_names is not None or not include_web_search:
+            tool_profile_kwargs = {
+                "allowed_names": allowed_tool_names,
+                "include_web_search": include_web_search,
+            }
+        extra_kwargs = (
+            self._prepare_responses_tools(tool_manager, **tool_profile_kwargs)
+            if tools_enabled
+            else {}
+        )
         tool_schema_count = (
             len(extra_kwargs.get("tools", []))
             if isinstance(extra_kwargs.get("tools"), list)
@@ -3721,10 +3792,15 @@ class Engine:
 
         # Step 4: Handle Responses API tool_calls if they were triggered
         responses_tools_started = time.perf_counter()
-        responses_action_results = await self._handle_responses_tool_calls(
-            api_client,
-            tool_manager,
-            cm,
+        responses_action_results = (
+            await self._handle_responses_tool_calls(
+                api_client,
+                tool_manager,
+                cm,
+                allowed_tool_names=allowed_tool_names,
+            )
+            if tools_enabled
+            else []
         )
         _trace_log_info(
             "engine.llm_step.responses_tools_done request=%s session=%s agent=%s "
@@ -3747,7 +3823,10 @@ class Engine:
             codeact_started = time.perf_counter()
             action_results.extend(
                 await self._execute_codeact_actions(
-                    cm, action_executor, assistant_response
+                    cm,
+                    action_executor,
+                    assistant_response,
+                    allowed_tool_names=allowed_tool_names,
                 )
             )
             _trace_log_info(

--- a/penguin/execution_profiles.py
+++ b/penguin/execution_profiles.py
@@ -1,0 +1,126 @@
+"""Per-turn execution profiles for lean chat and constrained research runs.
+
+The profile is intentionally resolved at the request boundary rather than
+stored on an agent. A user can move from an ordinary agent turn to a small,
+no-tool chat turn without changing the session's long-lived capabilities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+__all__ = [
+    "CHAT_SYSTEM_CONTEXT",
+    "RESEARCH_SYSTEM_CONTEXT",
+    "RESEARCH_TOOL_NAMES",
+    "ExecutionProfile",
+    "ExecutionProfileName",
+    "resolve_execution_profile",
+    "resolve_profile_system_context",
+    "resolve_profile_tools_enabled",
+]
+
+ExecutionProfileName = Literal["agent", "chat", "research"]
+
+# Research turns can inspect the project and gather information, but cannot
+# mutate files, execute commands, control a browser, or spawn agents.
+RESEARCH_TOOL_NAMES = (
+    "read_file",
+    "read_image",
+    "list_files",
+    "find_file",
+    "grep_search",
+    "analyze_project",
+    "perplexity_search",
+)
+
+# These prompts deliberately describe only the contract for the current turn.
+# The full agent prompt contains instructions and tool guidance that are useful
+# for autonomous work, but it needlessly dominates a casual answer or a
+# constrained research pass. They are applied to a request payload only; the
+# persisted conversation and the shared API client's default prompt remain
+# unchanged for future agent turns.
+CHAT_SYSTEM_CONTEXT = (
+    "You are Penguin in Chat mode. Answer directly and helpfully using the "
+    "conversation for context. Do not call tools, emit action markup, or claim "
+    "to have performed actions. Ask a concise clarifying question when needed."
+)
+
+RESEARCH_SYSTEM_CONTEXT = (
+    "You are Penguin in Research mode. Investigate and synthesize accurately. "
+    "Use only the read-only tools supplied when they materially help. Do not "
+    "modify files, execute commands, control browsers, or claim work beyond "
+    "the available evidence. Cite relevant sources or files and state uncertainty."
+)
+
+
+@dataclass(frozen=True)
+class ExecutionProfile:
+    """Resolved runtime policy for one model turn."""
+
+    name: ExecutionProfileName
+    tools_enabled: bool
+    allowed_tool_names: Optional[tuple[str, ...]]
+    include_web_search: bool
+    system_context: Optional[str]
+
+
+_PROFILES: dict[str, ExecutionProfile] = {
+    "agent": ExecutionProfile(
+        name="agent",
+        tools_enabled=True,
+        allowed_tool_names=None,
+        include_web_search=True,
+        system_context=None,
+    ),
+    "chat": ExecutionProfile(
+        name="chat",
+        tools_enabled=False,
+        allowed_tool_names=(),
+        include_web_search=False,
+        system_context=CHAT_SYSTEM_CONTEXT,
+    ),
+    "research": ExecutionProfile(
+        name="research",
+        tools_enabled=True,
+        allowed_tool_names=RESEARCH_TOOL_NAMES,
+        include_web_search=True,
+        system_context=RESEARCH_SYSTEM_CONTEXT,
+    ),
+}
+
+
+def resolve_execution_profile(value: Optional[str]) -> ExecutionProfile:
+    """Return a known profile, defaulting omitted values to full agent mode."""
+
+    normalized = (value or "agent").strip().lower()
+    profile = _PROFILES.get(normalized)
+    if profile is None:
+        supported = ", ".join(_PROFILES)
+        raise ValueError(f"execution_profile must be one of: {supported}")
+    return profile
+
+
+def resolve_profile_tools_enabled(
+    profile: ExecutionProfile,
+    requested_tools_enabled: Optional[bool],
+) -> bool:
+    """Apply an optional restrictive override without weakening chat safety."""
+
+    if profile.name == "chat":
+        return False
+    if requested_tools_enabled is None:
+        return profile.tools_enabled
+    return bool(requested_tools_enabled)
+
+
+def resolve_profile_system_context(value: Optional[str]) -> Optional[str]:
+    """Return the compact request-only system context for an execution profile.
+
+    ``None`` means preserve the API client's full configured system prompt.
+    The returned value is intentionally a plain immutable string so callers can
+    substitute it into one request without changing shared conversation state.
+    """
+
+    return resolve_execution_profile(value).system_context

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -31,6 +31,8 @@ from .model_config import ModelConfig
 from .provider_registry import ProviderRegistry
 from .provider_transform import apply_model_config_transforms, build_llm_error
 from penguin.constants import get_default_max_history_tokens
+from penguin.execution_profiles import resolve_profile_system_context
+from penguin.system.execution_context import get_current_execution_context
 from penguin.utils.callbacks import adapt_stream_callback
 from .adapters import get_adapter  # Keep for native preference
 from .litellm_support import load_litellm_gateway_class, load_litellm_module
@@ -384,6 +386,28 @@ class APIClient:
         # if self.model_config.use_assistants_api and hasattr(self.client_handler, 'assistant_manager'):
         #     self.client_handler.assistant_manager.update_system_prompt(prompt)
 
+    def _system_prompt_for_current_request(self) -> Optional[str]:
+        """Return a request-scoped system prompt without mutating this client.
+
+        ``APIClient`` instances are shared by concurrent sessions. The
+        execution profile therefore lives in the ``ContextVar``-backed request
+        context rather than on ``self``. Agent turns deliberately fall back to
+        the configured full prompt, while chat/research turns receive their
+        compact profile context only for this provider payload.
+        """
+
+        execution_context = get_current_execution_context()
+        profile_name = (
+            execution_context.execution_profile if execution_context else None
+        )
+        try:
+            profile_context = resolve_profile_system_context(profile_name)
+        except ValueError:
+            # Request routes validate profiles. Keep direct legacy callers on
+            # the normal prompt if they supply an invalid context value.
+            profile_context = None
+        return profile_context or self.system_prompt
+
     def _prepare_messages_with_system_prompt(
         self, messages: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
@@ -391,16 +415,23 @@ class APIClient:
         Inject the system prompt while preserving other system‑role
         messages (e.g. action results, iteration markers).
         """
-        if not self.system_prompt:
+        request_system_prompt = self._system_prompt_for_current_request()
+        if not request_system_prompt:
             return messages[:]  # nothing to do
 
         processed = []
         prompt_already_present = False
+        configured_system_prompt = self.system_prompt
 
         for msg in messages:
             if msg.get("role") == "system":
-                if msg.get("content") == self.system_prompt:
-                    # Drop existing duplicate of the global prompt
+                content = msg.get("content")
+                if (
+                    content == request_system_prompt
+                    or content == configured_system_prompt
+                ):
+                    # Drop the persisted full prompt (or a duplicate compact
+                    # prompt) before inserting the request-specific prompt.
                     prompt_already_present = True
                 else:
                     # KEEP other system messages (action results, etc.)
@@ -410,11 +441,16 @@ class APIClient:
 
         # Ensure the global system prompt is in slot‑0
         if not prompt_already_present:
-            processed.insert(0, {"role": "system", "content": self.system_prompt})
+            processed.insert(0, {"role": "system", "content": request_system_prompt})
         else:
             # If some other message grabbed index‑0, still enforce the prompt first
-            if processed and processed[0].get("content") != self.system_prompt:
-                processed.insert(0, {"role": "system", "content": self.system_prompt})
+            if (
+                not processed
+                or processed[0].get("content") != request_system_prompt
+            ):
+                processed.insert(
+                    0, {"role": "system", "content": request_system_prompt}
+                )
 
         return processed
 

--- a/penguin/llm/runtime.py
+++ b/penguin/llm/runtime.py
@@ -5,7 +5,7 @@ import inspect
 import json
 import logging
 import time
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
 
 from penguin.tools.runtime import (
     ORDERED_TOOL_BATCH_NAME,
@@ -313,6 +313,7 @@ def should_retry_provider_failure(
 def _get_tool_payload(
     tool_manager: Any,
     *,
+    allowed_names: Optional[Sequence[str]],
     include_web_search: bool,
 ) -> List[Dict[str, Any]]:
     tools_getter = getattr(tool_manager, "get_responses_tools", None)
@@ -323,10 +324,16 @@ def _get_tool_payload(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
         for parameter in signature.parameters.values()
     )
+    accepts_allowed_names = "allowed_names" in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    kwargs: Dict[str, Any] = {}
     if accepts_include_web_search:
-        tools_payload = tools_getter(include_web_search=include_web_search)
-    else:
-        tools_payload = tools_getter()
+        kwargs["include_web_search"] = include_web_search
+    if accepts_allowed_names and allowed_names is not None:
+        kwargs["allowed_names"] = list(allowed_names)
+    tools_payload = tools_getter(**kwargs)
     return list(tools_payload or [])
 
 
@@ -361,7 +368,13 @@ def _filter_native_loop_control_tools(
     return filtered
 
 
-def prepare_native_tool_kwargs(model_config: Any, tool_manager: Any) -> Dict[str, Any]:
+def prepare_native_tool_kwargs(
+    model_config: Any,
+    tool_manager: Any,
+    *,
+    allowed_names: Optional[Sequence[str]] = None,
+    include_web_search: bool = True,
+) -> Dict[str, Any]:
     """Build native tool kwargs for providers that support structured tool calls."""
 
     extra_kwargs: Dict[str, Any] = {}
@@ -374,7 +387,8 @@ def prepare_native_tool_kwargs(model_config: Any, tool_manager: Any) -> Dict[str
 
     tools_payload = _get_tool_payload(
         tool_manager,
-        include_web_search=tool_format == "openai_responses",
+        allowed_names=allowed_names,
+        include_web_search=(tool_format == "openai_responses" and include_web_search),
     )
     tools_payload = _filter_native_loop_control_tools(tools_payload)
     if not tools_payload:
@@ -412,11 +426,20 @@ def prepare_native_tool_kwargs(model_config: Any, tool_manager: Any) -> Dict[str
 
 
 def prepare_responses_tool_kwargs(
-    model_config: Any, tool_manager: Any
+    model_config: Any,
+    tool_manager: Any,
+    *,
+    allowed_names: Optional[Sequence[str]] = None,
+    include_web_search: bool = True,
 ) -> Dict[str, Any]:
     """Backward-compatible wrapper for native tool kwargs preparation."""
 
-    return prepare_native_tool_kwargs(model_config, tool_manager)
+    return prepare_native_tool_kwargs(
+        model_config,
+        tool_manager,
+        allowed_names=allowed_names,
+        include_web_search=include_web_search,
+    )
 
 
 def handler_has_pending_tool_call(api_client: Any) -> bool:
@@ -923,6 +946,7 @@ async def execute_pending_tool_calls(
     emit_action_result: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None,
     emit_tool_timeline: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None,
     persist_image_artifacts: Optional[Callable[[Dict[str, Any]], None]] = None,
+    allowed_tool_names: Optional[Sequence[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Execute all pending provider-captured tool calls using generic hooks."""
 
@@ -938,6 +962,19 @@ async def execute_pending_tool_calls(
         )
         if tool_call is not None
     ]
+    if allowed_tool_names is not None:
+        allowed = {name.strip() for name in allowed_tool_names if name.strip()}
+        blocked = [
+            tool_call.name for tool_call in tool_calls if tool_call.name not in allowed
+        ]
+        if blocked:
+            logger.warning(
+                "Ignoring provider tool calls outside this execution profile: %s",
+                blocked,
+            )
+        tool_calls = [
+            tool_call for tool_call in tool_calls if tool_call.name in allowed
+        ]
     if not tool_calls:
         return []
 

--- a/penguin/system/execution_context.py
+++ b/penguin/system/execution_context.py
@@ -22,6 +22,7 @@ class ExecutionContext:
     conversation_id: Optional[str] = None
     agent_id: Optional[str] = None
     agent_mode: Optional[str] = None
+    execution_profile: Optional[str] = None
     directory: Optional[str] = None
     project_root: Optional[str] = None
     workspace_root: Optional[str] = None
@@ -34,6 +35,7 @@ class ExecutionContext:
             "conversation_id": self.conversation_id,
             "agent_id": self.agent_id,
             "agent_mode": self.agent_mode,
+            "execution_profile": self.execution_profile,
             "directory": self.directory,
             "project_root": self.project_root,
             "workspace_root": self.workspace_root,

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NoReturn, Optional
+from typing import Any, Dict, List, Literal, NoReturn, Optional
 from fastapi import (
     APIRouter,
     Depends,
@@ -57,6 +57,10 @@ from penguin.core_runtime.session_goals import (
 )
 from penguin.system.execution_context import ExecutionContext, execution_context_scope, normalize_directory
 from penguin import __version__
+from penguin.execution_profiles import (
+    resolve_execution_profile,
+    resolve_profile_tools_enabled,
+)
 from penguin.utils.events import EventBus as UtilsEventBus
 from penguin.cli.events import EventBus as CLIEventBus, EventType
 from penguin.web.health import get_health_monitor
@@ -539,6 +543,7 @@ def _build_execution_context(
     agent_id: Optional[str],
     agent_mode: Optional[str],
     directory: Optional[str],
+    execution_profile: Optional[str] = None,
 ) -> ExecutionContext:
     """Create request-scoped execution context for concurrent web sessions."""
     path_info = get_path_info(core, directory=directory, session_id=session_id)
@@ -548,6 +553,7 @@ def _build_execution_context(
         conversation_id=conversation_id,
         agent_id=agent_id,
         agent_mode=agent_mode,
+        execution_profile=execution_profile,
         directory=effective_directory,
         project_root=effective_directory,
         workspace_root=effective_directory,
@@ -1025,6 +1031,8 @@ class MessageRequest(BaseModel):
     max_iterations: Optional[int] = None
     image_paths: Optional[List[str]] = None  # Multiple images supported (max 10)
     include_reasoning: Optional[bool] = False
+    execution_profile: Optional[Literal["agent", "chat", "research"]] = None
+    tools_enabled: Optional[bool] = None
     agent_id: Optional[str] = None
     agent_mode: Optional[str] = None
     directory: Optional[str] = None
@@ -4059,16 +4067,22 @@ async def handle_chat_message(
             if image_path not in image_paths:
                 image_paths.append(image_path)
 
+        execution_profile = resolve_execution_profile(request.execution_profile)
+        tools_enabled = resolve_profile_tools_enabled(
+            execution_profile,
+            request.tools_enabled,
+        )
         execution_context = _build_execution_context(
             core,
             session_id=effective_session_id,
             conversation_id=effective_session_id,
             agent_id=request.agent_id,
             agent_mode=resolved_agent_mode,
+            execution_profile=execution_profile.name,
             directory=bound_directory or request.directory,
         )
         _request_log_debug(
-            "chat.trace.start request=%s session=%s agent=%s mode=%s dir=%s model=%s streaming=%s client_msg=%s prompt=%r",
+            "chat.trace.start request=%s session=%s agent=%s mode=%s dir=%s model=%s request_streaming=%s client_msg=%s prompt=%r",
             execution_context.request_id or "unknown",
             request_session_id or "unknown",
             request.agent_id or "default",
@@ -4155,6 +4169,14 @@ async def handle_chat_message(
             )
 
         include_reasoning = _resolve_include_reasoning(request.include_reasoning)
+        _request_log_info(
+            "chat.execution_profile request=%s session=%s profile=%s tools=%s reasoning=%s",
+            execution_context.request_id or "unknown",
+            request_session_id or "unknown",
+            execution_profile.name,
+            tools_enabled,
+            include_reasoning,
+        )
 
         # If reasoning is requested, capture reasoning chunks via a local callback
         reasoning_buf: List[str] = []
@@ -4171,6 +4193,19 @@ async def handle_chat_message(
                     reasoning_buf.append(chunk)
 
             stream_cb = _rest_stream_cb
+
+        # The REST request may deliberately be non-streaming while Penguin
+        # streams internally to collect reasoning/runtime events. Keep the
+        # two dimensions separate in traces so a false outer flag is never
+        # mistaken for a non-streaming model invocation.
+        _request_log_info(
+            "chat.trace.streaming_mode request=%s session=%s request_streaming=%s effective_streaming=%s forced_for_reasoning=%s",
+            execution_context.request_id or "unknown",
+            request_session_id or "unknown",
+            bool(request.streaming),
+            effective_streaming,
+            include_reasoning and not bool(request.streaming),
+        )
 
         try:
             reasoning_variant_snapshot = _apply_reasoning_variant_override(
@@ -4279,6 +4314,13 @@ async def handle_chat_message(
                     stream_callback=stream_cb,
                     api_client_override=request_api_client,
                     model_config_override=request_model_config,
+                    tools_enabled=tools_enabled,
+                    allowed_tool_names=(
+                        list(execution_profile.allowed_tool_names)
+                        if execution_profile.allowed_tool_names is not None
+                        else None
+                    ),
+                    include_web_search=execution_profile.include_web_search,
                 )
                 process_ms = (time.perf_counter() - process_started) * 1000
             _request_log_debug(
@@ -4547,6 +4589,17 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
             include_reasoning = _resolve_include_reasoning(
                 data.get("include_reasoning")
             )
+            execution_profile = resolve_execution_profile(
+                data.get("execution_profile")
+                if isinstance(data.get("execution_profile"), str)
+                else None
+            )
+            tools_enabled = resolve_profile_tools_enabled(
+                execution_profile,
+                data.get("tools_enabled")
+                if isinstance(data.get("tools_enabled"), bool)
+                else None,
+            )
             variant = data.get("variant")
             service_tier = data.get("service_tier")
             model = data.get("model")
@@ -4579,6 +4632,7 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                 conversation_id=effective_session_id,
                 agent_id=agent_id,
                 agent_mode=resolved_agent_mode,
+                execution_profile=execution_profile.name,
                 directory=bound_directory or directory,
             )
 
@@ -4806,6 +4860,13 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                                 stream_callback=per_request_stream_callback,
                                 api_client_override=request_api_client,
                                 model_config_override=request_model_config,
+                                tools_enabled=tools_enabled,
+                                allowed_tool_names=(
+                                    list(execution_profile.allowed_tool_names)
+                                    if execution_profile.allowed_tool_names is not None
+                                    else None
+                                ),
+                                include_web_search=execution_profile.include_web_search,
                             )
                         )
 

--- a/tests/test_execution_profiles.py
+++ b/tests/test_execution_profiles.py
@@ -1,0 +1,334 @@
+"""Regression coverage for per-turn lean execution profiles."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from penguin.engine import Engine, EngineSettings
+from penguin.execution_profiles import (
+    CHAT_SYSTEM_CONTEXT,
+    RESEARCH_SYSTEM_CONTEXT,
+    RESEARCH_TOOL_NAMES,
+    resolve_execution_profile,
+    resolve_profile_tools_enabled,
+)
+from penguin.llm.api_client import APIClient
+from penguin.llm.runtime import execute_pending_tool_calls
+from penguin.system.execution_context import (
+    ExecutionContext,
+    execution_context_scope,
+    get_current_execution_context,
+)
+from penguin.web.routes import MessageRequest, handle_chat_message
+
+
+def test_chat_profile_never_enables_tools_even_when_requested() -> None:
+    profile = resolve_execution_profile("chat")
+
+    assert profile.tools_enabled is False
+    assert profile.allowed_tool_names == ()
+    assert profile.include_web_search is False
+    assert resolve_profile_tools_enabled(profile, True) is False
+
+
+def test_research_profile_is_read_only_and_keeps_web_search() -> None:
+    profile = resolve_execution_profile("research")
+
+    assert profile.tools_enabled is True
+    assert profile.include_web_search is True
+    assert set(profile.allowed_tool_names or ()) == set(RESEARCH_TOOL_NAMES)
+    assert "write_file" not in (profile.allowed_tool_names or ())
+    assert "execute_command" not in (profile.allowed_tool_names or ())
+
+
+@pytest.mark.asyncio
+async def test_profile_system_context_is_request_scoped_and_keeps_agent_full_prompt() -> (
+    None
+):
+    """Chat/research must not mutate a shared client's prompt for agent peers."""
+
+    full_system_prompt = "SYSTEM_PROMPT " * 2_000
+    original_messages = [
+        {"role": "system", "content": full_system_prompt},
+        {"role": "user", "content": "Give me a short answer."},
+    ]
+    api_client = object.__new__(APIClient)
+    api_client.system_prompt = full_system_prompt
+
+    async def prepare_for(profile: str) -> list[dict[str, Any]]:
+        with execution_context_scope(ExecutionContext(execution_profile=profile)):
+            # Exercise context-local behavior while another task can use the
+            # same client object at the same time.
+            await asyncio.sleep(0)
+            return api_client._prepare_messages_with_system_prompt(original_messages)
+
+    chat_payload, agent_payload, research_payload = await asyncio.gather(
+        prepare_for("chat"),
+        prepare_for("agent"),
+        prepare_for("research"),
+    )
+
+    assert api_client.system_prompt == full_system_prompt
+    assert original_messages[0]["content"] == full_system_prompt
+
+    assert chat_payload[0] == {"role": "system", "content": CHAT_SYSTEM_CONTEXT}
+    assert full_system_prompt not in [
+        message.get("content") for message in chat_payload
+    ]
+    assert len(CHAT_SYSTEM_CONTEXT) * 20 < len(full_system_prompt)
+
+    assert agent_payload[0] == {"role": "system", "content": full_system_prompt}
+    assert research_payload[0] == {
+        "role": "system",
+        "content": RESEARCH_SYSTEM_CONTEXT,
+    }
+    assert full_system_prompt not in [
+        message.get("content") for message in research_payload
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rest_route_forwards_chat_profile_as_a_no_tool_turn(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class Core:
+        def __init__(self) -> None:
+            self.runtime_config = SimpleNamespace(
+                workspace_root=str(tmp_path),
+                project_root=str(tmp_path),
+                active_root=str(tmp_path),
+            )
+            self._opencode_session_directories: dict[str, str] = {}
+
+        async def process(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            execution_context = get_current_execution_context()
+            captured["execution_profile"] = (
+                execution_context.execution_profile if execution_context else None
+            )
+            return {"assistant_response": "ok", "action_results": []}
+
+    response = await handle_chat_message(
+        MessageRequest(
+            text="Just answer directly",
+            session_id="profile-session",
+            execution_profile="chat",
+            tools_enabled=True,
+            include_reasoning=False,
+            streaming=False,
+        ),
+        core=cast(Any, Core()),
+    )
+
+    assert response["response"] == "ok"
+    assert captured["tools_enabled"] is False
+    assert captured["allowed_tool_names"] == []
+    assert captured["include_web_search"] is False
+    assert captured["execution_profile"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_trace_distinguishes_rest_and_internal_streaming(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: dict[str, Any] = {}
+    caplog.set_level(logging.INFO)
+
+    class Core:
+        def __init__(self) -> None:
+            self.runtime_config = SimpleNamespace(
+                workspace_root=str(tmp_path),
+                project_root=str(tmp_path),
+                active_root=str(tmp_path),
+            )
+            self._opencode_session_directories: dict[str, str] = {}
+
+        async def process(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"assistant_response": "ok", "action_results": []}
+
+    await handle_chat_message(
+        MessageRequest(
+            text="Explain the mode",
+            session_id="streaming-trace-session",
+            execution_profile="chat",
+            include_reasoning=True,
+            streaming=False,
+        ),
+        core=cast(Any, Core()),
+    )
+
+    assert captured["streaming"] is True
+    assert "request_streaming=False" in caplog.text
+    assert "effective_streaming=True" in caplog.text
+    assert "forced_for_reasoning=True" in caplog.text
+
+
+def test_research_schema_forwards_only_the_curated_tool_names() -> None:
+    model_config = SimpleNamespace(
+        provider="openai",
+        client_preference="native",
+        use_responses_api=False,
+        interrupt_on_tool_call=False,
+    )
+    captured: dict[str, Any] = {}
+
+    def get_responses_tools(
+        *,
+        allowed_names: list[str] | None = None,
+        include_web_search: bool = True,
+    ) -> list[dict[str, Any]]:
+        captured["allowed_names"] = allowed_names
+        captured["include_web_search"] = include_web_search
+        return [{"type": "function", "name": "read_file"}]
+
+    engine_like = SimpleNamespace(
+        _get_runtime_model_config=lambda: model_config,
+    )
+    profile = resolve_execution_profile("research")
+
+    extra_kwargs = Engine._prepare_responses_tools(
+        engine_like,
+        SimpleNamespace(get_responses_tools=get_responses_tools),
+        allowed_names=profile.allowed_tool_names,
+        include_web_search=profile.include_web_search,
+    )
+
+    assert captured == {
+        "allowed_names": list(RESEARCH_TOOL_NAMES),
+        "include_web_search": True,
+    }
+    assert extra_kwargs["tools"][0]["name"] == "read_file"
+
+
+@pytest.mark.asyncio
+async def test_chat_llm_step_skips_schemas_and_all_tool_execution() -> None:
+    session = SimpleNamespace(messages=[])
+    conversation = SimpleNamespace(
+        get_formatted_messages=MagicMock(
+            return_value=[{"role": "user", "content": "hello"}]
+        ),
+        session=session,
+        add_assistant_message=MagicMock(),
+    )
+    conversation_manager = SimpleNamespace(
+        conversation=conversation,
+        core=None,
+        get_current_session=lambda: session,
+    )
+    api_client = SimpleNamespace(client_handler=SimpleNamespace())
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, conversation_manager),
+        cast(Any, api_client),
+        MagicMock(),
+        MagicMock(),
+    )
+    engine._prepare_responses_tools = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("chat must not prepare native tool schemas")
+    )
+    engine._handle_responses_tool_calls = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("chat must not execute provider tool calls")
+    )
+    engine._execute_codeact_actions = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("chat must not execute ActionXML")
+    )
+    engine._call_llm_with_retry = AsyncMock(  # type: ignore[method-assign]
+        return_value="Hello from a lean turn."
+    )
+    engine._finalize_streaming_response = AsyncMock(  # type: ignore[method-assign]
+        return_value="Hello from a lean turn."
+    )
+    engine._extract_usage_from_api_client = MagicMock(  # type: ignore[method-assign]
+        return_value={}
+    )
+
+    result = await engine._llm_step(tools_enabled=False, streaming=False)
+
+    assert result["assistant_response"] == "Hello from a lean turn."
+    assert result["action_results"] == []
+    assert engine._call_llm_with_retry.await_args.args[-1] == {}
+    engine._prepare_responses_tools.assert_not_called()
+    engine._handle_responses_tool_calls.assert_not_awaited()
+    engine._execute_codeact_actions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_research_profile_drops_unadvertised_provider_tool_calls() -> None:
+    class Handler:
+        def get_and_clear_pending_tool_calls(self) -> list[dict[str, str]]:
+            return [
+                {
+                    "name": "write_file",
+                    "arguments": '{"path":"unsafe.txt","content":"no"}',
+                    "call_id": "call-write",
+                }
+            ]
+
+    execute_tool = MagicMock(side_effect=AssertionError("must not execute"))
+    result = await execute_pending_tool_calls(
+        api_client=SimpleNamespace(
+            client_handler=Handler(),
+            model_config=SimpleNamespace(provider="openai", model="gpt-test"),
+        ),
+        tool_manager=SimpleNamespace(execute_tool=execute_tool),
+        persist_action_result=lambda *_args: None,
+        allowed_tool_names=RESEARCH_TOOL_NAMES,
+    )
+
+    assert result == []
+    execute_tool.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_profile_does_not_queue_malformed_action_repair_turn() -> None:
+    session = SimpleNamespace(id="session-a", messages=[])
+    conversation = SimpleNamespace(
+        session=session,
+        prepare_conversation=MagicMock(),
+        add_message=MagicMock(),
+        save=MagicMock(return_value=True),
+    )
+    conversation_manager = SimpleNamespace(
+        core=None,
+        conversation=conversation,
+        get_agent_conversation=lambda *args, **kwargs: conversation,
+        save=MagicMock(return_value=True),
+        get_current_session=MagicMock(return_value=session),
+        agent_context_windows={},
+    )
+    engine = Engine(
+        EngineSettings(),
+        cast(Any, conversation_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    engine._llm_step = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "assistant_response": '<read_file path="notes.md">',
+            "action_results": [],
+            "usage": {},
+        }
+    )
+    engine._save_conversation = AsyncMock()  # type: ignore[method-assign]
+
+    result = await engine.run_response(
+        "answer directly",
+        streaming=False,
+        tools_enabled=False,
+    )
+
+    assert result["iterations"] == 1
+    assert result["assistant_response"] == '<read_file path="notes.md">'
+    conversation.add_message.assert_not_called()


### PR DESCRIPTION
## Summary

- add per-request `agent`, `chat`, and `research` execution profiles for Link and other API clients
- make chat turns compact and tool-free, while constraining research turns to a read-only tool allowlist
- propagate the profile through REST/WebSocket request scope, the core runtime, engine, and native tool handling without changing default agent behavior
- document the public request fields and add regression coverage for request isolation, prompt selection, tool-schema filtering, and tool-execution enforcement

## Integration notes

- based on current `main` after PR #72
- preserves PR #72's unconfigured `/goal` iteration and token-limit behavior
- excludes the unrelated task markdown and provider watcher from the original WIP snapshot
- PR #75 will overlap several runtime files and should be rebased/integrated separately if it lands later

## Verification

- `pytest -q tests/test_execution_profiles.py tests/test_execution_context.py tests/test_engine_responses_tool_action_results.py tests/test_tool_schema_contract.py tests/core_runtime/test_process_engine.py tests/core_runtime/test_process_runtime.py tests/test_core_process_facade_shims.py tests/test_core_process_runtime_shim.py tests/test_engine_run_task_thin_wrapper.py tests/core_runtime/test_session_goal_runtime.py tests/core_runtime/test_session_goals.py`
- 101 passed
- `python -m compileall -q` on touched Python modules
- `ruff format --check penguin/execution_profiles.py tests/test_execution_profiles.py`
- `git diff --check`