### PR TITLE
Enforce Link runtime permission policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             pydantic-spec: "pydantic==1.10.24"
           - python-version: "3.12"
             pydantic-spec: "pydantic>=2,<3"
@@ -36,6 +36,7 @@ jobs:
             penguin/web/services/link_inference.py \
             tests/llm/test_link_provider.py \
             tests/llm/test_link_runtime_contract.py \
+            tests/test_link_runtime_permission_policy.py \
             tests/web/test_external_subscription_service.py \
             tests/web/test_link_execution_authority.py
           ruff format --check \
@@ -52,6 +53,7 @@ jobs:
             tests/llm/test_link_provider.py \
             tests/llm/test_link_runtime_contract.py \
             tests/llm/test_provider_registry.py \
+            tests/test_link_runtime_permission_policy.py \
             tests/web/test_link_inference_service.py \
             tests/web/test_external_subscription_service.py \
             tests/web/test_link_execution_authority.py \
@@ -67,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             pydantic-spec: "pydantic==1.10.24"
           - python-version: "3.12"
             pydantic-spec: "pydantic>=2,<3"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -136,4 +136,4 @@ jobs:
         path: dist/
         
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1 
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Commands
 Style and Conventions
 - Follow .cursorrules at repo root. Key points: PEP 8, explicit > implicit, single responsibility, comprehensive type annotations, Google-style docstrings, robust exception handling, logging.
 - Imports: ruff/isort with profile=black; order stdlib, third-party, first-party (penguin). Combine "as" imports; known-first-party = ["penguin"].
-- Formatting: Black 88 col; Ruff line-length 88; quotes = double (ruff fmt). Target Python 3.9+ (ruff target 3.8, black target py39).
+- Formatting: Black 88 col; Ruff line-length 88; quotes = double (ruff fmt). Target Python 3.10+ (ruff target 3.8, black target py39).
 - Types: annotate all public functions and dataclasses; prefer precise types (dict[str, Any] over Dict). Use Pydantic types where appropriate.
 - Naming Penguin: Just call it "Penguin", not "Penguin AI", or "Penguin AI Assistant". In some cases "Penguin Agent" are reasonable though.
 - Naming: snake_case for functions/vars; PascalCase for classes; UPPER_SNAKE for constants; clear, descriptive names.

--- a/context/decisions/browser-backend-contract.md
+++ b/context/decisions/browser-backend-contract.md
@@ -11,7 +11,7 @@ Penguin will not add browser-harness to base dependencies or the `[browser]` ext
 ## Rationale
 
 - browser-harness is not published on PyPI yet.
-- Penguin supports Python `>=3.9,<3.13`; browser-harness currently targets newer Python and its own dependency constraints.
+- Penguin supports Python `>=3.10,<3.13`; browser-harness currently targets newer Python and its own dependency constraints.
 - PyDoll remains useful as an installable fallback for users who install `penguin-ai[browser]` without a local browser-harness checkout.
 - The public Penguin browser interface should remain backend-agnostic enough to swap browser-harness, PyDoll, Playwright/CDP, or a future better backend later.
 

--- a/penguin/security/permission_engine.py
+++ b/penguin/security/permission_engine.py
@@ -63,6 +63,7 @@ class Operation(Enum):
     FILESYSTEM_LIST = "filesystem.list"
     
     # Process operations
+    PROCESS_INSPECT = "process.inspect"
     PROCESS_EXECUTE = "process.execute"
     PROCESS_SPAWN = "process.spawn"
     PROCESS_KILL = "process.kill"
@@ -111,6 +112,7 @@ class Operation(Enum):
             cls.GIT_READ,
             cls.MEMORY_READ,
             cls.NETWORK_FETCH,
+            cls.PROCESS_INSPECT,
         }
 
 
@@ -549,4 +551,3 @@ class PermissionEnforcer:
             summary[key] = list(dict.fromkeys(summary[key]))
         
         return summary
-

--- a/penguin/security/policies/workspace.py
+++ b/penguin/security/policies/workspace.py
@@ -222,12 +222,19 @@ class WorkspaceBoundaryPolicy(PolicyEngine):
         """
         context = context or {}
 
+        requested_mode = context.get("permission_mode")
+        mode = {
+            "read_only": PermissionMode.READ_ONLY,
+            "workspace": PermissionMode.WORKSPACE,
+            "full_access": PermissionMode.FULL,
+        }.get(requested_mode, self._mode)
+
         # FULL mode allows everything (but we still log)
-        if self._mode == PermissionMode.FULL:
+        if mode == PermissionMode.FULL:
             return PermissionResult.ALLOW, "FULL mode - all operations allowed"
 
         # READ_ONLY mode denies all non-read operations
-        if self._mode == PermissionMode.READ_ONLY:
+        if mode == PermissionMode.READ_ONLY:
             if not Operation.is_read_only(operation):
                 # Special case: allow safe execute commands (grep, find, cat, etc.)
                 if operation == Operation.PROCESS_EXECUTE:

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -129,6 +129,14 @@ def _find_git_push_args(command: str) -> list[str] | None:
         return None
 
     separators = {"&&", "||", ";", "|"}
+    global_options_with_value = {
+        "-C",
+        "-c",
+        "--config-env",
+        "--git-dir",
+        "--namespace",
+        "--work-tree",
+    }
     for index, token in enumerate(tokens):
         if Path(token).name != "git":
             continue
@@ -136,12 +144,13 @@ def _find_git_push_args(command: str) -> list[str] | None:
         cursor = index + 1
         while cursor < len(tokens):
             token = tokens[cursor]
-            if token in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+            if token in global_options_with_value:
                 cursor += 2
                 continue
-            if token.startswith(
-                ("-C", "-c", "--git-dir=", "--work-tree=", "--namespace=")
-            ):
+            if token == "--":
+                cursor += 1
+                break
+            if token.startswith("-"):
                 cursor += 1
                 continue
             break

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 import logging
 import re
+import shlex
+from fnmatch import fnmatchcase
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     from penguin.security.permission_engine import PermissionEnforcer
@@ -49,6 +52,10 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     # Code execution
     "code_execution": [Operation.PROCESS_EXECUTE],
     "execute_command": [Operation.PROCESS_EXECUTE],
+    "process_start": [Operation.PROCESS_SPAWN],
+    "process_poll": [Operation.PROCESS_INSPECT],
+    "process_write_stdin": [Operation.PROCESS_EXECUTE],
+    "process_stop": [Operation.PROCESS_KILL],
     # Search operations (generally safe)
     "grep_search": [Operation.FILESYSTEM_READ],
     "memory_search": [Operation.MEMORY_READ],
@@ -109,9 +116,93 @@ def get_tool_operations(tool_name: str) -> list[Operation]:
     return TOOL_OPERATION_MAP.get(tool_name, [])
 
 
+def _find_git_push_args(command: str) -> list[str] | None:
+    """Return the arguments following a direct ``git push`` invocation.
+
+    This deliberately recognizes direct Git CLI invocations rather than trying
+    to interpret arbitrary shell programs. It closes the policy bypass where a
+    caller uses ``execute_command`` instead of Penguin's dedicated Git tool.
+    """
+    try:
+        tokens = shlex.split(str(command or ""), posix=True)
+    except ValueError:
+        return None
+
+    separators = {"&&", "||", ";", "|"}
+    for index, token in enumerate(tokens):
+        if Path(token).name != "git":
+            continue
+
+        cursor = index + 1
+        while cursor < len(tokens):
+            token = tokens[cursor]
+            if token in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+                cursor += 2
+                continue
+            if token.startswith(
+                ("-C", "-c", "--git-dir=", "--work-tree=", "--namespace=")
+            ):
+                cursor += 1
+                continue
+            break
+
+        if cursor < len(tokens) and tokens[cursor] == "push":
+            end = cursor + 1
+            while end < len(tokens) and tokens[end] not in separators:
+                end += 1
+            return tokens[cursor + 1 : end]
+
+    for token in tokens:
+        if (
+            token != command
+            and "git" in token
+            and any(char.isspace() for char in token)
+        ):
+            nested_args = _find_git_push_args(token)
+            if nested_args is not None:
+                return nested_args
+    return None
+
+
+def _get_tool_operations_for_input(
+    tool_name: str,
+    tool_input: dict[str, Any],
+) -> list[Operation]:
+    """Classify operations using both the tool identity and its payload."""
+    operations = list(get_tool_operations(tool_name))
+    if tool_name not in {
+        "execute_command",
+        "code_execution",
+        "process_start",
+        "process_write_stdin",
+    }:
+        return operations
+
+    command = (
+        tool_input.get("command") or tool_input.get("code") or tool_input.get("text")
+    )
+    push_args = _find_git_push_args(str(command or ""))
+    if push_args is None:
+        return operations
+
+    if Operation.GIT_PUSH not in operations:
+        operations.append(Operation.GIT_PUSH)
+    if any(
+        argument == "-f"
+        or argument == "--force"
+        or argument.startswith("--force=")
+        or argument == "--force-with-lease"
+        or argument.startswith("--force-with-lease=")
+        or argument.startswith("+")
+        for argument in push_args
+    ):
+        operations.append(Operation.GIT_FORCE)
+    return operations
+
+
 def extract_resource_from_input(
     tool_name: str, tool_input: dict[str, Any]
-) -> Optional[str]:
+) -> str | None:
     """Extract the primary resource (usually file path) from tool input.
 
     Args:
@@ -121,6 +212,10 @@ def extract_resource_from_input(
     Returns:
         Resource string (usually a path) or None if not applicable
     """
+    if tool_name in ("execute_command", "code_execution", "process_start"):
+        # For commands, the resource is the command itself
+        return tool_input.get("command") or tool_input.get("code")
+
     # File path extraction for common patterns
     path_keys = ["path", "file_path", "filepath", "file", "target", "directory", "dir"]
 
@@ -129,9 +224,6 @@ def extract_resource_from_input(
             return str(tool_input[key])
 
     # Special cases
-    if tool_name in ("execute_command", "code_execution"):
-        # For commands, the resource is the command itself
-        return tool_input.get("command") or tool_input.get("code")
 
     if tool_name in ("browser_navigate", "pydoll_browser_navigate", "browser_open_tab"):
         return tool_input.get("url")
@@ -151,11 +243,22 @@ def extract_resource_from_input(
     if tool_name in ("memory_search", "perplexity_search"):
         return tool_input.get("query")
 
+    if tool_name in ("process_write_stdin", "process_stop"):
+        return tool_input.get("process_id")
+
+    if tool_name == "git_push":
+        return (
+            tool_input.get("remote")
+            or tool_input.get("remote_name")
+            or tool_input.get("remote_url")
+            or tool_input.get("url")
+        )
+
     # For operations without a clear resource, return None
     return None
 
 
-def _resolve_resource_path(resource: str, context: Optional[dict[str, Any]]) -> str:
+def _resolve_resource_path(resource: str, context: dict[str, Any] | None) -> str:
     """Resolve relative resource paths against request-scoped directory hints."""
     text = str(resource or "").strip()
     if not text:
@@ -220,7 +323,7 @@ def _extract_apply_patch_paths(content: str) -> list[str]:
 def extract_resources_from_input(
     tool_name: str,
     tool_input: dict[str, Any],
-    context: Optional[dict[str, Any]] = None,
+    context: dict[str, Any] | None = None,
 ) -> list[str]:
     """Extract primary tool resources normalized for permission checks."""
     resources: list[str] = []
@@ -251,7 +354,13 @@ def extract_resources_from_input(
 
     single = extract_resource_from_input(tool_name, tool_input)
     if single:
-        resources.append(_resolve_resource_path(single, context))
+        operations = get_tool_operations(tool_name)
+        is_path_resource = any(
+            operation.value.startswith("filesystem.") for operation in operations
+        )
+        resources.append(
+            _resolve_resource_path(single, context) if is_path_resource else single
+        )
 
     deduped: list[str] = []
     seen: set[str] = set()
@@ -285,7 +394,7 @@ def is_safe_tool(tool_name: str) -> bool:
     return all(Operation.is_read_only(op) for op in operations)
 
 
-def get_highest_risk_operation(tool_name: str) -> Optional[Operation]:
+def get_highest_risk_operation(tool_name: str) -> Operation | None:
     """Get the highest-risk operation for a tool.
 
     Useful for permission checking when multiple operations are involved.
@@ -315,6 +424,7 @@ def get_highest_risk_operation(tool_name: str) -> Optional[Operation]:
         Operation.MEMORY_WRITE,
         Operation.FILESYSTEM_MKDIR,
         Operation.NETWORK_FETCH,
+        Operation.PROCESS_INSPECT,
         Operation.FILESYSTEM_READ,
         Operation.FILESYSTEM_LIST,
         Operation.GIT_READ,
@@ -332,8 +442,8 @@ def get_highest_risk_operation(tool_name: str) -> Optional[Operation]:
 def check_tool_permission(
     tool_name: str,
     tool_input: dict[str, Any],
-    enforcer: "PermissionEnforcer",
-    context: Optional[dict[str, Any]] = None,
+    enforcer: PermissionEnforcer,
+    context: dict[str, Any] | None = None,
 ) -> tuple[PermissionResult, str]:
     """Check if a tool execution is allowed.
 
@@ -350,14 +460,14 @@ def check_tool_permission(
     Returns:
         Tuple of (PermissionResult, reason_string)
     """
-    operations = get_tool_operations(tool_name)
+    operations = _get_tool_operations_for_input(tool_name, tool_input)
 
     if not operations:
         permission_mode = (context or {}).get("permission_mode")
         if permission_mode == "read_only":
             return PermissionResult.DENY, "Unknown tools are denied in read-only mode"
         if isinstance((context or {}).get("approval_policy"), dict):
-            return PermissionResult.ASK, "Unknown tool requires approval"
+            return PermissionResult.DENY, "Unknown tools are denied by request policy"
         # Legacy callers without a request policy retain the existing behavior.
         logger.debug(f"Tool '{tool_name}' not in permission map, allowing by default")
         return PermissionResult.ALLOW, "Unknown tool - allowed by default"
@@ -367,11 +477,18 @@ def check_tool_permission(
     ctx = dict(context or {})
     ctx["tool_name"] = tool_name
 
-    request_result = _check_request_approval_policy(operations, resources, ctx)
+    request_policy_allows = False
+    request_result = _check_request_approval_policy(
+        operations,
+        resources,
+        ctx,
+        tool_input,
+    )
     if request_result is not None:
         result, reason = request_result
         if result != PermissionResult.ALLOW:
             return result, reason
+        request_policy_allows = True
 
     # Check agent-specific policy first (if agent_id in context)
     agent_id = ctx.get("agent_id")
@@ -403,7 +520,7 @@ def check_tool_permission(
 
     # If any ASK, return ASK
     for result, operation, resource_candidate in results:
-        if result == PermissionResult.ASK:
+        if result == PermissionResult.ASK and not request_policy_allows:
             message = (
                 f"Operation '{operation.value}' requires approval for "
                 f"'{resource_candidate}'"
@@ -414,7 +531,7 @@ def check_tool_permission(
             )
 
     # Check if agent policy said ASK
-    if "_agent_ask" in ctx:
+    if "_agent_ask" in ctx and not request_policy_allows:
         return PermissionResult.ASK, ctx["_agent_ask"]
 
     return PermissionResult.ALLOW, "All operations allowed"
@@ -425,6 +542,7 @@ _READ_OPERATIONS = {
     Operation.FILESYSTEM_LIST,
     Operation.GIT_READ,
     Operation.MEMORY_READ,
+    Operation.PROCESS_INSPECT,
 }
 
 _ACTION_FOR_OPERATION = {
@@ -458,39 +576,257 @@ def _check_request_approval_policy(
     operations: list[Operation],
     resources: list[str],
     context: dict[str, Any],
-) -> Optional[tuple[PermissionResult, str]]:
+    tool_input: dict[str, Any],
+) -> tuple[PermissionResult, str] | None:
     """Apply Link's immutable per-turn policy before Penguin's local policy."""
     policy = context.get("approval_policy")
     if not isinstance(policy, dict):
         return None
 
-    targets = resources or [str(context.get("tool_name") or "unknown")]
     allow_lists = policy.get("allowLists")
     if not isinstance(allow_lists, dict):
         allow_lists = {}
+    permission_mode = str(policy.get("permissionMode") or "")
+    decisions: list[tuple[PermissionResult, str]] = []
 
     for operation in operations:
         if operation in _READ_OPERATIONS:
             continue
         action = _ACTION_FOR_OPERATION.get(operation)
         if action is None:
-            return (
-                PermissionResult.ASK,
-                f"Unclassified operation '{operation.value}' requires approval",
+            decisions.append(
+                (
+                    PermissionResult.DENY,
+                    f"Unclassified operation '{operation.value}' is denied",
+                )
             )
+            continue
+
         decision = policy.get(action, "ask")
         if decision == "deny":
-            return PermissionResult.DENY, f"Policy denies '{action}'"
-        if decision != "allow":
-            return PermissionResult.ASK, f"Policy requires approval for '{action}'"
+            decisions.append((PermissionResult.DENY, f"Policy denies '{action}'"))
+            continue
 
         allowed_values = allow_lists.get(_ALLOW_LIST_FOR_ACTION[action], [])
-        if isinstance(allowed_values, list) and allowed_values:
-            normalized = {str(value).strip() for value in allowed_values}
-            if any(str(target).strip() not in normalized for target in targets):
-                return PermissionResult.ASK, f"'{action}' target is not allow-listed"
+        if not isinstance(allowed_values, list):
+            allowed_values = []
+        targets = _targets_for_action(
+            action,
+            str(context.get("tool_name") or "unknown"),
+            tool_input,
+            resources,
+        )
+        allow_list_matches = (
+            bool(allowed_values)
+            and bool(targets)
+            and all(
+                _target_matches_allow_list(action, target, allowed_values, context)
+                for target in targets
+            )
+        )
+
+        if allow_list_matches and (
+            decision == "allow" or permission_mode in {"approve_safe_actions", "custom"}
+        ):
+            decisions.append((PermissionResult.ALLOW, f"Policy allows '{action}'"))
+            continue
+
+        if decision == "allow" and not allowed_values:
+            decisions.append((PermissionResult.ALLOW, f"Policy allows '{action}'"))
+            continue
+
+        if allowed_values:
+            decisions.append(
+                (
+                    PermissionResult.ASK,
+                    f"'{action}' target is not allow-listed",
+                )
+            )
+            continue
+
+        decisions.append(
+            (
+                PermissionResult.ASK,
+                f"Policy requires approval for '{action}'",
+            )
+        )
+
+    for result, reason in decisions:
+        if result == PermissionResult.DENY:
+            return result, reason
+    for result, reason in decisions:
+        if result == PermissionResult.ASK:
+            return result, reason
 
     return PermissionResult.ALLOW, "Request policy allows all operations"
+
+
+def _targets_for_action(
+    action: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    resources: list[str],
+) -> list[str]:
+    """Extract the resource representation expected by one policy action."""
+    if action == "shell" and tool_name in {
+        "execute_command",
+        "code_execution",
+        "process_start",
+        "process_write_stdin",
+    }:
+        command = (
+            tool_input.get("command")
+            or tool_input.get("code")
+            or tool_input.get("text")
+        )
+        return [str(command)] if command else resources
+
+    if action == "gitPush":
+        if tool_name == "git_push":
+            remote = (
+                tool_input.get("remote")
+                or tool_input.get("remote_name")
+                or tool_input.get("remote_url")
+                or tool_input.get("url")
+            )
+            return [str(remote)] if remote else []
+
+        command = (
+            tool_input.get("command")
+            or tool_input.get("code")
+            or tool_input.get("text")
+        )
+        push_args = _find_git_push_args(str(command or ""))
+        if push_args is None:
+            return []
+        remote = _extract_git_push_remote(push_args)
+        return [remote] if remote else []
+
+    return resources
+
+
+def _extract_git_push_remote(arguments: list[str]) -> str | None:
+    """Extract an explicit remote identity from Git push arguments."""
+    options_with_values = {
+        "--exec",
+        "--receive-pack",
+        "--repo",
+        "-o",
+        "--push-option",
+    }
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument.startswith("--repo="):
+            return argument.split("=", 1)[1]
+        if argument in options_with_values:
+            if argument == "--repo" and index + 1 < len(arguments):
+                return arguments[index + 1]
+            index += 2
+            continue
+        if argument.startswith("-"):
+            index += 1
+            continue
+        return argument
+    return None
+
+
+def _target_matches_allow_list(
+    action: str,
+    target: str,
+    allowed_values: list[Any],
+    context: dict[str, Any],
+) -> bool:
+    """Match a target using the resource semantics for its policy action."""
+    entries = [str(value).strip() for value in allowed_values if str(value).strip()]
+    if not entries:
+        return False
+
+    if action == "shell":
+        command = str(target).strip()
+        return any(_shell_pattern_matches(pattern, command) for pattern in entries)
+
+    if action in {"fileWrite", "fileDelete"}:
+        target_path = Path(_resolve_resource_path(target, context)).resolve()
+        for entry in entries:
+            allowed_path = Path(_resolve_resource_path(entry, context)).resolve()
+            if target_path == allowed_path or allowed_path in target_path.parents:
+                return True
+        return False
+
+    if action == "network":
+        hostname = _normalize_network_host(target)
+        if not hostname:
+            return False
+        return any(
+            fnmatchcase(hostname, pattern.lower().rstrip(".")) for pattern in entries
+        )
+
+    if action == "gitPush":
+        remote = _normalize_git_remote(target)
+        return any(remote == _normalize_git_remote(entry) for entry in entries)
+
+    return str(target).strip() in entries
+
+
+def _shell_pattern_matches(pattern: str, command: str) -> bool:
+    """Match shell patterns token-by-token without spanning control operators."""
+    try:
+        pattern_tokens = _tokenize_shell_pattern(pattern)
+        command_tokens = _tokenize_shell_pattern(command)
+    except ValueError:
+        return False
+
+    control_tokens = {"&&", "||", ";", "|", "&", ">", ">>", "<", "<<"}
+    if any(token in control_tokens for token in command_tokens):
+        return pattern_tokens == command_tokens
+    if len(pattern_tokens) != len(command_tokens):
+        return False
+    return all(
+        fnmatchcase(command_token, pattern_token)
+        for pattern_token, command_token in zip(pattern_tokens, command_tokens)
+    )
+
+
+def _tokenize_shell_pattern(value: str) -> list[str]:
+    """Tokenize a command while preserving shell control operators."""
+    lexer = shlex.shlex(value, posix=True, punctuation_chars=";&|<>")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _normalize_network_host(value: str) -> str | None:
+    """Return a lowercase hostname from a URL or host-like value."""
+    text = str(value or "").strip()
+    if not text:
+        return None
+    parsed = urlsplit(text if "://" in text else f"//{text}")
+    return parsed.hostname.lower().rstrip(".") if parsed.hostname else None
+
+
+def _normalize_git_remote(value: str) -> str:
+    """Normalize a Git remote name or URL for identity comparison."""
+    text = str(value or "").strip()
+    scp_match = (
+        re.fullmatch(r"(?:[^@\s]+@)?([^:\s]+):(.+)", text)
+        if "://" not in text
+        else None
+    )
+    if scp_match:
+        hostname, path = scp_match.groups()
+        path = path.rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        return f"{hostname.lower()}/{path.lstrip('/')}"
+    if "://" not in text:
+        return text
+    parsed = urlsplit(text)
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    path = parsed.path.rstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return f"{hostname}{path}"
 
 
 def _check_agent_permission(

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -353,7 +353,12 @@ def check_tool_permission(
     operations = get_tool_operations(tool_name)
 
     if not operations:
-        # Unknown tools - allow but log
+        permission_mode = (context or {}).get("permission_mode")
+        if permission_mode == "read_only":
+            return PermissionResult.DENY, "Unknown tools are denied in read-only mode"
+        if isinstance((context or {}).get("approval_policy"), dict):
+            return PermissionResult.ASK, "Unknown tool requires approval"
+        # Legacy callers without a request policy retain the existing behavior.
         logger.debug(f"Tool '{tool_name}' not in permission map, allowing by default")
         return PermissionResult.ALLOW, "Unknown tool - allowed by default"
 
@@ -361,6 +366,12 @@ def check_tool_permission(
     resource = resources[0] if resources else None
     ctx = dict(context or {})
     ctx["tool_name"] = tool_name
+
+    request_result = _check_request_approval_policy(operations, resources, ctx)
+    if request_result is not None:
+        result, reason = request_result
+        if result != PermissionResult.ALLOW:
+            return result, reason
 
     # Check agent-specific policy first (if agent_id in context)
     agent_id = ctx.get("agent_id")
@@ -407,6 +418,79 @@ def check_tool_permission(
         return PermissionResult.ASK, ctx["_agent_ask"]
 
     return PermissionResult.ALLOW, "All operations allowed"
+
+
+_READ_OPERATIONS = {
+    Operation.FILESYSTEM_READ,
+    Operation.FILESYSTEM_LIST,
+    Operation.GIT_READ,
+    Operation.MEMORY_READ,
+}
+
+_ACTION_FOR_OPERATION = {
+    Operation.FILESYSTEM_WRITE: "fileWrite",
+    Operation.FILESYSTEM_MKDIR: "fileWrite",
+    Operation.FILESYSTEM_DELETE: "fileDelete",
+    Operation.PROCESS_EXECUTE: "shell",
+    Operation.PROCESS_SPAWN: "shell",
+    Operation.PROCESS_KILL: "shell",
+    Operation.NETWORK_FETCH: "network",
+    Operation.NETWORK_POST: "network",
+    Operation.NETWORK_LISTEN: "network",
+    Operation.GIT_WRITE: "shell",
+    Operation.GIT_PUSH: "gitPush",
+    Operation.GIT_FORCE: "gitPush",
+    Operation.MEMORY_WRITE: "fileWrite",
+    Operation.MEMORY_DELETE: "fileDelete",
+}
+
+_ALLOW_LIST_FOR_ACTION = {
+    "shell": "shellCommands",
+    "fileWrite": "writablePaths",
+    "fileDelete": "writablePaths",
+    "gitPush": "gitRemotes",
+    "network": "networkHosts",
+    "secrets": "secretNames",
+}
+
+
+def _check_request_approval_policy(
+    operations: list[Operation],
+    resources: list[str],
+    context: dict[str, Any],
+) -> Optional[tuple[PermissionResult, str]]:
+    """Apply Link's immutable per-turn policy before Penguin's local policy."""
+    policy = context.get("approval_policy")
+    if not isinstance(policy, dict):
+        return None
+
+    targets = resources or [str(context.get("tool_name") or "unknown")]
+    allow_lists = policy.get("allowLists")
+    if not isinstance(allow_lists, dict):
+        allow_lists = {}
+
+    for operation in operations:
+        if operation in _READ_OPERATIONS:
+            continue
+        action = _ACTION_FOR_OPERATION.get(operation)
+        if action is None:
+            return (
+                PermissionResult.ASK,
+                f"Unclassified operation '{operation.value}' requires approval",
+            )
+        decision = policy.get(action, "ask")
+        if decision == "deny":
+            return PermissionResult.DENY, f"Policy denies '{action}'"
+        if decision != "allow":
+            return PermissionResult.ASK, f"Policy requires approval for '{action}'"
+
+        allowed_values = allow_lists.get(_ALLOW_LIST_FOR_ACTION[action], [])
+        if isinstance(allowed_values, list) and allowed_values:
+            normalized = {str(value).strip() for value in allowed_values}
+            if any(str(target).strip() not in normalized for target in targets):
+                return PermissionResult.ASK, f"'{action}' target is not allow-listed"
+
+    return PermissionResult.ALLOW, "Request policy allows all operations"
 
 
 def _check_agent_permission(

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -161,15 +161,35 @@ def _find_git_push_args(command: str) -> list[str] | None:
                 end += 1
             return tokens[cursor + 1 : end]
 
-    for token in tokens:
-        if (
-            token != command
-            and "git" in token
-            and any(char.isspace() for char in token)
-        ):
-            nested_args = _find_git_push_args(token)
-            if nested_args is not None:
-                return nested_args
+    shell_executables = {"bash", "dash", "ksh", "sh", "zsh"}
+    shell_options_with_value = {"-O", "+O", "--init-file", "--rcfile"}
+    for index, token in enumerate(tokens):
+        if Path(token).name not in shell_executables:
+            continue
+
+        cursor = index + 1
+        while cursor < len(tokens):
+            option = tokens[cursor]
+            if (
+                option in separators
+                or option == "--"
+                or not option.startswith(("-", "+"))
+            ):
+                break
+            if option in shell_options_with_value:
+                cursor += 2
+                continue
+            if (
+                option.startswith("-")
+                and not option.startswith("--")
+                and "c" in option[1:]
+            ):
+                if cursor + 1 < len(tokens):
+                    nested_args = _find_git_push_args(tokens[cursor + 1])
+                    if nested_args is not None:
+                        return nested_args
+                break
+            cursor += 1
     return None
 
 

--- a/penguin/system/execution_context.py
+++ b/penguin/system/execution_context.py
@@ -26,6 +26,8 @@ class ExecutionContext:
     project_root: Optional[str] = None
     workspace_root: Optional[str] = None
     request_id: Optional[str] = None
+    permission_mode: Optional[str] = None
+    approval_policy: Optional[dict[str, Any]] = None
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation for compatibility with existing APIs."""
@@ -38,6 +40,8 @@ class ExecutionContext:
             "project_root": self.project_root,
             "workspace_root": self.workspace_root,
             "request_id": self.request_id,
+            "permission_mode": self.permission_mode,
+            "approval_policy": self.approval_policy,
         }
 
 

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NoReturn, Optional
+from typing import Any, Dict, List, Literal, NoReturn, Optional
 from fastapi import (
     APIRouter,
     Depends,
@@ -553,6 +553,8 @@ def _build_execution_context(
     agent_id: Optional[str],
     agent_mode: Optional[str],
     directory: Optional[str],
+    permission_mode: Optional[str] = None,
+    approval_policy: Optional[Dict[str, Any]] = None,
 ) -> ExecutionContext:
     """Create request-scoped execution context for concurrent web sessions."""
     path_info = get_path_info(core, directory=directory, session_id=session_id)
@@ -566,6 +568,8 @@ def _build_execution_context(
         project_root=effective_directory,
         workspace_root=effective_directory,
         request_id=str(uuid.uuid4()),
+        permission_mode=permission_mode,
+        approval_policy=approval_policy,
     )
 
 
@@ -1050,6 +1054,8 @@ class MessageRequest(BaseModel):
     external_subscription_execution: Optional[ExternalSubscriptionExecutionRequest] = (
         None
     )
+    permission_mode: Optional[Literal["read_only", "workspace", "full_access"]] = None
+    approval_policy: Optional[Dict[str, Any]] = None
 
 
 _REASONING_EFFORT_VARIANTS = {
@@ -3989,6 +3995,20 @@ async def handle_chat_message(
                 detail="Link execution requires an authenticated HTTP request.",
             )
         authenticate_link_service_request(http_request)
+    if (
+        request.permission_mode is not None or request.approval_policy is not None
+    ) and not has_link_execution_authority:
+        raise HTTPException(
+            status_code=403,
+            detail="Runtime permission overrides require Link execution authority.",
+        )
+    if (
+        request.permission_mode is not None or request.approval_policy is not None
+    ) and os.environ.get("PENGUIN_YOLO", "").lower() in {"1", "true", "yes"}:
+        raise HTTPException(
+            status_code=503,
+            detail="Runtime permission enforcement is disabled by PENGUIN_YOLO.",
+        )
 
     temp_image_files: List[str] = []
     request_session_id: Optional[str] = None
@@ -4118,6 +4138,8 @@ async def handle_chat_message(
             agent_id=request.agent_id,
             agent_mode=resolved_agent_mode,
             directory=bound_directory or request.directory,
+            permission_mode=request.permission_mode,
+            approval_policy=request.approval_policy,
         )
         _request_log_debug(
             "chat.trace.start request=%s session=%s agent=%s mode=%s dir=%s model=%s streaming=%s client_msg=%s prompt=%r",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "penguin-ai"
 version = "0.9.1"
 description = "Penguin: A modular, extensible AI coding agent and software engineer with its own execution environment."
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 authors = [
   { name="Maximus Putnam", email="MaximusPutnam@gmail.com" },
 ]
@@ -21,7 +21,6 @@ keywords = ["ai", "agent", "ai-agent", "llm", "llm-agent", "assistant", "cogniti
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/api/test_opencode_provider_routes.py
+++ b/tests/api/test_opencode_provider_routes.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
+from penguin.system.execution_context import get_current_execution_context
 from penguin.web import routes as routes_module
 from penguin.web.routes import (
     MessageRequest,
@@ -315,6 +316,7 @@ async def test_chat_message_resolves_subscription_model_through_openai(
 ) -> None:
     monkeypatch.setenv("LINK_API_KEY", "link-service-secret")
     resolved_models: list[str | None] = []
+    observed_permission_contexts: list[dict[str, Any]] = []
 
     class _SubscriptionCore(_Core):
         async def resolve_request_runtime(
@@ -327,6 +329,9 @@ async def test_chat_message_resolves_subscription_model_through_openai(
             )
 
         async def process(self, **_kwargs: Any) -> dict[str, Any]:
+            execution_context = get_current_execution_context()
+            assert execution_context is not None
+            observed_permission_contexts.append(execution_context.as_dict())
             return {
                 "assistant_response": "hello from the subscription",
                 "action_results": [],
@@ -358,6 +363,16 @@ async def test_chat_message_resolves_subscription_model_through_openai(
             "integration_support": "ecosystem_compatible",
             "allow_fallback_to_link_gateway": False,
         },
+        permission_mode="read_only",
+        approval_policy={
+            "shell": "deny",
+            "fileWrite": "deny",
+            "fileDelete": "deny",
+            "gitPush": "deny",
+            "network": "deny",
+            "secrets": "deny",
+            "allowLists": {},
+        },
     )
 
     response = await handle_chat_message(
@@ -368,6 +383,17 @@ async def test_chat_message_resolves_subscription_model_through_openai(
 
     assert response["response"] == "hello from the subscription"
     assert resolved_models == ["openai/gpt-5.6-luna"]
+    assert len(observed_permission_contexts) == 1
+    assert observed_permission_contexts[0]["permission_mode"] == "read_only"
+    assert observed_permission_contexts[0]["approval_policy"] == {
+        "shell": "deny",
+        "fileWrite": "deny",
+        "fileDelete": "deny",
+        "gitPush": "deny",
+        "network": "deny",
+        "secrets": "deny",
+        "allowLists": {},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_link_provider.py
+++ b/tests/llm/test_link_provider.py
@@ -454,7 +454,7 @@ async def test_stream_http_error_reads_link_error_body_before_reporting() -> Non
     provider = _provider(handler)
     with pytest.raises(
         LLMProviderError,
-        match="The selected model rejected this request.",
+        match=r"The selected model rejected this request\.",
     ) as raised:
         await provider.get_response(
             [{"role": "user", "content": "hi"}],

--- a/tests/test_link_runtime_permission_policy.py
+++ b/tests/test_link_runtime_permission_policy.py
@@ -331,6 +331,33 @@ def test_link_git_push_classifier_uses_the_git_subcommand(tmp_path: Path) -> Non
     assert result == PermissionResult.ALLOW
 
 
+def test_link_git_push_classifier_ignores_quoted_data(tmp_path: Path) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    for command in (
+        "git commit -m 'do not git push yet'",
+        "git grep 'git push'",
+        "git config example.value 'documentation for git push'",
+        "git config alias.deploy 'git push origin main'",
+        "echo 'git push origin main'",
+        "bash --norc 'git push origin main'",
+    ):
+        result, _reason = check_tool_permission(
+            "execute_command",
+            {"command": command},
+            _enforcer(tmp_path),
+            context,
+        )
+
+        assert result == PermissionResult.ALLOW, command
+
+
 def test_link_git_push_deny_covers_nested_and_persistent_shells(
     tmp_path: Path,
 ) -> None:
@@ -343,7 +370,13 @@ def test_link_git_push_deny_covers_nested_and_persistent_shells(
     }
 
     for tool_name, tool_input in (
+        ("execute_command", {"command": "sh -c 'git push origin main'"}),
         ("execute_command", {"command": "bash -c 'git push origin main'"}),
+        (
+            "execute_command",
+            {"command": "bash --noprofile -lc 'git push origin main'"},
+        ),
+        ("execute_command", {"command": "zsh -lc 'git push origin main'"}),
         ("process_start", {"command": "git push origin main"}),
         ("process_write_stdin", {"process_id": "proc-1", "text": "git push\n"}),
     ):

--- a/tests/test_link_runtime_permission_policy.py
+++ b/tests/test_link_runtime_permission_policy.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from penguin.security.permission_engine import (
+    PermissionEnforcer,
+    PermissionMode,
+    PermissionResult,
+)
+from penguin.security.policies.workspace import WorkspaceBoundaryPolicy
+from penguin.security.tool_permissions import check_tool_permission
+
+
+def _enforcer(root: Path) -> PermissionEnforcer:
+    enforcer = PermissionEnforcer(mode=PermissionMode.WORKSPACE)
+    enforcer.add_policy(
+        WorkspaceBoundaryPolicy(
+            workspace_root=root,
+            project_root=root,
+            mode=PermissionMode.WORKSPACE,
+        )
+    )
+    return enforcer
+
+
+def _policy(decision: str) -> dict:
+    return {
+        "shell": decision,
+        "fileWrite": decision,
+        "fileDelete": decision,
+        "gitPush": decision,
+        "network": decision,
+        "secrets": decision,
+        "allowLists": {},
+    }
+
+
+def test_link_read_only_turn_denies_file_writes(tmp_path: Path) -> None:
+    result, _reason = check_tool_permission(
+        "write_file",
+        {"path": str(tmp_path / "blocked.txt")},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "read_only",
+            "approval_policy": _policy("deny"),
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.DENY
+
+
+def test_link_workspace_turn_preserves_ask_decisions(tmp_path: Path) -> None:
+    result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "pnpm test"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": _policy("ask"),
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.ASK
+
+
+def test_link_full_access_turn_can_relax_workspace_runtime_mode(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-link-policy.txt"
+    result, _reason = check_tool_permission(
+        "write_file",
+        {"path": str(outside)},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "full_access",
+            "approval_policy": _policy("allow"),
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.ALLOW

--- a/tests/test_link_runtime_permission_policy.py
+++ b/tests/test_link_runtime_permission_policy.py
@@ -21,15 +21,21 @@ def _enforcer(root: Path) -> PermissionEnforcer:
     return enforcer
 
 
-def _policy(decision: str) -> dict:
+def _policy(
+    decision: str,
+    *,
+    permission_mode: str = "workspace",
+    allow_lists: dict[str, list[str]] | None = None,
+) -> dict:
     return {
+        "permissionMode": permission_mode,
         "shell": decision,
         "fileWrite": decision,
         "fileDelete": decision,
         "gitPush": decision,
         "network": decision,
         "secrets": decision,
-        "allowLists": {},
+        "allowLists": allow_lists or {},
     }
 
 
@@ -77,3 +83,329 @@ def test_link_full_access_turn_can_relax_workspace_runtime_mode(tmp_path: Path) 
     )
 
     assert result == PermissionResult.ALLOW
+
+
+def test_link_shell_deny_covers_persistent_process_tools(tmp_path: Path) -> None:
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": _policy("deny"),
+        "directory": str(tmp_path),
+    }
+
+    for tool_name, tool_input in (
+        ("process_start", {"command": "pnpm dev"}),
+        ("process_write_stdin", {"process_id": "proc-1", "text": "yes\n"}),
+        ("process_stop", {"process_id": "proc-1"}),
+    ):
+        result, _reason = check_tool_permission(
+            tool_name,
+            tool_input,
+            _enforcer(tmp_path),
+            context,
+        )
+
+        assert result == PermissionResult.DENY
+
+
+def test_link_process_poll_remains_read_only_when_shell_is_denied(
+    tmp_path: Path,
+) -> None:
+    result, _reason = check_tool_permission(
+        "process_poll",
+        {"process_id": "proc-1"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": _policy("deny"),
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.ALLOW
+
+
+def test_link_approve_safe_actions_allows_matching_shell_pattern(
+    tmp_path: Path,
+) -> None:
+    policy = _policy(
+        "ask",
+        permission_mode="approve_safe_actions",
+        allow_lists={"shellCommands": ["pnpm test --filter *"]},
+    )
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    allowed, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "pnpm test --filter unit"},
+        _enforcer(tmp_path),
+        context,
+    )
+    unmatched, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "pnpm build"},
+        _enforcer(tmp_path),
+        context,
+    )
+
+    assert allowed == PermissionResult.ALLOW
+    assert unmatched == PermissionResult.ASK
+
+
+def test_link_shell_patterns_do_not_span_shell_control_operators(
+    tmp_path: Path,
+) -> None:
+    policy = _policy(
+        "ask",
+        permission_mode="approve_safe_actions",
+        allow_lists={"shellCommands": ["pnpm test *"]},
+    )
+
+    result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "pnpm test unit && rm -rf build"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": policy,
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.ASK
+
+
+def test_link_custom_policy_matches_relative_writable_paths(tmp_path: Path) -> None:
+    policy = _policy(
+        "ask",
+        permission_mode="custom",
+        allow_lists={"writablePaths": ["src"]},
+    )
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    allowed, _reason = check_tool_permission(
+        "write_file",
+        {"path": str(tmp_path / "src" / "app.py")},
+        _enforcer(tmp_path),
+        context,
+    )
+    unmatched, _reason = check_tool_permission(
+        "write_file",
+        {"path": str(tmp_path / "secrets.txt")},
+        _enforcer(tmp_path),
+        context,
+    )
+
+    assert allowed == PermissionResult.ALLOW
+    assert unmatched == PermissionResult.ASK
+
+
+def test_link_custom_policy_matches_network_hosts_not_full_urls(
+    tmp_path: Path,
+) -> None:
+    policy = _policy(
+        "ask",
+        permission_mode="custom",
+        allow_lists={"networkHosts": ["api.github.com", "*.example.com"]},
+    )
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    exact, _reason = check_tool_permission(
+        "browser_navigate",
+        {"url": "https://api.github.com/repos/Maximooch/penguin"},
+        _enforcer(tmp_path),
+        context,
+    )
+    wildcard, _reason = check_tool_permission(
+        "browser_navigate",
+        {"url": "https://docs.example.com/guide"},
+        _enforcer(tmp_path),
+        context,
+    )
+    unmatched, _reason = check_tool_permission(
+        "browser_navigate",
+        {"url": "https://example.net"},
+        _enforcer(tmp_path),
+        context,
+    )
+
+    assert exact == PermissionResult.ALLOW
+    assert wildcard == PermissionResult.ALLOW
+    assert unmatched == PermissionResult.ASK
+
+
+def test_link_git_push_deny_cannot_be_bypassed_through_shell(
+    tmp_path: Path,
+) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+
+    result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git push origin main"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": policy,
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.DENY
+
+
+def test_link_git_push_deny_dominates_shell_approval(
+    tmp_path: Path,
+) -> None:
+    policy = _policy("ask")
+    policy["gitPush"] = "deny"
+
+    result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git push origin main"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": policy,
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.DENY
+
+
+def test_link_git_push_deny_covers_nested_and_persistent_shells(
+    tmp_path: Path,
+) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    for tool_name, tool_input in (
+        ("execute_command", {"command": "bash -c 'git push origin main'"}),
+        ("process_start", {"command": "git push origin main"}),
+        ("process_write_stdin", {"process_id": "proc-1", "text": "git push\n"}),
+    ):
+        result, _reason = check_tool_permission(
+            tool_name,
+            tool_input,
+            _enforcer(tmp_path),
+            context,
+        )
+
+        assert result == PermissionResult.DENY
+
+
+def test_link_force_push_is_classified_as_git_push(tmp_path: Path) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+
+    for command in (
+        "git push --force origin main",
+        "git push origin +main",
+    ):
+        result, _reason = check_tool_permission(
+            "execute_command",
+            {"command": command},
+            _enforcer(tmp_path),
+            {
+                "permission_mode": "workspace",
+                "approval_policy": policy,
+                "directory": str(tmp_path),
+            },
+        )
+
+        assert result == PermissionResult.DENY
+
+
+def test_link_custom_policy_matches_git_remote_identity(tmp_path: Path) -> None:
+    policy = _policy(
+        "allow",
+        permission_mode="custom",
+        allow_lists={"gitRemotes": ["origin"]},
+    )
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    allowed, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git push origin main"},
+        _enforcer(tmp_path),
+        context,
+    )
+    unmatched, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git push upstream main"},
+        _enforcer(tmp_path),
+        context,
+    )
+
+    assert allowed == PermissionResult.ALLOW
+    assert unmatched == PermissionResult.ASK
+
+
+def test_link_custom_policy_normalizes_git_remote_urls(tmp_path: Path) -> None:
+    policy = _policy(
+        "ask",
+        permission_mode="custom",
+        allow_lists={
+            "gitRemotes": ["https://github.com/Maximooch/penguin.git"],
+            "shellCommands": ["git push --repo=git@github.com:Maximooch/penguin main"],
+        },
+    )
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    shell_result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git push --repo=git@github.com:Maximooch/penguin main"},
+        _enforcer(tmp_path),
+        context,
+    )
+    dedicated_result, _reason = check_tool_permission(
+        "git_push",
+        {"remote_url": "ssh://git@github.com/Maximooch/penguin"},
+        _enforcer(tmp_path),
+        context,
+    )
+
+    assert shell_result == PermissionResult.ALLOW
+    assert dedicated_result == PermissionResult.ALLOW
+
+
+def test_link_unknown_tool_fails_closed_when_request_policy_is_present(
+    tmp_path: Path,
+) -> None:
+    result, _reason = check_tool_permission(
+        "unclassified_mutating_tool",
+        {},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": _policy("allow"),
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.DENY

--- a/tests/test_link_runtime_permission_policy.py
+++ b/tests/test_link_runtime_permission_policy.py
@@ -285,6 +285,52 @@ def test_link_git_push_deny_dominates_shell_approval(
     assert result == PermissionResult.DENY
 
 
+def test_link_git_push_deny_handles_git_global_options(tmp_path: Path) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+    context = {
+        "permission_mode": "workspace",
+        "approval_policy": policy,
+        "directory": str(tmp_path),
+    }
+
+    for command in (
+        "git --no-pager push origin main",
+        "git -P push origin main",
+        "git --no-optional-locks push origin main",
+        "git --literal-pathspecs push origin main",
+        "git --config-env=http.extraHeader=HDR push origin main",
+        "git --git-dir .git push origin main",
+        "git -c core.askPass=true push origin main",
+    ):
+        result, _reason = check_tool_permission(
+            "execute_command",
+            {"command": command},
+            _enforcer(tmp_path),
+            context,
+        )
+
+        assert result == PermissionResult.DENY, command
+
+
+def test_link_git_push_classifier_uses_the_git_subcommand(tmp_path: Path) -> None:
+    policy = _policy("allow")
+    policy["gitPush"] = "deny"
+
+    result, _reason = check_tool_permission(
+        "execute_command",
+        {"command": "git config alias.example push"},
+        _enforcer(tmp_path),
+        {
+            "permission_mode": "workspace",
+            "approval_policy": policy,
+            "directory": str(tmp_path),
+        },
+    )
+
+    assert result == PermissionResult.ALLOW
+
+
 def test_link_git_push_deny_covers_nested_and_persistent_shells(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_permission_engine.py
+++ b/tests/test_permission_engine.py
@@ -58,6 +58,7 @@ class TestPermissionEnums:
         assert Operation.is_read_only(Operation.FILESYSTEM_READ) is True
         assert Operation.is_read_only(Operation.FILESYSTEM_LIST) is True
         assert Operation.is_read_only(Operation.MEMORY_READ) is True
+        assert Operation.is_read_only(Operation.PROCESS_INSPECT) is True
         assert Operation.is_read_only(Operation.FILESYSTEM_WRITE) is False
         assert Operation.is_read_only(Operation.PROCESS_EXECUTE) is False
 


### PR DESCRIPTION
## What changed

- accept Link's authenticated per-turn permission mode and effective approval-policy snapshot
- store the policy in request-scoped execution context rather than mutable global state
- enforce read-only, workspace, and full-access modes in Penguin's workspace and tool permission layers
- require approval for unknown or unclassified tools when a Link policy is present
- reject permission-bearing Link turns when `PENGUIN_YOLO` has disabled enforcement
- verify the authenticated request model carries the policy into the execution context
- run the runtime-permission contract in CI under Pydantic 1 and 2
- move Penguin's supported Python floor and CI matrix from EOL Python 3.9 to Python 3.10

## Why

Link's composer permission selector previously changed local UI state without changing runtime authority. Penguin must enforce the server-resolved policy for the control to be truthful and safe.

## Impact

Authenticated Link turns can narrow runtime authority per request. Workspace policy remains authoritative, and legacy non-Link callers retain their existing behavior. Python 3.9 is no longer advertised, tested, or accepted by package metadata.

## Validation

- Python 3.12 + Pydantic 2 Link provider/authority contracts: 58 passed
- Python 3.10 + Pydantic 1 Link provider/authority contracts: 58 passed
- Python 3.10 + Pydantic 1 goal/Engine/API contracts: 273 passed
- focused Ruff check and format check passed
- `git diff --check`

Companion Link policy resolution, transport, auditing, and composer wiring: https://github.com/Maximooch/Link/pull/273

These PRs must be merged/deployed together so the UI and Link backend cannot advertise controls against an older Penguin runtime that ignores them.
