### PR TITLE
Add Link and personal subscription inference to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,57 @@ permissions:
   contents: read
 
 jobs:
+  link-provider-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.9"
+            pydantic-spec: "pydantic==1.10.24"
+          - python-version: "3.12"
+            pydantic-spec: "pydantic>=2,<3"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install Penguin development dependencies
+        run: python -m pip install -e '.[dev]' '${{ matrix.pydantic-spec }}'
+      - name: Check Link provider and authority modules
+        run: |
+          ruff check \
+            penguin/llm/providers/link \
+            penguin/web/services/external_subscription.py \
+            penguin/web/services/link_inference.py \
+            tests/llm/test_link_provider.py \
+            tests/llm/test_link_runtime_contract.py \
+            tests/web/test_external_subscription_service.py \
+            tests/web/test_link_execution_authority.py
+          ruff format --check \
+            penguin/llm/providers/link \
+            penguin/web/services/external_subscription.py \
+            penguin/web/services/link_inference.py \
+            tests/llm/test_link_provider.py \
+            tests/llm/test_link_runtime_contract.py \
+            tests/web/test_external_subscription_service.py \
+            tests/web/test_link_execution_authority.py
+      - name: Run Link provider and Pydantic compatibility contracts
+        run: |
+          pytest -q \
+            tests/llm/test_link_provider.py \
+            tests/llm/test_link_runtime_contract.py \
+            tests/llm/test_provider_registry.py \
+            tests/web/test_link_inference_service.py \
+            tests/web/test_external_subscription_service.py \
+            tests/web/test_link_execution_authority.py \
+            tests/api/test_opencode_provider_routes.py::test_chat_message_rejects_cross_user_subscription_authority \
+            tests/api/test_opencode_provider_routes.py::test_chat_message_rejects_link_authority_from_ordinary_api_client \
+            tests/api/test_opencode_provider_routes.py::test_link_capabilities_reject_ordinary_api_clients \
+            tests/api/test_opencode_provider_routes.py::test_chat_message_resolves_subscription_model_through_openai
+
   python-goal-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/context/tasks/Penguin-Link-Inference-Provider.md
+++ b/context/tasks/Penguin-Link-Inference-Provider.md
@@ -1,0 +1,299 @@
+# Penguin Link Inference Provider
+
+Status: implemented on the current Link/Penguin working branches; live Sandbox smoke pending
+Target repository: `/Users/maximusputnam/Code/Penguin/penguin`
+Link counterpart: `apps/backend/src/inference/`
+
+## Purpose
+
+When Link resolves a model as Link-managed, every Penguin model call for that
+turn must go through Link's inference broker. Penguin must not turn a Link
+catalog selection into a direct OpenRouter call.
+
+The required execution path is:
+
+```text
+Link session request
+  -> Penguin reasoning/tool loop
+  -> LinkProvider (one request per model invocation)
+  -> Link /api/v1/responses (preferred) or /api/v1/chat/completions
+  -> durable reservation
+  -> provider dispatch intent
+  -> meter_event + meter_outbox
+  -> Polar
+```
+
+This is a provider transport concern, not an agent-loop concern. The Engine and
+conversation manager should continue consuming Penguin's existing normalized
+LLM contracts.
+
+## Non-goals
+
+- Do not put billing arithmetic, provider credentials, or OpenRouter policy in
+  Penguin.
+- Do not use Link's browser cookie from Penguin.
+- Do not aggregate a multi-step agent turn into one inferred usage event. Each
+  provider invocation is separately reserved and metered by Link.
+- Do not route through LiteLLM. Penguin deliberately treats LiteLLM as an
+  optional legacy path; it would add another policy/normalization layer without
+  solving Link ownership or attribution.
+- Do not silently fall back from Link to direct OpenRouter when Link-managed
+  execution was selected.
+
+## Personal ChatGPT subscription route
+
+Penguin also exposes its locally authenticated ChatGPT subscription as a
+provider capability for Link sessions. This is independent from the
+Link-managed `LinkProvider`: Penguin remains the agent runtime in both cases,
+but the subscription route keeps OAuth and provider quota custody inside the
+local Penguin process.
+
+- `GET /api/v1/link/capabilities` returns a versioned, credential-free catalog
+  for the authenticated Codex Responses compatibility transport.
+- Link binds that local runtime/provider capability to one Link user. User A's
+  personal subscription cannot serve User B, a workspace, or unattributed
+  scheduled/system work.
+- Each request carries an immutable `external_subscription_execution`
+  descriptor. Penguin validates the owner, selected model, transport, and
+  local OAuth state before model dispatch and echoes the execution facts plus
+  observed usage in its result.
+- Fallback to Link-managed inference is false for the beta contract. Missing
+  auth, quota exhaustion, model mismatch, or runtime disappearance fails
+  explicitly rather than spending Link credits.
+- Link records the echoed usage in its normal statistics pipeline as
+  externally billed work. It creates no Link credit reservation and no Polar
+  projection for this route.
+- A User A-initiated run may finish after the browser disconnects because the
+  captured descriptor remains attributed to User A; losing that attribution
+  makes the route ineligible.
+
+## Existing Penguin seams
+
+Implement against these current abstractions:
+
+| Concern                  | Existing seam                                                             | Required change                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Provider selection       | `penguin/llm/provider_registry.py`                                        | Add a first-class `link` preference/handler rather than recognizing Link by URL substring.                          |
+| Runtime configuration    | `penguin/llm/client.py` (`LinkConfig`, `LLMClientConfig`)                 | Replace process-global-ish mutable attribution with an immutable request-scoped Link execution context.             |
+| Canonical request/result | `penguin/llm/contracts.py` (`LLMRequest`, `LLMResult`, `ProviderRuntime`) | Preserve these contracts; add only the context fields needed for request identity and protocol capabilities.        |
+| Streaming lifecycle      | `penguin/llm/stream_handler.py` and `APIClient` lifecycle state           | Map Link SSE events into the existing lifecycle and tool-call contracts.                                            |
+| Current proof            | `tests/llm/test_link_runtime_contract.py`                                 | Expand from “headers reach an OpenRouter gateway” to “Link owns the transport and direct OpenRouter is impossible.” |
+
+## Configuration contract
+
+Add an explicit provider preference:
+
+```yaml
+model:
+  provider: openrouter # model namespace; not credential ownership
+  client_preference: link # transport and policy owner
+  model: openai/gpt-5.6-luna
+```
+
+Static process configuration:
+
+```text
+LINK_INFERENCE_BASE_URL=http://localhost:3001/api/v1
+LINK_INFERENCE_SERVICE_TOKEN=<service credential>
+LINK_INFERENCE_PROTOCOL=responses  # responses | chat_completions
+```
+
+The service token authenticates Penguin as a Link runtime. It must not encode a
+single workspace or user. Per-invocation attribution is request context.
+
+Define an immutable context value (name may follow Penguin conventions):
+
+```python
+@dataclass(frozen=True)
+class LinkInferenceContext:
+    workspace_id: str
+    user_id: str
+    session_id: str
+    agent_id: str
+    run_id: str
+    requested_model_id: str
+    execution_source: Literal["link_gateway"]
+    provider_state_owner: Literal["link_managed"]
+    settlement_mode: Literal["debit_link_credits"]
+```
+
+`invocation_id` is unique for each model call, including follow-up calls after
+tool results. Retrying the same uncertain HTTP attempt reuses the invocation ID;
+a logically new model call gets a new ID.
+
+## Transport contract
+
+### Authentication and attribution
+
+Every request sends:
+
+```http
+X-Link-Service-Name: penguin
+X-Link-Service-Auth: <LINK_INFERENCE_SERVICE_TOKEN>
+X-Link-Workspace-Id: <workspace_id>
+X-Link-User-Id: <user_id>
+X-Link-Session-Id: <session_id>
+X-Link-Agent-Id: <agent_id>
+X-Link-Run-Id: <run_id>
+X-Link-Request-Id: <invocation_id>
+```
+
+Link must authenticate the service credential and verify that the asserted
+workspace/run context is authorized. Penguin must never forward a provider key.
+
+### Protocol selection
+
+Implement a small protocol strategy inside `LinkProvider`:
+
+1. Prefer `POST {base_url}/responses` when configured and supported.
+2. Use `POST {base_url}/chat/completions` for models/features not yet covered by
+   the Responses adapter.
+3. Protocol selection is explicit capability negotiation, never retry-based
+   guessing after a provider effect may have occurred.
+
+The implementation supports:
+
+- text input/output;
+- streaming text and reasoning deltas;
+- tool definitions, tool choice, tool-call deltas, and tool results;
+- bounded maximum output tokens;
+- temperature and provider-neutral reasoning effort where supported;
+- cancellation and idle timeout;
+- normalized usage and provider request ID capture.
+
+Multimodal requests must fail before dispatch until Link advertises a metered
+multimodal capability.
+
+### Request identity
+
+Send `X-Link-Request-Id` on both protocols. The same invocation ID is used for
+reservation idempotency, provider dispatch intent, meter event, and Polar
+idempotency. Penguin may retry only when Link explicitly reports a pre-dispatch
+failure. A disconnect/timeout after dispatch is an uncertain outcome and must
+not be automatically replayed under a new ID.
+
+### Response/error semantics
+
+Map Link responses into existing Penguin errors:
+
+| Link result                     | Penguin behavior                                                       |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| 400 policy/unsupported input    | non-retryable `LLMProviderError`                                       |
+| 401/403 service or context auth | non-retryable configuration/security error                             |
+| 402 insufficient credits        | non-retryable quota/billing error surfaced to Link                     |
+| 409 idempotency conflict        | non-retryable invariant error                                          |
+| 429                             | retry only when Link supplies a safe retry signal                      |
+| 5xx before-dispatch marker      | bounded retry with same invocation ID                                  |
+| disconnect or ambiguous 5xx     | mark lifecycle disconnected/uncertain; do not call OpenRouter directly |
+
+Preserve Link response headers (`X-Link-Inference-Request-Id`, execution source,
+settlement mode, meter key) in `LLMResult.provider_data` for diagnostics. Usage
+reported to Penguin is observational only; Link's durable meter is authoritative.
+
+## Provider registry changes
+
+`ProviderRegistry.create_handler()` accepts `client_preference="link"`
+and construct `LinkProvider`. Do not route Link through
+`OpenRouterGateway(base_url=...)`; that is the current defect because the
+gateway still owns OpenRouter-specific assumptions and makes Link support look
+like a URL override.
+
+`LinkProvider` implements Penguin's normalized provider surface for:
+
+- `ProviderRuntime`;
+- `UsageReportingRuntime`;
+- `ToolCallRuntime`;
+- `ErrorReportingRuntime`;
+- `RequestLifecycleRuntime`.
+
+It should use Penguin's shared connection pool and stream lifecycle helpers.
+Keep request/response translation in protocol-specific modules, for example:
+
+```text
+penguin/llm/providers/link/
+  __init__.py
+  provider.py
+  context.py
+  responses_protocol.py
+  chat_completions_protocol.py
+  errors.py
+```
+
+The exact directory can follow the ongoing provider consolidation, but protocol
+translation and orchestration must remain separate.
+
+## Runtime propagation
+
+Link's agent route knows workspace, user, session, agent, and run and carries
+an immutable `LinkInferenceContext` through the A2A/runtime request into each
+Engine model invocation. Do not mutate a singleton client through
+`/system/config/llm` between requests; concurrent workspaces would race.
+
+At the provider boundary:
+
+```python
+if execution.provider_state_owner == "link_managed":
+    assert client_preference == "link"
+    assert link_context is not None
+```
+
+Conversely, a `link` client preference without a complete Link-managed
+descriptor must fail closed.
+
+## Tests And Evidence
+
+Follow Penguin's deterministic provider testing pyramid.
+
+1. Registry tests
+
+   - `client_preference="link"` creates `LinkProvider`.
+   - Link-managed selection cannot instantiate `OpenRouterGateway` or
+     `LiteLLMGateway`.
+
+2. Request contract tests
+
+   - all attribution and request-ID headers are present;
+   - service token is present but provider credentials are absent;
+   - Responses and Chat Completions translations preserve tools/reasoning;
+   - every follow-up model invocation gets its own ID.
+
+3. Stream fixtures
+
+   - text, reasoning, tools, usage, incomplete stream, error event, cancellation;
+   - native tool-call adjacency remains valid after translation.
+
+4. Reliability/state-machine tests
+
+   - safe pre-dispatch failure retries with the same ID;
+   - ambiguous disconnect is not replayed and never falls back direct;
+   - concurrent workspaces retain distinct immutable context;
+   - cancellation closes the Link response and reports the correct lifecycle.
+
+5. Link integration test
+
+   - run a fake Link broker and assert the sequence
+     `reserve -> dispatch intent -> meter -> outbox` for every Penguin model
+     invocation.
+
+6. Opt-in sandbox smoke
+   - one real Link workspace prompt produces a matching Link meter event and
+     Polar Sandbox event with the same request identity.
+
+The registry, request translation, streaming/tool/usage, immutable-context, and
+ambiguous-transport tests are implemented under `tests/llm` and `tests/web`.
+The live smoke remains gated by the Polar customer/refund scopes, webhook
+secret, approved product id, and provider spend cap documented in Track 8.
+
+## Acceptance criteria
+
+- A Link UI Penguin turn using a Link-managed model creates at least one Link
+  `meter_event`; a multi-step/tool turn creates one per provider invocation.
+- No direct request reaches OpenRouter from Penguin for that execution mode.
+- The model, user, workspace, session, agent, run, and invocation are
+  attributable on every request.
+- The runtime supports both Responses and Chat Completions without coupling the
+  provider abstraction to either wire format.
+- Policy, pricing, credentials, reservation, settlement, reconciliation, and
+  Polar delivery remain entirely Link-owned.
+- Concurrent Link workspaces cannot overwrite each other's routing context.
+- LiteLLM is neither required nor involved.

--- a/penguin/.env.example
+++ b/penguin/.env.example
@@ -18,6 +18,13 @@ PENGUIN_CLIENT_PREFERENCE=openrouter
 PENGUIN_CORS_ORIGINS=*
 PENGUIN_DEBUG=1
 PENGUIN_WORKSPACE=/workspace
+# Link-managed inference (required only when Link supplies link_execution)
+# The token must equal Link's LINK_INTERNAL_SERVICE_SECRET. It authenticates
+# Penguin as a service; workspace/user/session/run identity remains per request.
+LINK_INFERENCE_BASE_URL=http://localhost:3001/api/v1
+LINK_INFERENCE_SERVICE_TOKEN=
+LINK_INFERENCE_SERVICE_NAME=penguin
+LINK_INFERENCE_PROTOCOL=responses
 # ==============================
 # GitHub Integration (Optional)
 # ==============================

--- a/penguin/.env.example
+++ b/penguin/.env.example
@@ -19,6 +19,14 @@ PENGUIN_CORS_ORIGINS=*
 PENGUIN_DEBUG=1
 PENGUIN_WORKSPACE=/workspace
 # Link-managed inference (required only when Link supplies link_execution)
+# Inbound Link-to-Penguin service authentication. Configure Link's
+# PENGUIN_API_KEY with the same value. Generic Penguin API keys cannot assert
+# Link-managed or personal-subscription execution authority.
+LINK_API_KEY=
+# Narrow local-beta ownership binding: this runtime's local ChatGPT OAuth
+# credential may serve only this Link user. Cloud/multi-runtime pairing uses a
+# future credential binding service rather than caller-supplied identity.
+PENGUIN_LINK_SUBSCRIPTION_OWNER_USER_ID=
 # The token must equal Link's LINK_INTERNAL_SERVICE_SECRET. It authenticates
 # Penguin as a service; workspace/user/session/run identity remains per request.
 LINK_INFERENCE_BASE_URL=http://localhost:3001/api/v1

--- a/penguin/.env.example
+++ b/penguin/.env.example
@@ -20,8 +20,10 @@ PENGUIN_DEBUG=1
 PENGUIN_WORKSPACE=/workspace
 # Link-managed inference (required only when Link supplies link_execution)
 # Inbound Link-to-Penguin service authentication. Configure Link's
-# PENGUIN_API_KEY with the same value. Generic Penguin API keys cannot assert
-# Link-managed or personal-subscription execution authority.
+# PENGUIN_LINK_API_KEY with the same value. Keep this value out of
+# PENGUIN_API_KEYS: it is intentionally limited to capability discovery and
+# descriptor-bearing Link-managed or personal-subscription execution. Penguin
+# refuses to start when the normalized credential values overlap.
 LINK_API_KEY=
 # Narrow local-beta ownership binding: this runtime's local ChatGPT OAuth
 # credential may serve only this Link user. Cloud/multi-runtime pairing uses a

--- a/penguin/llm/api_client.py
+++ b/penguin/llm/api_client.py
@@ -29,6 +29,7 @@ from .contracts import (
 )
 from .model_config import ModelConfig
 from .provider_registry import ProviderRegistry
+from .providers.link.context import LinkInferenceContext
 from .provider_transform import apply_model_config_transforms, build_llm_error
 from penguin.constants import get_default_max_history_tokens
 from penguin.utils.callbacks import adapt_stream_callback
@@ -285,6 +286,7 @@ class APIClient:
         *,
         base_url: Optional[str] = None,
         extra_headers: Optional[Dict[str, str]] = None,
+        link_context: Optional[LinkInferenceContext] = None,
     ):
         """
         Initialize the APIClient.
@@ -302,6 +304,7 @@ class APIClient:
         self._last_response_result: Optional[LLMCallResult] = None
         self._base_url = base_url
         self._extra_headers = dict(extra_headers or {})
+        self._link_context = link_context
         self.provider_registry = ProviderRegistry(
             native_adapter_factory=get_adapter,
             litellm_gateway_loader=load_litellm_gateway_class,
@@ -319,6 +322,7 @@ class APIClient:
                 model_config,
                 base_url=self._base_url,
                 extra_headers=self._extra_headers,
+                link_context=self._link_context,
             )
             self.logger.info(
                 "Using %s for %s (provider=%s, preference=%s)",

--- a/penguin/llm/client.py
+++ b/penguin/llm/client.py
@@ -32,6 +32,7 @@ from .api_client import APIClient
 from .adapters import get_adapter
 from .litellm_support import load_litellm_gateway_class
 from .provider_registry import ProviderRegistry
+from .providers.link.context import LinkInferenceContext
 
 if TYPE_CHECKING:
     from .model_config import ModelConfig
@@ -166,6 +167,7 @@ class LLMClient:
         self,
         model_config: "ModelConfig",
         config: Optional[LLMClientConfig] = None,
+        link_context: Optional[LinkInferenceContext] = None,
     ):
         """Initialize LLM client with optional Link configuration.
 
@@ -175,6 +177,7 @@ class LLMClient:
         """
         self.model_config = model_config
         self._config = config or LLMClientConfig.from_env()
+        self._link_context = link_context
         self._config_lock = threading.RLock()
         self._api_client: Optional[APIClient] = None
         self._api_client_lock = threading.RLock()
@@ -299,6 +302,7 @@ class LLMClient:
                 self.model_config,
                 base_url=base_url,
                 extra_headers=link_headers,
+                link_context=self._link_context,
             )
             return self._api_client
 
@@ -316,6 +320,7 @@ class LLMClient:
                 self.model_config,
                 base_url=base_url,
                 extra_headers=link_headers,
+                link_context=self._link_context,
             )
             return self._gateway
 

--- a/penguin/llm/client.py
+++ b/penguin/llm/client.py
@@ -288,6 +288,15 @@ class LLMClient:
 
             return headers
 
+    def _reject_legacy_link_proxy(self) -> None:
+        """Prevent Link execution through a generic provider/base-URL path."""
+
+        if self._config.is_link_proxy or self._config.link.is_configured:
+            raise ValueError(
+                "Legacy Link proxy routing is disabled. Link-managed execution "
+                "must use the first-class LinkProvider with request-scoped context."
+            )
+
     def _get_api_client(self) -> APIClient:
         """Get or create the shared APIClient with current Link-aware config."""
         with self._api_client_lock:
@@ -295,6 +304,7 @@ class LLMClient:
                 return self._api_client
 
             with self._config_lock:
+                self._reject_legacy_link_proxy()
                 base_url = self._config.base_url
                 link_headers = self.get_link_headers()
 
@@ -313,6 +323,7 @@ class LLMClient:
                 return self._gateway
 
             with self._config_lock:
+                self._reject_legacy_link_proxy()
                 base_url = self._config.base_url
                 link_headers = self.get_link_headers()
 

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -55,7 +55,7 @@ class ModelConfig:
 
     model: str
     provider: str
-    client_preference: Literal["native", "litellm", "openrouter"] = "openrouter"
+    client_preference: Literal["native", "litellm", "openrouter", "link"] = "openrouter"
     api_base: Optional[str] = None
     api_key: Optional[str] = None
     api_version: Optional[str] = None

--- a/penguin/llm/provider_registry.py
+++ b/penguin/llm/provider_registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from .model_config import ModelConfig
 from .provider_transform import (
@@ -10,6 +10,9 @@ from .provider_transform import (
     is_openai_compatible_provider,
     normalize_client_preference,
 )
+
+if TYPE_CHECKING:
+    from .providers.link.context import LinkInferenceContext
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +25,9 @@ LiteLLMGatewayLoader = Callable[[str], Any]
 class ProviderContext:
     """Transport/runtime context passed into provider resolution."""
 
-    base_url: Optional[str] = None
-    extra_headers: Dict[str, str] = field(default_factory=dict)
+    base_url: str | None = None
+    extra_headers: dict[str, str] = field(default_factory=dict)
+    link_context: LinkInferenceContext | None = None
 
 
 class ProviderRegistry:
@@ -47,8 +51,9 @@ class ProviderRegistry:
         self,
         model_config: ModelConfig,
         *,
-        base_url: Optional[str] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
+        base_url: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        link_context: LinkInferenceContext | None = None,
     ) -> Any:
         """Create a handler for the requested provider/runtime path."""
 
@@ -56,10 +61,13 @@ class ProviderRegistry:
         context = ProviderContext(
             base_url=base_url,
             extra_headers=dict(extra_headers or {}),
+            link_context=link_context,
         )
         preference = normalize_client_preference(prepared.client_preference)
 
-        if preference == "openrouter":
+        if preference == "link":
+            handler = self._create_link_handler(prepared, context)
+        elif preference == "openrouter":
             handler = self._create_openrouter_handler(prepared, context)
         elif preference == "litellm":
             handler = self._create_litellm_handler(prepared, context)
@@ -68,11 +76,30 @@ class ProviderRegistry:
         else:
             raise ValueError(
                 "Invalid client_preference: "
-                f"{prepared.client_preference}. Must be 'native', 'litellm', or 'openrouter'."
+                f"{prepared.client_preference}. Must be 'native', 'litellm', "
+                "'openrouter', or 'link'."
             )
 
         self._apply_extra_headers(handler, context.extra_headers)
         return handler
+
+    def _create_link_handler(
+        self,
+        model_config: ModelConfig,
+        context: ProviderContext,
+    ) -> Any:
+        from .providers.link import LinkProvider, LinkProviderConfig
+
+        if context.link_context is None:
+            raise ValueError(
+                "client_preference='link' requires immutable Link inference context"
+            )
+        config = LinkProviderConfig.from_env(base_url=context.base_url)
+        return LinkProvider(
+            model_config=model_config,
+            context=context.link_context,
+            config=config,
+        )
 
     def _create_openrouter_handler(
         self,
@@ -118,7 +145,7 @@ class ProviderRegistry:
     def _apply_extra_headers(
         self,
         handler: Any,
-        extra_headers: Dict[str, str],
+        extra_headers: dict[str, str],
     ) -> None:
         """Best-effort header injection for transport-aware wrappers like Link."""
 

--- a/penguin/llm/provider_transform.py
+++ b/penguin/llm/provider_transform.py
@@ -14,7 +14,7 @@ OPENAI_COMPATIBLE_PROVIDER_ALIASES = {
     "openai-compatible",
     "openai_compat",
 }
-VALID_CLIENT_PREFERENCES = {"native", "litellm", "openrouter"}
+VALID_CLIENT_PREFERENCES = {"native", "litellm", "openrouter", "link"}
 
 
 def normalize_provider_name(provider: str) -> str:

--- a/penguin/llm/providers/__init__.py
+++ b/penguin/llm/providers/__init__.py
@@ -1,0 +1,3 @@
+"""First-class LLM provider transports."""
+
+__all__: list[str] = []

--- a/penguin/llm/providers/link/__init__.py
+++ b/penguin/llm/providers/link/__init__.py
@@ -1,0 +1,6 @@
+"""Link-owned inference transport for Penguin."""
+
+from .context import LinkInferenceContext
+from .provider import LinkProvider, LinkProviderConfig
+
+__all__ = ["LinkInferenceContext", "LinkProvider", "LinkProviderConfig"]

--- a/penguin/llm/providers/link/chat_completions_protocol.py
+++ b/penguin/llm/providers/link/chat_completions_protocol.py
@@ -1,0 +1,117 @@
+"""Chat Completions wire translation for LinkProvider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...contracts import FinishReason, LLMToolCall, LLMUsage
+from ...provider_transform import normalize_finish_reason
+
+
+def build_chat_completions_body(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_output_tokens: int,
+    temperature: float | None,
+    stream: bool,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+    reasoning: Any = None,
+) -> dict[str, Any]:
+    """Build a text-only Chat Completions request."""
+
+    for message in messages:
+        if not isinstance(message.get("content"), str) and not (
+            message.get("role") == "assistant" and message.get("content") is None
+        ):
+            raise ValueError(
+                "Link-managed inference supports text messages only until "
+                "multimodal metering is enabled."
+            )
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_completion_tokens": max_output_tokens,
+        "stream": stream,
+    }
+    if stream:
+        body["stream_options"] = {"include_usage": True}
+    if temperature is not None:
+        body["temperature"] = temperature
+    if tools:
+        body["tools"] = tools
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    if reasoning is not None:
+        body["reasoning"] = reasoning
+    return body
+
+
+def parse_chat_completions_body(
+    payload: dict[str, Any],
+) -> tuple[str, str, list[LLMToolCall], LLMUsage, FinishReason, dict[str, Any]]:
+    choices = payload.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    choice = choice if isinstance(choice, dict) else {}
+    message = choice.get("message")
+    message = message if isinstance(message, dict) else {}
+    text = message.get("content") if isinstance(message.get("content"), str) else ""
+    reasoning = message.get("reasoning")
+    reasoning = reasoning if isinstance(reasoning, str) else ""
+    tool_calls: list[LLMToolCall] = []
+    raw_tool_calls = message.get("tool_calls")
+    if isinstance(raw_tool_calls, list):
+        for raw in raw_tool_calls:
+            function = raw.get("function") if isinstance(raw, dict) else None
+            if not isinstance(function, dict):
+                continue
+            tool_calls.append(
+                LLMToolCall(
+                    name=str(function.get("name") or ""),
+                    arguments=str(function.get("arguments") or "{}"),
+                    call_id=str(raw.get("id") or "") or None,
+                )
+            )
+    usage = normalize_chat_usage(payload.get("usage"))
+    finish = normalize_finish_reason(choice.get("finish_reason"))
+    return (
+        text,
+        reasoning,
+        tool_calls,
+        usage,
+        finish,
+        {"response_id": payload.get("id")},
+    )
+
+
+def normalize_chat_usage(value: Any) -> LLMUsage:
+    usage = value if isinstance(value, dict) else {}
+    prompt_details = usage.get("prompt_tokens_details")
+    completion_details = usage.get("completion_tokens_details")
+    prompt_details = prompt_details if isinstance(prompt_details, dict) else {}
+    completion_details = (
+        completion_details if isinstance(completion_details, dict) else {}
+    )
+    return LLMUsage(
+        input_tokens=_int(usage.get("prompt_tokens")),
+        output_tokens=_int(usage.get("completion_tokens")),
+        reasoning_tokens=_int(completion_details.get("reasoning_tokens")),
+        cache_read_tokens=_int(prompt_details.get("cached_tokens")),
+        total_tokens=_int(usage.get("total_tokens")),
+        provider_data=dict(usage),
+    )
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = [
+    "build_chat_completions_body",
+    "normalize_chat_usage",
+    "parse_chat_completions_body",
+]

--- a/penguin/llm/providers/link/context.py
+++ b/penguin/llm/providers/link/context.py
@@ -1,0 +1,55 @@
+"""Immutable per-turn attribution for Link-managed inference."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class LinkInferenceContext:
+    """Link-owned execution facts that must remain request scoped."""
+
+    workspace_id: str
+    user_id: str
+    session_id: str
+    agent_id: str
+    run_id: str
+    requested_model_id: str
+    execution_source: Literal["link_gateway"] = "link_gateway"
+    provider_state_owner: Literal["link_managed"] = "link_managed"
+    settlement_mode: Literal["debit_link_credits"] = "debit_link_credits"
+
+    def __post_init__(self) -> None:
+        required = {
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "session_id": self.session_id,
+            "agent_id": self.agent_id,
+            "run_id": self.run_id,
+            "requested_model_id": self.requested_model_id,
+        }
+        missing = [name for name, value in required.items() if not value.strip()]
+        if missing:
+            raise ValueError(
+                "Link inference context is missing required values: "
+                + ", ".join(missing)
+            )
+
+    def headers(self, invocation_id: str) -> dict[str, str]:
+        """Return per-invocation attribution headers without credentials."""
+
+        return {
+            "X-Link-Workspace-Id": self.workspace_id,
+            "X-Link-User-Id": self.user_id,
+            "X-Link-Session-Id": self.session_id,
+            "X-Link-Agent-Id": self.agent_id,
+            "X-Link-Run-Id": self.run_id,
+            "X-Link-Request-Id": invocation_id,
+            # Link currently consumes this compatibility name for settlement
+            # idempotency. Keep both names equal during the protocol migration.
+            "X-Link-Inference-Request-Id": invocation_id,
+        }
+
+
+__all__ = ["LinkInferenceContext"]

--- a/penguin/llm/providers/link/provider.py
+++ b/penguin/llm/providers/link/provider.py
@@ -1,0 +1,618 @@
+"""First-class Link-owned inference provider for Penguin."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import httpx
+
+from ...contracts import (
+    ErrorCategory,
+    FinishReason,
+    LLMError,
+    LLMPreparedRequest,
+    LLMProviderCapabilities,
+    LLMProviderError,
+    LLMRequestLifecycle,
+    LLMToolCall,
+    LLMUsage,
+    ProviderRequestStatus,
+    StreamCallback,
+)
+from ...provider_transform import build_llm_error, extract_retry_after_seconds
+from .chat_completions_protocol import (
+    build_chat_completions_body,
+    normalize_chat_usage,
+    parse_chat_completions_body,
+)
+from .responses_protocol import (
+    build_responses_body,
+    normalize_responses_usage,
+    parse_responses_body,
+)
+
+if TYPE_CHECKING:
+    from .context import LinkInferenceContext
+
+LinkProtocol = Literal["responses", "chat_completions"]
+
+
+@dataclass(frozen=True)
+class LinkProviderConfig:
+    """Static Link transport configuration; never carries user attribution."""
+
+    base_url: str
+    service_token: str
+    service_name: str = "penguin"
+    protocol: LinkProtocol = "responses"
+    idle_timeout_seconds: float = 300.0
+
+    @classmethod
+    def from_env(cls, *, base_url: str | None = None) -> LinkProviderConfig:
+        protocol = os.getenv("LINK_INFERENCE_PROTOCOL", "responses").strip().lower()
+        if protocol not in {"responses", "chat_completions"}:
+            raise ValueError(
+                "LINK_INFERENCE_PROTOCOL must be 'responses' or 'chat_completions'."
+            )
+        resolved_base_url = (
+            base_url
+            or os.getenv("LINK_INFERENCE_BASE_URL")
+            or os.getenv("LINK_INFERENCE_URL")
+            or "http://localhost:3001/api/v1"
+        ).rstrip("/")
+        service_token = (
+            os.getenv("LINK_INFERENCE_SERVICE_TOKEN")
+            or os.getenv("LINK_INTERNAL_SERVICE_SECRET")
+            or ""
+        ).strip()
+        if not service_token:
+            raise ValueError("LINK_INFERENCE_SERVICE_TOKEN is required.")
+        return cls(
+            base_url=resolved_base_url,
+            service_token=service_token,
+            service_name=os.getenv("LINK_INFERENCE_SERVICE_NAME", "penguin"),
+            protocol=cast("LinkProtocol", protocol),
+        )
+
+
+class LinkProvider:
+    """Send one Penguin model invocation through Link's authorized broker."""
+
+    provider = "link"
+
+    def __init__(
+        self,
+        *,
+        model_config: Any,
+        context: LinkInferenceContext,
+        config: LinkProviderConfig,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if context.provider_state_owner != "link_managed":
+            raise ValueError("LinkProvider requires provider_state_owner=link_managed.")
+        if context.execution_source != "link_gateway":
+            raise ValueError("LinkProvider requires execution_source=link_gateway.")
+        if context.settlement_mode != "debit_link_credits":
+            raise ValueError(
+                "LinkProvider requires settlement_mode=debit_link_credits."
+            )
+        self.model_config = model_config
+        self.context = context
+        self.config = config
+        self._http_client = http_client
+        self._last_usage = LLMUsage()
+        self._last_error: LLMError | None = None
+        self._last_lifecycle: LLMRequestLifecycle | None = None
+        self._last_finish_reason = FinishReason.UNKNOWN
+        self._last_reasoning = ""
+        self._pending_tool_calls: list[LLMToolCall] = []
+        self._last_provider_data: dict[str, Any] = {}
+
+    def get_capabilities(self) -> LLMProviderCapabilities:
+        return LLMProviderCapabilities(
+            provider="link",
+            model=str(self.model_config.model),
+            native_tools=True,
+            streaming=True,
+            reasoning=bool(getattr(self.model_config, "supports_reasoning", False)),
+            vision=False,
+            max_context_tokens=getattr(
+                self.model_config, "max_context_window_tokens", None
+            ),
+            max_output_tokens=getattr(self.model_config, "max_output_tokens", None),
+            provider_data={"protocol": self.config.protocol},
+        )
+
+    async def prepare_request(
+        self,
+        messages: list[dict[str, Any]],
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> LLMPreparedRequest:
+        invocation_id = str(kwargs.pop("invocation_id", "") or uuid.uuid4())
+        protocol, route, body = self._build_request(
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            stream=stream,
+            kwargs=kwargs,
+        )
+        return LLMPreparedRequest(
+            provider="link",
+            model=str(self.model_config.model),
+            protocol=protocol,
+            route=route,
+            body=body,
+            transport="link_sse" if stream else "link_http",
+            headers=self._headers(invocation_id, include_secret=False),
+            capabilities=self.get_capabilities(),
+            diagnostics={"invocation_id": invocation_id},
+            provider_data={"execution_source": "link_gateway"},
+        )
+
+    async def get_response(
+        self,
+        messages: list[dict[str, Any]],
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        stream: bool = False,
+        stream_callback: StreamCallback | None = None,
+        **kwargs: Any,
+    ) -> str:
+        invocation_id = str(kwargs.pop("invocation_id", "") or uuid.uuid4())
+        protocol, route, body = self._build_request(
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            stream=stream,
+            kwargs=kwargs,
+        )
+        lifecycle = LLMRequestLifecycle(
+            request_id=invocation_id,
+            provider="link",
+            model=str(self.model_config.model),
+            status=ProviderRequestStatus.RUNNING,
+            stream=stream,
+            transport="link_sse" if stream else "link_http",
+            started_at=time.time(),
+            last_event_at=time.time(),
+            provider_data={"protocol": protocol, "route": route},
+        )
+        self._last_lifecycle = lifecycle
+        self._last_error = None
+        self._pending_tool_calls = []
+
+        try:
+            client = await self._client()
+            if stream:
+                result = await self._stream_response(
+                    client=client,
+                    route=route,
+                    body=body,
+                    headers=self._headers(invocation_id),
+                    protocol=protocol,
+                    callback=stream_callback,
+                    lifecycle=lifecycle,
+                )
+            else:
+                response = await client.post(
+                    f"{self.config.base_url}/{route}",
+                    json=body,
+                    headers=self._headers(invocation_id),
+                    timeout=self.config.idle_timeout_seconds,
+                )
+                await self._raise_for_link_error(response, lifecycle)
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise ValueError("Link returned a non-object inference response.")
+                result = self._parse_buffered(protocol, payload)
+                self._capture_response_headers(response.headers)
+
+            text, reasoning, tool_calls, usage, finish, provider_data = result
+            self._last_usage = usage
+            self._last_reasoning = reasoning
+            self._pending_tool_calls = list(tool_calls)
+            self._last_finish_reason = finish
+            self._last_provider_data.update(provider_data)
+            lifecycle.status = ProviderRequestStatus.COMPLETED
+            lifecycle.finish_reason = finish
+            lifecycle.provider_response_id = _optional_str(
+                provider_data.get("response_id")
+            )
+            lifecycle.ended_at = time.time()
+            lifecycle.last_event_at = lifecycle.ended_at
+            lifecycle.provider_data.update(self._last_provider_data)
+            return text
+        except asyncio.CancelledError:
+            lifecycle.status = ProviderRequestStatus.CANCELLED
+            lifecycle.ended_at = time.time()
+            raise
+        except LLMProviderError as error:
+            self._last_error = error.error
+            lifecycle.error = error.error
+            lifecycle.status = (
+                ProviderRequestStatus.DISCONNECTED
+                if error.error.category
+                in {ErrorCategory.NETWORK, ErrorCategory.TIMEOUT}
+                else ProviderRequestStatus.FAILED
+            )
+            lifecycle.ended_at = time.time()
+            raise
+        except (httpx.HTTPError, asyncio.TimeoutError) as error:
+            llm_error = build_llm_error(
+                message=f"Link inference transport outcome is uncertain: {error}",
+                provider="link",
+                model=str(self.model_config.model),
+                category=(
+                    ErrorCategory.TIMEOUT
+                    if isinstance(error, (httpx.TimeoutException, asyncio.TimeoutError))
+                    else ErrorCategory.NETWORK
+                ),
+                retryable=False,
+                provider_data={"dispatch_outcome": "uncertain"},
+            )
+            self._last_error = llm_error
+            lifecycle.error = llm_error
+            lifecycle.status = ProviderRequestStatus.DISCONNECTED
+            lifecycle.ended_at = time.time()
+            raise LLMProviderError(llm_error) from error
+        except Exception as error:
+            llm_error = build_llm_error(
+                message=f"Link inference response handling failed: {error}",
+                provider="link",
+                model=str(self.model_config.model),
+                category=ErrorCategory.RUNTIME,
+                retryable=False,
+                provider_data={"dispatch_outcome": "uncertain"},
+            )
+            self._last_error = llm_error
+            lifecycle.error = llm_error
+            lifecycle.status = ProviderRequestStatus.FAILED
+            lifecycle.ended_at = time.time()
+            raise LLMProviderError(llm_error) from error
+
+    def count_tokens(self, content: Any) -> int:
+        """Return a conservative local estimate; Link owns billing counts."""
+
+        text = content if isinstance(content, str) else json.dumps(content, default=str)
+        return max((len(text) + 3) // 4, 1)
+
+    def get_last_usage(self) -> dict[str, Any]:
+        return self._last_usage.to_dict()
+
+    def get_last_error(self) -> LLMError | None:
+        return self._last_error
+
+    def get_last_request_lifecycle(self) -> LLMRequestLifecycle | None:
+        return self._last_lifecycle
+
+    def get_last_finish_reason(self) -> FinishReason:
+        return self._last_finish_reason
+
+    def get_last_reasoning(self) -> str:
+        return self._last_reasoning
+
+    def has_pending_tool_call(self) -> bool:
+        return bool(self._pending_tool_calls)
+
+    def get_and_clear_last_tool_call(self) -> dict[str, Any] | None:
+        calls = self.get_and_clear_pending_tool_calls()
+        return calls[-1] if calls else None
+
+    def get_and_clear_pending_tool_calls(self) -> list[dict[str, Any]]:
+        calls = [
+            {
+                "id": call.call_id,
+                "type": "function",
+                "function": {"name": call.name, "arguments": call.arguments},
+            }
+            for call in self._pending_tool_calls
+        ]
+        self._pending_tool_calls = []
+        return calls
+
+    async def _client(self) -> httpx.AsyncClient:
+        if self._http_client is not None:
+            return self._http_client
+        # Import lazily to avoid api_client -> registry -> provider cycles.
+        from ...api_client import ConnectionPoolManager
+
+        return await ConnectionPoolManager.get_instance().get_client(
+            self.config.base_url
+        )
+
+    def _build_request(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        max_output_tokens: int | None,
+        temperature: float | None,
+        stream: bool,
+        kwargs: dict[str, Any],
+    ) -> tuple[LinkProtocol, str, dict[str, Any]]:
+        maximum = max_output_tokens or getattr(
+            self.model_config, "max_output_tokens", None
+        )
+        if not isinstance(maximum, int) or maximum <= 0:
+            raise ValueError(
+                "Link-managed inference requires a positive bounded maximum output."
+            )
+        tools = kwargs.pop("tools", None)
+        tool_choice = kwargs.pop("tool_choice", None)
+        reasoning = kwargs.pop("reasoning", None)
+        if reasoning is None:
+            effort = getattr(self.model_config, "reasoning_effort", None)
+            reasoning = {"effort": effort} if effort else None
+        if kwargs:
+            # Do not forward provider-specific knobs across the Link boundary.
+            unsupported = ", ".join(sorted(kwargs))
+            raise ValueError(f"Unsupported Link inference options: {unsupported}")
+        if self.config.protocol == "responses":
+            return (
+                "responses",
+                "responses",
+                build_responses_body(
+                    model=str(self.model_config.model),
+                    messages=messages,
+                    max_output_tokens=maximum,
+                    temperature=temperature,
+                    stream=stream,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    reasoning=reasoning,
+                ),
+            )
+        return (
+            "chat_completions",
+            "chat/completions",
+            build_chat_completions_body(
+                model=str(self.model_config.model),
+                messages=messages,
+                max_output_tokens=maximum,
+                temperature=temperature,
+                stream=stream,
+                tools=tools,
+                tool_choice=tool_choice,
+                reasoning=reasoning,
+            ),
+        )
+
+    def _headers(
+        self, invocation_id: str, *, include_secret: bool = True
+    ) -> dict[str, str]:
+        headers = {
+            "Accept": "text/event-stream, application/json",
+            "Content-Type": "application/json",
+            **self.context.headers(invocation_id),
+        }
+        if include_secret:
+            headers["X-Link-Service-Name"] = self.config.service_name
+            headers["X-Link-Service-Auth"] = self.config.service_token
+        return headers
+
+    async def _stream_response(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        route: str,
+        body: dict[str, Any],
+        headers: dict[str, str],
+        protocol: LinkProtocol,
+        callback: StreamCallback | None,
+        lifecycle: LLMRequestLifecycle,
+    ) -> tuple[str, str, list[LLMToolCall], LLMUsage, FinishReason, dict[str, Any]]:
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_calls: dict[int, dict[str, str]] = {}
+        usage = LLMUsage()
+        finish = FinishReason.UNKNOWN
+        response_id: str | None = None
+        async with client.stream(
+            "POST",
+            f"{self.config.base_url}/{route}",
+            json=body,
+            headers=headers,
+            timeout=httpx.Timeout(self.config.idle_timeout_seconds),
+        ) as response:
+            await self._raise_for_link_error(response, lifecycle)
+            self._capture_response_headers(response.headers)
+            lifecycle.status = ProviderRequestStatus.STREAMING
+            async for line in response.aiter_lines():
+                lifecycle.last_event_at = time.time()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if not data or data == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    # Link preserves provider SSE delivery even when an
+                    # optional metadata frame is malformed. Ignore that frame
+                    # rather than converting completed provider work into a
+                    # retryable Penguin turn.
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if protocol == "responses":
+                    delta = _optional_str(event.get("delta"))
+                    event_type = str(event.get("type") or "")
+                    response_payload = event.get("response")
+                    if isinstance(response_payload, dict):
+                        response_id = response_id or _optional_str(
+                            response_payload.get("id")
+                        )
+                        if isinstance(response_payload.get("usage"), dict):
+                            usage = normalize_responses_usage(
+                                response_payload.get("usage")
+                            )
+                    if (
+                        event_type
+                        in {
+                            "response.output_text.delta",
+                            "response.refusal.delta",
+                        }
+                        and delta
+                    ):
+                        text_parts.append(delta)
+                        await _emit(callback, delta, "assistant")
+                    elif "reasoning" in event_type and delta:
+                        reasoning_parts.append(delta)
+                        await _emit(callback, delta, "reasoning")
+                    elif event_type == "response.output_item.done":
+                        item = event.get("item")
+                        if (
+                            isinstance(item, dict)
+                            and item.get("type") == "function_call"
+                        ):
+                            index = len(tool_calls)
+                            tool_calls[index] = {
+                                "id": str(item.get("call_id") or ""),
+                                "name": str(item.get("name") or ""),
+                                "arguments": str(item.get("arguments") or "{}"),
+                            }
+                    elif event_type == "response.completed":
+                        finish = FinishReason.STOP
+                else:
+                    response_id = response_id or _optional_str(event.get("id"))
+                    if isinstance(event.get("usage"), dict):
+                        usage = normalize_chat_usage(event.get("usage"))
+                    choices = event.get("choices")
+                    choice = choices[0] if isinstance(choices, list) and choices else {}
+                    choice = choice if isinstance(choice, dict) else {}
+                    delta_payload = choice.get("delta")
+                    delta_payload = (
+                        delta_payload if isinstance(delta_payload, dict) else {}
+                    )
+                    text_delta = _optional_str(delta_payload.get("content"))
+                    reasoning_delta = _optional_str(delta_payload.get("reasoning"))
+                    if text_delta:
+                        text_parts.append(text_delta)
+                        await _emit(callback, text_delta, "assistant")
+                    if reasoning_delta:
+                        reasoning_parts.append(reasoning_delta)
+                        await _emit(callback, reasoning_delta, "reasoning")
+                    raw_tools = delta_payload.get("tool_calls")
+                    if isinstance(raw_tools, list):
+                        for raw in raw_tools:
+                            if not isinstance(raw, dict):
+                                continue
+                            index = int(raw.get("index") or 0)
+                            current = tool_calls.setdefault(
+                                index, {"id": "", "name": "", "arguments": ""}
+                            )
+                            current["id"] = str(raw.get("id") or current["id"])
+                            function = raw.get("function")
+                            if isinstance(function, dict):
+                                current["name"] += str(function.get("name") or "")
+                                current["arguments"] += str(
+                                    function.get("arguments") or ""
+                                )
+                    from ...provider_transform import normalize_finish_reason
+
+                    candidate_finish = normalize_finish_reason(
+                        choice.get("finish_reason")
+                    )
+                    if candidate_finish != FinishReason.UNKNOWN:
+                        finish = candidate_finish
+
+        normalized_tools = [
+            LLMToolCall(
+                name=value["name"],
+                arguments=value["arguments"] or "{}",
+                call_id=value["id"] or None,
+            )
+            for _, value in sorted(tool_calls.items())
+        ]
+        if normalized_tools:
+            finish = FinishReason.TOOL_CALLS
+        elif finish == FinishReason.UNKNOWN:
+            finish = FinishReason.STOP
+        return (
+            "".join(text_parts),
+            "".join(reasoning_parts),
+            normalized_tools,
+            usage,
+            finish,
+            {"response_id": response_id},
+        )
+
+    def _parse_buffered(
+        self, protocol: LinkProtocol, payload: dict[str, Any]
+    ) -> tuple[str, str, list[LLMToolCall], LLMUsage, FinishReason, dict[str, Any]]:
+        if protocol == "responses":
+            return parse_responses_body(payload)
+        return parse_chat_completions_body(payload)
+
+    async def _raise_for_link_error(
+        self,
+        response: httpx.Response,
+        lifecycle: LLMRequestLifecycle,
+    ) -> None:
+        if response.is_success:
+            return
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        error_payload = payload.get("error") if isinstance(payload, dict) else None
+        error_payload = error_payload if isinstance(error_payload, dict) else {}
+        detail = str(
+            error_payload.get("message") or response.text or response.reason_phrase
+        )
+        dispatch_state = response.headers.get("x-link-dispatch-state", "unknown")
+        retryable = bool(
+            response.status_code >= 500 and dispatch_state == "not_started"
+        )
+        error = build_llm_error(
+            message=detail,
+            provider="link",
+            model=str(self.model_config.model),
+            status_code=response.status_code,
+            retry_after_seconds=extract_retry_after_seconds(response),
+            retryable=retryable,
+            provider_data={
+                "dispatch_state": dispatch_state,
+                "link_error": error_payload,
+            },
+        )
+        lifecycle.provider_data["dispatch_state"] = dispatch_state
+        raise LLMProviderError(error)
+
+    def _capture_response_headers(self, headers: httpx.Headers) -> None:
+        names = {
+            "x-link-inference-request-id": "request_id",
+            "x-link-execution-source": "execution_source",
+            "x-link-settlement-mode": "settlement_mode",
+            "x-link-meter-event-key": "meter_event_key",
+        }
+        for header, key in names.items():
+            value = headers.get(header)
+            if value:
+                self._last_provider_data[key] = value
+
+
+async def _emit(
+    callback: StreamCallback | None, text: str, message_type: str
+) -> None:
+    if callback is None or not text:
+        return
+    result = callback(text, message_type)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__ = ["LinkProtocol", "LinkProvider", "LinkProviderConfig"]

--- a/penguin/llm/providers/link/provider.py
+++ b/penguin/llm/providers/link/provider.py
@@ -214,6 +214,27 @@ class LinkProvider:
                 payload = response.json()
                 if not isinstance(payload, dict):
                     raise ValueError("Link returned a non-object inference response.")
+                if protocol == "responses":
+                    response_status = str(payload.get("status") or "completed")
+                    if response_status != "completed":
+                        event_type = f"response.{response_status}"
+                        raise LLMProviderError(
+                            build_llm_error(
+                                message=_responses_stream_error_message(
+                                    event_type,
+                                    payload,
+                                    payload,
+                                ),
+                                provider="link",
+                                model=str(self.model_config.model),
+                                category=ErrorCategory.RUNTIME,
+                                retryable=False,
+                                provider_data={
+                                    "dispatch_outcome": "terminal_failure",
+                                    "response_status": response_status,
+                                },
+                            )
+                        )
                 result = self._parse_buffered(protocol, payload)
                 self._capture_response_headers(response.headers)
 
@@ -416,6 +437,7 @@ class LinkProvider:
         usage = LLMUsage()
         finish = FinishReason.UNKNOWN
         response_id: str | None = None
+        terminal_event_seen = False
         async with client.stream(
             "POST",
             f"{self.config.base_url}/{route}",
@@ -482,6 +504,30 @@ class LinkProvider:
                             }
                     elif event_type == "response.completed":
                         finish = FinishReason.STOP
+                        terminal_event_seen = True
+                    elif event_type in {
+                        "response.failed",
+                        "response.incomplete",
+                        "response.error",
+                        "error",
+                    }:
+                        raise LLMProviderError(
+                            build_llm_error(
+                                message=_responses_stream_error_message(
+                                    event_type,
+                                    event,
+                                    response_payload,
+                                ),
+                                provider="link",
+                                model=str(self.model_config.model),
+                                category=ErrorCategory.RUNTIME,
+                                retryable=False,
+                                provider_data={
+                                    "dispatch_outcome": "terminal_failure",
+                                    "stream_event": event_type,
+                                },
+                            )
+                        )
                 else:
                     response_id = response_id or _optional_str(event.get("id"))
                     if isinstance(event.get("usage"), dict):
@@ -524,6 +570,25 @@ class LinkProvider:
                     )
                     if candidate_finish != FinishReason.UNKNOWN:
                         finish = candidate_finish
+                        terminal_event_seen = True
+
+        if not terminal_event_seen:
+            raise LLMProviderError(
+                build_llm_error(
+                    message=(
+                        "Link inference stream ended without a protocol terminal "
+                        "event; the provider outcome is uncertain."
+                    ),
+                    provider="link",
+                    model=str(self.model_config.model),
+                    category=ErrorCategory.NETWORK,
+                    retryable=False,
+                    provider_data={
+                        "dispatch_outcome": "uncertain",
+                        "protocol": protocol,
+                    },
+                )
+            )
 
         normalized_tools = [
             LLMToolCall(
@@ -535,8 +600,6 @@ class LinkProvider:
         ]
         if normalized_tools:
             finish = FinishReason.TOOL_CALLS
-        elif finish == FinishReason.UNKNOWN:
-            finish = FinishReason.STOP
         return (
             "".join(text_parts),
             "".join(reasoning_parts),
@@ -601,9 +664,33 @@ class LinkProvider:
                 self._last_provider_data[key] = value
 
 
-async def _emit(
-    callback: StreamCallback | None, text: str, message_type: str
-) -> None:
+def _responses_stream_error_message(
+    event_type: str,
+    event: dict[str, Any],
+    response: Any,
+) -> str:
+    """Extract a stable diagnostic from a terminal Responses failure event."""
+
+    candidates: list[Any] = [event.get("message"), event.get("error")]
+    if isinstance(response, dict):
+        candidates.extend(
+            [
+                response.get("error"),
+                response.get("incomplete_details"),
+                response.get("status_details"),
+            ]
+        )
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        if isinstance(candidate, dict):
+            message = candidate.get("message") or candidate.get("reason")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+    return f"Link inference stream ended with {event_type}."
+
+
+async def _emit(callback: StreamCallback | None, text: str, message_type: str) -> None:
     if callback is None or not text:
         return
     result = callback(text, message_type)

--- a/penguin/llm/providers/link/responses_protocol.py
+++ b/penguin/llm/providers/link/responses_protocol.py
@@ -1,0 +1,178 @@
+"""OpenAI Responses wire translation for LinkProvider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...contracts import FinishReason, LLMToolCall, LLMUsage
+
+
+def build_responses_body(
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_output_tokens: int,
+    temperature: float | None,
+    stream: bool,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+    reasoning: Any = None,
+) -> dict[str, Any]:
+    """Translate Penguin messages into a text-only Responses request."""
+
+    instructions: list[str] = []
+    items: list[dict[str, Any]] = []
+    for message in messages:
+        role = str(message.get("role") or "user")
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise ValueError(
+                "Link-managed inference supports text messages only until "
+                "multimodal metering is enabled."
+            )
+        if role == "system":
+            instructions.append(content)
+            continue
+        if role == "tool":
+            call_id = str(message.get("tool_call_id") or "").strip()
+            if not call_id:
+                raise ValueError("Tool results sent through Link require tool_call_id.")
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": content,
+                }
+            )
+            continue
+        if role not in {"user", "assistant"}:
+            raise ValueError(f"Unsupported Link Responses message role: {role}")
+        items.append(
+            {
+                "role": role,
+                "content": [
+                    {
+                        "type": "input_text" if role == "user" else "output_text",
+                        "text": content,
+                    }
+                ],
+            }
+        )
+
+        tool_calls = message.get("tool_calls")
+        if role == "assistant" and isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                function = (
+                    tool_call.get("function") if isinstance(tool_call, dict) else None
+                )
+                if not isinstance(function, dict):
+                    continue
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": str(tool_call.get("id") or ""),
+                        "name": str(function.get("name") or ""),
+                        "arguments": str(function.get("arguments") or "{}"),
+                    }
+                )
+
+    body: dict[str, Any] = {
+        "model": model,
+        "input": items,
+        "max_output_tokens": max_output_tokens,
+        "stream": stream,
+    }
+    if instructions:
+        body["instructions"] = "\n\n".join(instructions)
+    if temperature is not None:
+        body["temperature"] = temperature
+    if tools:
+        body["tools"] = tools
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    if reasoning is not None:
+        body["reasoning"] = reasoning
+    return body
+
+
+def parse_responses_body(
+    payload: dict[str, Any],
+) -> tuple[str, str, list[LLMToolCall], LLMUsage, FinishReason, dict[str, Any]]:
+    """Normalize one buffered Responses result."""
+
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[LLMToolCall] = []
+    output = payload.get("output")
+    if isinstance(payload.get("output_text"), str):
+        text_parts.append(payload["output_text"])
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "function_call":
+                tool_calls.append(
+                    LLMToolCall(
+                        name=str(item.get("name") or ""),
+                        arguments=str(item.get("arguments") or "{}"),
+                        call_id=str(item.get("call_id") or "") or None,
+                        item_id=str(item.get("id") or "") or None,
+                    )
+                )
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                value = part.get("text")
+                if not isinstance(value, str):
+                    continue
+                if part.get("type") in {"reasoning_text", "summary_text"}:
+                    reasoning_parts.append(value)
+                else:
+                    text_parts.append(value)
+
+    usage = normalize_responses_usage(payload.get("usage"))
+    status = str(payload.get("status") or "completed")
+    finish = (
+        FinishReason.TOOL_CALLS
+        if tool_calls
+        else (FinishReason.STOP if status == "completed" else FinishReason.UNKNOWN)
+    )
+    return (
+        "".join(text_parts),
+        "".join(reasoning_parts),
+        tool_calls,
+        usage,
+        finish,
+        {"response_id": payload.get("id"), "status": status},
+    )
+
+
+def normalize_responses_usage(value: Any) -> LLMUsage:
+    usage = value if isinstance(value, dict) else {}
+    input_details = usage.get("input_tokens_details")
+    output_details = usage.get("output_tokens_details")
+    input_details = input_details if isinstance(input_details, dict) else {}
+    output_details = output_details if isinstance(output_details, dict) else {}
+    return LLMUsage(
+        input_tokens=_int(usage.get("input_tokens")),
+        output_tokens=_int(usage.get("output_tokens")),
+        reasoning_tokens=_int(output_details.get("reasoning_tokens")),
+        cache_read_tokens=_int(input_details.get("cached_tokens")),
+        total_tokens=_int(usage.get("total_tokens")),
+        provider_data=dict(usage),
+    )
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = ["build_responses_body", "normalize_responses_usage", "parse_responses_body"]

--- a/penguin/llm/providers/link/responses_protocol.py
+++ b/penguin/llm/providers/link/responses_protocol.py
@@ -25,15 +25,12 @@ def build_responses_body(
     for message in messages:
         role = str(message.get("role") or "user")
         content = message.get("content")
-        if not isinstance(content, str):
-            raise ValueError(
-                "Link-managed inference supports text messages only until "
-                "multimodal metering is enabled."
-            )
         if role == "system":
+            _require_text_content(content)
             instructions.append(content)
             continue
         if role == "tool":
+            _require_text_content(content)
             call_id = str(message.get("tool_call_id") or "").strip()
             if not call_id:
                 raise ValueError("Tool results sent through Link require tool_call_id.")
@@ -47,34 +44,54 @@ def build_responses_body(
             continue
         if role not in {"user", "assistant"}:
             raise ValueError(f"Unsupported Link Responses message role: {role}")
-        items.append(
-            {
-                "role": role,
-                "content": [
-                    {
-                        "type": "input_text" if role == "user" else "output_text",
-                        "text": content,
-                    }
-                ],
-            }
-        )
+        if role == "user":
+            _require_text_content(content)
+            items.append(_message_item(role, content))
+            continue
+
+        assistant_has_output = False
+        if isinstance(content, str):
+            items.append(_message_item(role, content))
+            assistant_has_output = True
+        elif content is not None:
+            _require_text_content(content)
 
         tool_calls = message.get("tool_calls")
-        if role == "assistant" and isinstance(tool_calls, list):
+        if isinstance(tool_calls, list):
             for tool_call in tool_calls:
-                function = (
-                    tool_call.get("function") if isinstance(tool_call, dict) else None
-                )
+                if not isinstance(tool_call, dict):
+                    raise ValueError(
+                        "Assistant tool calls sent through Link are invalid."
+                    )
+                function = tool_call.get("function")
                 if not isinstance(function, dict):
-                    continue
+                    raise ValueError(
+                        "Assistant tool calls sent through Link are invalid."
+                    )
+                call_id = str(tool_call.get("id") or "").strip()
+                name = str(function.get("name") or "").strip()
+                if not call_id or not name:
+                    raise ValueError(
+                        "Assistant tool calls sent through Link require an id and name."
+                    )
+                arguments = function.get("arguments")
+                if arguments is not None and not isinstance(arguments, str):
+                    raise ValueError(
+                        "Assistant tool-call arguments sent through Link must be text."
+                    )
                 items.append(
                     {
                         "type": "function_call",
-                        "call_id": str(tool_call.get("id") or ""),
-                        "name": str(function.get("name") or ""),
-                        "arguments": str(function.get("arguments") or "{}"),
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": arguments or "{}",
                     }
                 )
+                assistant_has_output = True
+        if not assistant_has_output:
+            raise ValueError(
+                "Assistant history sent through Link requires text or tool calls."
+            )
 
     body: dict[str, Any] = {
         "model": model,
@@ -93,6 +110,26 @@ def build_responses_body(
     if reasoning is not None:
         body["reasoning"] = reasoning
     return body
+
+
+def _require_text_content(content: Any) -> None:
+    if not isinstance(content, str):
+        raise ValueError(
+            "Link-managed inference supports text messages only until "
+            "multimodal metering is enabled."
+        )
+
+
+def _message_item(role: str, content: str) -> dict[str, Any]:
+    return {
+        "role": role,
+        "content": [
+            {
+                "type": "input_text" if role == "user" else "output_text",
+                "text": content,
+            }
+        ],
+    }
 
 
 def parse_responses_body(

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -161,6 +161,12 @@ def _rehydrate_provider_credentials(core: PenguinCore) -> None:
 
 def create_app() -> "FastAPI":
     """Create and configure the FastAPI application."""
+    # AuthenticationMiddleware reads its key material during construction.
+    # Load the persistent user environment before importing and instantiating
+    # AuthConfig so a normal `penguin-web` restart retains dedicated service
+    # credentials such as LINK_API_KEY.
+    _ensure_env_loaded()
+
     try:
         from fastapi import FastAPI
         from fastapi.responses import FileResponse

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -99,11 +99,6 @@ class AuthConfig:
         if api_keys_str:
             keys.update(k.strip() for k in api_keys_str.split(",") if k.strip())
 
-        # Load Link API key if present
-        link_key = os.getenv("LINK_API_KEY")
-        if link_key:
-            keys.add(link_key.strip())
-
         return keys
 
     def _load_public_endpoints(self) -> set:
@@ -458,6 +453,34 @@ def validate_api_key(api_key: str, config: AuthConfig) -> bool:
     return any(secrets.compare_digest(api_key, key) for key in config.api_keys)
 
 
+def authenticate_link_service_request(
+    request: Request,
+    config: Optional[AuthConfig] = None,
+) -> dict[str, Any]:
+    """Authenticate a request as Link's dedicated internal service identity."""
+
+    auth_config = config or AuthConfig()
+    expected = str(auth_config.link_api_key or "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Link service authentication is not configured in Penguin.",
+        )
+
+    candidate = extract_api_key(request) or extract_bearer_token(request) or ""
+    if not secrets.compare_digest(candidate, expected):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Link execution requires the dedicated Link service credential.",
+        )
+
+    return {
+        "method": "link_service",
+        "subject": "link",
+        "metadata": {"service": "link"},
+    }
+
+
 def validate_startup_token(
     token: str, config: AuthConfig, connection: Any = None
 ) -> bool:
@@ -632,6 +655,15 @@ def authenticate_connection(
 
     api_key = extract_api_key(connection)
     if api_key:
+        if auth_config.link_api_key and secrets.compare_digest(
+            api_key,
+            auth_config.link_api_key,
+        ):
+            return {
+                "method": "link_service",
+                "subject": "link",
+                "metadata": {"service": "link"},
+            }
         if validate_api_key(api_key, auth_config):
             return {
                 "method": "api_key",

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -40,6 +40,15 @@ _DYNAMIC_PATH_SEGMENT = re.compile(
     r"^(?:[0-9]+|[0-9a-fA-F-]{8,}|session_[A-Za-z0-9_:-]+|msg_[A-Za-z0-9_:-]+|task_[A-Za-z0-9_:-]+)$"
 )
 _SEEN_AUTH_FAILURES: "OrderedDict[tuple[str, str], None]" = OrderedDict()
+LINK_SERVICE_HTTP_SCOPE = frozenset(
+    {
+        ("GET", "/api/v1/link/capabilities"),
+        ("POST", "/api/v1/chat/message"),
+    }
+)
+LINK_SERVICE_FORBIDDEN_DETAIL = (
+    "The Link execution credential is not authorized for this endpoint."
+)
 
 # Security scheme for Bearer token
 security = HTTPBearer(auto_error=False)
@@ -64,7 +73,12 @@ class AuthConfig:
         self.jwt_expiration_hours = int(os.getenv("PENGUIN_JWT_EXPIRATION_HOURS", "24"))
 
         # Link-specific configuration
-        self.link_api_key = os.getenv("LINK_API_KEY")
+        self.link_api_key = os.getenv("LINK_API_KEY", "").strip() or None
+        if self.link_api_key and self.link_api_key in self.api_keys:
+            raise ValueError(
+                "LINK_API_KEY must not also appear in PENGUIN_API_KEYS; "
+                "configure distinct credentials."
+            )
         self.link_auth_required = (
             os.getenv("PENGUIN_LINK_AUTH_REQUIRED", "false").lower() == "true"
         )
@@ -569,6 +583,16 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 },
             )
 
+        if (
+            auth_result["method"] == "link_service"
+            and (request.method.upper(), request.url.path)
+            not in LINK_SERVICE_HTTP_SCOPE
+        ):
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={"detail": LINK_SERVICE_FORBIDDEN_DETAIL},
+            )
+
         # Add auth info to request state
         request.state.authenticated = True
         request.state.auth_method = auth_result["method"]
@@ -718,6 +742,12 @@ async def require_websocket_auth(
             code=status.WS_1008_POLICY_VIOLATION,
             reason=build_unauthorized_message(auth_config),
         ) from exc
+
+    if auth_result["method"] == "link_service":
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason=LINK_SERVICE_FORBIDDEN_DETAIL,
+        )
 
     websocket.state.authenticated = True
     websocket.state.auth_method = auth_result["method"]

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -55,7 +55,11 @@ from penguin.core_runtime.session_goals import (
     GoalPersistenceError,
     GoalValidationError,
 )
-from penguin.system.execution_context import ExecutionContext, execution_context_scope, normalize_directory
+from penguin.system.execution_context import (
+    ExecutionContext,
+    execution_context_scope,
+    normalize_directory,
+)
 from penguin import __version__
 from penguin.utils.events import EventBus as UtilsEventBus
 from penguin.cli.events import EventBus as CLIEventBus, EventType
@@ -1043,9 +1047,9 @@ class MessageRequest(BaseModel):
     service_tier: Optional[str] = None
     parts: Optional[List[Dict[str, Any]]] = None
     link_execution: Optional[LinkExecutionRequest] = None
-    external_subscription_execution: Optional[
-        ExternalSubscriptionExecutionRequest
-    ] = None
+    external_subscription_execution: Optional[ExternalSubscriptionExecutionRequest] = (
+        None
+    )
 
 
 _REASONING_EFFORT_VARIANTS = {
@@ -3962,10 +3966,23 @@ async def handle_chat_message(
     http_request: Request = None,
 ):
     """Process a chat message, with optional conversation support."""
-    if (
+    has_link_execution_authority = (
         request.link_execution is not None
         or request.external_subscription_execution is not None
-    ):
+    )
+    is_link_service = bool(
+        http_request is not None
+        and getattr(http_request.state, "auth_method", None) == "link_service"
+    )
+    if is_link_service and not has_link_execution_authority:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "The Link execution credential requires a Link-managed or "
+                "personal-subscription execution descriptor."
+            ),
+        )
+    if has_link_execution_authority:
         if http_request is None:
             raise HTTPException(
                 status_code=403,
@@ -4404,9 +4421,7 @@ async def handle_chat_message(
         if isinstance(process_result.get("usage"), dict):
             resp["usage"] = process_result.get("usage")
         if request.external_subscription_execution is not None:
-            resp["execution"] = (
-                request.external_subscription_execution.public_result()
-            )
+            resp["execution"] = request.external_subscription_execution.public_result()
         reasoning_text = "".join(reasoning_buf) if include_reasoning else ""
         reasoning_note = _build_reasoning_visibility_note(
             include_reasoning=include_reasoning,
@@ -4851,8 +4866,7 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                     _request_log_info(
                         "chat.stream.service_tier.request session=%s model=%s service_tier=%s",
                         effective_session_id or "unknown",
-                        getattr(request_model_config, "model", None)
-                        or requested_model,
+                        getattr(request_model_config, "model", None) or requested_model,
                         service_tier_override,
                     )
                 reasoning_variant_snapshot = _apply_reasoning_variant_override(
@@ -5304,6 +5318,7 @@ async def get_project(project_id: str, core: PenguinCore = Depends(get_core)):
 # @router.put("/api/v1/projects/{project_id}")
 # async def update_project(...):
 
+
 @router.delete("/api/v1/projects/{project_id}")
 async def delete_project(project_id: str, core: PenguinCore = Depends(get_core)):
     """Delete a project and its tasks."""
@@ -5388,6 +5403,7 @@ async def get_task(task_id: str, core: PenguinCore = Depends(get_core)):
 # @router.put("/api/v1/tasks/{task_id}")
 # async def update_task(...):
 
+
 @router.delete("/api/v1/tasks/{task_id}")
 async def delete_task(task_id: str, core: PenguinCore = Depends(get_core)):
     """Delete a task by ID."""
@@ -5423,9 +5439,9 @@ async def resume_task_clarification(
         project = None
         if task.project_id and hasattr(core.project_manager, "get_project_async"):
             project = await core.project_manager.get_project_async(task.project_id)
-        resolved_directory = normalize_directory(request.directory) or normalize_directory(
-            getattr(project, "workspace_path", None)
-        )
+        resolved_directory = normalize_directory(
+            request.directory
+        ) or normalize_directory(getattr(project, "workspace_path", None))
         execution_context = ExecutionContext(
             session_id=request.session_id,
             conversation_id=request.session_id,
@@ -5566,9 +5582,9 @@ async def execute_task_from_project(
                 if asyncio.iscoroutine(project_candidate)
                 else project_candidate
             )
-        resolved_directory = normalize_directory(payload.directory) or normalize_directory(
-            getattr(project, "workspace_path", None)
-        )
+        resolved_directory = normalize_directory(
+            payload.directory
+        ) or normalize_directory(getattr(project, "workspace_path", None))
         execution_context = ExecutionContext(
             session_id=payload.session_id,
             conversation_id=payload.session_id,
@@ -6321,9 +6337,7 @@ async def session_goal_run(
 
 
 @router.delete("/session/{session_id}/goal")
-async def session_goal_clear(
-    session_id: str, core: PenguinCore = Depends(get_core)
-):
+async def session_goal_clear(session_id: str, core: PenguinCore = Depends(get_core)):
     """Clear the persisted session goal."""
     try:
         await session_goal_service.clear_goal(core, session_id)

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -4125,11 +4125,23 @@ async def handle_chat_message(
                     request.external_subscription_execution,
                     requested_model or None,
                 )
+                # The Link capability contract intentionally advertises
+                # provider-local Codex model ids. Penguin's generic runtime
+                # resolver requires a provider-qualified id when the model is
+                # discovered dynamically rather than declared in config.
+                subscription_runtime_model = (
+                    requested_model
+                    if "/" in requested_model
+                    else (
+                        f"{request.external_subscription_execution.provider}/"
+                        f"{requested_model}"
+                    )
+                )
                 (
                     request_model_config,
                     request_api_client,
                 ) = await _resolve_request_runtime_for_model(
-                    core, requested_model or None
+                    core, subscription_runtime_model
                 )
             else:
                 (

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -66,6 +66,15 @@ from penguin.web.services.configuration import (
 )
 from penguin.web.services.command_registry import list_opencode_commands
 from penguin.web.services.notification_settings import notification_settings_payload
+from penguin.web.services.external_subscription import (
+    ExternalSubscriptionExecutionRequest,
+    build_external_subscription_capabilities,
+    validate_external_subscription_execution,
+)
+from penguin.web.services.link_inference import (
+    LinkExecutionRequest,
+    resolve_link_inference_runtime,
+)
 from penguin.web.services.opencode_events import schedule_opencode_event
 from penguin.system.runtime_events import wrap_opencode_event
 from penguin.web.services.conversations import (
@@ -1032,6 +1041,10 @@ class MessageRequest(BaseModel):
     variant: Optional[str] = None
     service_tier: Optional[str] = None
     parts: Optional[List[Dict[str, Any]]] = None
+    link_execution: Optional[LinkExecutionRequest] = None
+    external_subscription_execution: Optional[
+        ExternalSubscriptionExecutionRequest
+    ] = None
 
 
 _REASONING_EFFORT_VARIANTS = {
@@ -3586,6 +3599,13 @@ async def api_config_providers(core: PenguinCore = Depends(get_core)):
     return await opencode_config_providers(core=core)
 
 
+@router.get("/api/v1/link/capabilities")
+async def api_link_capabilities() -> dict[str, Any]:
+    """Return versioned Link capabilities without provider credentials."""
+
+    return build_external_subscription_capabilities()
+
+
 @router.get("/api/v1/provider")
 async def api_provider_list(core: PenguinCore = Depends(get_core)):
     """Alias for OpenCode-compatible provider list endpoint."""
@@ -4084,10 +4104,40 @@ async def handle_chat_message(
             request.model.strip() if isinstance(request.model, str) else ""
         )
         try:
-            (
-                request_model_config,
-                request_api_client,
-            ) = await _resolve_request_runtime_for_model(core, requested_model or None)
+            if (
+                request.link_execution is not None
+                and request.external_subscription_execution is not None
+            ):
+                raise ValueError(
+                    "Link-managed and external-subscription execution are mutually exclusive."
+                )
+            if request.link_execution is not None:
+                (
+                    request_model_config,
+                    request_api_client,
+                ) = resolve_link_inference_runtime(
+                    core,
+                    request.link_execution,
+                    requested_model or None,
+                )
+            elif request.external_subscription_execution is not None:
+                validate_external_subscription_execution(
+                    request.external_subscription_execution,
+                    requested_model or None,
+                )
+                (
+                    request_model_config,
+                    request_api_client,
+                ) = await _resolve_request_runtime_for_model(
+                    core, requested_model or None
+                )
+            else:
+                (
+                    request_model_config,
+                    request_api_client,
+                ) = await _resolve_request_runtime_for_model(
+                    core, requested_model or None
+                )
         except Exception as exc:
             detail = str(exc) or f"Failed to resolve model runtime '{requested_model}'"
             raise HTTPException(status_code=400, detail=detail) from exc
@@ -4295,13 +4345,23 @@ async def handle_chat_message(
             )
 
         # Build response
-        if request_session_id:
+        if (
+            request_session_id
+            and request.link_execution is None
+            and request.external_subscription_execution is None
+        ):
             _queue_session_title_refresh(
                 core,
                 request_session_id,
                 provider_id=getattr(request_model_config, "provider", None),
                 model_id=getattr(request_model_config, "model", None),
                 fallback_text=request.text if isinstance(request.text, str) else None,
+            )
+        elif request_session_id:
+            _title_log_info(
+                "session.title.auto_refresh session=%s "
+                "status=skip_link_routed_internal_work",
+                request_session_id,
             )
 
         resp: Dict[str, Any] = {
@@ -4314,6 +4374,12 @@ async def handle_chat_message(
             resp["recoverable"] = bool(process_result.get("recoverable"))
         if isinstance(process_result.get("error"), dict):
             resp["error"] = process_result.get("error")
+        if isinstance(process_result.get("usage"), dict):
+            resp["usage"] = process_result.get("usage")
+        if request.external_subscription_execution is not None:
+            resp["execution"] = (
+                request.external_subscription_execution.public_result()
+            )
         reasoning_text = "".join(reasoning_buf) if include_reasoning else ""
         reasoning_note = _build_reasoning_visibility_note(
             include_reasoning=include_reasoning,

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -119,6 +119,7 @@ from penguin.web.services.token_usage import get_token_usage_payload
 from penguin.web.middleware.auth import (
     AuthenticationError,
     AuthConfig,
+    authenticate_link_service_request,
     authenticate_local_session_token,
     build_session_cookie_settings,
     create_session_token,
@@ -3600,9 +3601,10 @@ async def api_config_providers(core: PenguinCore = Depends(get_core)):
 
 
 @router.get("/api/v1/link/capabilities")
-async def api_link_capabilities() -> dict[str, Any]:
+async def api_link_capabilities(http_request: Request) -> dict[str, Any]:
     """Return versioned Link capabilities without provider credentials."""
 
+    authenticate_link_service_request(http_request)
     return build_external_subscription_capabilities()
 
 
@@ -3955,9 +3957,22 @@ async def discover_models(core: PenguinCore = Depends(get_core)):
 
 @router.post("/api/v1/chat/message")
 async def handle_chat_message(
-    request: MessageRequest, core: PenguinCore = Depends(get_core)
+    request: MessageRequest,
+    core: PenguinCore = Depends(get_core),
+    http_request: Request = None,
 ):
     """Process a chat message, with optional conversation support."""
+    if (
+        request.link_execution is not None
+        or request.external_subscription_execution is not None
+    ):
+        if http_request is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Link execution requires an authenticated HTTP request.",
+            )
+        authenticate_link_service_request(http_request)
+
     temp_image_files: List[str] = []
     request_session_id: Optional[str] = None
     request_task: Optional[asyncio.Task[Any]] = None

--- a/penguin/web/services/external_subscription.py
+++ b/penguin/web/services/external_subscription.py
@@ -1,0 +1,153 @@
+"""Link-facing external-subscription capability and execution contracts."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from penguin.web.services.provider_catalog import codex_oauth_provider_models
+from penguin.web.services.provider_credentials import get_provider_credentials
+
+EXTERNAL_SUBSCRIPTION_PROTOCOL_VERSION = 1
+
+
+class ExternalSubscriptionExecutionRequest(BaseModel):
+    """Immutable external-subscription authority supplied by Link."""
+
+    protocol_version: Literal[1]
+    owner_user_id: str
+    user_id: str
+    requested_model_id: str
+    agent_runtime: Literal["penguin"]
+    provider: Literal["openai"]
+    inference_transport: Literal["codex_responses_compat"]
+    execution_source: Literal["local_penguin"]
+    provider_state_owner: Literal["user_owned"]
+    credential_custodian: Literal["local_penguin"]
+    settlement_mode: Literal["subscription_quota"]
+    usage_authority: Literal["local_runtime_observed"]
+    integration_support: Literal["ecosystem_compatible"]
+    allow_fallback_to_link_gateway: Literal[False] = False
+
+    def public_result(self) -> dict[str, Any]:
+        """Return execution facts without credentials or local auth records."""
+
+        return self.model_dump()
+
+
+def build_external_subscription_capabilities() -> dict[str, Any]:
+    """Describe locally authenticated subscriptions without exposing secrets."""
+
+    records = get_provider_credentials()
+    openai_record = records.get("openai")
+    authenticated = bool(
+        isinstance(openai_record, dict)
+        and openai_record.get("type") == "oauth"
+        and (
+            str(openai_record.get("access") or "").strip()
+            or str(openai_record.get("refresh") or "").strip()
+        )
+    )
+    discovered = (
+        codex_oauth_provider_models(openai_record).get("openai", {})
+        if authenticated
+        else {}
+    )
+    models = [
+        _model_capability(model_id, config)
+        for model_id, config in sorted(
+            discovered.items(),
+            key=lambda item: (_model_priority(item[1]), item[0]),
+        )
+        if isinstance(model_id, str) and isinstance(config, dict)
+    ]
+
+    return {
+        "protocol_version": EXTERNAL_SUBSCRIPTION_PROTOCOL_VERSION,
+        "agent_runtime": "penguin",
+        "subscriptions": [
+            {
+                "provider": "openai",
+                "inference_transport": "codex_responses_compat",
+                "credential_custodian": "local_penguin",
+                "account_scope": "personal",
+                "settlement_mode": "subscription_quota",
+                "usage_authority": "local_runtime_observed",
+                "usage_reporting_level": "turn_aggregate",
+                "integration_support": "ecosystem_compatible",
+                "authenticated": authenticated,
+                "catalog_state": (
+                    "ready" if models else "empty" if authenticated else "disconnected"
+                ),
+                "models": models,
+            }
+        ],
+    }
+
+
+def validate_external_subscription_execution(
+    execution: ExternalSubscriptionExecutionRequest,
+    requested_model: str | None,
+) -> None:
+    """Fail closed unless Link's user-scoped request matches local OAuth state."""
+
+    if execution.owner_user_id != execution.user_id:
+        raise ValueError("A personal subscription can only serve its owning Link user.")
+    selected = str(requested_model or "").strip()
+    if not selected or selected != execution.requested_model_id:
+        raise ValueError(
+            "The requested model does not match Link's external-subscription execution."
+        )
+
+    openai_record = get_provider_credentials().get("openai")
+    if not isinstance(openai_record, dict) or openai_record.get("type") != "oauth":
+        raise ValueError(
+            "ChatGPT subscription authentication is unavailable in this "
+            "Penguin runtime."
+        )
+    if not (
+        str(openai_record.get("access") or "").strip()
+        or str(openai_record.get("refresh") or "").strip()
+    ):
+        raise ValueError(
+            "ChatGPT subscription authentication requires reauthentication."
+        )
+
+
+def _model_capability(model_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    supported_reasoning = config.get("supported_reasoning_levels")
+    return {
+        "id": model_id,
+        "name": str(config.get("name") or config.get("model") or model_id),
+        "context_window": _positive_int(
+            config.get("max_context_window_tokens") or config.get("context_window")
+        ),
+        "max_output_tokens": _positive_int(config.get("max_output_tokens")),
+        "reasoning": bool(
+            config.get("reasoning_enabled")
+            or (
+                isinstance(supported_reasoning, (list, tuple))
+                and bool(supported_reasoning)
+            )
+        ),
+        "vision": bool(config.get("vision_enabled")),
+        "tools": True,
+    }
+
+
+def _model_priority(config: dict[str, Any]) -> int:
+    value = config.get("priority")
+    return value if isinstance(value, int) and value >= 0 else 1_000_000
+
+
+def _positive_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and value > 0 else None
+
+
+__all__ = [
+    "EXTERNAL_SUBSCRIPTION_PROTOCOL_VERSION",
+    "ExternalSubscriptionExecutionRequest",
+    "build_external_subscription_capabilities",
+    "validate_external_subscription_execution",
+]

--- a/penguin/web/services/external_subscription.py
+++ b/penguin/web/services/external_subscription.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -10,6 +11,7 @@ from penguin.web.services.provider_catalog import codex_oauth_provider_models
 from penguin.web.services.provider_credentials import get_provider_credentials
 
 EXTERNAL_SUBSCRIPTION_PROTOCOL_VERSION = 1
+LINK_SUBSCRIPTION_OWNER_ENV = "PENGUIN_LINK_SUBSCRIPTION_OWNER_USER_ID"
 
 
 class ExternalSubscriptionExecutionRequest(BaseModel):
@@ -33,7 +35,10 @@ class ExternalSubscriptionExecutionRequest(BaseModel):
     def public_result(self) -> dict[str, Any]:
         """Return execution facts without credentials or local auth records."""
 
-        return self.model_dump()
+        model_dump = getattr(self, "model_dump", None)
+        if callable(model_dump):
+            return model_dump()
+        return self.dict()
 
 
 def build_external_subscription_capabilities() -> dict[str, Any]:
@@ -94,6 +99,17 @@ def validate_external_subscription_execution(
 
     if execution.owner_user_id != execution.user_id:
         raise ValueError("A personal subscription can only serve its owning Link user.")
+    bound_owner_user_id = os.getenv(LINK_SUBSCRIPTION_OWNER_ENV, "").strip()
+    if not bound_owner_user_id:
+        raise ValueError(
+            "This Penguin runtime is not paired with a Link user for personal "
+            "subscription execution."
+        )
+    if execution.user_id != bound_owner_user_id:
+        raise ValueError(
+            "The requested Link user does not own this Penguin runtime's "
+            "personal subscription binding."
+        )
     selected = str(requested_model or "").strip()
     if not selected or selected != execution.requested_model_id:
         raise ValueError(

--- a/penguin/web/services/link_inference.py
+++ b/penguin/web/services/link_inference.py
@@ -1,0 +1,77 @@
+"""Request-scoped Link-managed inference runtime construction."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from penguin.llm.api_client import APIClient
+from penguin.llm.model_config import ModelConfig
+from penguin.llm.providers.link.context import LinkInferenceContext
+
+
+class LinkExecutionRequest(BaseModel):
+    """Immutable execution authority supplied by Link's trusted backend."""
+
+    workspace_id: str
+    user_id: str
+    session_id: str
+    agent_id: str
+    run_id: str
+    requested_model_id: str
+    execution_source: Literal["link_gateway"]
+    provider_state_owner: Literal["link_managed"]
+    settlement_mode: Literal["debit_link_credits"]
+    allow_fallback_to_link_gateway: bool = False
+
+
+def resolve_link_inference_runtime(
+    core: Any,
+    execution: LinkExecutionRequest,
+    requested_model: str | None,
+) -> tuple[ModelConfig, APIClient]:
+    """Build a Link provider without mutating Penguin's shared model runtime."""
+
+    selected = (requested_model or "").strip()
+    if selected and selected != execution.requested_model_id:
+        raise ValueError(
+            "The requested model does not match Link's server-resolved execution."
+        )
+
+    current = getattr(core, "model_config", None)
+    if not isinstance(current, ModelConfig):
+        raise ValueError("Penguin has no base model configuration for this request.")
+
+    model_config = replace(
+        current,
+        model=execution.requested_model_id,
+        provider="link",
+        client_preference="link",
+        api_base=None,
+        api_key=None,
+        use_responses_api=True,
+    )
+    context = LinkInferenceContext(
+        workspace_id=execution.workspace_id,
+        user_id=execution.user_id,
+        session_id=execution.session_id,
+        agent_id=execution.agent_id,
+        run_id=execution.run_id,
+        requested_model_id=execution.requested_model_id,
+    )
+    base_url = (
+        os.getenv("LINK_INFERENCE_BASE_URL")
+        or os.getenv("LINK_INFERENCE_URL")
+        or "http://localhost:3001/api/v1"
+    ).rstrip("/")
+    return model_config, APIClient(
+        model_config,
+        base_url=base_url,
+        link_context=context,
+    )
+
+
+__all__ = ["LinkExecutionRequest", "resolve_link_inference_runtime"]

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -208,6 +208,66 @@ async def test_chat_message_rejects_cross_user_subscription_authority(
 
 
 @pytest.mark.asyncio
+async def test_chat_message_resolves_subscription_model_through_openai(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved_models: list[str | None] = []
+
+    class _SubscriptionCore(_Core):
+        async def resolve_request_runtime(
+            self, model_id: str | None
+        ) -> tuple[Any, Any]:
+            resolved_models.append(model_id)
+            return (
+                SimpleNamespace(provider="openai", model="gpt-5.6-luna"),
+                SimpleNamespace(),
+            )
+
+        async def process(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "assistant_response": "hello from the subscription",
+                "action_results": [],
+            }
+
+    monkeypatch.setattr(
+        routes_module,
+        "validate_external_subscription_execution",
+        lambda _execution, _model: None,
+    )
+    request = MessageRequest(
+        text="hello",
+        model="gpt-5.6-luna",
+        directory=str(tmp_path),
+        streaming=False,
+        external_subscription_execution={
+            "protocol_version": 1,
+            "owner_user_id": "user-a",
+            "user_id": "user-a",
+            "requested_model_id": "gpt-5.6-luna",
+            "agent_runtime": "penguin",
+            "provider": "openai",
+            "inference_transport": "codex_responses_compat",
+            "execution_source": "local_penguin",
+            "provider_state_owner": "user_owned",
+            "credential_custodian": "local_penguin",
+            "settlement_mode": "subscription_quota",
+            "usage_authority": "local_runtime_observed",
+            "integration_support": "ecosystem_compatible",
+            "allow_fallback_to_link_gateway": False,
+        },
+    )
+
+    response = await handle_chat_message(
+        request=request,
+        core=cast(Any, _SubscriptionCore(tmp_path)),
+    )
+
+    assert response["response"] == "hello from the subscription"
+    assert resolved_models == ["openai/gpt-5.6-luna"]
+
+
+@pytest.mark.asyncio
 async def test_config_providers_and_auth_methods(tmp_path: Path) -> None:
     core = _Core(tmp_path)
     typed_core = cast(Any, core)

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -174,6 +174,40 @@ async def test_chat_message_model_load_failure_surfaces_reason(
 
 
 @pytest.mark.asyncio
+async def test_chat_message_rejects_cross_user_subscription_authority(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    request = MessageRequest(
+        text="hello",
+        model="gpt-5.4",
+        directory=str(tmp_path),
+        external_subscription_execution={
+            "protocol_version": 1,
+            "owner_user_id": "user-a",
+            "user_id": "user-b",
+            "requested_model_id": "gpt-5.4",
+            "agent_runtime": "penguin",
+            "provider": "openai",
+            "inference_transport": "codex_responses_compat",
+            "execution_source": "local_penguin",
+            "provider_state_owner": "user_owned",
+            "credential_custodian": "local_penguin",
+            "settlement_mode": "subscription_quota",
+            "usage_authority": "local_runtime_observed",
+            "integration_support": "ecosystem_compatible",
+            "allow_fallback_to_link_gateway": False,
+        },
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await handle_chat_message(request=request, core=cast(Any, core))
+
+    assert exc.value.status_code == 400
+    assert "owning Link user" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_config_providers_and_auth_methods(tmp_path: Path) -> None:
     core = _Core(tmp_path)
     typed_core = cast(Any, core)

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
 from penguin.web import routes as routes_module
 from penguin.web.routes import (
@@ -22,6 +23,7 @@ from penguin.web.routes import (
     api_config_providers,
     api_config_update,
     api_instance_dispose,
+    api_link_capabilities,
     api_provider_auth,
     api_provider_list,
     api_provider_oauth_authorize,
@@ -46,6 +48,17 @@ from penguin.web.services.opencode_provider import get_provider_auth_records
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def _api_request(*, api_key: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/chat/message",
+            "headers": [(b"x-api-key", api_key.encode())],
+        }
+    )
 
 
 class _Core:
@@ -176,7 +189,9 @@ async def test_chat_message_model_load_failure_surfaces_reason(
 @pytest.mark.asyncio
 async def test_chat_message_rejects_cross_user_subscription_authority(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
     core = _Core(tmp_path)
     request = MessageRequest(
         text="hello",
@@ -201,10 +216,73 @@ async def test_chat_message_rejects_cross_user_subscription_authority(
     )
 
     with pytest.raises(HTTPException) as exc:
-        await handle_chat_message(request=request, core=cast(Any, core))
+        await handle_chat_message(
+            request=request,
+            core=cast(Any, core),
+            http_request=_api_request(api_key="link-service-secret"),
+        )
 
     assert exc.value.status_code == 400
     assert "owning Link user" in str(exc.value.detail)
+
+
+def test_chat_message_rejects_link_authority_from_ordinary_api_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ordinary-client-secret")
+    app = FastAPI()
+    app.include_router(routes_module.router)
+    previous_core = getattr(routes_module.router, "core", None)
+    routes_module.router.core = _Core(tmp_path)
+    payload = {
+        "text": "hello",
+        "model": "openai/gpt-5.4-nano",
+        "link_execution": {
+            "workspace_id": "workspace-1",
+            "user_id": "user-1",
+            "session_id": "session-1",
+            "agent_id": "agent-1",
+            "run_id": "run-1",
+            "requested_model_id": "openai/gpt-5.4-nano",
+            "execution_source": "link_gateway",
+            "provider_state_owner": "link_managed",
+            "settlement_mode": "debit_link_credits",
+            "allow_fallback_to_link_gateway": False,
+        },
+    }
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v1/chat/message",
+                headers={"X-API-Key": "ordinary-client-secret"},
+                json=payload,
+            )
+    finally:
+        routes_module.router.core = previous_core
+
+    assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "Link execution requires the dedicated Link service credential."
+    )
+
+
+@pytest.mark.asyncio
+async def test_link_capabilities_reject_ordinary_api_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ordinary-client-secret")
+
+    with pytest.raises(HTTPException) as raised:
+        await api_link_capabilities(
+            http_request=_api_request(api_key="ordinary-client-secret")
+        )
+
+    assert raised.value.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -212,6 +290,7 @@ async def test_chat_message_resolves_subscription_model_through_openai(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
     resolved_models: list[str | None] = []
 
     class _SubscriptionCore(_Core):
@@ -261,6 +340,7 @@ async def test_chat_message_resolves_subscription_model_through_openai(
     response = await handle_chat_message(
         request=request,
         core=cast(Any, _SubscriptionCore(tmp_path)),
+        http_request=_api_request(api_key="link-service-secret"),
     )
 
     assert response["response"] == "hello from the subscription"

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -271,6 +271,29 @@ def test_chat_message_rejects_link_authority_from_ordinary_api_client(
 
 
 @pytest.mark.asyncio
+async def test_link_service_credential_cannot_run_chat_without_execution_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    http_request = _api_request(api_key="link-service-secret")
+    http_request.state.auth_method = "link_service"
+
+    with pytest.raises(HTTPException) as raised:
+        await handle_chat_message(
+            request=MessageRequest(text="ordinary chat"),
+            core=cast(Any, _Core(tmp_path)),
+            http_request=http_request,
+        )
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail == (
+        "The Link execution credential requires a Link-managed or "
+        "personal-subscription execution descriptor."
+    )
+
+
+@pytest.mark.asyncio
 async def test_link_capabilities_reject_ordinary_api_clients(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/api/test_web_app_credentials_rehydrate.py
+++ b/tests/api/test_web_app_credentials_rehydrate.py
@@ -6,6 +6,7 @@ import os
 from types import SimpleNamespace
 
 from penguin.web import app as web_app
+from penguin.web.middleware import auth as web_auth
 
 
 def test_rehydrate_provider_credentials_applies_all_valid_records(monkeypatch) -> None:
@@ -189,3 +190,28 @@ def test_create_core_does_not_construct_remote_provider_without_credentials(
     core = web_app._create_core()
 
     assert core.api_client is None
+
+
+def test_create_app_loads_user_env_before_auth_config(monkeypatch) -> None:
+    startup_order: list[str] = []
+
+    def _load_env() -> None:
+        startup_order.append("env")
+
+    class _AuthConfig:
+        def __init__(self) -> None:
+            startup_order.append("auth")
+            assert startup_order == ["env", "auth"]
+
+    monkeypatch.setattr(web_app, "_ensure_env_loaded", _load_env)
+    monkeypatch.setattr(web_auth, "AuthConfig", _AuthConfig)
+    monkeypatch.setattr(web_app, "get_or_create_core", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        web_app,
+        "_rehydrate_provider_credentials",
+        lambda _core: None,
+    )
+
+    web_app.create_app()
+
+    assert startup_order == ["env", "auth"]

--- a/tests/llm/test_link_provider.py
+++ b/tests/llm/test_link_provider.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+import pytest
+
+from penguin.llm.contracts import ProviderRequestStatus
+from penguin.llm.model_config import ModelConfig
+from penguin.llm.providers.link import (
+    LinkInferenceContext,
+    LinkProvider,
+    LinkProviderConfig,
+)
+
+if TYPE_CHECKING:
+    from penguin.llm.providers.link.provider import LinkProtocol
+
+
+def _context(workspace_id: str = "workspace-1") -> LinkInferenceContext:
+    return LinkInferenceContext(
+        workspace_id=workspace_id,
+        user_id=f"user-{workspace_id}",
+        session_id=f"session-{workspace_id}",
+        agent_id="agent-1",
+        run_id=f"run-{workspace_id}",
+        requested_model_id="openai/gpt-5.4-nano",
+    )
+
+
+def _model() -> ModelConfig:
+    return ModelConfig(
+        model="openai/gpt-5.4-nano",
+        provider="openrouter",
+        client_preference="link",
+        max_output_tokens=128,
+    )
+
+
+def _provider(
+    handler: Any,
+    *,
+    context: LinkInferenceContext | None = None,
+    protocol: str = "responses",
+) -> LinkProvider:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    config = LinkProviderConfig(
+        base_url="http://link.test/api/v1",
+        service_token="service-secret",
+        protocol=cast("LinkProtocol", protocol),
+    )
+    return LinkProvider(
+        model_config=_model(),
+        context=context or _context(),
+        config=config,
+        http_client=client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_responses_request_has_attribution_without_provider_key() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        captured["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(
+            200,
+            headers={
+                "X-Link-Inference-Request-Id": request.headers[
+                    "X-Link-Inference-Request-Id"
+                ],
+                "X-Link-Meter-Event-Key": "inference:request-1",
+            },
+            json={
+                "id": "response-1",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "hello"}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 2,
+                    "total_tokens": 12,
+                },
+            },
+        )
+
+    provider = _provider(handler)
+    result = await provider.get_response(
+        [{"role": "user", "content": "hi"}],
+        max_output_tokens=32,
+    )
+
+    assert result == "hello"
+    assert captured["headers"]["x-link-workspace-id"] == "workspace-1"
+    assert captured["headers"]["x-link-service-auth"] == "service-secret"
+    assert (
+        captured["headers"]["x-link-request-id"]
+        == captured["headers"]["x-link-inference-request-id"]
+    )
+    assert "authorization" not in captured["headers"]
+    assert "openrouter" not in captured["headers"]
+    assert captured["body"]["max_output_tokens"] == 32
+    assert captured["timeout"]["read"] == 300.0
+    assert provider.get_last_usage()["input_tokens"] == 10
+    assert provider.get_last_request_lifecycle().status == (
+        ProviderRequestStatus.COMPLETED
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_preserves_text_reasoning_tools_and_usage() -> None:
+    async def callback(text: str, message_type: str) -> None:
+        chunks.append((message_type, text))
+
+    chunks: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        events = [
+            {"id": "gen-1", "choices": [{"delta": {"reasoning": "think "}}]},
+            {"id": "gen-1", "choices": [{"delta": {"content": "hello"}}]},
+            {
+                "id": "gen-1",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call-1",
+                                    "function": {
+                                        "name": "read_file",
+                                        "arguments": '{"path":',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "gen-1",
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": '"a"}'},
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 5,
+                    "total_tokens": 25,
+                },
+            },
+        ]
+        body = "data: malformed-optional-frame\n\n"
+        body += "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+        body += "data: [DONE]\n\n"
+        return httpx.Response(
+            200, text=body, headers={"content-type": "text/event-stream"}
+        )
+
+    provider = _provider(handler, protocol="chat_completions")
+    result = await provider.get_response(
+        [{"role": "user", "content": "hi"}],
+        max_output_tokens=32,
+        stream=True,
+        stream_callback=callback,
+        tools=[{"type": "function", "function": {"name": "read_file"}}],
+    )
+
+    assert result == "hello"
+    assert chunks == [("reasoning", "think "), ("assistant", "hello")]
+    assert provider.get_last_reasoning() == "think "
+    assert provider.get_last_usage()["total_tokens"] == 25
+    assert provider.get_and_clear_pending_tool_calls() == [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "arguments": '{"path":"a"}',
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_providers_do_not_share_link_context() -> None:
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            (
+                request.headers["X-Link-Workspace-Id"],
+                request.headers["X-Link-Request-Id"],
+            )
+        )
+        return httpx.Response(
+            200,
+            json={"id": "r", "status": "completed", "output_text": "ok"},
+        )
+
+    first = _provider(handler, context=_context("workspace-a"))
+    second = _provider(handler, context=_context("workspace-b"))
+    await __import__("asyncio").gather(
+        first.get_response([{"role": "user", "content": "a"}]),
+        second.get_response([{"role": "user", "content": "b"}]),
+    )
+
+    assert {workspace for workspace, _ in seen} == {"workspace-a", "workspace-b"}
+    assert len({request_id for _, request_id in seen}) == 2
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_disconnect_is_not_retryable() -> None:
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ReadError("connection reset after dispatch")
+
+    provider = _provider(handler)
+    with pytest.raises(Exception) as raised:
+        await provider.get_response([{"role": "user", "content": "hi"}])
+
+    assert calls == 1
+    assert provider.get_last_error() is not None
+    assert provider.get_last_error().retryable is False
+    assert provider.get_last_request_lifecycle().status == (
+        ProviderRequestStatus.DISCONNECTED
+    )
+    assert "uncertain" in str(raised.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_link_response_is_terminal_and_not_retryable() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text="not-json",
+            headers={"content-type": "application/json"},
+        )
+
+    provider = _provider(handler)
+    with pytest.raises(Exception):
+        await provider.get_response([{"role": "user", "content": "hi"}])
+
+    error = provider.get_last_error()
+    assert error is not None
+    assert error.retryable is False
+    assert provider.get_last_request_lifecycle().status == ProviderRequestStatus.FAILED

--- a/tests/llm/test_link_provider.py
+++ b/tests/llm/test_link_provider.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import pytest
 
-from penguin.llm.contracts import ProviderRequestStatus
+from penguin.llm.contracts import LLMProviderError, ProviderRequestStatus
 from penguin.llm.model_config import ModelConfig
 from penguin.llm.providers.link import (
     LinkInferenceContext,
@@ -227,6 +228,80 @@ async def test_concurrent_providers_do_not_share_link_context() -> None:
 
 
 @pytest.mark.asyncio
+async def test_responses_tool_turn_uses_two_distinct_link_invocations() -> None:
+    requests: list[dict[str, Any]] = []
+    request_ids: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        request_ids.append(request.headers["X-Link-Request-Id"])
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "id": "response-1",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "call_id": "call-1",
+                            "name": "read_file",
+                            "arguments": '{"path":"notes.txt"}',
+                        }
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "id": "response-2",
+                "status": "completed",
+                "output_text": "The file says hello.",
+            },
+        )
+
+    provider = _provider(handler)
+    await provider.get_response(
+        [{"role": "user", "content": "Read notes.txt"}],
+        tools=[{"type": "function", "name": "read_file"}],
+    )
+    tool_calls = provider.get_and_clear_pending_tool_calls()
+    result = await provider.get_response(
+        [
+            {"role": "user", "content": "Read notes.txt"},
+            {"role": "assistant", "content": None, "tool_calls": tool_calls},
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "hello",
+            },
+        ],
+        tools=[{"type": "function", "name": "read_file"}],
+    )
+
+    assert result == "The file says hello."
+    assert len(requests) == 2
+    assert len(set(request_ids)) == 2
+    assert requests[1]["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Read notes.txt"}],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call-1",
+            "name": "read_file",
+            "arguments": '{"path":"notes.txt"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": "hello",
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ambiguous_disconnect_is_not_retryable() -> None:
     calls = 0
 
@@ -249,6 +324,78 @@ async def test_ambiguous_disconnect_is_not_retryable() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_eof_before_terminal_event_is_uncertain_and_not_retryable() -> (
+    None
+):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        event = {
+            "type": "response.output_text.delta",
+            "delta": "partial",
+        }
+        return httpx.Response(
+            200,
+            text=f"data: {json.dumps(event)}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = _provider(handler)
+    with pytest.raises(LLMProviderError, match="terminal event") as raised:
+        await provider.get_response(
+            [{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+    assert raised.value.error.retryable is False
+    assert raised.value.error.provider_data["dispatch_outcome"] == "uncertain"
+    assert provider.get_last_request_lifecycle().status == (
+        ProviderRequestStatus.DISCONNECTED
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event", "expected_message"),
+    [
+        (
+            {
+                "type": "response.failed",
+                "response": {"error": {"message": "provider failed"}},
+            },
+            "provider failed",
+        ),
+        (
+            {
+                "type": "response.incomplete",
+                "response": {"incomplete_details": {"reason": "max_output_tokens"}},
+            },
+            "max_output_tokens",
+        ),
+        ({"type": "error", "message": "explicit stream error"}, "stream error"),
+    ],
+)
+async def test_responses_terminal_failure_events_are_not_reported_as_completed(
+    event: dict[str, Any],
+    expected_message: str,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=f"data: {json.dumps(event)}\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = _provider(handler)
+    with pytest.raises(LLMProviderError, match=expected_message) as raised:
+        await provider.get_response(
+            [{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+    assert raised.value.error.retryable is False
+    assert provider.get_last_request_lifecycle().status == ProviderRequestStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_invalid_link_response_is_terminal_and_not_retryable() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -265,3 +412,91 @@ async def test_invalid_link_response_is_terminal_and_not_retryable() -> None:
     assert error is not None
     assert error.retryable is False
     assert provider.get_last_request_lifecycle().status == ProviderRequestStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_buffered_incomplete_response_is_not_reported_as_completed() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "response-incomplete",
+                "status": "incomplete",
+                "output_text": "partial",
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        )
+
+    provider = _provider(handler)
+    with pytest.raises(LLMProviderError, match="max_output_tokens"):
+        await provider.get_response([{"role": "user", "content": "hi"}])
+
+    assert provider.get_last_request_lifecycle().status == ProviderRequestStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_stream_read_timeout_is_uncertain_and_not_replayed() -> None:
+    calls = 0
+
+    class _TimeoutStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            raise httpx.ReadTimeout("stream idle timeout")
+            yield b""  # pragma: no cover
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200,
+            stream=_TimeoutStream(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = _provider(handler)
+    with pytest.raises(LLMProviderError, match="outcome is uncertain") as raised:
+        await provider.get_response(
+            [{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+    assert calls == 1
+    assert raised.value.error.retryable is False
+    assert provider.get_last_request_lifecycle().status == (
+        ProviderRequestStatus.DISCONNECTED
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_remains_cancelled() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _BlockingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            started.set()
+            await release.wait()
+            yield b"data: [DONE]\n\n"
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            stream=_BlockingStream(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    provider = _provider(handler)
+    task = asyncio.create_task(
+        provider.get_response(
+            [{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert provider.get_last_request_lifecycle().status == (
+        ProviderRequestStatus.CANCELLED
+    )

--- a/tests/llm/test_link_runtime_contract.py
+++ b/tests/llm/test_link_runtime_contract.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any
+import pytest
 
-from penguin.llm.client import LLMClient, LLMClientConfig, LinkConfig
+from penguin.llm.client import LinkConfig, LLMClient, LLMClientConfig
 from penguin.llm.model_config import ModelConfig
 
 
-def test_llm_client_routes_link_headers_through_shared_provider_runtime() -> None:
+def test_llm_client_rejects_the_legacy_openrouter_as_link_proxy_path() -> None:
     model_config = ModelConfig(
         model="openai/gpt-5.4-nano",
         provider="openrouter",
@@ -27,34 +26,5 @@ def test_llm_client_routes_link_headers_through_shared_provider_runtime() -> Non
         ),
     )
 
-    captured: dict[str, Any] = {}
-
-    def _create_handler(
-        model_config: ModelConfig,
-        *,
-        base_url: str | None = None,
-        extra_headers: dict[str, str] | None = None,
-    ) -> Any:
-        captured["provider"] = model_config.provider
-        captured["model"] = model_config.model
-        captured["base_url"] = base_url
-        captured["extra_headers"] = dict(extra_headers or {})
-        return SimpleNamespace(extra_headers=dict(extra_headers or {}))
-
-    client._provider_registry.create_handler = _create_handler  # type: ignore[method-assign]
-
-    gateway = client._get_gateway()
-
-    assert gateway.extra_headers["X-Link-User-Id"] == "user-123"
-    assert captured == {
-        "provider": "openrouter",
-        "model": "openai/gpt-5.4-nano",
-        "base_url": "http://localhost:3001/api/v1",
-        "extra_headers": {
-            "X-Link-User-Id": "user-123",
-            "X-Link-Session-Id": "session-456",
-            "X-Link-Agent-Id": "agent-789",
-            "X-Link-Workspace-Id": "workspace-abc",
-            "Authorization": "Bearer link-secret",
-        },
-    }
+    with pytest.raises(ValueError, match="first-class LinkProvider"):
+        client._get_gateway()

--- a/tests/llm/test_provider_registry.py
+++ b/tests/llm/test_provider_registry.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from penguin.llm.model_config import ModelConfig
 from penguin.llm.provider_registry import ProviderRegistry
+from penguin.llm.providers.link import LinkInferenceContext, LinkProvider
 
 
 def _unused_litellm_loader(feature: str) -> Any:
@@ -96,3 +97,38 @@ def test_provider_registry_routes_openrouter_gateway_with_context(
         "base_url": "http://localhost:3001/api/v1",
         "extra_headers": {"X-Link-User-Id": "user-123"},
     }
+
+
+def test_provider_registry_routes_link_to_first_class_provider(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("LINK_INFERENCE_SERVICE_TOKEN", "link-service-secret")
+    registry = ProviderRegistry(
+        native_adapter_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("native adapter must not be used for Link")
+        ),
+        litellm_gateway_loader=_unused_litellm_loader,
+    )
+    config = ModelConfig(
+        model="openai/gpt-5.4-nano",
+        provider="openrouter",
+        client_preference="link",
+        max_output_tokens=256,
+    )
+    context = LinkInferenceContext(
+        workspace_id="workspace-1",
+        user_id="user-1",
+        session_id="session-1",
+        agent_id="agent-1",
+        run_id="run-1",
+        requested_model_id=config.model,
+    )
+
+    handler = registry.create_handler(
+        config,
+        base_url="http://link.test/api/v1",
+        link_context=context,
+    )
+
+    assert isinstance(handler, LinkProvider)
+    assert handler.context == context

--- a/tests/web/test_external_subscription_service.py
+++ b/tests/web/test_external_subscription_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pytest
+
+from penguin.web.services import external_subscription as service
+
+
+def _execution(**overrides: object) -> service.ExternalSubscriptionExecutionRequest:
+    values: dict[str, object] = {
+        "protocol_version": 1,
+        "owner_user_id": "user-a",
+        "user_id": "user-a",
+        "requested_model_id": "gpt-5.4",
+        "agent_runtime": "penguin",
+        "provider": "openai",
+        "inference_transport": "codex_responses_compat",
+        "execution_source": "local_penguin",
+        "provider_state_owner": "user_owned",
+        "credential_custodian": "local_penguin",
+        "settlement_mode": "subscription_quota",
+        "usage_authority": "local_runtime_observed",
+        "integration_support": "ecosystem_compatible",
+        "allow_fallback_to_link_gateway": False,
+    }
+    values.update(overrides)
+    return service.ExternalSubscriptionExecutionRequest(**values)
+
+
+def test_capability_reports_oauth_models_without_credentials(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {
+            "openai": {
+                "type": "oauth",
+                "access": "secret-access",
+                "refresh": "secret-refresh",
+                "accountId": "account-secret",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        service,
+        "codex_oauth_provider_models",
+        lambda _record: {
+            "openai": {
+                "gpt-5.4": {
+                    "name": "GPT-5.4",
+                    "context_window": 200_000,
+                    "max_output_tokens": 32_000,
+                    "reasoning_enabled": True,
+                    "vision_enabled": True,
+                    "source": "codex",
+                }
+            }
+        },
+    )
+
+    payload = service.build_external_subscription_capabilities()
+
+    assert payload["protocol_version"] == 1
+    subscription = payload["subscriptions"][0]
+    assert subscription["authenticated"] is True
+    assert subscription["models"][0]["id"] == "gpt-5.4"
+    serialized = repr(payload)
+    assert "secret-access" not in serialized
+    assert "secret-refresh" not in serialized
+    assert "account-secret" not in serialized
+
+
+def test_execution_rejects_cross_user_subscription(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {"openai": {"type": "oauth", "access": "secret"}},
+    )
+
+    with pytest.raises(ValueError, match="owning Link user"):
+        service.validate_external_subscription_execution(
+            _execution(user_id="user-b"),
+            "gpt-5.4",
+        )
+
+
+def test_execution_requires_local_oauth_and_exact_model(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {"openai": {"type": "api", "key": "not-returned"}},
+    )
+
+    with pytest.raises(ValueError, match="authentication is unavailable"):
+        service.validate_external_subscription_execution(
+            _execution(),
+            "gpt-5.4",
+        )
+
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {"openai": {"type": "oauth", "access": "secret"}},
+    )
+    with pytest.raises(ValueError, match="requested model does not match"):
+        service.validate_external_subscription_execution(
+            _execution(),
+            "gpt-5.4-mini",
+        )

--- a/tests/web/test_external_subscription_service.py
+++ b/tests/web/test_external_subscription_service.py
@@ -68,6 +68,25 @@ def test_capability_reports_oauth_models_without_credentials(monkeypatch) -> Non
     assert "account-secret" not in serialized
 
 
+def test_public_execution_result_supports_pydantic_1(monkeypatch) -> None:
+    if hasattr(service.ExternalSubscriptionExecutionRequest, "model_dump"):
+        monkeypatch.setattr(
+            service.ExternalSubscriptionExecutionRequest,
+            "model_dump",
+            None,
+        )
+    monkeypatch.setattr(
+        service.ExternalSubscriptionExecutionRequest,
+        "dict",
+        lambda self: dict(self.__dict__),
+    )
+
+    result = _execution().public_result()
+
+    assert result["owner_user_id"] == "user-a"
+    assert result["settlement_mode"] == "subscription_quota"
+
+
 def test_execution_rejects_cross_user_subscription(monkeypatch) -> None:
     monkeypatch.setattr(
         service,
@@ -82,7 +101,40 @@ def test_execution_rejects_cross_user_subscription(monkeypatch) -> None:
         )
 
 
+def test_execution_requires_a_penguin_owned_link_user_binding(monkeypatch) -> None:
+    monkeypatch.delenv("PENGUIN_LINK_SUBSCRIPTION_OWNER_USER_ID", raising=False)
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {"openai": {"type": "oauth", "access": "secret"}},
+    )
+
+    with pytest.raises(ValueError, match="not paired with a Link user"):
+        service.validate_external_subscription_execution(
+            _execution(),
+            "gpt-5.4",
+        )
+
+
+def test_execution_rejects_a_different_user_than_the_runtime_binding(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_LINK_SUBSCRIPTION_OWNER_USER_ID", "user-b")
+    monkeypatch.setattr(
+        service,
+        "get_provider_credentials",
+        lambda: {"openai": {"type": "oauth", "access": "secret"}},
+    )
+
+    with pytest.raises(ValueError, match="does not own this Penguin runtime"):
+        service.validate_external_subscription_execution(
+            _execution(),
+            "gpt-5.4",
+        )
+
+
 def test_execution_requires_local_oauth_and_exact_model(monkeypatch) -> None:
+    monkeypatch.setenv("PENGUIN_LINK_SUBSCRIPTION_OWNER_USER_ID", "user-a")
     monkeypatch.setattr(
         service,
         "get_provider_credentials",

--- a/tests/web/test_link_execution_authority.py
+++ b/tests/web/test_link_execution_authority.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, WebSocketException
+from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from penguin.web.middleware.auth import (
     AuthConfig,
+    AuthenticationMiddleware,
     authenticate_connection,
     authenticate_link_service_request,
+    require_websocket_auth,
 )
 
 
@@ -58,3 +63,158 @@ def test_ordinary_api_key_cannot_authorize_link_execution(monkeypatch) -> None:
         )["subject"]
         == "api_client"
     )
+
+
+def test_link_service_key_cannot_also_be_an_ordinary_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "false")
+    monkeypatch.setenv("LINK_API_KEY", "shared-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "shared-secret")
+
+    with pytest.raises(
+        ValueError,
+        match="LINK_API_KEY must not also appear in PENGUIN_API_KEYS",
+    ):
+        AuthConfig()
+
+
+def test_link_service_key_overlap_uses_normalized_comma_separated_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "  shared-secret  ")
+    monkeypatch.setenv(
+        "PENGUIN_API_KEYS",
+        "ordinary-one,  shared-secret  , ordinary-two",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="LINK_API_KEY must not also appear in PENGUIN_API_KEYS",
+    ):
+        AuthConfig()
+
+
+def test_distinct_normalized_link_and_ordinary_api_keys_still_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "  link-service-secret  ")
+    monkeypatch.setenv(
+        "PENGUIN_API_KEYS",
+        "ordinary-one, ordinary-client-secret",
+    )
+    config = AuthConfig()
+
+    assert (
+        authenticate_connection(
+            _request(api_key="link-service-secret"),
+            config,
+        )["method"]
+        == "link_service"
+    )
+    assert (
+        authenticate_connection(
+            _request(api_key="ordinary-client-secret"),
+            config,
+        )["method"]
+        == "api_key"
+    )
+
+
+def _scoped_link_service_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ordinary-client-secret")
+    app = FastAPI()
+
+    @app.get("/api/v1/link/capabilities")
+    async def capabilities() -> dict[str, bool]:
+        return {"allowed": True}
+
+    @app.post("/api/v1/chat/message")
+    async def chat_message() -> dict[str, bool]:
+        return {"allowed": True}
+
+    for method, path in (
+        ("POST", "/api/v1/security/yolo"),
+        ("GET", "/api/v1/security/config"),
+        ("POST", "/api/v1/system/config/project-root"),
+        ("POST", "/api/v1/system/config/llm"),
+        ("PUT", "/api/v1/auth/openai"),
+    ):
+        app.add_api_route(
+            path,
+            lambda: {"allowed": False},
+            methods=[method],
+        )
+
+    app.add_middleware(AuthenticationMiddleware, config=AuthConfig())
+    return app
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/api/v1/security/yolo"),
+        ("GET", "/api/v1/security/config"),
+        ("POST", "/api/v1/system/config/project-root"),
+        ("POST", "/api/v1/system/config/llm"),
+        ("PUT", "/api/v1/auth/openai"),
+    ],
+)
+def test_link_service_key_is_rejected_outside_its_exact_http_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    path: str,
+) -> None:
+    with TestClient(_scoped_link_service_app(monkeypatch)) as client:
+        response = client.request(
+            method,
+            path,
+            headers={"X-API-Key": "link-service-secret"},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "The Link execution credential is not authorized for this endpoint."
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/v1/link/capabilities"),
+        ("POST", "/api/v1/chat/message"),
+    ],
+)
+def test_link_service_key_is_accepted_only_for_execution_routes(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    path: str,
+) -> None:
+    with TestClient(_scoped_link_service_app(monkeypatch)) as client:
+        response = client.request(
+            method,
+            path,
+            headers={"X-API-Key": "link-service-secret"},
+        )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_link_service_key_cannot_authenticate_a_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    websocket = SimpleNamespace(
+        url=SimpleNamespace(path="/api/v1/events/ws"),
+        headers={"X-API-Key": "link-service-secret"},
+        state=SimpleNamespace(),
+    )
+
+    with pytest.raises(WebSocketException) as raised:
+        await require_websocket_auth(websocket)
+
+    assert raised.value.code == 1008

--- a/tests/web/test_link_execution_authority.py
+++ b/tests/web/test_link_execution_authority.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from penguin.web.middleware.auth import (
+    AuthConfig,
+    authenticate_connection,
+    authenticate_link_service_request,
+)
+
+
+def _request(*, api_key: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/chat/message",
+            "headers": [(b"x-api-key", api_key.encode())],
+        }
+    )
+
+
+def test_link_execution_requires_the_dedicated_link_service_key(monkeypatch) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ordinary-client-secret")
+    config = AuthConfig()
+
+    auth = authenticate_link_service_request(
+        _request(api_key="link-service-secret"),
+        config,
+    )
+
+    assert auth == {
+        "method": "link_service",
+        "subject": "link",
+        "metadata": {"service": "link"},
+    }
+
+
+def test_ordinary_api_key_cannot_authorize_link_execution(monkeypatch) -> None:
+    monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
+    monkeypatch.setenv("PENGUIN_API_KEYS", "ordinary-client-secret")
+    config = AuthConfig()
+
+    with pytest.raises(HTTPException) as raised:
+        authenticate_link_service_request(
+            _request(api_key="ordinary-client-secret"),
+            config,
+        )
+
+    assert raised.value.status_code == 403
+    assert (
+        authenticate_connection(
+            _request(api_key="ordinary-client-secret"),
+            config,
+        )["subject"]
+        == "api_client"
+    )

--- a/tests/web/test_link_inference_service.py
+++ b/tests/web/test_link_inference_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from penguin.llm.model_config import ModelConfig
+from penguin.llm.providers.link import LinkProvider
+from penguin.web.services.link_inference import (
+    LinkExecutionRequest,
+    resolve_link_inference_runtime,
+)
+
+
+def _execution() -> LinkExecutionRequest:
+    return LinkExecutionRequest(
+        workspace_id="workspace-1",
+        user_id="user-1",
+        session_id="session-1",
+        agent_id="agent-1",
+        run_id="run-1",
+        requested_model_id="openai/gpt-5.4-nano",
+        execution_source="link_gateway",
+        provider_state_owner="link_managed",
+        settlement_mode="debit_link_credits",
+    )
+
+
+def test_builds_request_scoped_link_provider_without_mutating_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_INFERENCE_SERVICE_TOKEN", "service-secret")
+    original = ModelConfig(
+        model="anthropic/claude-sonnet-4",
+        provider="openrouter",
+        client_preference="openrouter",
+        max_output_tokens=512,
+    )
+    core = SimpleNamespace(model_config=original)
+
+    model_config, api_client = resolve_link_inference_runtime(
+        core,
+        _execution(),
+        "openai/gpt-5.4-nano",
+    )
+
+    assert model_config.client_preference == "link"
+    assert model_config.provider == "link"
+    assert isinstance(api_client.client_handler, LinkProvider)
+    assert api_client.client_handler.context.workspace_id == "workspace-1"
+    assert core.model_config is original
+    assert original.client_preference == "openrouter"
+
+
+def test_rejects_model_that_differs_from_link_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINK_INFERENCE_SERVICE_TOKEN", "service-secret")
+    core = SimpleNamespace(
+        model_config=ModelConfig(
+            model="openai/gpt-5.4-nano",
+            provider="openrouter",
+            max_output_tokens=128,
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        resolve_link_inference_runtime(core, _execution(), "openai/gpt-5.4")


### PR DESCRIPTION
## What changed

Replays the four commits from #79 onto current `main`.

PR #79 was accidentally opened against and merged into `prompting/refactor`. The prompting refactor subsequently reached `main` through #78, but the Link/provider work did not. This correction contains only #79's 27-file delta and does not merge the broader branch history.

## Included

- first-class Link-managed inference provider and protocol adapters
- personal ChatGPT subscription execution through Penguin
- execution-credential authority and route containment
- provider lifecycle, incomplete-stream, tool-history, and Pydantic compatibility handling
- deterministic provider, auth, runtime, and route coverage

## Verification

- 75 focused provider/auth/route tests pass locally
- `git diff --check` passes
- original #79 Python 3.9/Pydantic 1 and Python 3.12/Pydantic 2 contract jobs were green

GitHub CI on this PR will revalidate the same matrix against current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Link-managed inference with dedicated authentication, execution authority, and request attribution.
  * Added support for Responses and Chat Completions protocols, including streaming, tool calls, reasoning, usage, and error handling.
  * Added external subscription capability discovery and validated execution.
  * Added a protected capabilities endpoint and new configuration guidance.
* **Bug Fixes**
  * Prevented unauthorized or incorrectly routed Link requests.
  * Ensured environment credentials load correctly during web app startup.
* **Tests**
  * Added comprehensive coverage for provider behavior, authorization, subscriptions, runtime routing, streaming, and failure scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->