### PR TITLE
Fix first-run onboarding and TUI cancellation

### DIFF
--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -2,261 +2,215 @@
 sidebar_position: 2
 ---
 
-# Getting Started (v0.4.0)
+# Getting Started
 
-Welcome! This guide will get you up and running with Penguin v0.4.0, featuring advanced conversation management, real-time streaming, and comprehensive checkpoint capabilities.
-
----
+This guide covers Penguin's current terminal-first installation and first-run flow.
 
 ## 1. Install
 
-### Core Installation
-```bash
-uv tool install penguin-ai        # recommended: installs the main CLI/TUI entrypoints
-
-# Alternative: plain pip still works
-pip install penguin-ai            # Python package + CLI/TUI + web runtime
-```
-
-### Feature-Rich Installation
-```bash
-pip install "penguin-ai[all]"    # Optional extras for memory/browser/legacy UI features
-```
-
-### Installation Options
-* `pip install "penguin-ai[web]"` – compatibility alias; base install already includes the web runtime
-* `pip install "penguin-ai[tui]"` – compatibility alias; base install already includes the OpenCode-style TUI launcher
-* `pip install "penguin-ai[legacy_tui]"` – installs the older Textual prototype / experimental UI
-* `pip install "penguin-ai[minimal]"` – lightweight library-only installation
-* `pip install "penguin-ai[dev]"` – development dependencies for contributors
-
-### What's Included
-
-**Core Features:**
-- Interactive TUI launcher via `penguin`, `ptui`, or `penguin-tui`
-- Headless/scriptable CLI via `penguin-cli`
-- Python API for programmatic use
-- Advanced conversation management with checkpoints
-- Real-time streaming with event-driven architecture
-- SQLite-backed project and task management
-- Enhanced token management with category-based budgets
-- Runtime model switching capabilities
-
-## 2. Verify Installation
-```bash
-penguin --version     # prints version string
-penguin --help        # shows the default launcher options
-ptui --help           # direct TUI alias
-penguin-cli --help    # headless/scriptable CLI entrypoint
-```
-
-### Check Configuration
-```bash
-penguin-cli config check  # validates required keys are present
-penguin config debug      # prints extended diagnostic info
-penguin config edit       # open the config file in your editor
-```
-
----
-
-## 3. First Steps
-
-### Enhanced Interactive Chat
-```bash
-penguin               # launches the default terminal UI
-ptui                  # same TUI, explicit alias
-penguin-tui           # same TUI, explicit alias matching the split runtime naming
-```
-
-Use `penguin-cli` for non-interactive automation and scripts:
+The recommended installation uses `uv`:
 
 ```bash
-penguin-cli -p "Help me debug this Python function"  # one-off prompt
-penguin-cli chat                                     # explicit synonym for interactive chat
+uv tool install penguin-ai
 ```
 
-<!-- TODO: Checkpointing command support -->
+Plain `pip` also works:
 
-### Model Management
-Model subcommands are not yet exposed via CLI. Use defaults in config for now.
-
-### Advanced Project & Task Management
 ```bash
-# Create a project
-penguin-cli project create "Runtime Demo" -d "Demonstrating new features"
-
-# List projects (note the ID from the table)
-penguin-cli project list
-
-# Create a task for that project (replace <PROJECT_ID>)
-penguin-cli project task create <PROJECT_ID> "Implement streaming chat"
-
-# View tasks (optionally filtered by project)
-penguin-cli project task list [<PROJECT_ID>]
+pip install penguin-ai
 ```
 
-### Enhanced Web Interface (optional)
+The base package includes the main CLI, terminal UI, and web runtime. Optional extras are available for development and legacy integrations:
+
 ```bash
-pip install "penguin-ai[web]"   # compatibility alias; base install already includes this runtime
-penguin-web                      # Web/API server at http://127.0.0.1:9000
-# API docs at http://127.0.0.1:9000/api/docs
+pip install "penguin-ai[all]"          # optional integrations
+pip install "penguin-ai[legacy_tui]"   # older Textual prototype
+pip install "penguin-ai[dev]"          # contributor tooling
 ```
 
-### TUI Runtime Notes
+Verify the installation:
 
-The terminal UI now lives in the OpenCode-derived `penguin-tui/` workspace inside this repository.
-
-- In a source checkout, Penguin prefers local `penguin-tui/packages/opencode` sources.
-- Outside a source checkout, it can bootstrap a cached sidecar binary under `~/.cache/penguin/tui`.
-- Advanced overrides: `PENGUIN_OPENCODE_DIR`, `PENGUIN_TUI_BIN_PATH`, and `PENGUIN_TUI_RELEASE_URL`.
-
-### Programmatic API with Streaming
-```python
-from penguin.web.app import PenguinAPI
-
-# Initialize with enhanced features
-api = PenguinAPI()
-
-# Chat with streaming and checkpointing
-response = await api.chat(
-    "Help me refactor this code",
-    streaming=True,
-    conversation_id="my-session"
-)
-
-# Create checkpoints programmatically
-checkpoint_id = await api.core.create_checkpoint(
-    name="Before refactoring",
-    description="Saving state before major changes"
-)
-```
-
-### FastAPI Integration
-```python
-from fastapi import FastAPI
-from penguin.web.app import create_app
-
-# Embed Penguin in your FastAPI application
-app = create_app()
-# Penguin API is now available at /api/v1/
-```
-
----
-
-## 4. Enhanced Configuration
-
-### Environment Variables
 ```bash
-# API Keys
-ANTHROPIC_API_KEY=your_key_here
-OPENAI_API_KEY=your_key_here
-OPENROUTER_API_KEY=your_key_here
-
-# Model Configuration
-PENGUIN_DEFAULT_MODEL=openai/gpt-5
-PENGUIN_CLIENT_PREFERENCE=native  # native, litellm, or openrouter
-PENGUIN_STREAMING_ENABLED=true
-
-# Performance Settings
-PENGUIN_FAST_STARTUP=true
-PENGUIN_MAX_TOKENS=400000
+penguin --version
+penguin --help
+penguin-cli --help
 ```
 
-### Execution Root (Project vs Workspace)
-Penguin separates where it edits code from where it stores assistant state:
+## 2. First Run
 
-- Project root: your current repository (CWD/git root) for file edits, shell commands, diffs, and analysis.
-- Workspace root: Penguin’s own data (conversations, notes, logs, memory) at `WORKSPACE_PATH`.
+Run:
 
-Control which root file tools operate on:
-
-- CLI flag: `--root project|workspace` (applies for the current run)
-- Env var: `PENGUIN_WRITE_ROOT=project|workspace` (overrides config)
-- Config default: `defaults.write_root: project` (set to workspace to sandbox writes)
-- Fallback default: `project`
-
-On startup the CLI prints the active execution root, e.g.
-```
-Execution root: project (/path/to/your/repo)
-```
-
-Set workspace as the default once:
 ```bash
-penguin config set defaults.write_root workspace
+penguin
 ```
 
-### Advanced Configuration File
-Create `config.yml` for comprehensive settings:
+On a fresh installation, Penguin runs onboarding **before** launching the terminal UI.
+
+### Workspace
+
+The only required onboarding choice is the workspace location. Penguin stores conversations, memory, notes, logs, projects, and context there. Press Enter to accept the platform-appropriate default:
+
+```text
+~/penguin_workspace
+```
+
+On Windows this resolves under the current user's home directory, for example:
+
+```text
+C:\Users\Alice\penguin_workspace
+```
+
+Penguin verifies that the directory can be created and written before saving it.
+
+### Connect an AI model — optional
+
+After selecting a workspace, onboarding asks whether to connect an AI model. You can:
+
+- choose a supported provider and model;
+- use an existing provider credential from the environment;
+- enter a credential for Penguin to store in its user-level `.env`; or
+- choose **Skip for now** at the connection, provider, model, or credential step.
+
+An OpenRouter key is **not required** to install, onboard, or launch Penguin. OpenRouter is one optional provider alongside direct providers and local Ollama models.
+
+If you skip model setup, the TUI still launches. Penguin waits to initialize a provider until a model and any required credential are available. Before sending an AI prompt, connect one by rerunning:
+
+```bash
+penguin config setup
+```
+
+Rerunning setup preserves existing configuration and uses the current workspace as the default.
+
+## 3. Launching Penguin
+
+All current TUI entrypoints share the same first-run preflight:
+
+```bash
+penguin
+ptui
+penguin-tui
+```
+
+Use the headless CLI for scripts and one-off commands:
+
+```bash
+penguin-cli -p "Help me debug this Python function"
+penguin-cli chat
+```
+
+Useful configuration commands:
+
+```bash
+penguin config setup   # change workspace or connect a model
+penguin config check   # check required workspace configuration
+penguin config debug   # inspect resolved configuration
+penguin config edit    # open the user configuration file
+```
+
+## 4. Interrupting a Running Session
+
+While a prompt, stream, or tool is active in the TUI, press `Esc` once to interrupt it. Penguin sends an abort request, cancels the tracked request, and returns the session to idle without waiting for slow provider or tool cleanup.
+
+Cleanup continues on a best-effort basis in the background. Repeatedly pressing `Esc` should not be necessary.
+
+## 5. Provider Configuration
+
+Provider credentials may be supplied with environment variables:
+
+```bash
+OPENAI_API_KEY=...
+ANTHROPIC_API_KEY=...
+OPENROUTER_API_KEY=...
+```
+
+Local Ollama models do not require an API key.
+
+Model routing can also be configured explicitly:
+
+```bash
+PENGUIN_DEFAULT_MODEL=openai/gpt-5.2
+PENGUIN_DEFAULT_PROVIDER=openrouter
+PENGUIN_CLIENT_PREFERENCE=openrouter
+```
+
+A minimal workspace-only configuration is valid:
+
 ```yaml
+workspace:
+  path: ~/penguin_workspace
+model: null
+```
+
+A connected model configuration looks like:
+
+```yaml
+workspace:
+  path: ~/penguin_workspace
 model:
-  default: anthropic/claude-3-5-sonnet
-  client_preference: openrouter
+  default: gpt-5.2
+  provider: openai
+  client_preference: native
   streaming_enabled: true
-  max_context_window_tokens: 200000
-
-performance:
-  fast_startup: true
-  diagnostics_enabled: true
-
-checkpoints:
-  enabled: true
-  frequency: 1
-  retention:
-    keep_all_hours: 24
-    max_age_days: 30
-
-memory:
-  indexing_enabled: true
-  providers:
-    - chroma
-    - lance
 ```
 
-## Next Steps
+## 6. Project and Workspace Roots
 
-### Essential Guides
-- [CLI Commands Reference](usage/cli_commands.md) - Complete command documentation with new checkpoint features
-- [Project Management](usage/project_management.md) - Enhanced project and task management
-- [Web Interface Guide](usage/web_interface.md) - Using the enhanced web UI with streaming
-- [Configuration Options](configuration.md) - Detailed configuration with model switching
+Penguin separates the project it edits from the workspace where it stores assistant state:
 
-### New v0.4.0 Features
-- [Checkpoint Management](usage/checkpointing.md) - Conversation state management and branching
-- [Streaming and Events](usage/streaming.md) - Real-time streaming and event-driven architecture
-- [Model Management](usage/model_management.md) - Runtime model switching and configuration
-- [Performance Optimization](usage/performance.md) - Fast startup and diagnostics
+- **Project root:** the current repository or working directory used by file and shell tools.
+- **Workspace root:** Penguin's conversations, notes, logs, memory, projects, and context.
 
-### Advanced Topics
-- [System Architecture](system/) - Deep dive into conversation management and token budgeting
-- [Custom Tools](advanced/custom_tools.md) - Extending Penguin with custom functionality
-- [API Reference](api_reference/) - Complete Python API documentation with new methods
-- [Event System](advanced/events.md) - Working with the event-driven architecture
+Select the file-operation root for a run with:
 
-### Troubleshooting
-**Common Issues:**
-
-1. **Command not found**: Ensure you installed with `pip install penguin-ai`, not the minimal option
-2. **Web interface not starting**: Base install already includes the runtime; `pip install "penguin-ai[web]"` is only a compatibility alias. Then check port 8000.
-3. **API errors**: Verify API keys and use `penguin config debug` for configuration issues
-4. **Streaming not working**: Ensure your model supports streaming and check client preference settings
-5. **Checkpoint errors**: Check disk space and file permissions for the workspace directory
-6. **Performance issues**: Try `fast_startup=true` in config or use `penguin profile` / `penguin perf-test` for profiling
-7. **TUI bootstrap problems**: If sidecar download or source auto-detection fails, set `PENGUIN_OPENCODE_DIR` or `PENGUIN_TUI_BIN_PATH` explicitly.
-
-### Getting Help
-
-- **GitHub Issues**: [Report bugs and feature requests](https://github.com/Maximooch/penguin/issues)
-- **Documentation**: Check the [System Documentation](system/) for advanced configuration
-- **Performance**: Use `penguin profile` or `penguin perf-test` for system performance insights
-- **Configuration**: Run `penguin config check` or `penguin config debug` to inspect your settings. You can also review your `config.yml` by doing `penguin config edit`
-<!-- For environment variables, if they aren't expored but within Penguin, should we assume they're just saved to a .env file, or do some further safety checking? What was it that Bun was doing? Look into that -->
-
-**Quick Diagnostic Commands:**
 ```bash
-penguin --version              # Check version
-penguin --help                 # CLI options
-penguin profile               # Profile startup and save a report
-penguin perf-test             # Benchmark startup performance
-penguin config debug          # Extended config + environment diagnostics
+penguin --root project
+penguin --root workspace
 ```
 
+Or set the default with `PENGUIN_WRITE_ROOT=project|workspace`.
+
+## 7. Web Runtime
+
+The base install includes the web/API runtime:
+
+```bash
+penguin-web
+```
+
+By default it listens at `http://127.0.0.1:9000`; API documentation is available at `/api/docs`.
+
+## Troubleshooting
+
+### `OPENROUTER_API_KEY required` on first launch
+
+Current first-run behavior should route to workspace onboarding before any provider client is initialized. If this appears on a fresh install, capture the output of:
+
+```bash
+penguin --version
+penguin config debug
+```
+
+and report which entrypoint was used.
+
+### No AI model connected
+
+Launch is allowed without a provider. Run `penguin config setup` before sending prompts, or select a local Ollama model.
+
+### TUI does not stop immediately after `Esc`
+
+A single `Esc` should return the session to idle promptly. Capture the web-server log around the `/session/<id>/abort` request and report any tool that remains active.
+
+### TUI bootstrap fails
+
+Penguin prefers local TUI sources in a source checkout and otherwise bootstraps a cached sidecar. Advanced overrides include `PENGUIN_OPENCODE_DIR`, `PENGUIN_TUI_BIN_PATH`, and `PENGUIN_TUI_RELEASE_URL`.
+
+### Configuration or permissions fail
+
+Confirm the configured workspace exists and is writable. Use:
+
+```bash
+penguin config debug
+penguin config edit
+```
+
+For additional options, see [Configuration](configuration.md) and the [CLI reference](usage/cli_commands.md).

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -1286,7 +1286,7 @@ def main_entry(
             console.print(
                 "[yellow]You may need to install additional dependencies:[/yellow]"
             )
-            console.print("[yellow]  pip install questionary httpx[/yellow]")
+            console.print("[yellow]  pip install questionary PyYAML rich[/yellow]")
             console.print("[yellow]Or manually create a config file.[/yellow]\n")
         elif check_first_run():
             console.print(
@@ -1730,9 +1730,9 @@ def config_setup():
         console.print(
             "[yellow]You may need to install additional dependencies:[/yellow]"
         )
-        console.print("[yellow]  pip install questionary httpx[/yellow]")
+        console.print("[yellow]  pip install questionary PyYAML rich[/yellow]")
         console.print("[yellow]Or install with setup extras:[/yellow]")
-        console.print("[yellow]  pip install penguin[setup][/yellow]")
+        console.print("[yellow]  pip install penguin-ai[/yellow]")
         raise typer.Exit(code=1)
 
     try:
@@ -1795,7 +1795,7 @@ def config_test_routing():
     if not setup_available:
         console.print(f"[red]Setup wizard not available: {setup_import_error}[/red]")
         console.print(
-            "[yellow]Install setup dependencies first: pip install questionary httpx[/yellow]"
+            "[yellow]Install setup dependencies first: pip install questionary PyYAML rich[/yellow]"
         )
         raise typer.Exit(code=1)
 

--- a/penguin/cli/entrypoint.py
+++ b/penguin/cli/entrypoint.py
@@ -7,7 +7,7 @@ Penguin TUI while preserving explicit routes for headless CLI workflows.
 from __future__ import annotations
 
 import sys
-from typing import Sequence
+from typing import Any, Sequence
 
 _FORCE_TUI_ALIASES = {"tui", "ptui"}
 _FORCE_CLI_ALIASES = {"cli", "headless"}
@@ -126,8 +126,24 @@ def main_cli(argv: Sequence[str] | None = None) -> int:
 
 def main_tui(argv: Sequence[str] | None = None) -> int:
     """Run workspace onboarding when needed, then launch the Penguin TUI."""
-    if _needs_tui_setup() and not _setup_succeeded(_run_tui_setup()):
-        return 1
+    if _needs_tui_setup():
+        try:
+            result: dict[str, Any] = _run_tui_setup()
+        except KeyboardInterrupt:
+            print(
+                "Setup interrupted. Run 'penguin config setup' when ready.",
+                file=sys.stderr,
+            )
+            return 1
+        except Exception as exc:
+            print(f"Setup failed: {exc}", file=sys.stderr)
+            return 1
+        if not _setup_succeeded(result):
+            print(
+                f"Setup error: {result.get('error', 'Unknown setup error')}",
+                file=sys.stderr,
+            )
+            return 1
 
     from .opencode_launcher import main as launcher_main
 
@@ -141,14 +157,14 @@ def _needs_tui_setup() -> bool:
     return bool(check_first_run())
 
 
-def _run_tui_setup() -> object:
+def _run_tui_setup() -> dict[str, Any]:
     """Run first-time workspace onboarding synchronously."""
     from penguin.setup import run_setup_wizard_sync
 
     return run_setup_wizard_sync()
 
 
-def _setup_succeeded(result: object) -> bool:
+def _setup_succeeded(result: dict[str, Any]) -> bool:
     return isinstance(result, dict) and not result.get("error")
 
 

--- a/penguin/cli/entrypoint.py
+++ b/penguin/cli/entrypoint.py
@@ -125,10 +125,31 @@ def main_cli(argv: Sequence[str] | None = None) -> int:
 
 
 def main_tui(argv: Sequence[str] | None = None) -> int:
-    """Run the Penguin TUI launcher directly."""
+    """Run workspace onboarding when needed, then launch the Penguin TUI."""
+    if _needs_tui_setup() and not _setup_succeeded(_run_tui_setup()):
+        return 1
+
     from .opencode_launcher import main as launcher_main
 
     return _to_exit_code(launcher_main(_normalize_argv(argv)))
+
+
+def _needs_tui_setup() -> bool:
+    """Return whether workspace onboarding must run before the TUI."""
+    from penguin.setup import check_first_run
+
+    return bool(check_first_run())
+
+
+def _run_tui_setup() -> object:
+    """Run first-time workspace onboarding synchronously."""
+    from penguin.setup import run_setup_wizard_sync
+
+    return run_setup_wizard_sync()
+
+
+def _setup_succeeded(result: object) -> bool:
+    return isinstance(result, dict) and not result.get("error")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/penguin/cli/entrypoint.py
+++ b/penguin/cli/entrypoint.py
@@ -139,10 +139,12 @@ def main_tui(argv: Sequence[str] | None = None) -> int:
             print(f"Setup failed: {exc}", file=sys.stderr)
             return 1
         if not _setup_succeeded(result):
-            print(
-                f"Setup error: {result.get('error', 'Unknown setup error')}",
-                file=sys.stderr,
+            error = (
+                result.get("error", "Unknown setup error")
+                if isinstance(result, dict)
+                else "Unknown setup error"
             )
+            print(f"Setup error: {error}", file=sys.stderr)
             return 1
 
     from .opencode_launcher import main as launcher_main

--- a/penguin/config.py
+++ b/penguin/config.py
@@ -27,7 +27,7 @@ def get_project_root() -> Path:
     # If running from source
     return Path(__file__).parent.parent
 
-def load_config():
+def load_config(*, _include_resolution_metadata: bool = False):
     """Load configuration by merging multiple locations with clear precedence.
 
     Precedence (lowest → highest):
@@ -67,8 +67,22 @@ def load_config():
                 base[key] = value
         return base
 
-    # 0) Start with empty config
+    # 0) Start with empty config. Track explicit model fields separately so
+    # package defaults cannot make a workspace-only config look connected.
     merged: Dict[str, Any] = {}
+    explicit_model_settings: Dict[str, Any] = {}
+
+    def merge_explicit_model_settings(data: Dict[str, Any]) -> None:
+        nonlocal explicit_model_settings
+        if "model" not in data:
+            return
+        model_settings = data.get("model")
+        if isinstance(model_settings, dict):
+            explicit_model_settings = deep_merge_dicts(
+                explicit_model_settings, model_settings
+            )
+        else:
+            explicit_model_settings = {}
 
     # 1) Package default
     package_config_path = Path(__file__).parent / "config.yml"
@@ -102,7 +116,10 @@ def load_config():
     try:
         if user_config_path.exists():
             with open(user_config_path) as f:
-                merged = deep_merge_dicts(merged, yaml.safe_load(f) or {})
+                user_config = yaml.safe_load(f) or {}
+                if isinstance(user_config, dict):
+                    merged = deep_merge_dicts(merged, user_config)
+                    merge_explicit_model_settings(user_config)
                 logger.debug(f"Loaded user config: {user_config_path}")
     except Exception as e:
         logger.warning(f"Error loading user config {user_config_path}: {e}")
@@ -131,7 +148,10 @@ def load_config():
     try:
         if project_config_path.exists():
             with open(project_config_path) as f:
-                merged = deep_merge_dicts(merged, yaml.safe_load(f) or {})
+                project_config = yaml.safe_load(f) or {}
+                if isinstance(project_config, dict):
+                    merged = deep_merge_dicts(merged, project_config)
+                    merge_explicit_model_settings(project_config)
                 logger.debug(f"Loaded project config: {project_config_path}")
     except Exception as e:
         logger.warning(f"Error loading project config {project_config_path}: {e}")
@@ -139,7 +159,10 @@ def load_config():
     try:
         if project_local_path.exists():
             with open(project_local_path) as f:
-                merged = deep_merge_dicts(merged, yaml.safe_load(f) or {})
+                project_local = yaml.safe_load(f) or {}
+                if isinstance(project_local, dict):
+                    merged = deep_merge_dicts(merged, project_local)
+                    merge_explicit_model_settings(project_local)
                 logger.debug(f"Loaded project local overrides: {project_local_path}")
     except Exception as e:
         logger.warning(f"Error loading project local settings {project_local_path}: {e}")
@@ -150,7 +173,10 @@ def load_config():
             override_path = Path(os.getenv('PENGUIN_CONFIG_PATH')).expanduser()
             if override_path.exists():
                 with open(override_path) as f:
-                    merged = deep_merge_dicts(merged, yaml.safe_load(f) or {})
+                    override_config = yaml.safe_load(f) or {}
+                    if isinstance(override_config, dict):
+                        merged = deep_merge_dicts(merged, override_config)
+                        merge_explicit_model_settings(override_config)
                     logger.debug(f"Loaded override config: {override_path}")
     except Exception as e:
         logger.warning(f"Error loading override config via PENGUIN_CONFIG_PATH: {e}")
@@ -188,6 +214,8 @@ def load_config():
         logger.debug("No config file found, using defaults")
         return {}
 
+    if _include_resolution_metadata:
+        merged["_explicit_model_settings"] = explicit_model_settings
     return merged
 
 # -------------------------
@@ -1398,7 +1426,7 @@ class Config:
 
         # Prefer the merged config resolver, unless an explicit file path was provided
         if config_path is None:
-            config_data = load_config()
+            config_data = load_config(_include_resolution_metadata=True)
         else:
             try:
                 with open(config_path) as f:
@@ -1463,24 +1491,24 @@ class Config:
         init_diagnostics(config_data)
 
         # --- Determine Model Config --- #
-        default_model_settings = config_data.get("model", {})
+        default_model_settings = config_data.pop("_explicit_model_settings", None)
+        if not isinstance(default_model_settings, dict):
+            default_model_settings = config_data.get("model", {})
         if not isinstance(default_model_settings, dict):
             default_model_settings = {}
-        model_explicitly_configured = bool(default_model_settings) or bool(
-            os.getenv("PENGUIN_DEFAULT_MODEL") or os.getenv("PENGUIN_DEFAULT_PROVIDER")
-        )
-        # A workspace-only config is valid. Empty model/provider values keep
-        # provider construction lazy until the user connects an AI model.
-        default_model_id = (
+        default_model_id = str(
             os.getenv("PENGUIN_DEFAULT_MODEL")
             or default_model_settings.get("default")
-            or ("anthropic/claude-3-5-sonnet-20240620" if model_explicitly_configured else "")
-        )
-        default_provider = (
+            or ""
+        ).strip()
+        default_provider = str(
             os.getenv("PENGUIN_DEFAULT_PROVIDER")
             or default_model_settings.get("provider")
-            or ("openrouter" if model_explicitly_configured else "")
-        )
+            or ""
+        ).strip()
+        model_explicitly_configured = bool(default_model_id or default_provider)
+        # A workspace-only or partially tuned config is valid. Missing model and
+        # provider values stay empty until the user explicitly connects one.
         default_client_pref = (
             os.getenv("PENGUIN_CLIENT_PREFERENCE")
             or default_model_settings.get("client_preference")

--- a/penguin/config.py
+++ b/penguin/config.py
@@ -147,7 +147,7 @@ def load_config():
     # 5) Explicit override (highest single-file override)
     try:
         if os.getenv('PENGUIN_CONFIG_PATH'):
-            override_path = Path(os.getenv('PENGUIN_CONFIG_PATH'))
+            override_path = Path(os.getenv('PENGUIN_CONFIG_PATH')).expanduser()
             if override_path.exists():
                 with open(override_path) as f:
                     merged = deep_merge_dicts(merged, yaml.safe_load(f) or {})
@@ -1464,10 +1464,28 @@ class Config:
 
         # --- Determine Model Config --- #
         default_model_settings = config_data.get("model", {})
-        # ENV VARS TAKE PRECEDENCE over config.yml for container deployments
-        default_model_id = os.getenv("PENGUIN_DEFAULT_MODEL") or default_model_settings.get("default") or "anthropic/claude-3-5-sonnet-20240620"
-        default_provider = os.getenv("PENGUIN_DEFAULT_PROVIDER") or default_model_settings.get("provider") or "openrouter"
-        default_client_pref = os.getenv("PENGUIN_CLIENT_PREFERENCE") or default_model_settings.get("client_preference") or "openrouter"
+        if not isinstance(default_model_settings, dict):
+            default_model_settings = {}
+        model_explicitly_configured = bool(default_model_settings) or bool(
+            os.getenv("PENGUIN_DEFAULT_MODEL") or os.getenv("PENGUIN_DEFAULT_PROVIDER")
+        )
+        # A workspace-only config is valid. Empty model/provider values keep
+        # provider construction lazy until the user connects an AI model.
+        default_model_id = (
+            os.getenv("PENGUIN_DEFAULT_MODEL")
+            or default_model_settings.get("default")
+            or ("anthropic/claude-3-5-sonnet-20240620" if model_explicitly_configured else "")
+        )
+        default_provider = (
+            os.getenv("PENGUIN_DEFAULT_PROVIDER")
+            or default_model_settings.get("provider")
+            or ("openrouter" if model_explicitly_configured else "")
+        )
+        default_client_pref = (
+            os.getenv("PENGUIN_CLIENT_PREFERENCE")
+            or default_model_settings.get("client_preference")
+            or ("openrouter" if model_explicitly_configured else "native")
+        )
 
         model_configs_section = config_data.get("model_configs")
         if not isinstance(model_configs_section, dict):
@@ -1532,11 +1550,13 @@ class Config:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        if not self.model_config.model:
-            raise ValueError("model_name must be specified in the effective model config")
-
+        model_config = (
+            self.model_config.get_config()
+            if self.model_config is not None and self.model_config.model
+            else {}
+        )
         return {
-            "default_model_config": self.model_config.get_config(),
+            "default_model_config": model_config,
             "global_temperature": self.temperature,
             "global_max_output_tokens": self.max_output_tokens,
             "diagnostics": {

--- a/penguin/core_runtime/model_runtime.py
+++ b/penguin/core_runtime/model_runtime.py
@@ -31,7 +31,7 @@ LinkConfigFactory = Callable[..., Any]
 LiteLLMLoader = Callable[[str], Any]
 
 
-def _provider_credential_available(model_config: ModelConfig) -> bool:
+def provider_credential_available(model_config: ModelConfig) -> bool:
     """Return whether a configured provider can be initialized for a request."""
     provider = str(getattr(model_config, "provider", "") or "").strip().lower()
     if provider in {"ollama", "local"}:
@@ -313,7 +313,7 @@ async def resolve_request_runtime(
     else:
         new_model_config = copy.deepcopy(owner.model_config)
 
-    if not _provider_credential_available(new_model_config):
+    if not provider_credential_available(new_model_config):
         raise ValueError(_missing_provider_credential_message(new_model_config))
 
     api_client = api_client_factory(model_config=new_model_config)
@@ -611,6 +611,7 @@ __all__ = [
     "ensure_litellm_runtime_state",
     "list_available_models",
     "load_model_for_core",
+    "provider_credential_available",
     "refresh_api_client",
     "resolve_model_provider",
     "resolve_request_runtime",

--- a/penguin/core_runtime/model_runtime.py
+++ b/penguin/core_runtime/model_runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
 from typing import Any, Awaitable, Callable, Mapping, Optional
 
 from penguin.llm.model_config import (
@@ -28,6 +29,37 @@ LLMClientFactory = Callable[[ModelConfig, Any], Any]
 LLMClientConfigFactory = Callable[..., Any]
 LinkConfigFactory = Callable[..., Any]
 LiteLLMLoader = Callable[[str], Any]
+
+
+def _provider_credential_available(model_config: ModelConfig) -> bool:
+    """Return whether a configured provider can be initialized for a request."""
+    provider = str(getattr(model_config, "provider", "") or "").strip().lower()
+    if provider in {"ollama", "local"}:
+        return True
+    if str(getattr(model_config, "api_key", "") or "").strip():
+        return True
+    credential_envs = {
+        "openai": ("OPENAI_API_KEY", "OPENAI_OAUTH_ACCESS_TOKEN"),
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+    }.get(provider, (f"{provider.upper()}_API_KEY",) if provider else ())
+    return any(str(os.getenv(name) or "").strip() for name in credential_envs)
+
+
+def _missing_provider_credential_message(model_config: ModelConfig) -> str:
+    provider = str(getattr(model_config, "provider", "") or "").strip().lower()
+    env_name = {
+        "openai": "OPENAI_API_KEY (or OpenAI OAuth)",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
+    }.get(
+        provider, f"{provider.upper()}_API_KEY" if provider else "provider credential"
+    )
+    return (
+        f"Connect a credential for {provider or 'the selected provider'} before "
+        f"sending a prompt. Set {env_name}, run 'penguin config setup', or choose "
+        "Connect provider in the TUI command palette."
+    )
 
 
 def _coerce_optional_int(value: Any) -> int | None:
@@ -270,10 +302,19 @@ async def resolve_request_runtime(
     )
 
     requested_model = model_id.strip() if isinstance(model_id, str) else ""
+    if not requested_model and not (current_raw and current_provider):
+        raise ValueError(
+            "Connect an AI model before sending a prompt. "
+            "Run 'penguin config setup' or choose Connect provider in the "
+            "TUI command palette."
+        )
     if requested_model and requested_model not in {current_raw, current_qualified}:
         new_model_config, _ = await owner._build_model_config_for_model(requested_model)
     else:
         new_model_config = copy.deepcopy(owner.model_config)
+
+    if not _provider_credential_available(new_model_config):
+        raise ValueError(_missing_provider_credential_message(new_model_config))
 
     api_client = api_client_factory(model_config=new_model_config)
     api_client.set_system_prompt(owner.system_prompt)

--- a/penguin/core_runtime/model_runtime.py
+++ b/penguin/core_runtime/model_runtime.py
@@ -42,6 +42,7 @@ def provider_credential_available(model_config: ModelConfig) -> bool:
         "openai": ("OPENAI_API_KEY", "OPENAI_OAUTH_ACCESS_TOKEN"),
         "anthropic": ("ANTHROPIC_API_KEY",),
         "openrouter": ("OPENROUTER_API_KEY",),
+        "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     }.get(provider, (f"{provider.upper()}_API_KEY",) if provider else ())
     return any(str(os.getenv(name) or "").strip() for name in credential_envs)
 

--- a/penguin/core_runtime/startup.py
+++ b/penguin/core_runtime/startup.py
@@ -400,9 +400,11 @@ async def create_core_instance(
                 logger.info(
                     "STARTUP: Tool manager created in %.4fs with %s tools",
                     startup_timing.elapsed_since(tool_manager_start),
-                    len(tool_manager.tools)
-                    if hasattr(tool_manager, "tools")
-                    else "unknown",
+                    (
+                        len(tool_manager.tools)
+                        if hasattr(tool_manager, "tools")
+                        else "unknown"
+                    ),
                 )
                 progress.complete_step()
                 startup_timing.record_step("Create tool manager", logger=logger)
@@ -505,6 +507,21 @@ def build_api_client(
     """Build the startup API client after env files are available."""
 
     ensure_env_loaded()
+    provider = str(getattr(model_config, "provider", "") or "").strip().lower()
+    model = str(getattr(model_config, "model", "") or "").strip()
+    if not provider or not model:
+        return None
+
+    if provider not in {"ollama", "local"}:
+        api_key = str(getattr(model_config, "api_key", "") or "").strip()
+        credential_envs = {
+            "openai": ("OPENAI_API_KEY", "OPENAI_OAUTH_ACCESS_TOKEN"),
+            "anthropic": ("ANTHROPIC_API_KEY",),
+            "openrouter": ("OPENROUTER_API_KEY",),
+        }.get(provider, (f"{provider.upper()}_API_KEY",))
+        if not api_key and not any(os.getenv(name) for name in credential_envs):
+            return None
+
     api_client = api_client_factory(model_config=model_config)
     api_client.set_system_prompt(system_prompt)
     return api_client

--- a/penguin/core_runtime/startup.py
+++ b/penguin/core_runtime/startup.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, MutableMapping
 
+from penguin.core_runtime.model_runtime import provider_credential_available
+
 ActionExecutorFactory = Callable[..., Any]
 ApiClientFactory = Callable[..., Any]
 CheckpointConfigFactory = Callable[..., Any]
@@ -512,15 +514,8 @@ def build_api_client(
     if not provider or not model:
         return None
 
-    if provider not in {"ollama", "local"}:
-        api_key = str(getattr(model_config, "api_key", "") or "").strip()
-        credential_envs = {
-            "openai": ("OPENAI_API_KEY", "OPENAI_OAUTH_ACCESS_TOKEN"),
-            "anthropic": ("ANTHROPIC_API_KEY",),
-            "openrouter": ("OPENROUTER_API_KEY",),
-        }.get(provider, (f"{provider.upper()}_API_KEY",))
-        if not api_key and not any(os.getenv(name) for name in credential_envs):
-            return None
+    if not provider_credential_available(model_config):
+        return None
 
     api_client = api_client_factory(model_config=model_config)
     api_client.set_system_prompt(system_prompt)

--- a/penguin/core_runtime/stream_events.py
+++ b/penguin/core_runtime/stream_events.py
@@ -490,27 +490,22 @@ async def abort_session(
     await emit_opencode_session_status(owner, sid, "idle")
 
     if callable(adapter_abort):
+        cleanup_tasks = getattr(owner, "_opencode_abort_cleanup_tasks", None)
+        if not isinstance(cleanup_tasks, set):
+            cleanup_tasks = set()
+            owner._opencode_abort_cleanup_tasks = cleanup_tasks
 
         async def _cleanup_adapter() -> None:
             try:
                 await adapter_abort(reason="Tool execution was interrupted")
             except Exception:
                 logger.warning("Failed to abort active TUI parts", exc_info=True)
+            finally:
+                cleanup_tasks.discard(asyncio.current_task())
 
-        cleanup_tasks = getattr(owner, "_opencode_abort_cleanup_tasks", None)
-        if not isinstance(cleanup_tasks, set):
-            cleanup_tasks = set()
-            owner._opencode_abort_cleanup_tasks = cleanup_tasks
         cleanup_task = asyncio.create_task(_cleanup_adapter())
         cleanup_tasks.add(cleanup_task)
         aborted = True
-
-        def _finish_cleanup(task: asyncio.Task[Any]) -> None:
-            cleanup_tasks.discard(task)
-            if not task.cancelled():
-                task.exception()
-
-        cleanup_task.add_done_callback(_finish_cleanup)
 
     return aborted
 

--- a/penguin/core_runtime/stream_events.py
+++ b/penguin/core_runtime/stream_events.py
@@ -503,6 +503,7 @@ async def abort_session(
             owner._opencode_abort_cleanup_tasks = cleanup_tasks
         cleanup_task = asyncio.create_task(_cleanup_adapter())
         cleanup_tasks.add(cleanup_task)
+        aborted = True
 
         def _finish_cleanup(task: asyncio.Task[Any]) -> None:
             cleanup_tasks.discard(task)

--- a/penguin/core_runtime/stream_events.py
+++ b/penguin/core_runtime/stream_events.py
@@ -399,9 +399,11 @@ async def emit_ui_event(
                         owner,
                         session_id,
                         status_type,
-                        info=data.get("data")
-                        if isinstance(data.get("data"), dict)
-                        else None,
+                        info=(
+                            data.get("data")
+                            if isinstance(data.get("data"), dict)
+                            else None
+                        ),
                     )
     except Exception as e:
         logger.error("[TUI_ADAPTER] ERROR in event_bus.emit: %s", e, exc_info=True)
@@ -428,14 +430,6 @@ async def abort_session(
 
     adapter = owner._get_tui_adapter(sid)
     adapter_abort = getattr(adapter, "abort", None)
-    if callable(adapter_abort):
-        try:
-            adapter_aborted = await adapter_abort(
-                reason="Tool execution was interrupted"
-            )
-            aborted = bool(adapter_aborted) or aborted
-        except Exception:
-            logger.warning("Failed to abort active TUI parts", exc_info=True)
 
     tasks_map = getattr(owner, "_opencode_process_tasks", None)
     if isinstance(tasks_map, dict):
@@ -494,6 +488,29 @@ async def abort_session(
             aborted = True
 
     await emit_opencode_session_status(owner, sid, "idle")
+
+    if callable(adapter_abort):
+
+        async def _cleanup_adapter() -> None:
+            try:
+                await adapter_abort(reason="Tool execution was interrupted")
+            except Exception:
+                logger.warning("Failed to abort active TUI parts", exc_info=True)
+
+        cleanup_tasks = getattr(owner, "_opencode_abort_cleanup_tasks", None)
+        if not isinstance(cleanup_tasks, set):
+            cleanup_tasks = set()
+            owner._opencode_abort_cleanup_tasks = cleanup_tasks
+        cleanup_task = asyncio.create_task(_cleanup_adapter())
+        cleanup_tasks.add(cleanup_task)
+
+        def _finish_cleanup(task: asyncio.Task[Any]) -> None:
+            cleanup_tasks.discard(task)
+            if not task.cancelled():
+                task.exception()
+
+        cleanup_task.add_done_callback(_finish_cleanup)
+
     return aborted
 
 
@@ -643,9 +660,11 @@ def finalize_streaming_message(
                     logger.warning(
                         "stream.finalize.fallback_used request=%s session=%s "
                         "conversation=%s requested_scope=%s fallback_scope=%s",
-                        execution_context.request_id
-                        if execution_context
-                        else "unknown",
+                        (
+                            execution_context.request_id
+                            if execution_context
+                            else "unknown"
+                        ),
                         resolved_session_id or "",
                         resolved_conversation_id or "",
                         resolved_stream_scope_id,
@@ -660,9 +679,11 @@ def finalize_streaming_message(
                         "stream.finalize.single_active_fallback request=%s "
                         "session=%s conversation=%s requested_scope=%s "
                         "fallback_scope=%s",
-                        execution_context.request_id
-                        if execution_context
-                        else "unknown",
+                        (
+                            execution_context.request_id
+                            if execution_context
+                            else "unknown"
+                        ),
                         resolved_session_id or "",
                         resolved_conversation_id or "",
                         resolved_stream_scope_id,

--- a/penguin/setup/__init__.py
+++ b/penguin/setup/__init__.py
@@ -2,38 +2,46 @@
 
 # Try to import setup functions, providing fallbacks if dependencies are missing
 try:
-    from .wizard import run_setup_wizard_sync, run_setup_wizard, check_first_run, check_config_completeness, check_setup_dependencies
+    from .wizard import (
+        check_config_completeness,
+        check_first_run,
+        check_setup_dependencies,
+        run_setup_wizard,
+        run_setup_wizard_sync,
+    )
+
     SETUP_AVAILABLE = True
     SETUP_ERROR = None
 except ImportError as e:
     SETUP_AVAILABLE = False
     SETUP_ERROR = str(e)
-    
+
     # Provide fallback functions that indicate the issue
     def run_setup_wizard_sync():
         return {"error": f"Setup wizard unavailable: {SETUP_ERROR}"}
-    
+
     async def run_setup_wizard():
         return {"error": f"Setup wizard unavailable: {SETUP_ERROR}"}
-    
+
     def check_first_run():
         # If setup isn't available, assume setup is not needed
         # (user will need to configure manually)
         return False
-    
+
     def check_config_completeness():
         # If setup isn't available, assume config is complete
         return True
-    
+
     def check_setup_dependencies():
-        return False, ["questionary", "httpx", "PyYAML", "rich"]
+        return False, ["questionary", "PyYAML", "rich"]
+
 
 __all__ = [
-    "run_setup_wizard_sync", 
-    "run_setup_wizard", 
-    "check_first_run", 
-    "check_config_completeness",
-    "check_setup_dependencies",
     "SETUP_AVAILABLE",
-    "SETUP_ERROR"
-] 
+    "SETUP_ERROR",
+    "check_config_completeness",
+    "check_first_run",
+    "check_setup_dependencies",
+    "run_setup_wizard",
+    "run_setup_wizard_sync",
+]

--- a/penguin/setup/wizard.py
+++ b/penguin/setup/wizard.py
@@ -126,7 +126,10 @@ def check_config_completeness() -> bool:
     Connecting an AI model and credential is optional and must not gate startup.
     """
     workspace = _load_config().get("workspace")
-    return isinstance(workspace, dict) and bool(str(workspace.get("path", "")).strip())
+    if not isinstance(workspace, dict):
+        return False
+    raw_path = str(workspace.get("path", "")).strip()
+    return bool(raw_path) and _workspace_ready(Path(raw_path).expanduser())
 
 
 def check_provider_ready(config: dict[str, Any] | None = None) -> bool:
@@ -141,14 +144,14 @@ def check_provider_ready(config: dict[str, Any] | None = None) -> bool:
     if provider in {"ollama", "local"}:
         return True
     env_names = {
-        "openai": ("OPENAI_API_KEY",),
+        "openai": ("OPENAI_API_KEY", "OPENAI_OAUTH_ACCESS_TOKEN"),
         "anthropic": ("ANTHROPIC_API_KEY",),
         "openrouter": ("OPENROUTER_API_KEY",),
         "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
         "mistral": ("MISTRAL_API_KEY",),
         "deepseek": ("DEEPSEEK_API_KEY",),
     }.get(provider, ())
-    return any(os.getenv(name) for name in env_names)
+    return any(str(os.getenv(name) or "").strip() for name in env_names)
 
 
 def check_first_run() -> bool:
@@ -184,7 +187,10 @@ def _persist_api_key(provider: str, api_key: str) -> bool:
                 break
         else:
             existing.append(line)
+        env_path.touch(mode=0o600, exist_ok=True)
+        os.chmod(env_path, 0o600)
         env_path.write_text("\n".join(existing) + "\n", encoding="utf-8")
+        os.chmod(env_path, 0o600)
         os.environ[key] = api_key
         return True
     except OSError:
@@ -200,6 +206,11 @@ def save_config(config: dict[str, Any]) -> Path | None:
     except OSError as exc:
         console.print(f"[bold red]Could not save configuration:[/bold red] {exc}")
         return None
+
+
+def _workspace_ready(path: Path) -> bool:
+    """Return whether an existing workspace is a writable directory."""
+    return path.exists() and path.is_dir() and os.access(path, os.W_OK | os.X_OK)
 
 
 def _validate_workspace(value: str) -> bool | str:
@@ -333,14 +344,14 @@ async def run_setup_wizard() -> dict[str, Any]:
     }
     await _optional_model_setup(config)
 
+    try:
+        _create_workspace(workspace_path)
+    except OSError as exc:
+        return {"error": f"Could not initialize workspace: {exc}"}
     saved = save_config(config)
     if saved is None:
         return {"error": "Failed to save configuration"}
-    try:
-        _create_workspace(workspace_path)
-        mark_setup_complete()
-    except OSError as exc:
-        return {"error": f"Could not initialize workspace: {exc}"}
+    mark_setup_complete()
 
     console.print("\n[bold green]Penguin is ready.[/bold green]")
     console.print(f"Workspace: [cyan]{workspace_path}[/cyan]")

--- a/penguin/setup/wizard.py
+++ b/penguin/setup/wizard.py
@@ -1,1020 +1,399 @@
+"""Workspace-first onboarding for Penguin."""
+
+from __future__ import annotations
+
 import asyncio
-import json
 import os
 import platform
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
-import httpx
 import questionary
 import yaml
 from rich.console import Console
-from penguin.llm.model_config import safe_context_window
 
-# Create rich console for enhanced output
 console = Console()
 
-# Define consistent styling for questionary
-STYLE = questionary.Style([
-    ('qmark', 'fg:cyan bold'),           # Question mark
-    ('question', 'fg:white bold'),       # Questions
-    ('answer', 'fg:cyan bold'),          # Answers
-    ('pointer', 'fg:cyan bold'),         # Selection pointer
-    ('highlighted', 'fg:cyan bold'),     # Highlighted option
-    ('selected', 'fg:green'),            # Selected option
-    ('instruction', 'fg:white'),         # Instructions
-    ('text', 'fg:white'),                # Regular text
-    ('disabled', 'fg:gray italic')       # Disabled options
-])
+STYLE = questionary.Style(
+    [
+        ("qmark", "fg:cyan bold"),
+        ("question", "fg:white bold"),
+        ("answer", "fg:cyan bold"),
+        ("pointer", "fg:cyan bold"),
+        ("highlighted", "fg:cyan bold"),
+        ("selected", "fg:green"),
+        ("instruction", "fg:white"),
+        ("text", "fg:white"),
+        ("disabled", "fg:gray italic"),
+    ]
+)
 
-def check_setup_dependencies() -> Tuple[bool, List[str]]:
-    """
-    Check if all required dependencies for the setup wizard are available.
-    
-    Returns:
-        Tuple of (all_available: bool, missing_packages: List[str])
-    """
+WORKSPACE_DIRS = [
+    "conversations",
+    "memory_db",
+    "logs",
+    "notes",
+    "projects",
+    "context",
+]
+
+PROVIDERS: dict[str, dict[str, Any]] = {
+    "OpenAI": {
+        "id": "openai",
+        "env": "OPENAI_API_KEY",
+        "models": ["gpt-5.2", "gpt-5.1", "gpt-4.1"],
+    },
+    "Anthropic": {
+        "id": "anthropic",
+        "env": "ANTHROPIC_API_KEY",
+        "models": ["claude-opus-4-5", "claude-sonnet-4-5", "claude-haiku-4-5"],
+    },
+    "OpenRouter": {
+        "id": "openrouter",
+        "env": "OPENROUTER_API_KEY",
+        "client_preference": "openrouter",
+        "models": [
+            "openai/gpt-5.2",
+            "anthropic/claude-sonnet-4-5",
+            "google/gemini-3-pro-preview",
+        ],
+    },
+    "Ollama (local)": {
+        "id": "ollama",
+        "env": None,
+        "models": ["qwen3-coder", "gpt-oss:20b", "llama3.3"],
+    },
+}
+
+
+def check_setup_dependencies() -> tuple[bool, list[str]]:
     required_packages = {
-        'questionary': 'questionary',
-        'httpx': 'httpx',
-        'yaml': 'PyYAML',
-        'rich': 'rich',
+        "questionary": "questionary",
+        "yaml": "PyYAML",
+        "rich": "rich",
     }
-    
-    missing = []
-    
+    missing: list[str] = []
     for module_name, package_name in required_packages.items():
         try:
             __import__(module_name)
         except ImportError:
             missing.append(package_name)
-    
-    return len(missing) == 0, missing
+    return not missing, missing
 
-def display_dependency_install_instructions(missing_packages: List[str]) -> None:
-    """Display instructions for installing missing dependencies"""
-    console.print(f"[bold red]⚠️ Missing required dependencies for setup wizard:[/bold red]")
-    console.print(f"[yellow]Missing packages:[/yellow] {', '.join(missing_packages)}")
-    console.print("\n[bold cyan]To install missing dependencies:[/bold cyan]")
-    console.print(f"[white]pip install {' '.join(missing_packages)}[/white]")
-    console.print("\n[bold cyan]Or install all optional dependencies:[/bold cyan]")
-    console.print("[white]pip install penguin[setup][/white]")
-    console.print("\n[dim]After installing dependencies, run 'penguin config setup' to configure Penguin.[/dim]")
 
-def check_first_run() -> bool:
-    """
-    Check if this is the first run of Penguin by looking for setup completion indicators.
-    
-    Returns:
-        True if setup is needed, False if already completed
-    """
-    # Check for setup completion file
-    setup_complete_file = get_config_path().parent / ".penguin_setup_complete"
-    if setup_complete_file.exists():
-        return False
-    
-    # Check if config exists and has required fields
-    config_path = get_config_path()
-    if not config_path.exists():
-        return True
-        
-    # Check config completeness
-    return not check_config_completeness()
+def display_dependency_install_instructions(missing_packages: list[str]) -> None:
+    console.print("[bold red]Missing setup dependencies.[/bold red]")
+    console.print(f"[yellow]Install:[/yellow] pip install {' '.join(missing_packages)}")
 
-def check_config_completeness() -> bool:
-    """
-    Check if the current config.yml has all required fields for basic operation.
-    
-    Returns:
-        True if config is complete enough to run, False if setup is needed
-    """
-    config_path = get_config_path()
-    if not config_path.exists():
-        return False
-        
-    try:
-        with open(config_path, 'r') as f:
-            config = yaml.safe_load(f)
-            
-        if not config:
-            return False
-            
-        # Check for required sections
-        required_sections = ['model', 'workspace']
-        for section in required_sections:
-            if section not in config:
-                return False
-                
-        # Check if we have a valid model configuration
-        model_config = config.get('model', {})
-        if not model_config.get('default'):
-            return False
-            
-        # Check if workspace path is set
-        workspace_config = config.get('workspace', {})
-        if not workspace_config.get('path'):
-            return False
-            
-        # Check for API access (environment variables or config)
-        # This is optional - some models might not need API keys
-        provider = model_config.get('provider', '')
-        has_api_access = _check_api_access(provider)
-        
-        # If no API access is configured, we should run setup
-        # (unless it's a local model like Ollama)
-        if not has_api_access and provider not in ['ollama', 'local']:
-            console.print("[yellow]⚠️ No API access configured. Run 'penguin config setup' to configure API keys.[/yellow]")
-            return False
-            
-        return True
-        
-    except Exception as e:
-        console.print(f"[red]Error checking config completeness: {e}[/red]")
-        return False
-
-def _check_api_access(provider: str) -> bool:
-    """Check if API access is configured for the given provider"""
-    api_key_env_vars = {
-        'anthropic': ['ANTHROPIC_API_KEY'],
-        'openai': ['OPENAI_API_KEY'],
-        'openrouter': ['OPENROUTER_API_KEY'],
-        'google': ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
-        'mistral': ['MISTRAL_API_KEY'],
-        'deepseek': ['DEEPSEEK_API_KEY'],
-        'ollama': [],  # Local, no API key needed
-        'local': [],   # Local, no API key needed
-    }
-    
-    env_vars = api_key_env_vars.get(provider.lower(), [])
-    if not env_vars:  # Local provider, assume it's available
-        return True
-        
-    return any(os.getenv(var) for var in env_vars)
-
-def mark_setup_complete():
-    """Mark setup as completed by creating a completion file"""
-    setup_complete_file = get_config_path().parent / ".penguin_setup_complete"
-    try:
-        with open(setup_complete_file, 'w') as f:
-            f.write(f"Setup completed on {os.getenv('USER', 'user')}@{platform.node()} at {platform.system()}\n")
-        console.print(f"[green]✓ Setup marked as complete[/green]")
-    except Exception as e:
-        console.print(f"[yellow]Warning: Could not mark setup as complete: {e}[/yellow]")
-
-async def fetch_models_from_openrouter() -> List[Dict[str, Any]]:
-    """
-    Fetch available models from OpenRouter API
-    Returns a list of model data objects
-    """
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get("https://openrouter.ai/api/v1/models", timeout=10.0)
-            response.raise_for_status()
-            data = response.json()
-            return data.get("data", [])
-    except Exception as e:
-        console.print(f"[bold red]⚠️ Failed to fetch models from OpenRouter:[/bold red] {e}")
-        return []
-
-def get_local_models_cache() -> List[Dict[str, Any]]:
-    """
-    Get cached models list if available
-    Returns empty list if no cache found
-    """
-    cache_path = Path.home() / ".config" / "penguin" / "models_cache.json"
-    if cache_path.exists():
-        try:
-            with open(cache_path, "r") as f:
-                return json.load(f)
-        except Exception:
-            return []
-    return []
-
-def save_models_cache(models: List[Dict[str, Any]]) -> None:
-    """Save models to local cache for faster startup next time"""
-    cache_path = Path.home() / ".config" / "penguin" / "models_cache.json"
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    try:
-        with open(cache_path, "w") as f:
-            json.dump(models, f)
-    except Exception as e:
-        console.print(f"[bold yellow]⚠️ Failed to cache models:[/bold yellow] {e}")
-
-def prepare_model_choices(models: List[Dict[str, Any]]) -> Tuple[List[str], Dict[str, str]]:
-    """
-    Convert models list to:
-    1. List of formatted choice strings
-    2. Mapping from choice string to model ID
-    """
-    choices = []
-    model_map = {}
-    
-    # Add popular/recommended models at the top
-    recommended = [
-        "anthropic/claude-3-5-sonnet-20240620",
-        "openai/o3-mini",
-        "google/gemini-2-5-pro-preview", 
-        "mistral/devstral",
-        "meta-llama/llama-3-70b-instruct",
-    ]
-    
-    # Add all recommended models first (if they exist in the data)
-    for rec_id in recommended:
-        for model in models:
-            model_id = model.get("id", "")
-            if model_id == rec_id:
-                context_length = model.get("context_length", "unknown")
-                display = f"{model_id} ({context_length} tokens)"
-                choices.append(display)
-                model_map[display] = model_id
-                break
-    
-    # Then add the rest
-    for model in models:
-        model_id = model.get("id", "")
-        # Skip if already added as recommended
-        if any(model_id == rec for rec in recommended):
-            continue
-            
-        context_length = model.get("context_length", "unknown")
-        display = f"{model_id} ({context_length} tokens)"
-        choices.append(display)
-        model_map[display] = model_id
-    
-    # Always add custom option at the end
-    choices.append("Custom (specify)")
-    
-    return choices, model_map
-
-def display_section_header(title: str) -> None:
-    """Display a formatted section header for visual hierarchy"""
-    console.print(f"\n[bold cyan]━━━━ {title} ━━━━[/bold cyan]")
-
-async def run_setup_wizard() -> Dict[str, Any]:
-    """
-    Run the first-time setup wizard for Penguin.
-    Returns the completed configuration dictionary.
-    """
-    # Clear screen for better focus (optional)
-    os.system('cls' if os.name == 'nt' else 'clear')
-    
-    # Welcome banner with visual hierarchy
-    console.print("\n[bold cyan]╭───────────────────────────────────────────╮[/bold cyan]")
-    console.print("[bold cyan]│[/bold cyan]  [bold white]🐧 PENGUIN SETUP WIZARD[/bold white]  [bold cyan]│[/bold cyan]")
-    console.print("[bold cyan]╰───────────────────────────────────────────╯[/bold cyan]")
-    console.print("\nWelcome! Let's configure your environment for optimal performance.\n")
-
-    # Setup steps indicator for better user orientation
-    steps = ["Workspace", "Model Selection", "API Configuration", "Advanced Options", "Finalize"]
-    current_step = 1
-    total_steps = len(steps)
-    
-    # Track progress
-    def show_progress():
-        progress_text = " → ".join([
-            f"[bold cyan]{s}[/bold cyan]" if i+1 == current_step else 
-            f"[green]✓ {s}[/green]" if i+1 < current_step else 
-            f"[dim]{s}[/dim]" 
-            for i, s in enumerate(steps)
-        ])
-        console.print(f"\n[Progress: {current_step}/{total_steps}] {progress_text}\n")
-    
-    # ----- STEP 1: WORKSPACE CONFIGURATION -----
-    show_progress()
-    display_section_header("Workspace Configuration")
-    console.print("This is where Penguin will store your projects and contextual data.")
-    
-    default_workspace = str(Path.home() / "penguin_workspace")
-    console.print("[dim](Press Enter to accept default)[/dim]")
-    workspace_path = await questionary.text(
-        "Workspace directory:",
-        default=default_workspace,
-        style=STYLE
-    ).ask_async()
-    
-    current_step += 1
-    
-    # ----- STEP 2: MODEL SELECTION -----
-    show_progress()
-    display_section_header("Model Selection")
-    console.print("Choose which AI model Penguin will use by default.")
-    
-    # Show loading indicator for model fetching
-    with console.status("[bold cyan]Fetching available models...[/bold cyan]", spinner="dots"):
-        # First try local cache for fast startup
-        models = get_local_models_cache()
-        
-        # If cache is empty, fetch from API
-        if not models:
-            models = await fetch_models_from_openrouter()
-            if models:
-                # Save to cache for next time
-                save_models_cache(models)
-                console.print("[green]✓[/green] Models retrieved and cached for future use")
-            else:
-                console.print("[yellow]⚠️ Could not retrieve models from API, using defaults[/yellow]")
-    
-    # Prepare model choices with better formatting
-    if models:
-        choices, model_map = prepare_model_choices(models)
-        console.print(f"[green]✓[/green] Found [bold]{len(models)}[/bold] available models")
-    else:
-        # Fallback to default list if API call fails
-        choices = [
-            "anthropic/claude-3-5-sonnet-20240620 (200K tokens)",
-            "openai/o3-mini (128K tokens)",
-            "google/gemini-2-5-pro-preview (1M tokens)",
-            "mistral/devstral (32K tokens)",
-            "Custom (specify)"
-        ]
-        model_map = {choice: choice.split(" ")[0] for choice in choices if "Custom" not in choice}
-        console.print("[yellow]ℹ️ Using default model list[/yellow]")
-    
-    # Show helpful tips for model selection
-    console.print("\n[dim]💡 Tip: Larger context windows (more tokens) let Penguin process more information at once.[/dim]")
-    console.print("[dim]   For code-heavy tasks, 32K+ tokens is recommended.[/dim]\n")
-    
-    # Display instruction before the prompt instead of as a parameter
-    console.print("[dim](Type to search, ↑↓ to navigate)[/dim]")
-    # Model selection with autocomplete and improved styling
-    model_selection = await questionary.autocomplete(
-        "Choose your default AI model:",
-        choices=choices,
-        validate=lambda val: val in choices or "Please select from the list or type 'Custom (specify)'",
-        match_middle=True,  # Allow matching in the middle of strings
-        style=STYLE
-    ).ask_async()
-    
-    # Handle custom model entry with improved validation
-    if model_selection == "Custom (specify)":
-        console.print("[dim](Format: provider/model-name)[/dim]")
-        model = await questionary.text(
-            "Enter custom model identifier:",
-            validate=lambda val: len(val) > 0 or "Model identifier cannot be empty",
-            style=STYLE
-        ).ask_async()
-    else:
-        # Get the actual model ID from the display string
-        model = model_map.get(model_selection, model_selection.split(" ")[0])
-    
-    # Show confirmation of selection
-    console.print(f"[green]✓[/green] Selected model: [bold cyan]{model}[/bold cyan]")
-    
-    # Determine the actual provider and client preference that will be used
-    # This logic should match what's used in the config generation
-    provider_from_model = model.split('/')[0] if '/' in model else "anthropic"
-    
-    # Check if this model will be routed through OpenRouter
-    # If models were fetched from OpenRouter API and this model was in that list,
-    # then it should use OpenRouter regardless of the provider prefix
-    will_use_openrouter = False
-    
-    if models and "/" in model:
-        # Check if this model was in the OpenRouter models list
-        model_in_openrouter_list = any(m.get("id") == model for m in models)
-        if model_in_openrouter_list:
-            will_use_openrouter = True
-            console.print(f"[dim]ℹ️ This model will be accessed through OpenRouter (found in OpenRouter catalog).[/dim]")
-    
-    # Fallback to hardcoded list for cases where OpenRouter API wasn't available
-    if not will_use_openrouter and provider_from_model in ["openai", "anthropic", "google", "mistral"] and "/" in model:
-        will_use_openrouter = True
-        console.print(f"[dim]ℹ️ This model will be accessed through OpenRouter for unified API access.[/dim]")
-    
-    if will_use_openrouter:
-        actual_provider = "openrouter"
-    else:
-        actual_provider = provider_from_model
-        if "/" in model:
-            console.print(f"[dim]ℹ️ This model will be accessed directly through the {actual_provider} provider.[/dim]")
-    
-    current_step += 1
-    
-    # ----- STEP 3: API CONFIGURATION -----
-    show_progress()
-    display_section_header("API Configuration")
-    console.print(f"Configure access to the {actual_provider} API.")
-    
-    # Auto-detect context length and max output tokens for the chosen model
-    context_window_auto = None
-    max_output_tokens_auto = None
-    if models:
-        for _m in models:
-            if _m.get("id") == model:
-                context_length = _m.get("context_length")
-                context_window_auto = safe_context_window(context_length) or context_length
-                # Use official max_output_tokens field when provided, no fallback.
-                if _m.get("max_output_tokens") is not None:
-                    max_output_tokens_auto = _m.get("max_output_tokens")
-                    if context_window_auto:
-                        max_output_tokens_auto = min(max_output_tokens_auto, context_window_auto)
-                break
-    
-    need_api_key = await questionary.confirm(
-        f"Do you need to set up an API key for {actual_provider}?",
-        default=True,
-        style=STYLE
-    ).ask_async()
-    
-    api_key = None
-    if need_api_key:
-        # Show help text for API key based on actual provider
-        if actual_provider == "openrouter":
-            console.print("\n[dim]ℹ️ OpenRouter API keys can be obtained at: https://openrouter.ai/keys[/dim]")
-            console.print("[dim]   OpenRouter provides unified access to models from multiple providers.[/dim]")
-        elif actual_provider == "anthropic":
-            console.print("\n[dim]ℹ️ Anthropic API keys can be obtained at: https://console.anthropic.com/[/dim]")
-        elif actual_provider == "openai":
-            console.print("\n[dim]ℹ️ OpenAI API keys can be obtained at: https://platform.openai.com/api-keys[/dim]")
-        elif actual_provider == "google":
-            console.print("\n[dim]ℹ️ Google AI API keys can be obtained through Google AI Studio[/dim]")
-        else:
-            console.print(f"\n[dim]ℹ️ Please obtain an API key for {actual_provider}[/dim]")
-        
-        console.print("[dim](Input is hidden for security)[/dim]")
-        api_key = await questionary.password(
-            f"Enter your {actual_provider} API key:",
-            validate=lambda val: len(val) > 10 or "API key seems too short",
-            style=STYLE
-        ).ask_async()
-        
-        # Persist key to ~/.config/penguin/.env and export it
-        if _persist_api_key(actual_provider, api_key):
-            console.print("[green]✓[/green] API key saved to ~/.config/penguin/.env and exported for this session")
-        else:
-            console.print("[yellow]⚠️ Could not persist API key automatically. It will be shown in next steps.[/yellow]")
-    else:
-        console.print("[yellow]ℹ️ No API key provided. You'll need to set this up later.[/yellow]")
-    
-    current_step += 1
-    
-    # ----- STEP 4: ADVANCED OPTIONS -----
-    show_progress()
-    display_section_header("Advanced Options")
-    
-    # Default config values
-    config = {
-        "workspace": {
-            "path": workspace_path,
-            "create_dirs": [
-                "conversations", "memory_db", "logs", "notes", "projects", "context"
-            ]
-        },
-        "model": {
-            "default": model,
-            "provider": "openrouter" if will_use_openrouter else provider_from_model,
-            "client_preference": "openrouter" if will_use_openrouter else "native",
-            "streaming_enabled": True,
-            "temperature": 0.7,
-            "context_window": context_window_auto,
-            "max_output_tokens": max_output_tokens_auto,
-        },
-        "api": {
-            "base_url": None,  # Will be determined based on provider
-        },
-        "tools": {
-            "enabled": True,
-            "allow_web_access": True,
-            "allow_file_operations": True,
-            "allow_code_execution": True
-        },
-        "diagnostics": {
-            "enabled": False,
-            "verbose_logging": False
-        }
-    }
-    
-    if api_key:
-        # Store API key as environment variable suggestion
-        env_var_name = f"{actual_provider.upper()}_API_KEY"
-        console.print(f"\n[dim]💡 Tip: You can set {env_var_name}={api_key[:8]}... as an environment variable[/dim]")
-        console.print(f"[dim]   This is more secure than storing it in the config file.[/dim]")
-    
-    # Advanced configuration with better grouping
-    show_advanced = await questionary.confirm(
-        "Would you like to configure advanced options?",
-        default=False,
-        style=STYLE
-    ).ask_async()
-    
-    if show_advanced:
-        console.print("\n[bold]Performance Settings[/bold]")
-        # Model temperature - use text with float validation instead of float
-        console.print("[dim](Lower = more deterministic, Higher = more creative)[/dim]")
-        temperature = await questionary.text(
-            "Model temperature (0.0-1.0):",
-            default="0.7",
-            validate=lambda val: (val.replace('.', '', 1).isdigit() and 0.0 <= float(val) <= 1.0) or "Please enter a number between 0.0 and 1.0",
-            style=STYLE
-        ).ask_async()
-        config["model"]["temperature"] = float(temperature)
-        
-        # In the advanced section, only ask for context window if we couldn't auto-detect it
-        if context_window_auto is None:
-            console.print("\n[dim]💡 Tip: Larger context windows use more API tokens but can handle more complex tasks.[/dim]")
-            context_window_choice = await questionary.select(
-                "Maximum context window:",
-                choices=[
-                    "8K tokens (Basic tasks, lower cost)",
-                    "16K tokens (Standard projects)",
-                    "32K tokens (Complex projects)",
-                    "128K tokens (Large codebases)",
-                    "200K tokens (Extended capability)",
-                    "1M tokens (Maximum capability)"
-                ],
-                default="32K tokens (Complex projects)",
-                style=STYLE
-            ).ask_async()
-
-            token_map = {
-                "8K tokens (Basic tasks, lower cost)": 8000,
-                "16K tokens (Standard projects)": 16000,
-                "32K tokens (Complex projects)": 32000,
-                "128K tokens (Large codebases)": 128000,
-                "200K tokens (Extended capability)": 200000,
-                "1M tokens (Maximum capability)": 1000000
-            }
-            config["model"]["context_window"] = token_map[context_window_choice]
-            
-            # If we couldn't auto-detect, prompt for max_output_tokens as well.
-            if max_output_tokens_auto is None:
-                console.print("\n[dim]💡 Tip: This is the maximum number of tokens the model can generate in a single response. Check the what's the max_tokens (or max_output_tokens) in the model spec of the model you selected.[/dim]")
-                max_output_tokens_str = await questionary.text(
-                    "Maximum output tokens (max_output_tokens):",
-                    default="8192",
-                    validate=lambda val: val.isdigit() or "Please enter a number.",
-                    style=STYLE
-                ).ask_async()
-                config["model"]["max_output_tokens"] = int(max_output_tokens_str)
-        
-        # Tool permissions with better organization
-        console.print("\n[bold]Security & Permissions[/bold]")
-        console.print("[dim](For documentation lookups and information retrieval)[/dim]")
-        config["tools"]["allow_web_access"] = await questionary.confirm(
-            "Allow Penguin to access the web?", 
-            default=True,
-            style=STYLE
-        ).ask_async()
-        
-        console.print("[dim](Required for testing/running code suggestions)[/dim]")
-        config["tools"]["allow_code_execution"] = await questionary.confirm(
-            "Allow Penguin to execute code?", 
-            default=True,
-            style=STYLE
-        ).ask_async()
-        
-        # Diagnostics with better explanations
-        console.print("\n[bold]Diagnostics & Logging[/bold]")
-        console.print("[dim](Helps improve Penguin, no personal data collected)[/dim]")
-        config["diagnostics"]["enabled"] = await questionary.confirm(
-            "Enable diagnostics collection?", 
-            default=False,
-            style=STYLE
-        ).ask_async()
-        
-        if config["diagnostics"]["enabled"]:
-            console.print("[dim](Creates detailed logs, helpful for troubleshooting)[/dim]")
-            config["diagnostics"]["verbose_logging"] = await questionary.confirm(
-                "Enable verbose logging?", 
-                default=False,
-                style=STYLE
-            ).ask_async()
-    
-    current_step += 1
-    
-    # ----- STEP 5: FINALIZE -----
-    show_progress()
-    display_section_header("Configuration Summary")
-    
-    # Display current configuration in a more visually appealing way
-    console.print("\n[bold]Your Configuration:[/bold]")
-    console.print(f"  • Workspace: [cyan]{config['workspace']['path']}[/cyan]")
-    console.print(f"  • Model: [cyan]{config['model']['default']}[/cyan]")
-    console.print(f"  • Provider: [cyan]{config['model']['provider']}[/cyan]")
-    console.print(f"  • Temperature: [cyan]{config['model']['temperature']}[/cyan]")
-    console.print(f"  • Context Window: [cyan]{config['model'].get('context_window', 'unknown')} tokens[/cyan]")
-    console.print(f"  • Max Output: [cyan]{config['model'].get('max_output_tokens', 'unknown')} tokens[/cyan]")
-    console.print(f"  • Web Access: {'Enabled' if config['tools']['allow_web_access'] else 'Disabled'}")
-    console.print(f"  • Code Execution: {'Enabled' if config['tools']['allow_code_execution'] else 'Disabled'}")
-    console.print(f"  • Diagnostics: [cyan]{'Enabled' if config['diagnostics']['enabled'] else 'Disabled'}[/cyan]")
-    
-    # Ask to save the final configuration
-    if await questionary.confirm(
-        "Save this configuration?", 
-        default=True,
-        style=STYLE
-    ).ask_async():
-        # Show saving indicator
-        with console.status("[bold cyan]Saving configuration...[/bold cyan]", spinner="dots"):
-            saved_config_path = save_config(config)
-        
-        if saved_config_path:
-            console.print("[bold green]✓ Configuration saved successfully![/bold green]")
-            console.print(f"[dim]Saved to:[/dim] {saved_config_path}")
-            
-            # Mark setup as complete
-            mark_setup_complete()
-        
-            # Create workspace directory with progress indicator
-            if not os.path.exists(config["workspace"]["path"]):
-                try:
-                    with console.status("[bold cyan]Creating workspace directory...[/bold cyan]", spinner="dots"):
-                        os.makedirs(config["workspace"]["path"])
-                        
-                        # Create subdirectories
-                        for subdir in config["workspace"]["create_dirs"]:
-                            os.makedirs(os.path.join(config["workspace"]["path"], subdir), exist_ok=True)
-                            
-                        console.print(f"[bold green]✓ Created workspace directory:[/bold green] {config['workspace']['path']}")
-                except Exception as e:
-                        console.print(f"[bold red]⚠️ Could not create workspace directory:[/bold red] {e}")
-            
-            # Show API key setup reminder if needed
-            if api_key:
-                env_var_name = f"{actual_provider.upper()}_API_KEY"
-                console.print(f"\n[bold yellow]📋 Next Steps:[/bold yellow]")
-                console.print(f"Set your API key as an environment variable:")
-                console.print(f"  [dim]export {env_var_name}=\"{api_key}\"[/dim]")
-                console.print(f"Or add it to your shell profile (.bashrc, .zshrc, etc.)")
-            
-            # Ask to open the config file for review
-            if await questionary.confirm(
-                    "Would you like to open the config file for review?", 
-                    default=False,
-                    style=STYLE
-                ).ask_async():
-                    cfg_path = saved_config_path
-                    # In Codespaces/containers, prefer $EDITOR if available, else fallback
-                    editor = os.environ.get("EDITOR")
-                    opened = False
-                    if editor and shutil.which(editor.split()[0]):
-                        try:
-                            subprocess.run([*editor.split(), str(cfg_path)], check=True)
-                            opened = True
-                        except Exception:
-                            opened = False
-                    if not opened:
-                        opened = open_in_default_editor(cfg_path)
-                    if opened:
-                        console.print(f"[green]✓ Opened config file:[/green] {cfg_path}")
-                    else:
-                        console.print(f"[yellow]⚠️ Could not open config file. It's located at:[/yellow] {cfg_path}")
-        else:
-            console.print("[bold red]Failed to save configuration. Please check permissions and try again.[/bold red]")
-    else:
-        console.print("[yellow]Configuration not saved. Run setup again when ready.[/yellow]")
-    
-    # Final success message
-    console.print("\n[bold green]╭───────────────────────────────────────────╮[/bold green]")
-    console.print("[bold green]│[/bold green]    [bold white]🎉 PENGUIN SETUP COMPLETE![/bold white]    [bold green]│[/bold green]")
-    console.print("[bold green]╰───────────────────────────────────────────╯[/bold green]")
-    console.print("\nYou're ready to start using Penguin AI Assistant!\n")
-    console.print("[dim]You can always update these settings by running 'penguin config setup' later.[/dim]")
-    console.print("[dim]Run 'penguin' to launch the assistant.[/dim]\n")
-    
-    return config
 
 def _user_config_dir() -> Path:
-    """Return cross-platform user config directory for Penguin."""
-    if os.name == 'posix':  # Linux/macOS
-        return Path(os.environ.get('XDG_CONFIG_HOME', Path.home() / '.config')) / 'penguin'
-    return Path(os.environ.get('APPDATA', Path.home() / 'AppData' / 'Roaming')) / 'penguin'
+    if os.name == "posix":
+        return (
+            Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "penguin"
+        )
+    return (
+        Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming")) / "penguin"
+    )
+
 
 def get_config_path() -> Path:
-    """Return the path to the user config file (env override wins)."""
-    # 1) Explicit override
-    if os.environ.get("PENGUIN_CONFIG_PATH"):
-        return Path(os.environ["PENGUIN_CONFIG_PATH"]).expanduser()
-    # 2) User config directory (do not write into repo path)
+    override = os.environ.get("PENGUIN_CONFIG_PATH")
+    if override:
+        return Path(override).expanduser()
     return _user_config_dir() / "config.yml"
 
-def _persist_api_key(provider: str, api_key: str) -> bool:
-    """Write provider API key to ~/.config/penguin/.env and export in-process.
 
-    Returns True on success, False on failure.
+def _setup_complete_path() -> Path:
+    return get_config_path().parent / ".penguin_setup_complete"
+
+
+def _load_config() -> dict[str, Any]:
+    path = get_config_path()
+    if not path.exists():
+        return {}
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def check_config_completeness() -> bool:
+    """Return whether required workspace onboarding is complete.
+
+    Connecting an AI model and credential is optional and must not gate startup.
     """
+    workspace = _load_config().get("workspace")
+    return isinstance(workspace, dict) and bool(str(workspace.get("path", "")).strip())
+
+
+def check_provider_ready(config: dict[str, Any] | None = None) -> bool:
+    config = config or _load_config()
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return False
+    provider = str(model.get("provider", "")).strip().lower()
+    model_id = str(model.get("default", "")).strip()
+    if not provider or not model_id:
+        return False
+    if provider in {"ollama", "local"}:
+        return True
+    env_names = {
+        "openai": ("OPENAI_API_KEY",),
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "openrouter": ("OPENROUTER_API_KEY",),
+        "google": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        "mistral": ("MISTRAL_API_KEY",),
+        "deepseek": ("DEEPSEEK_API_KEY",),
+    }.get(provider, ())
+    return any(os.getenv(name) for name in env_names)
+
+
+def check_first_run() -> bool:
+    # Existing workspace configs are onboarded even if they predate the marker.
+    return not check_config_completeness()
+
+
+def mark_setup_complete() -> None:
+    path = _setup_complete_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    user = os.getenv("USERNAME") or os.getenv("USER", "user")
+    path.write_text(
+        f"Setup completed on {user}@{platform.node()} at {platform.system()}\n",
+        encoding="utf-8",
+    )
+
+
+def _persist_api_key(provider: str, api_key: str) -> bool:
     try:
         env_dir = _user_config_dir()
         env_dir.mkdir(parents=True, exist_ok=True)
         env_path = env_dir / ".env"
-        # Read existing lines (if any)
-        existing: list[str] = []
-        if env_path.exists():
-            existing = env_path.read_text(encoding="utf-8").splitlines()
+        existing = (
+            env_path.read_text(encoding="utf-8").splitlines()
+            if env_path.exists()
+            else []
+        )
         key = f"{provider.upper()}_API_KEY"
-        kv = f"{key}={api_key}"
-        replaced = False
-        for i, line in enumerate(existing):
-            if line.startswith(f"{key}="):
-                existing[i] = kv
-                replaced = True
+        line = f"{key}={api_key}"
+        for index, current in enumerate(existing):
+            if current.startswith(f"{key}="):
+                existing[index] = line
                 break
-        if not replaced:
-            existing.append(kv)
+        else:
+            existing.append(line)
         env_path.write_text("\n".join(existing) + "\n", encoding="utf-8")
-        # Export for current process so the rest of the run sees it
         os.environ[key] = api_key
         return True
-    except Exception:
+    except OSError:
         return False
 
-def save_config(config: Dict[str, Any]) -> Optional[Path]:
-    """
-    Save the config to a YAML file and return the resolved path.
 
-    Returns:
-        Path on success; None on failure.
-    """
-    config_path = get_config_path()
-
+def save_config(config: dict[str, Any]) -> Path | None:
+    path = get_config_path()
     try:
-        # Make sure parent directory exists
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write config with nice formatting
-        with open(config_path, 'w') as f:
-            yaml.dump(config, f, sort_keys=False, default_flow_style=False)
-
-        return config_path
-    except PermissionError:
-        console.print(f"[bold red]⚠️ Permission denied:[/bold red] Cannot write to {config_path}")
-        console.print("[yellow]Try running with administrator/sudo privileges or choose a different location.[/yellow]")
-        return None
-    except Exception as e:
-        console.print(f"[bold red]⚠️ Error saving configuration:[/bold red] {str(e)}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+        return path
+    except OSError as exc:
+        console.print(f"[bold red]Could not save configuration:[/bold red] {exc}")
         return None
 
-def open_in_default_editor(file_path: Path) -> bool:
-    """
-    Open a file in the default text editor
-    
-    Args:
-        file_path: Path to the file to open
-        
-    Returns:
-        bool: True if successful, False otherwise
-    """
-    with console.status(f"[bold cyan]Opening {file_path.name}...[/bold cyan]", spinner="dots"):
-        try:
-            if platform.system() == 'Windows':
-                os.startfile(file_path)
-            elif platform.system() == 'Darwin':  # macOS
-                subprocess.run(['open', file_path], check=True)
-            else:  # Linux
-                # In headless environments (e.g., Codespaces) xdg-open may not exist
-                if shutil.which('xdg-open') is None:
-                    console.print(
-                        f"[yellow]⚠️ GUI launcher not available (xdg-open not found). File saved at:[/yellow] {file_path}"
-                    )
-                    return False
-                subprocess.run(['xdg-open', file_path], check=True)
-            return True
-        except FileNotFoundError as e:
-                # Differentiate missing editor launcher vs missing file
-                if file_path.exists():
-                    console.print(
-                        f"[yellow]⚠️ Could not launch editor ({e}). File saved at:[/yellow] {file_path}"
-                    )
-                else:
-                    console.print(f"[bold red]⚠️ File not found:[/bold red] {file_path}")
-                return False
-        except PermissionError:
-                console.print(f"[bold red]⚠️ Permission denied:[/bold red] Cannot open {file_path}")
-                return False
-        except subprocess.SubprocessError as e:
-                console.print(f"[bold red]⚠️ Failed to open editor:[/bold red] {str(e)}")
-                console.print(f"[dim]You can manually edit the file at: {file_path}[/dim]")
-                return False
-        except Exception as e:
-                console.print(f"[bold red]⚠️ Error opening file:[/bold red] {str(e)}")
-        return False
 
-# For integration with CLI: The /models command handler
-async def handle_models_command(args: List[str]) -> Dict[str, Any]:
-    """
-    Handle /models command to list, search, and set models
-    
-    Examples:
-    - /models list
-    - /models search "claude"
-    - /models set anthropic/claude-3-5-sonnet
-    """
-    if not args:
-        return {"error": "Missing models subcommand. Try 'list', 'search', or 'set'"}
-    
-    subcmd = args[0].lower()
-    
-    # Fetch models from OpenRouter with visual feedback
-    models = get_local_models_cache()
-    if not models:
-        with console.status("[bold cyan]Fetching models from OpenRouter...[/bold cyan]", spinner="dots"):
-            models = await fetch_models_from_openrouter()
-            if models:
-                save_models_cache(models)
-                console.print("[green]✓[/green] Models retrieved and cached successfully")
-            else:
-                console.print("[yellow]⚠️ Could not retrieve models from API[/yellow]")
-    
-    if subcmd == "list":
-        # Format for display with better visual structure
-        display_section_header("Available Models")
-        
-        if not models:
-            console.print("[yellow]No models found. Unable to connect to model provider.[/yellow]")
-            return {"models_list": [], "error": "No models found"}
-        
-        # Group models by provider for better organization
-        providers = {}
-        for model in models:
-            model_id = model.get("id", "unknown")
-            provider = model_id.split('/')[0] if '/' in model_id else "unknown"
-            
-            if provider not in providers:
-                providers[provider] = []
-                
-            providers[provider].append({
-                "id": model_id,
-                "name": model.get("name", model_id),
-                "context_length": model.get("context_length", "unknown"),
-            })
-        
-        # Display models grouped by provider
-        for provider, provider_models in providers.items():
-            console.print(f"\n[bold cyan]{provider.capitalize()} Models:[/bold cyan]")
-            for model in provider_models:
-                context = f"({model['context_length']} tokens)" if model['context_length'] != "unknown" else ""
-                console.print(f"  • [cyan]{model['id']}[/cyan] {context}")
-        
-        # Prepare data for return
-        model_list = []
-        for model in models:
-            model_id = model.get("id", "unknown")
-            context_length = model.get("context_length", "unknown")
-            model_list.append({
-                "id": model_id,
-                "name": model.get("name", model_id),
-                "provider": model_id.split('/')[0] if '/' in model_id else "unknown",
-                "context_length": context_length,
-            })
-        
-        return {"models_list": model_list}
-    
-    elif subcmd == "search" and len(args) > 1:
-        query = args[1].lower()
-        display_section_header(f"Search Results for '{query}'")
-        
-        # Search by ID, name, or provider with visual feedback
-        results = []
-        matched_count = 0
-        
-        with console.status(f"[bold cyan]Searching for models matching '{query}'...[/bold cyan]", spinner="dots"):
-            for model in models:
-                model_id = model.get("id", "").lower()
-                name = model.get("name", "").lower()
-                if query in model_id or query in name:
-                    matched_count += 1
-                    results.append({
-                        "id": model.get("id"),
-                        "name": model.get("name", model.get("id")),
-                        "context_length": model.get("context_length", "unknown"),
-                    })
-        
-        if results:
-            console.print(f"[green]Found {matched_count} matching models[/green]")
-            for model in results:
-                context = f"({model['context_length']} tokens)" if model['context_length'] != "unknown" else ""
-                console.print(f"  • [cyan]{model['id']}[/cyan] {context}")
-        else:
-            console.print(f"[yellow]No models found matching '{query}'[/yellow]")
-        
-        return {"search_results": results}
-    
-    elif subcmd == "set" and len(args) > 1:
-        model_id = args[1]
-        display_section_header("Set Model")
-        
-        # Validate model exists if we have model data
-        model_exists = False
-        model_details = None
-        
-        if models:
-            for model in models:
-                if model.get("id") == model_id:
-                    model_exists = True
-                    model_details = model
-                    break
-            
-            if not model_exists:
-                console.print(f"[yellow]⚠️ Warning: Model '{model_id}' not found in available models.[/yellow]")
-                console.print("[dim]The model may still be valid if it's from a provider not listed in OpenRouter.[/dim]")
-        
-        # Show confirmation with model details if available
-        if model_details:
-            context_length = model_details.get("context_length", "unknown")
-            console.print(f"[bold]Model Details:[/bold]")
-            console.print(f"  • ID: [cyan]{model_id}[/cyan]")
-            console.print(f"  • Context Window: [cyan]{context_length} tokens[/cyan]")
-        
-        # In a real implementation, this would call the model loading function
-        console.print(f"[green]✓ Model set to:[/green] [bold cyan]{model_id}[/bold cyan]")
-        return {"status": f"Model set to: {model_id}", "model_id": model_id, "success": True}
-    
-    return {"error": f"Unknown models subcommand: {subcmd}"}
+def _validate_workspace(value: str) -> bool | str:
+    raw = str(value or "").strip()
+    if not raw:
+        return "Workspace location is required"
+    path = Path(raw).expanduser()
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        probe = path / ".penguin-write-test"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except OSError as exc:
+        return f"Penguin cannot write to this location: {exc}"
+    return True
+
+
+def _create_workspace(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for directory in WORKSPACE_DIRS:
+        (path / directory).mkdir(parents=True, exist_ok=True)
+
+
+async def _optional_model_setup(config: dict[str, Any]) -> None:
+    choice = await questionary.select(
+        "Connect an AI model?",
+        choices=["Connect now", "Skip for now"],
+        default="Connect now",
+        style=STYLE,
+    ).ask_async()
+    if choice != "Connect now":
+        # Fresh installs need an explicit empty model section so lower-precedence
+        # package defaults cannot silently reconnect OpenRouter. On reruns, Skip
+        # means "leave my current connection unchanged."
+        config.setdefault("model", None)
+        console.print(
+            "[dim]Skipped. Run 'penguin config setup' to connect a model later.[/dim]"
+        )
+        return
+
+    provider_choices = [*PROVIDERS, "Skip for now"]
+    provider_label = await questionary.select(
+        "Choose a provider:", choices=provider_choices, style=STYLE
+    ).ask_async()
+    if provider_label not in PROVIDERS:
+        config.setdefault("model", None)
+        return
+    provider = PROVIDERS[provider_label]
+
+    model_choices = [*provider["models"], "Custom model", "Skip for now"]
+    model = await questionary.select(
+        "Choose a model:", choices=model_choices, style=STYLE
+    ).ask_async()
+    if model == "Skip for now" or model is None:
+        config.setdefault("model", None)
+        return
+    if model == "Custom model":
+        model = await questionary.text(
+            "Model identifier:",
+            validate=lambda value: bool(str(value).strip())
+            or "Model identifier is required",
+            style=STYLE,
+        ).ask_async()
+        if model is None:
+            config.setdefault("model", None)
+            return
+
+    config["model"] = {
+        "default": str(model).strip(),
+        "provider": provider["id"],
+        "client_preference": provider.get("client_preference", "native"),
+        "streaming_enabled": True,
+        "temperature": 0.7,
+    }
+
+    env_name = provider["env"]
+    if not env_name or os.getenv(env_name):
+        if env_name:
+            console.print(f"[green]Found {env_name} in the environment.[/green]")
+        return
+    credential_choice = await questionary.select(
+        "Add a credential now?",
+        choices=["Enter credential", "Skip for now"],
+        default="Enter credential",
+        style=STYLE,
+    ).ask_async()
+    if credential_choice != "Enter credential":
+        console.print(f"[dim]Set {env_name} before sending a prompt.[/dim]")
+        return
+    api_key = await questionary.password(
+        f"Enter {env_name}:",
+        validate=lambda value: bool(str(value).strip()) or "Credential cannot be empty",
+        style=STYLE,
+    ).ask_async()
+    if api_key and not _persist_api_key(provider["id"], str(api_key).strip()):
+        console.print(
+            f"[yellow]Could not save the credential. Set {env_name} manually.[/yellow]"
+        )
+
+
+async def run_setup_wizard() -> dict[str, Any]:
+    """Run workspace-first onboarding; connecting an AI model is optional."""
+    console.print("\n[bold cyan]Penguin setup[/bold cyan]")
+    console.print(
+        "Penguin needs a workspace for projects, conversations, memory, and logs. "
+        "Connecting an AI model is optional.\n"
+    )
+
+    existing = _load_config()
+    existing_workspace = (
+        existing.get("workspace") if isinstance(existing.get("workspace"), dict) else {}
+    )
+    default_workspace = str(
+        existing_workspace.get("path") or Path.home() / "penguin_workspace"
+    )
+    workspace_input = await questionary.text(
+        "Workspace location:",
+        default=default_workspace,
+        validate=_validate_workspace,
+        style=STYLE,
+    ).ask_async()
+    if workspace_input is None:
+        return {"error": "Setup interrupted"}
+    workspace_path = Path(str(workspace_input).strip()).expanduser().resolve()
+
+    config = dict(existing)
+    config["workspace"] = {
+        **existing_workspace,
+        "path": str(workspace_path),
+        "create_dirs": WORKSPACE_DIRS,
+    }
+    await _optional_model_setup(config)
+
+    saved = save_config(config)
+    if saved is None:
+        return {"error": "Failed to save configuration"}
+    try:
+        _create_workspace(workspace_path)
+        mark_setup_complete()
+    except OSError as exc:
+        return {"error": f"Could not initialize workspace: {exc}"}
+
+    console.print("\n[bold green]Penguin is ready.[/bold green]")
+    console.print(f"Workspace: [cyan]{workspace_path}[/cyan]")
+    model = config.get("model")
+    if isinstance(model, dict) and model.get("default"):
+        console.print(f"AI model: [cyan]{model['default']}[/cyan]")
+        if not check_provider_ready(config):
+            console.print(
+                "[yellow]A credential is still needed before sending AI "
+                "prompts.[/yellow]"
+            )
+    else:
+        console.print("AI model: [dim]Not connected[/dim]")
+        console.print("Run [cyan]penguin config setup[/cyan] whenever you are ready.")
+    console.print(f"[dim]Configuration saved to {saved}[/dim]\n")
+    return config
+
 
 def test_provider_routing() -> None:
-    """Test function to verify provider routing logic"""
-    
-    # Simulate OpenRouter models list (what would be fetched from their API)
-    mock_openrouter_models = [
-        {"id": "google/gemini-2-5-pro-preview"},
-        {"id": "openai/gpt-4o"},
-        {"id": "anthropic/claude-3-5-sonnet-20240620"},
-        {"id": "mistral/devstral"},
-        {"id": "meta-llama/llama-3-70b-instruct"},
-        {"id": "deepseek/deepseek-chat"},
-        {"id": "cohere/command-r-plus"},
-        {"id": "perplexity/llama-3.1-sonar-large-128k-online"},
-        {"id": "x-ai/grok-beta"},
-    ]
-    
-    test_cases = [
-        # (model_id, expected_actual_provider, expected_config_provider, expected_client_preference, in_openrouter_list)
-        ("google/gemini-2-5-pro-preview", "openrouter", "openrouter", "openrouter", True),
-        ("openai/gpt-4o", "openrouter", "openrouter", "openrouter", True),
-        ("anthropic/claude-3-5-sonnet-20240620", "openrouter", "openrouter", "openrouter", True),
-        ("mistral/devstral", "openrouter", "openrouter", "openrouter", True),
-        ("meta-llama/llama-3-70b-instruct", "openrouter", "openrouter", "openrouter", True),
-        ("deepseek/deepseek-chat", "openrouter", "openrouter", "openrouter", True),
-        ("cohere/command-r-plus", "openrouter", "openrouter", "openrouter", True),
-        ("perplexity/llama-3.1-sonar-large-128k-online", "openrouter", "openrouter", "openrouter", True),
-        ("x-ai/grok-beta", "openrouter", "openrouter", "openrouter", True),
-        ("ollama/llama3", "ollama", "ollama", "native", False),  # Not in OpenRouter
-        ("claude-3-sonnet", "anthropic", "anthropic", "native", False),  # No slash, direct provider
-        ("some-unknown/model", "some-unknown", "some-unknown", "native", False),  # Not in OpenRouter
-    ]
-    
-    console.print("[bold cyan]🧪 Testing Provider Routing Logic[/bold cyan]\n")
-    
-    for model, expected_actual, expected_config, expected_client, in_or_list in test_cases:
-        # Replicate the improved logic from the setup wizard
-        provider_from_model = model.split('/')[0] if '/' in model else "anthropic"
-        
-        # Check if this model will be routed through OpenRouter
-        will_use_openrouter = False
-        models = mock_openrouter_models if in_or_list else []
-        
-        if models and "/" in model:
-            # Check if this model was in the OpenRouter models list
-            model_in_openrouter_list = any(m.get("id") == model for m in models)
-            if model_in_openrouter_list:
-                will_use_openrouter = True
-        
-        # Fallback to hardcoded list for cases where OpenRouter API wasn't available
-        if not will_use_openrouter and provider_from_model in ["openai", "anthropic", "google", "mistral"] and "/" in model:
-            will_use_openrouter = True
-        
-        if will_use_openrouter:
-            actual_provider = "openrouter"
-        else:
-            actual_provider = provider_from_model
-            
-        # Generate config values
-        config_provider = "openrouter" if will_use_openrouter else provider_from_model
-        client_preference = "openrouter" if will_use_openrouter else "native"
-        
-        # Check results
-        status_actual = "✓" if actual_provider == expected_actual else "❌"
-        status_config = "✓" if config_provider == expected_config else "❌"
-        status_client = "✓" if client_preference == expected_client else "❌"
-        
-        openrouter_status = "📡" if in_or_list else "🔗"
-        console.print(f"{openrouter_status} Model: {model}")
-        console.print(f"  {status_actual} API Key Provider: {actual_provider} (expected: {expected_actual})")
-        console.print(f"  {status_config} Config Provider: {config_provider} (expected: {expected_config})")
-        console.print(f"  {status_client} Client Preference: {client_preference} (expected: {expected_client})")
-        console.print()
-    
-    console.print("[dim]Legend: 📡 = Found in OpenRouter catalog, 🔗 = Direct provider access[/dim]")
+    """Print the provider/runtime mapping used by onboarding choices."""
+    console.print("[bold cyan]Provider routing[/bold cyan]")
+    for label, provider in PROVIDERS.items():
+        preference = provider.get("client_preference", "native")
+        console.print(
+            f"{label}: provider={provider['id']}, client_preference={preference}"
+        )
 
-# Create a sync wrapper for the wizard for standalone use
-def run_setup_wizard_sync() -> Dict[str, Any]:
-    """Synchronous wrapper for the setup wizard"""
-    
-    # Check dependencies first
-    deps_available, missing_deps = check_setup_dependencies()
+
+def open_in_default_editor(file_path: Path) -> bool:
+    try:
+        if platform.system() == "Windows":
+            os.startfile(file_path)  # type: ignore[attr-defined]
+        elif platform.system() == "Darwin":
+            subprocess.run(["open", str(file_path)], check=True)
+        else:
+            if shutil.which("xdg-open") is None:
+                return False
+            subprocess.run(["xdg-open", str(file_path)], check=True)
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def run_setup_wizard_sync() -> dict[str, Any]:
+    deps_available, missing = check_setup_dependencies()
     if not deps_available:
-        console.print("[bold yellow]🐧 Penguin Setup Wizard[/bold yellow]")
-        display_dependency_install_instructions(missing_deps)
-        return {"error": f"Missing dependencies: {', '.join(missing_deps)}"}
-    
+        display_dependency_install_instructions(missing)
+        return {"error": f"Missing dependencies: {', '.join(missing)}"}
     try:
         return asyncio.run(run_setup_wizard())
     except KeyboardInterrupt:
-        console.print("\n[yellow]Setup interrupted by user.[/yellow]")
+        console.print("\n[yellow]Setup interrupted.[/yellow]")
         return {"error": "Setup interrupted"}
-    except Exception as e:
-        console.print(f"[red]Setup wizard error: {e}[/red]")
-        return {"error": str(e)} 
+    except Exception as exc:
+        console.print(f"[red]Setup wizard error: {exc}[/red]")
+        return {"error": str(exc)}

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -15,6 +15,7 @@ from typing import Optional, Dict, Any, List, AsyncGenerator, Callable, Awaitabl
 from penguin import __version__
 from penguin.config import config, Config, _ensure_env_loaded
 from penguin.core import PenguinCore
+from penguin.core_runtime import startup as core_startup
 from penguin.run_mode import RunMode
 from penguin.llm.api_client import APIClient, ConnectionPoolManager
 from penguin.llm.model_config import ModelConfig
@@ -82,9 +83,14 @@ def _create_core() -> PenguinCore:
         config_obj = Config.load_config()
         model_config = config_obj.model_config
 
-        # Initialize components using live Config-derived model_config
-        api_client = APIClient(model_config=model_config)
-        api_client.set_system_prompt(SYSTEM_PROMPT)
+        # A workspace-only onboarding is valid. Defer provider construction until
+        # a model/provider has actually been configured.
+        api_client = core_startup.build_api_client(
+            model_config,
+            system_prompt=SYSTEM_PROMPT,
+            api_client_factory=APIClient,
+            ensure_env_loaded=_ensure_env_loaded,
+        )
         # Pass a stable dict derived from live Config
         config_dict = config_obj.to_dict() if hasattr(config_obj, "to_dict") else {}
         tool_manager = ToolManager(config_dict, log_error)
@@ -338,6 +344,7 @@ def create_app() -> "FastAPI":
             if authorize_path.exists():
                 return FileResponse(str(authorize_path), headers=NO_CACHE_HEADERS)
             return {"message": "Authorization UI not found."}
+
     else:
 
         @app.get("/")
@@ -639,15 +646,15 @@ class PenguinAPI:
             return {
                 "status": "healthy",
                 "core_initialized": self.core is not None,
-                "api_client_ready": self.core.api_client is not None
-                if self.core
-                else False,
-                "tool_manager_ready": self.core.tool_manager is not None
-                if self.core
-                else False,
-                "conversation_manager_ready": self.core.conversation_manager is not None
-                if self.core
-                else False,
+                "api_client_ready": (
+                    self.core.api_client is not None if self.core else False
+                ),
+                "tool_manager_ready": (
+                    self.core.tool_manager is not None if self.core else False
+                ),
+                "conversation_manager_ready": (
+                    self.core.conversation_manager is not None if self.core else False
+                ),
             }
         except Exception as e:
             return {"status": "unhealthy", "error": str(e)}

--- a/penguin/web/services/opencode_provider.py
+++ b/penguin/web/services/opencode_provider.py
@@ -218,8 +218,7 @@ def _model_variants_payload(
     )
     if metadata_efforts:
         return {
-            effort: {"reasoning": {"effort": effort}}
-            for effort in metadata_efforts
+            effort: {"reasoning": {"effort": effort}} for effort in metadata_efforts
         }
 
     provider_value = provider_id.strip().lower()
@@ -818,9 +817,10 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
     providers: list[dict[str, Any]] = []
     default: dict[str, str] = {}
     auth_records = get_provider_credentials()
-    refresh_scheduled = _schedule_provider_catalog_refresh(
-        auth_records
-    ) or _provider_catalog_refresh_active()
+    refresh_scheduled = (
+        _schedule_provider_catalog_refresh(auth_records)
+        or _provider_catalog_refresh_active()
+    )
     provider_models = _merge_cached_provider_catalog_models(
         config_provider_models,
         auth_records,
@@ -840,7 +840,8 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
 
     enabled_filters, disabled_filters = _provider_filters(config_data)
 
-    provider_set = set(provider_models.keys())
+    provider_set = provider_ids(core)
+    provider_set.update(provider_models.keys())
     provider_set.update(auth_records.keys())
     provider_set.update(env_connected_provider_ids())
     if current_provider:
@@ -866,9 +867,9 @@ def build_config_providers_payload(core: Any) -> dict[str, Any]:
             source = (
                 "env"
                 if any(os.getenv(name) for name in provider_env(provider_id))
-                else "api"
-                if provider_connected(provider_id, auth_records)
-                else "custom"
+                else (
+                    "api" if provider_connected(provider_id, auth_records) else "custom"
+                )
             )
         connected = provider_connected(provider_id, auth_records)
         catalog = _provider_catalog_state(
@@ -905,9 +906,10 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
     """Build OpenCode-compatible ``provider.list`` payload."""
     config_provider_models = collect_provider_models(core)
     auth_records = get_provider_credentials()
-    refresh_scheduled = _schedule_provider_catalog_refresh(
-        auth_records
-    ) or _provider_catalog_refresh_active()
+    refresh_scheduled = (
+        _schedule_provider_catalog_refresh(auth_records)
+        or _provider_catalog_refresh_active()
+    )
     provider_models = _merge_cached_provider_catalog_models(
         config_provider_models,
         auth_records,
@@ -934,7 +936,8 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
         config_data = {}
     enabled_filters, disabled_filters = _provider_filters(config_data)
 
-    provider_set = set(provider_models.keys())
+    provider_set = provider_ids(core)
+    provider_set.update(provider_models.keys())
     provider_set.update(auth_records.keys())
     provider_set.update(env_connected_provider_ids())
     if current_provider:
@@ -957,9 +960,7 @@ def build_provider_list_payload(core: Any) -> dict[str, Any]:
             source = (
                 "env"
                 if any(os.getenv(name) for name in provider_env(provider_id))
-                else "api"
-                if connected_flag
-                else "custom"
+                else "api" if connected_flag else "custom"
             )
         catalog = _provider_catalog_state(
             connected=connected_flag,

--- a/penguin/web/services/provider_catalog.py
+++ b/penguin/web/services/provider_catalog.py
@@ -328,9 +328,7 @@ def apply_cached_codex_model_metadata(model_config: Any) -> None:
         model_id = model_id.split("/", 1)[1]
     auth_record = get_provider_credentials().get("openai")
     metadata = (
-        codex_oauth_cached_provider_models(auth_record)
-        .get("openai", {})
-        .get(model_id)
+        codex_oauth_cached_provider_models(auth_record).get("openai", {}).get(model_id)
     )
     if not isinstance(metadata, dict):
         return
@@ -505,9 +503,7 @@ def codex_oauth_provider_models(
         if default_reasoning_level:
             conf["default_reasoning_level"] = default_reasoning_level
         if isinstance(item.get("supports_reasoning_summaries"), bool):
-            conf["supports_reasoning_summaries"] = item[
-                "supports_reasoning_summaries"
-            ]
+            conf["supports_reasoning_summaries"] = item["supports_reasoning_summaries"]
         if isinstance(priority, int):
             conf["priority"] = priority
         discovered[model_id] = conf
@@ -680,8 +676,13 @@ def collect_provider_models(core: Any) -> dict[str, dict[str, dict[str, Any]]]:
 
 
 def provider_ids(core: Any) -> set[str]:
-    """Return provider ids currently relevant for runtime."""
-    ids = set(collect_provider_models(core).keys())
+    """Return provider ids available for connection or relevant to runtime."""
+    # Provider discovery must not depend on already having credentials or a
+    # configured model; otherwise a workspace-only first run has no providers
+    # to connect to. Metadata is the stable baseline, while config/runtime/env
+    # sources add custom providers and active aliases.
+    ids = set(_PROVIDER_METADATA.keys())
+    ids.update(collect_provider_models(core).keys())
     current_model = (
         core.get_current_model() if hasattr(core, "get_current_model") else None
     )

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -201,6 +201,8 @@ async def test_workspace_only_core_exposes_connectable_provider_roster(
 ) -> None:
     monkeypatch.setattr(provider_service, "get_provider_credentials", lambda: {})
     monkeypatch.setattr(provider_service, "env_connected_provider_ids", lambda: set())
+    monkeypatch.setattr(provider_service, "provider_connected", lambda *_args: False)
+    monkeypatch.setattr(provider_service, "load_config", lambda: {})
     monkeypatch.setattr(
         provider_service,
         "_schedule_provider_catalog_refresh",

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -195,6 +195,36 @@ async def test_config_providers_and_auth_methods(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_workspace_only_core_exposes_connectable_provider_roster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(provider_service, "get_provider_credentials", lambda: {})
+    monkeypatch.setattr(provider_service, "env_connected_provider_ids", lambda: set())
+    monkeypatch.setattr(
+        provider_service,
+        "_schedule_provider_catalog_refresh",
+        lambda *_args, **_kwargs: False,
+    )
+
+    core = _Core(tmp_path)
+    core.config.model_configs = {}
+    core._current_model = {"provider": "", "model": ""}
+    typed_core = cast(Any, core)
+
+    config_payload = await opencode_config_providers(core=typed_core)
+    provider_payload = await opencode_provider_list(core=typed_core)
+
+    config_ids = {item["id"] for item in config_payload["providers"]}
+    provider_ids = {item["id"] for item in provider_payload["all"]}
+    expected = {"openai", "anthropic", "openrouter", "google", "ollama"}
+
+    assert expected <= config_ids
+    assert expected <= provider_ids
+    assert provider_payload["connected"] == []
+
+
+@pytest.mark.asyncio
 async def test_config_payload_canonicalizes_unqualified_current_model(
     tmp_path: Path,
 ) -> None:

--- a/tests/api/test_web_app_credentials_rehydrate.py
+++ b/tests/api/test_web_app_credentials_rehydrate.py
@@ -120,3 +120,72 @@ def test_create_core_primes_credentials_before_loading_config(monkeypatch) -> No
     core = web_app._create_core()
 
     assert isinstance(core, _Core)
+
+
+def test_create_core_does_not_construct_provider_when_model_is_not_configured(
+    monkeypatch,
+) -> None:
+    config_obj = SimpleNamespace(
+        model_config=SimpleNamespace(model="", provider=""),
+        to_dict=lambda: {"workspace": {"path": "/tmp/penguin"}},
+    )
+    monkeypatch.setattr(web_app, "_ensure_env_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_app, "_prime_provider_credentials_environment", lambda: None
+    )
+    monkeypatch.setattr(web_app.Config, "load_config", lambda: config_obj)
+    monkeypatch.setattr(
+        web_app,
+        "APIClient",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider client must be lazy until a model is configured")
+        ),
+    )
+    monkeypatch.setattr(web_app, "ToolManager", lambda *_args, **_kwargs: object())
+
+    class _Core:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(web_app, "PenguinCore", _Core)
+
+    core = web_app._create_core()
+
+    assert core.api_client is None
+
+
+def test_create_core_does_not_construct_remote_provider_without_credentials(
+    monkeypatch,
+) -> None:
+    config_obj = SimpleNamespace(
+        model_config=SimpleNamespace(
+            model="openai/gpt-5.2",
+            provider="openrouter",
+            api_key=None,
+        ),
+        to_dict=lambda: {"workspace": {"path": "/tmp/penguin"}},
+    )
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(web_app, "_ensure_env_loaded", lambda: None)
+    monkeypatch.setattr(
+        web_app, "_prime_provider_credentials_environment", lambda: None
+    )
+    monkeypatch.setattr(web_app.Config, "load_config", lambda: config_obj)
+    monkeypatch.setattr(
+        web_app,
+        "APIClient",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider client must remain lazy without credentials")
+        ),
+    )
+    monkeypatch.setattr(web_app, "ToolManager", lambda *_args, **_kwargs: object())
+
+    class _Core:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(web_app, "PenguinCore", _Core)
+
+    core = web_app._create_core()
+
+    assert core.api_client is None

--- a/tests/core_runtime/test_model_runtime.py
+++ b/tests/core_runtime/test_model_runtime.py
@@ -456,6 +456,43 @@ async def test_resolve_request_runtime_requires_selected_provider_credential(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("credential_name", ["GOOGLE_API_KEY", "GEMINI_API_KEY"])
+async def test_resolve_request_runtime_accepts_google_credential_aliases(
+    monkeypatch: pytest.MonkeyPatch, credential_name: str
+) -> None:
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv(credential_name, "google-key")
+    model_config = ModelConfig(model="gemini-2.5-pro", provider="google")
+
+    class FakeAPIClient:
+        def __init__(self, *, model_config: ModelConfig) -> None:
+            self.model_config = model_config
+            self.system_prompt = ""
+
+        def set_system_prompt(self, prompt: str) -> None:
+            self.system_prompt = prompt
+
+    owner = SimpleNamespace(
+        model_config=model_config,
+        system_prompt="system",
+        get_current_model=lambda: {
+            "model": "gemini-2.5-pro",
+            "provider": "google",
+        },
+    )
+
+    resolved, api_client = await resolve_request_runtime(
+        owner,
+        None,
+        api_client_factory=FakeAPIClient,
+    )
+
+    assert resolved.provider == "google"
+    assert api_client.system_prompt == "system"
+
+
+@pytest.mark.asyncio
 async def test_resolve_request_runtime_reuses_current_model_without_mutation() -> None:
     model_config = ModelConfig(model="gpt-4o", provider="openai", api_key="test-key")
     model_config.temperature = 0.1

--- a/tests/core_runtime/test_model_runtime.py
+++ b/tests/core_runtime/test_model_runtime.py
@@ -160,7 +160,7 @@ def test_current_model_payload_uses_explicit_output_token_name() -> None:
 
 
 def test_refresh_api_client_propagates_to_runtime_components() -> None:
-    model_config = ModelConfig(model="gpt-4o", provider="openai")
+    model_config = ModelConfig(model="gpt-4o", provider="openai", api_key="test-key")
     context_window = SimpleNamespace()
     conversation_manager = SimpleNamespace(context_window=context_window)
     engine = SimpleNamespace()
@@ -415,8 +415,49 @@ def test_apply_new_model_config_propagates_budget_and_model_config() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_request_runtime_requires_connected_model() -> None:
+    owner = SimpleNamespace(
+        model_config=ModelConfig(model="", provider=""),
+        system_prompt="system",
+        get_current_model=lambda: {"model": "", "provider": ""},
+    )
+
+    with pytest.raises(ValueError, match="Connect an AI model"):
+        await resolve_request_runtime(
+            owner,
+            None,
+            api_client_factory=lambda **_kwargs: None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_request_runtime_requires_selected_provider_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    owner = SimpleNamespace(
+        model_config=ModelConfig(
+            model="openai/gpt-5.2",
+            provider="openrouter",
+        ),
+        system_prompt="system",
+        get_current_model=lambda: {
+            "model": "openai/gpt-5.2",
+            "provider": "openrouter",
+        },
+    )
+
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        await resolve_request_runtime(
+            owner,
+            None,
+            api_client_factory=lambda **_kwargs: None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_resolve_request_runtime_reuses_current_model_without_mutation() -> None:
-    model_config = ModelConfig(model="gpt-4o", provider="openai")
+    model_config = ModelConfig(model="gpt-4o", provider="openai", api_key="test-key")
     model_config.temperature = 0.1
     built_models: list[str] = []
 
@@ -455,7 +496,7 @@ async def test_resolve_request_runtime_reuses_current_model_without_mutation() -
 
 @pytest.mark.asyncio
 async def test_resolve_request_runtime_builds_requested_override() -> None:
-    requested = ModelConfig(model="gpt-5", provider="openai")
+    requested = ModelConfig(model="gpt-5", provider="openai", api_key="test-key")
     built_models: list[str] = []
 
     class FakeAPIClient:

--- a/tests/core_runtime/test_startup.py
+++ b/tests/core_runtime/test_startup.py
@@ -256,8 +256,8 @@ async def test_create_core_instance_builds_core_with_startup_dependencies(
     config = SimpleNamespace(
         model_config=SimpleNamespace(
             model="configured-model",
-            provider="configured-provider",
-            client_preference="openai",
+            provider="ollama",
+            client_preference="native",
         ),
         api=SimpleNamespace(base_url="https://api.example.test/v1"),
         fast_startup=True,
@@ -305,7 +305,7 @@ async def test_create_core_instance_builds_core_with_startup_dependencies(
         _Core,
         config=config,
         model="override-model",
-        provider="override-provider",
+        provider="ollama",
         workspace_path=None,
         enable_cli=False,
         show_progress=True,
@@ -330,7 +330,7 @@ async def test_create_core_instance_builds_core_with_startup_dependencies(
     assert isinstance(result, _Core)
     assert created["config"] is config
     assert created["model_config"].model == "override-model"
-    assert created["model_config"].provider == "override-provider"
+    assert created["model_config"].provider == "ollama"
     assert created["api_client"].system_prompt == "system prompt"
     assert created["tool_manager"].payload == {"config": True}
     assert created["tool_manager"].error_logger is log_error
@@ -512,9 +512,53 @@ def test_resolve_fast_startup_preserves_current_config_override_behavior() -> No
     assert not startup.resolve_fast_startup(SimpleNamespace(), False)
 
 
+def test_build_api_client_skips_remote_provider_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    model_config = SimpleNamespace(
+        model="openai/gpt-5.2",
+        provider="openrouter",
+        api_key=None,
+    )
+
+    client = startup.build_api_client(
+        model_config,
+        system_prompt="system prompt",
+        api_client_factory=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("provider client must remain lazy without credentials")
+        ),
+        ensure_env_loaded=lambda: None,
+    )
+
+    assert client is None
+
+
+def test_build_api_client_allows_local_provider_without_credentials() -> None:
+    calls: list[str] = []
+    model_config = SimpleNamespace(model="qwen3-coder", provider="ollama", api_key=None)
+
+    class _Client:
+        def __init__(self, *, model_config: Any) -> None:
+            calls.append(model_config.provider)
+
+        def set_system_prompt(self, prompt: str) -> None:
+            calls.append(prompt)
+
+    client = startup.build_api_client(
+        model_config,
+        system_prompt="system prompt",
+        api_client_factory=_Client,
+        ensure_env_loaded=lambda: None,
+    )
+
+    assert isinstance(client, _Client)
+    assert calls == ["ollama", "system prompt"]
+
+
 def test_build_api_client_loads_env_then_sets_system_prompt() -> None:
     calls: list[tuple[str, Any]] = []
-    model_config = SimpleNamespace(model="gpt-5")
+    model_config = SimpleNamespace(model="gpt-5", provider="ollama")
 
     class _Client:
         def __init__(self, *, model_config: Any) -> None:

--- a/tests/core_runtime/test_startup.py
+++ b/tests/core_runtime/test_startup.py
@@ -556,6 +556,38 @@ def test_build_api_client_rejects_whitespace_only_credentials(
     assert client is None
 
 
+@pytest.mark.parametrize("credential_name", ["GOOGLE_API_KEY", "GEMINI_API_KEY"])
+def test_build_api_client_accepts_google_credential_aliases(
+    monkeypatch: pytest.MonkeyPatch, credential_name: str
+) -> None:
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv(credential_name, "google-key")
+    calls: list[str] = []
+    model_config = SimpleNamespace(
+        model="gemini-2.5-pro",
+        provider="google",
+        api_key=None,
+    )
+
+    class _Client:
+        def __init__(self, *, model_config: Any) -> None:
+            calls.append(model_config.provider)
+
+        def set_system_prompt(self, prompt: str) -> None:
+            calls.append(prompt)
+
+    client = startup.build_api_client(
+        model_config,
+        system_prompt="system prompt",
+        api_client_factory=_Client,
+        ensure_env_loaded=lambda: None,
+    )
+
+    assert isinstance(client, _Client)
+    assert calls == ["google", "system prompt"]
+
+
 def test_build_api_client_allows_local_provider_without_credentials() -> None:
     calls: list[str] = []
     model_config = SimpleNamespace(model="qwen3-coder", provider="ollama", api_key=None)

--- a/tests/core_runtime/test_startup.py
+++ b/tests/core_runtime/test_startup.py
@@ -534,6 +534,28 @@ def test_build_api_client_skips_remote_provider_without_credentials(
     assert client is None
 
 
+def test_build_api_client_rejects_whitespace_only_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "   ")
+    model_config = SimpleNamespace(
+        model="openai/gpt-5.2",
+        provider="openrouter",
+        api_key="\t",
+    )
+
+    client = startup.build_api_client(
+        model_config,
+        system_prompt="system prompt",
+        api_client_factory=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("whitespace is not a credential")
+        ),
+        ensure_env_loaded=lambda: None,
+    )
+
+    assert client is None
+
+
 def test_build_api_client_allows_local_provider_without_credentials() -> None:
     calls: list[str] = []
     model_config = SimpleNamespace(model="qwen3-coder", provider="ollama", api_key=None)

--- a/tests/core_runtime/test_stream_events.py
+++ b/tests/core_runtime/test_stream_events.py
@@ -604,6 +604,38 @@ async def test_abort_session_does_not_wait_for_slow_adapter_cleanup() -> None:
     await asyncio.sleep(0)
 
 
+@pytest.mark.asyncio
+async def test_abort_session_accepts_adapter_only_cleanup() -> None:
+    cleanup_started = asyncio.Event()
+
+    class _Adapter:
+        async def abort(self, reason: str) -> bool:
+            assert reason == "Tool execution was interrupted"
+            cleanup_started.set()
+            return True
+
+    owner = SimpleNamespace(
+        event_bus=_EventBus(),
+        _get_tui_adapter=lambda _session_id: _Adapter(),
+        _stream_manager=SimpleNamespace(get_active_agents=lambda: []),
+        _opencode_abort_sessions=set(),
+        _opencode_process_tasks={},
+        _opencode_stream_states={},
+        _opencode_tool_parts={},
+        _opencode_tool_info={},
+    )
+
+    aborted = await stream_events.abort_session(
+        owner,
+        "session_1",
+        logger=logging.getLogger("test.stream_events"),
+    )
+
+    assert aborted is True
+    await asyncio.sleep(0)
+    assert cleanup_started.is_set()
+
+
 def test_persist_finalized_message_writes_target_session_store() -> None:
     trace_messages: list[tuple[str, tuple[Any, ...]]] = []
     persisted_messages: list[Any] = []

--- a/tests/core_runtime/test_stream_events.py
+++ b/tests/core_runtime/test_stream_events.py
@@ -527,6 +527,7 @@ async def test_abort_session_cancels_tasks_cleans_scoped_state_and_emits_idle() 
     )
 
     assert aborted is True
+    await asyncio.sleep(0)
     assert adapter.reasons == ["Tool execution was interrupted"]
     assert "session_1" in owner._opencode_abort_sessions
     with pytest.raises(asyncio.CancelledError):
@@ -555,6 +556,52 @@ async def test_abort_session_cancels_tasks_cleans_scoped_state_and_emits_idle() 
     assert status_event["type"] == "session.status"
     assert status_event["properties"]["sessionID"] == "session_1"
     assert status_event["properties"]["status"]["type"] == "idle"
+
+
+@pytest.mark.asyncio
+async def test_abort_session_does_not_wait_for_slow_adapter_cleanup() -> None:
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+
+    class _SlowAbortAdapter:
+        async def abort(self, reason: str) -> bool:
+            assert reason == "Tool execution was interrupted"
+            cleanup_started.set()
+            await allow_cleanup.wait()
+            return True
+
+    async def _sleep_forever() -> None:
+        await asyncio.sleep(60)
+
+    pending_task = asyncio.create_task(_sleep_forever())
+    owner = SimpleNamespace(
+        event_bus=_EventBus(),
+        _get_tui_adapter=lambda _session_id: _SlowAbortAdapter(),
+        _stream_manager=SimpleNamespace(get_active_agents=lambda: []),
+        _opencode_abort_sessions=set(),
+        _opencode_process_tasks={"session_1": {pending_task}},
+        _opencode_stream_states={"session_1": {"active": True}},
+        _opencode_tool_parts={},
+        _opencode_tool_info={},
+    )
+
+    aborted = await asyncio.wait_for(
+        stream_events.abort_session(
+            owner,
+            "session_1",
+            logger=logging.getLogger("test.stream_events"),
+        ),
+        timeout=0.1,
+    )
+
+    assert aborted is True
+    assert pending_task.cancelled()
+    assert cleanup_started.is_set()
+    status_event = owner.event_bus.events[-1][1]
+    assert status_event["properties"]["status"]["type"] == "idle"
+
+    allow_cleanup.set()
+    await asyncio.sleep(0)
 
 
 def test_persist_finalized_message_writes_target_session_store() -> None:

--- a/tests/core_runtime/test_stream_events.py
+++ b/tests/core_runtime/test_stream_events.py
@@ -527,11 +527,13 @@ async def test_abort_session_cancels_tasks_cleans_scoped_state_and_emits_idle() 
     )
 
     assert aborted is True
-    await asyncio.sleep(0)
-    assert adapter.reasons == ["Tool execution was interrupted"]
-    assert "session_1" in owner._opencode_abort_sessions
     with pytest.raises(asyncio.CancelledError):
         await pending_task
+    cleanup_tasks = owner._opencode_abort_cleanup_tasks
+    await asyncio.wait_for(asyncio.gather(*cleanup_tasks), timeout=0.1)
+    assert not cleanup_tasks
+    assert adapter.reasons == ["Tool execution was interrupted"]
+    assert "session_1" in owner._opencode_abort_sessions
 
     assert owner._opencode_stream_states["session_1"]["active"] is False
     assert owner._opencode_stream_states["session_1"]["stream_id"] is None
@@ -595,13 +597,16 @@ async def test_abort_session_does_not_wait_for_slow_adapter_cleanup() -> None:
     )
 
     assert aborted is True
-    assert pending_task.cancelled()
-    assert cleanup_started.is_set()
+    with pytest.raises(asyncio.CancelledError):
+        await pending_task
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.1)
     status_event = owner.event_bus.events[-1][1]
     assert status_event["properties"]["status"]["type"] == "idle"
 
     allow_cleanup.set()
-    await asyncio.sleep(0)
+    cleanup_tasks = owner._opencode_abort_cleanup_tasks
+    await asyncio.wait_for(asyncio.gather(*cleanup_tasks), timeout=0.1)
+    assert not cleanup_tasks
 
 
 @pytest.mark.asyncio
@@ -632,8 +637,10 @@ async def test_abort_session_accepts_adapter_only_cleanup() -> None:
     )
 
     assert aborted is True
-    await asyncio.sleep(0)
-    assert cleanup_started.is_set()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.1)
+    cleanup_tasks = owner._opencode_abort_cleanup_tasks
+    await asyncio.wait_for(asyncio.gather(*cleanup_tasks), timeout=0.1)
+    assert not cleanup_tasks
 
 
 def test_persist_finalized_message_writes_target_session_store() -> None:

--- a/tests/test_cli_entrypoint_dispatcher.py
+++ b/tests/test_cli_entrypoint_dispatcher.py
@@ -150,3 +150,39 @@ def test_direct_tui_entrypoint_stops_when_setup_is_cancelled(monkeypatch):
 
     assert code == 1
     assert calls == []
+
+
+def test_direct_tui_entrypoint_prints_setup_error(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+    monkeypatch.setattr(
+        entrypoint,
+        "_run_tui_setup",
+        lambda: {"error": "workspace unavailable"},
+    )
+
+    assert entrypoint.main_tui([]) == 1
+    assert "workspace unavailable" in capsys.readouterr().err
+
+
+def test_direct_tui_entrypoint_handles_setup_exception(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+
+    def _raise_setup_error() -> dict[str, object]:
+        raise RuntimeError("setup exploded")
+
+    monkeypatch.setattr(entrypoint, "_run_tui_setup", _raise_setup_error)
+
+    assert entrypoint.main_tui([]) == 1
+    assert "setup exploded" in capsys.readouterr().err
+
+
+def test_direct_tui_entrypoint_handles_setup_interrupt(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+
+    def _interrupt_setup() -> dict[str, object]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(entrypoint, "_run_tui_setup", _interrupt_setup)
+
+    assert entrypoint.main_tui([]) == 1
+    assert "interrupted" in capsys.readouterr().err.lower()

--- a/tests/test_cli_entrypoint_dispatcher.py
+++ b/tests/test_cli_entrypoint_dispatcher.py
@@ -100,3 +100,53 @@ def test_main_routes_project_path_to_tui(monkeypatch):
 
     assert code == 34
     assert calls == [("tui", ["."])]
+
+
+def test_direct_tui_entrypoint_runs_first_run_setup_before_launcher(monkeypatch):
+    calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+
+    def _setup():
+        calls.append(("setup", []))
+        return {"workspace": {"path": "/tmp/penguin"}}
+
+    monkeypatch.setattr(entrypoint, "_run_tui_setup", _setup)
+
+    from penguin.cli import opencode_launcher
+
+    monkeypatch.setattr(
+        opencode_launcher,
+        "main",
+        lambda args: calls.append(("launcher", list(args))) or 34,
+    )
+
+    code = entrypoint.main_tui(["--url", "http://localhost:8000"])
+
+    assert code == 34
+    assert calls == [
+        ("setup", []),
+        ("launcher", ["--url", "http://localhost:8000"]),
+    ]
+
+
+def test_direct_tui_entrypoint_stops_when_setup_is_cancelled(monkeypatch):
+    calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+    monkeypatch.setattr(
+        entrypoint,
+        "_run_tui_setup",
+        lambda: {"error": "Setup interrupted"},
+    )
+
+    from penguin.cli import opencode_launcher
+
+    monkeypatch.setattr(
+        opencode_launcher,
+        "main",
+        lambda args: calls.append(("launcher", list(args))) or 34,
+    )
+
+    code = entrypoint.main_tui([])
+
+    assert code == 1
+    assert calls == []

--- a/tests/test_cli_entrypoint_dispatcher.py
+++ b/tests/test_cli_entrypoint_dispatcher.py
@@ -186,3 +186,13 @@ def test_direct_tui_entrypoint_handles_setup_interrupt(monkeypatch, capsys) -> N
 
     assert entrypoint.main_tui([]) == 1
     assert "interrupted" in capsys.readouterr().err.lower()
+
+
+def test_direct_tui_entrypoint_handles_non_mapping_setup_result(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(entrypoint, "_needs_tui_setup", lambda: True)
+    monkeypatch.setattr(entrypoint, "_run_tui_setup", lambda: None)
+
+    assert entrypoint.main_tui([]) == 1
+    assert "Unknown setup error" in capsys.readouterr().err

--- a/tests/test_config_workspace_path.py
+++ b/tests/test_config_workspace_path.py
@@ -43,6 +43,8 @@ def test_explicit_skipped_model_config_does_not_inherit_default_model(
         encoding="utf-8",
     )
     monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("PENGUIN_CWD", str(tmp_path / "outside-project"))
     monkeypatch.delenv("PENGUIN_DEFAULT_MODEL", raising=False)
     monkeypatch.delenv("PENGUIN_DEFAULT_PROVIDER", raising=False)
     monkeypatch.delenv("PENGUIN_WORKSPACE", raising=False)
@@ -52,3 +54,51 @@ def test_explicit_skipped_model_config_does_not_inherit_default_model(
     assert cfg.workspace_path == workspace
     assert cfg.model_config.model == ""
     assert cfg.model_config.provider == ""
+
+
+def test_partial_model_settings_do_not_synthesize_model_or_provider(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace = tmp_path / "workspace"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "workspace": {"path": str(workspace)},
+                "model": {"temperature": 0.2},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("PENGUIN_CWD", str(tmp_path / "outside-project"))
+    monkeypatch.delenv("PENGUIN_DEFAULT_MODEL", raising=False)
+    monkeypatch.delenv("PENGUIN_DEFAULT_PROVIDER", raising=False)
+    monkeypatch.delenv("PENGUIN_WORKSPACE", raising=False)
+
+    cfg = config_module.Config.load_config()
+
+    assert cfg.model_config.model == ""
+    assert cfg.model_config.provider == ""
+
+
+def test_provider_override_does_not_synthesize_default_model(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(tmp_path / "workspace")}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("PENGUIN_CWD", str(tmp_path / "outside-project"))
+    monkeypatch.delenv("PENGUIN_DEFAULT_MODEL", raising=False)
+    monkeypatch.setenv("PENGUIN_DEFAULT_PROVIDER", "anthropic")
+    monkeypatch.delenv("PENGUIN_WORKSPACE", raising=False)
+
+    cfg = config_module.Config.load_config()
+
+    assert cfg.model_config.model == ""
+    assert cfg.model_config.provider == "anthropic"

--- a/tests/test_config_workspace_path.py
+++ b/tests/test_config_workspace_path.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
+import yaml
+
 config_module = importlib.import_module("penguin.config")
 
 
@@ -29,3 +31,24 @@ def test_workspace_path_from_config_data_falls_back_when_not_writable(
 
     assert resolved == fallback
     assert fallback.exists()
+
+
+def test_explicit_skipped_model_config_does_not_inherit_default_model(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace = tmp_path / "workspace"
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(workspace)}, "model": None}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("PENGUIN_DEFAULT_MODEL", raising=False)
+    monkeypatch.delenv("PENGUIN_DEFAULT_PROVIDER", raising=False)
+    monkeypatch.delenv("PENGUIN_WORKSPACE", raising=False)
+
+    cfg = config_module.Config.load_config()
+
+    assert cfg.workspace_path == workspace
+    assert cfg.model_config.model == ""
+    assert cfg.model_config.provider == ""

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,25 +1,71 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import os
+import stat
+from pathlib import Path
 
 import yaml
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from penguin.setup import wizard
 
 
 def test_workspace_only_config_is_complete(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
     config_path.write_text(
-        yaml.safe_dump({"workspace": {"path": str(tmp_path / "workspace")}}),
+        yaml.safe_dump({"workspace": {"path": str(workspace_path)}}),
         encoding="utf-8",
     )
     monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
 
     assert wizard.check_config_completeness() is True
     assert wizard.check_first_run() is False
+
+
+def test_deleted_workspace_config_is_incomplete(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(tmp_path / "missing")}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+
+    assert wizard.check_config_completeness() is False
+    assert not (tmp_path / "missing").exists()
+
+
+def test_non_directory_workspace_config_is_incomplete(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    workspace_path.write_text("not a directory", encoding="utf-8")
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(workspace_path)}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+
+    assert wizard.check_config_completeness() is False
+
+
+def test_unwritable_workspace_config_is_incomplete(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(workspace_path)}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        wizard.os,
+        "access",
+        lambda path, _mode: Path(path) != workspace_path,
+    )
+
+    assert wizard.check_config_completeness() is False
 
 
 class _Prompt:
@@ -195,3 +241,46 @@ def test_persist_api_key_preserves_existing_env_entries(
         "OPENAI_API_KEY=new-secret",
     ]
     assert wizard.os.environ["OPENAI_API_KEY"] == "new-secret"
+    if os.name == "posix":
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+
+
+def test_openai_oauth_credential_marks_provider_ready(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_OAUTH_ACCESS_TOKEN", "oauth-token")
+    config = {
+        "workspace": {"path": str(tmp_path)},
+        "model": {"provider": "openai", "default": "gpt-5.2"},
+    }
+
+    assert wizard.check_provider_ready(config) is True
+
+
+def test_workspace_is_created_before_configuration_is_saved(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        wizard.questionary,
+        "text",
+        lambda *args, **kwargs: _Prompt(str(workspace_path)),
+    )
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt("Skip for now"),
+    )
+
+    def _fail_workspace(_path: Path) -> None:
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(wizard, "_create_workspace", _fail_workspace)
+
+    result = wizard.run_setup_wizard_sync()
+
+    assert result == {"error": "Could not initialize workspace: disk unavailable"}
+    assert not config_path.exists()

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from penguin.setup import wizard
+
+
+def test_workspace_only_config_is_complete(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        yaml.safe_dump({"workspace": {"path": str(tmp_path / "workspace")}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+
+    assert wizard.check_config_completeness() is True
+    assert wizard.check_first_run() is False
+
+
+class _Prompt:
+    def __init__(self, answer):
+        self.answer = answer
+
+    async def ask_async(self):
+        return self.answer
+
+
+def test_onboarding_can_skip_ai_without_openrouter_or_model_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        wizard.questionary,
+        "text",
+        lambda *args, **kwargs: _Prompt(str(workspace_path)),
+    )
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt("Skip for now"),
+        raising=False,
+    )
+
+    result = wizard.run_setup_wizard_sync()
+
+    assert "error" not in result
+    assert result["workspace"]["path"] == str(workspace_path.resolve())
+    assert result["model"] is None
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"] is None
+    assert (config_path.parent / ".penguin_setup_complete").exists()
+    for directory in wizard.WORKSPACE_DIRS:
+        assert (workspace_path / directory).is_dir()
+
+
+def test_onboarding_skip_ai_overrides_inherited_default_model(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "workspace"
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        wizard.questionary,
+        "text",
+        lambda *args, **kwargs: _Prompt(str(workspace_path)),
+    )
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt("Skip for now"),
+    )
+
+    result = wizard.run_setup_wizard_sync()
+
+    assert result["model"] is None
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"] is None
+
+
+def test_optional_model_setup_uses_provider_runtime_mapping(monkeypatch) -> None:
+    answers = iter(["Connect now", "OpenRouter", "openai/gpt-5.2", "Skip for now"])
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt(next(answers)),
+    )
+    config: dict = {}
+
+    import asyncio
+
+    asyncio.run(wizard._optional_model_setup(config))
+
+    assert config["model"]["provider"] == "openrouter"
+    assert config["model"]["client_preference"] == "openrouter"
+
+
+def test_rerunning_onboarding_preserves_existing_config_and_workspace_default(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "existing-workspace"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "workspace": {"path": str(workspace_path), "custom": "keep"},
+                "diagnostics": {"enabled": True},
+                "model": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    seen_defaults: list[str] = []
+
+    def _text(*args, **kwargs):
+        seen_defaults.append(kwargs.get("default"))
+        return _Prompt(kwargs.get("default"))
+
+    monkeypatch.setattr(wizard.questionary, "text", _text)
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt("Skip for now"),
+    )
+
+    result = wizard.run_setup_wizard_sync()
+
+    assert seen_defaults == [str(workspace_path)]
+    assert result["workspace"]["custom"] == "keep"
+    assert result["diagnostics"] == {"enabled": True}
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["diagnostics"] == {"enabled": True}
+    assert saved["workspace"]["custom"] == "keep"
+
+
+def test_rerunning_onboarding_skip_preserves_existing_model(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.yml"
+    workspace_path = tmp_path / "existing-workspace"
+    existing_model = {
+        "default": "gpt-5.2",
+        "provider": "openai",
+        "client_preference": "native",
+    }
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "workspace": {"path": str(workspace_path)},
+                "model": existing_model,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PENGUIN_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(
+        wizard.questionary,
+        "text",
+        lambda *args, **kwargs: _Prompt(kwargs.get("default")),
+    )
+    monkeypatch.setattr(
+        wizard.questionary,
+        "select",
+        lambda *args, **kwargs: _Prompt("Skip for now"),
+    )
+
+    result = wizard.run_setup_wizard_sync()
+
+    assert result["model"] == existing_model
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"] == existing_model
+
+
+def test_persist_api_key_preserves_existing_env_entries(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_home = tmp_path / "config"
+    env_path = config_home / "penguin" / ".env"
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text("OTHER_SETTING=keep\nOPENAI_API_KEY=old\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert wizard._persist_api_key("openai", "new-secret") is True
+
+    assert env_path.read_text(encoding="utf-8").splitlines() == [
+        "OTHER_SETTING=keep",
+        "OPENAI_API_KEY=new-secret",
+    ]
+    assert wizard.os.environ["OPENAI_API_KEY"] == "new-secret"


### PR DESCRIPTION
## Summary

Fixes the fresh-install flow so Penguin can launch without an OpenRouter API key, makes AI model connection optional during onboarding, restores provider discovery after setup is skipped, and removes slow adapter cleanup from the TUI abort critical path.

## User-facing changes

- Run setup before the default TUI entrypoints on a fresh install.
- Require only a writable Penguin workspace during onboarding.
- Present **Connect an AI model** as an optional, skippable step.
- Allow provider, model, and credential selection to be deferred.
- Keep workspace-only configuration valid instead of inheriting the packaged OpenRouter default.
- Avoid initializing a remote provider until a model and required credential are available.
- Return actionable setup guidance when prompting without a connected model or required credential.
- Seed `/provider` and `/config/providers` from Penguin's stable provider metadata so a workspace-only installation can still open **Connect a provider**.
- Preserve existing workspace/model settings when setup is rerun and the optional model step is skipped.
- Refresh first-run documentation and Windows examples.

## Cancellation

The session abort route previously awaited potentially slow adapter/tool cleanup before cancelling the tracked request and publishing `idle`. That could leave the TUI in a running/streaming state for 20–30 seconds after `Esc` reached the server.

This change cancels tracked work, clears stream state, and publishes `idle` immediately. Adapter cleanup continues as tracked best-effort background work.

## Validation

- 116 focused onboarding/startup/cancellation tests passed before the provider-discovery follow-up.
- 96 provider/auth/startup/setup tests passed after the follow-up.
- 26 provider-route tests passed.
- Ruff passed.
- Black formatting checks passed.
- Python compilation passed.
- `git diff --check` passed.
- Manual Codespaces usage confirmed:
  - setup can be skipped without an OpenRouter key;
  - the TUI launches in workspace-only mode;
  - the provider connection dialog is populated after skipped setup;
  - OpenAI OAuth/model use succeeds.

## Known unrelated test issue

A broad affected-suite run produced 769 passing tests, 1 skipped test, and one pre-existing failure in `tests/api/test_concurrent_session_isolation.py` because `routes_module` is undefined. The same failure reproduces on `main` and is unrelated to this branch.

## Deferred

Local Ollama currently inherits generic API-key connection UX. Credentialless local discovery and local-model semantics are intentionally deferred to `context/tasks/local-ai.md` outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-first onboarding now runs before the TUI, with a required writable workspace-location step and an optional “connect an AI model” step.
  * Provider selection/visibility is available even without credentials, and provider setup supports rerunning.
* **Bug Fixes**
  * Improved startup and runtime behavior when no model is connected or provider credentials are missing, with clearer guidance.
  * TUI/Web sessions handle `Esc`-abort more reliably without waiting on slow cleanup; improved abort and session status behavior.
* **Documentation**
  * Getting-started guide simplified and updated with new onboarding flow, configuration examples, and expanded troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->