### PR TITLE
refactor(cli): extract startup and dispatch boundaries

### DIFF
--- a/penguin/cli/bootstrap.py
+++ b/penguin/cli/bootstrap.py
@@ -1,0 +1,141 @@
+"""Dependency composition for the Python CLI."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from penguin.cli.environment import set_cli_workspace_path
+from penguin.cli.interface import PenguinInterface
+from penguin.cli.model_runtime import build_cli_model_config
+from penguin.config import Config, WORKSPACE_PATH, _ensure_env_loaded
+from penguin.core import PenguinCore
+from penguin.llm.api_client import APIClient
+from penguin.llm.model_config import ModelConfig
+from penguin.system_prompt import SYSTEM_PROMPT
+from penguin.tools import ToolManager
+from penguin.utils.log_error import log_error
+
+__all__ = ["BootstrapDependencies", "BootstrapResult", "bootstrap_cli"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    """Fully constructed CLI dependencies, safe to publish atomically."""
+
+    core: PenguinCore
+    interface: PenguinInterface
+    model_config: ModelConfig
+    api_client: APIClient
+    tool_manager: ToolManager
+    loaded_config: Config
+    workspace: Path
+
+
+@dataclass(frozen=True)
+class BootstrapDependencies:
+    """Injectable factories for deterministic startup tests."""
+
+    config_loader: Callable[[], Config] = Config.load_config
+    api_client_factory: Callable[..., APIClient] = APIClient
+    tool_manager_factory: Callable[..., ToolManager] = ToolManager
+    core_factory: Callable[..., PenguinCore] = PenguinCore
+    interface_factory: Callable[[PenguinCore], PenguinInterface] = PenguinInterface
+    env_loader: Callable[[], None] = _ensure_env_loaded
+
+
+class _ConfigWrapper:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._data.setdefault("diagnostics", {"enabled": False})
+
+    def __getattr__(self, name: str) -> Any:
+        if name not in self._data:
+            raise AttributeError(name)
+        value = self._data[name]
+        return _ConfigWrapper(value) if isinstance(value, dict) else value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._data.get(key, default)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+
+def _compatible_config(config: Any) -> Any:
+    return _ConfigWrapper(config) if isinstance(config, dict) else config
+
+
+def bootstrap_cli(
+    *,
+    model_override: str | None = None,
+    workspace_override: Path | None = None,
+    no_streaming_override: bool = False,
+    fast_startup_override: bool = False,
+    dependencies: BootstrapDependencies | None = None,
+) -> BootstrapResult:
+    """Construct CLI dependencies without mutating compatibility globals."""
+
+    deps = dependencies or BootstrapDependencies()
+    started_at = time.monotonic()
+    workspace_source = workspace_override or os.environ.get("PENGUIN_WORKSPACE")
+    if workspace_source:
+        set_cli_workspace_path(workspace_source)
+
+    loaded_config = deps.config_loader()
+    workspace = (
+        Path(
+            workspace_override
+            or os.environ.get("PENGUIN_WORKSPACE")
+            or getattr(loaded_config, "workspace_path", WORKSPACE_PATH)
+        )
+        .expanduser()
+        .resolve()
+    )
+    source_model = loaded_config.model_config
+    model_config = build_cli_model_config(
+        loaded_config,
+        model_override=model_override,
+        streaming_enabled=(
+            False if no_streaming_override else source_model.streaming_enabled
+        ),
+    )
+
+    deps.env_loader()
+    api_client = deps.api_client_factory(model_config=model_config)
+    api_client.set_system_prompt(SYSTEM_PROMPT)
+    config_dict = (
+        loaded_config.to_dict()
+        if hasattr(loaded_config, "to_dict")
+        else getattr(loaded_config, "__dict__", loaded_config)
+    )
+    tool_manager = deps.tool_manager_factory(
+        config_dict,
+        log_error,
+        fast_startup=(
+            fast_startup_override or bool(getattr(loaded_config, "fast_startup", False))
+        ),
+    )
+    core = deps.core_factory(
+        config=_compatible_config(loaded_config),
+        api_client=api_client,
+        tool_manager=tool_manager,
+        model_config=model_config,
+    )
+    interface = deps.interface_factory(core)
+    logger.info("CLI dependencies constructed in %.2fs", time.monotonic() - started_at)
+    return BootstrapResult(
+        core=core,
+        interface=interface,
+        model_config=model_config,
+        api_client=api_client,
+        tool_manager=tool_manager,
+        loaded_config=loaded_config,
+        workspace=workspace,
+    )

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -223,7 +223,16 @@ else:
     from prompt_toolkit.formatted_text import HTML  # type: ignore
 
 from penguin._version import __version__
+from penguin.cli.bootstrap import bootstrap_cli
+from penguin.cli.environment import (
+    preconfigure_cli_environment,
+    set_cli_workspace_path,
+)
 from penguin.cli.interface import PenguinInterface
+from penguin.cli.model_runtime import (
+    project_reasoning_config as _project_reasoning_config,
+    resolve_reasoning_config as _resolve_cli_reasoning_config,
+)
 from penguin.config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -425,68 +434,6 @@ def _ensure_config_compatible(config_data: Any) -> Any:
     return config_data
 
 
-def _project_reasoning_config(model_config: ModelConfig) -> dict[str, Any]:
-    """Project reasoning fields without converting implicit state to explicit off."""
-
-    reasoning_enabled_explicit = bool(
-        getattr(model_config, "_reasoning_enabled_explicit", False)
-    )
-    reasoning_effort_explicit = bool(
-        getattr(model_config, "_reasoning_effort_explicit", False)
-    )
-    return {
-        "reasoning_enabled": (
-            model_config.reasoning_enabled
-            if reasoning_enabled_explicit
-            else None
-        ),
-        "reasoning_effort": (
-            model_config.reasoning_effort if reasoning_effort_explicit else None
-        ),
-        "reasoning_max_tokens": (
-            model_config.reasoning_max_tokens
-            if reasoning_enabled_explicit
-            else None
-        ),
-        "reasoning_exclude": model_config.reasoning_exclude,
-        "supports_reasoning": model_config.supports_reasoning,
-        "supported_reasoning_levels": model_config.supported_reasoning_levels,
-    }
-
-
-def _resolve_cli_reasoning_config(model_dict: dict[str, Any]) -> dict[str, Any]:
-    """Resolve flat or nested CLI reasoning configuration without inventing values."""
-
-    nested = model_dict.get("reasoning")
-    reasoning = nested if isinstance(nested, dict) else {}
-    if "enabled" in reasoning:
-        reasoning_enabled: bool | None = bool(reasoning.get("enabled"))
-    elif "reasoning_enabled" in model_dict:
-        configured_enabled = model_dict.get("reasoning_enabled")
-        reasoning_enabled = (
-            None if configured_enabled is None else bool(configured_enabled)
-        )
-    else:
-        reasoning_enabled = None
-    reasoning_effort = reasoning.get(
-        "effort", model_dict.get("reasoning_effort")
-    )
-    return {
-        "reasoning_enabled": reasoning_enabled,
-        "reasoning_effort": reasoning_effort,
-        "reasoning_max_tokens": reasoning.get(
-            "max_tokens", model_dict.get("reasoning_max_tokens")
-        ),
-        "reasoning_exclude": bool(
-            reasoning.get("exclude", model_dict.get("reasoning_exclude", False))
-        ),
-        "supports_reasoning": model_dict.get("supports_reasoning"),
-        "supported_reasoning_levels": model_dict.get(
-            "supported_reasoning_levels"
-        ),
-    }
-
-
 async def _initialize_core_components_globally(
     model_override: Optional[str] = None,
     workspace_override: Optional[Path] = None,
@@ -502,177 +449,21 @@ async def _initialize_core_components_globally(
         # For now, first initialization is sticky for simplicity.
         return
 
-    logger.info("Initializing core components globally...")
-    init_start_time = time.time()
-
-    workspace_source = workspace_override or os.environ.get("PENGUIN_WORKSPACE")
-    if workspace_source:
-        _set_cli_workspace_path(workspace_source)
-
-    _loaded_config = Config.load_config()  # Use Config object with parsed agent_personas
-
-    effective_workspace = Path(
-        workspace_override or os.environ.get("PENGUIN_WORKSPACE", str(WORKSPACE_PATH))
-    ).expanduser().resolve()
-    logger.debug(f"Effective workspace path for global init: {effective_workspace}")
-    # Note: PenguinCore itself uses WORKSPACE_PATH from config for ProjectManager.
-    # A more direct way to override this in Core would be needed if ProjectManager path needs to change.
-
-    # Access _loaded_config as a dictionary or using property access
-    streaming_enabled = not no_streaming_override
-
-    # Try both attribute-style and dict-style access to handle different Config implementations
-    if hasattr(_loaded_config, "model") and callable(
-        getattr(_loaded_config, "model", None)
-    ):
-        # Config.model() returns a dict-like object
-        model_dict = _loaded_config.model()
-        streaming_enabled = not no_streaming_override and model_dict.get(
-            "streaming_enabled", True
-        )
-    elif hasattr(_loaded_config, "model") and not callable(
-        getattr(_loaded_config, "model", None)
-    ):
-        # Config.model is a property that returns a dict-like object
-        model_dict = _loaded_config.model
-        streaming_enabled = not no_streaming_override and model_dict.get(
-            "streaming_enabled", True
-        )
-    elif isinstance(_loaded_config, dict) and "model" in _loaded_config:
-        # _loaded_config is a dict with a model key
-        streaming_enabled = not no_streaming_override and _loaded_config["model"].get(
-            "streaming_enabled", True
-        )
-
-    # Create ModelConfig with safe access
-    # Check for Config dataclass FIRST (before generic model checks)
-    if hasattr(_loaded_config, "model_config"):
-        # It's a Config dataclass object (from Config.load_config())
-        _model_cfg = _loaded_config.model_config
-        if _model_cfg:
-            model_dict = {
-                "default": getattr(_model_cfg, "model", None),
-                "provider": getattr(_model_cfg, "provider", None),
-                "client_preference": getattr(_model_cfg, "client_preference", None),
-                "streaming_enabled": getattr(_model_cfg, "streaming_enabled", True),
-                "temperature": getattr(_model_cfg, "temperature", 0.7),
-                "vision_enabled": getattr(_model_cfg, "vision_enabled", False),
-                "max_output_tokens": getattr(_model_cfg, "max_output_tokens", None),
-                "context_window": getattr(_model_cfg, "max_context_window_tokens", None),
-                **_project_reasoning_config(_model_cfg),
-            }
-        else:
-            model_dict = {}
-        api_obj = getattr(_loaded_config, "api", None)
-        api_base = getattr(api_obj, "base_url", None) if api_obj else None
-    elif hasattr(_loaded_config, "model") and callable(
-        getattr(_loaded_config, "model", None)
-    ):
-        # Model is a method that returns a dict-like object
-        model_dict = _loaded_config.model()
-        api_dict = getattr(_loaded_config, "api", {})
-        if isinstance(api_dict, dict):
-            api_base = api_dict.get("base_url")
-        else:
-            api_base = getattr(api_dict, "base_url", None)
-    elif hasattr(_loaded_config, "model") and not callable(
-        getattr(_loaded_config, "model", None)
-    ):
-        # Model is a property that returns a dict-like object
-        model_dict = _loaded_config.model
-        api_dict = getattr(_loaded_config, "api", {})
-        if isinstance(api_dict, dict):
-            api_base = api_dict.get("base_url")
-        else:
-            api_base = getattr(api_dict, "base_url", None)
-    elif isinstance(_loaded_config, dict):
-        # Direct dictionary access
-        model_dict = _loaded_config.get("model", {})
-        api_dict = _loaded_config.get("api", {})
-        api_base = api_dict.get("base_url") if isinstance(api_dict, dict) else None
-    else:
-        # Fallback for unknown config type
-        model_dict = {}
-        api_base = None
-
-    reasoning_config = _resolve_cli_reasoning_config(model_dict)
-    _model_config = ModelConfig(
-        model=model_override or model_dict.get("default", DEFAULT_MODEL),
-        provider=model_dict.get("provider", DEFAULT_PROVIDER),
-        api_base=api_base,  # Use the api_base we determined above
-        client_preference=model_dict.get("client_preference", "openrouter"),
-        streaming_enabled=streaming_enabled,
-        vision_enabled=model_dict.get("vision_enabled", False),
-        max_output_tokens=model_dict.get(
-            "max_output_tokens", model_dict.get("max_tokens", 8000)
-        ),
-        max_context_window_tokens=model_dict.get(
-            "max_context_window_tokens",
-            model_dict.get("context_window"),
-        ),
-        temperature=model_dict.get("temperature", 0.7),
-        reasoning_enabled=reasoning_config["reasoning_enabled"],
-        reasoning_effort=reasoning_config["reasoning_effort"],
-        reasoning_max_tokens=reasoning_config["reasoning_max_tokens"],
-        reasoning_exclude=reasoning_config["reasoning_exclude"],
-        supports_reasoning=reasoning_config["supports_reasoning"],
-        supported_reasoning_levels=reasoning_config[
-            "supported_reasoning_levels"
-        ],
-        service_tier=model_dict.get("service_tier"),
+    result = bootstrap_cli(
+        model_override=model_override,
+        workspace_override=workspace_override,
+        no_streaming_override=no_streaming_override,
+        fast_startup_override=fast_startup_override,
     )
+    _core = result.core
+    _interface = result.interface
+    _model_config = result.model_config
+    _api_client = result.api_client
+    _tool_manager = result.tool_manager
+    _loaded_config = result.loaded_config
 
-    # Ensure .env files are loaded before API client needs API keys
-    _ensure_env_loaded()
-    _api_client = APIClient(model_config=_model_config)
-    _api_client.set_system_prompt(SYSTEM_PROMPT)
-
-    # Determine fast startup setting from config or override
-    config_fast_startup = False
-    try:
-        if hasattr(_loaded_config, "fast_startup"):
-            config_fast_startup = _loaded_config.fast_startup
-        elif isinstance(_loaded_config, dict):
-            config_fast_startup = _loaded_config.get("performance", {}).get(
-                "fast_startup", False
-            )
-    except Exception:
-        pass
-
-    effective_fast_startup = fast_startup_override or config_fast_startup
-
-    # Convert config to dict format for ToolManager while preserving typed fields
-    # like `skills` that are not present in a raw dataclass `__dict__` shape.
-    config_dict = (
-        _loaded_config.to_dict()
-        if hasattr(_loaded_config, "to_dict")
-        else (_loaded_config.__dict__ if hasattr(_loaded_config, "__dict__") else _loaded_config)
-    )
-    _tool_manager = ToolManager(
-        config_dict, log_error, fast_startup=effective_fast_startup
-    )
-
-    # Make sure our config is compatible with what PenguinCore expects
-    wrapped_config = _ensure_config_compatible(_loaded_config)
-
-    # PenguinCore's __init__ will use its passed config to set up ProjectManager with WORKSPACE_PATH
-    _core = PenguinCore(
-        config=wrapped_config,
-        api_client=_api_client,
-        tool_manager=_tool_manager,
-        model_config=_model_config,
-    )
-    # If workspace_override needs to directly influence PenguinCore's ProjectManager path,
-    # PenguinCore would need to accept a workspace_path argument or have a setter.
-
-    _interface = PenguinInterface(_core)
-
-    # Set core on command registry for unified command handling
+    # Publish compatibility state only after every dependency was constructed.
     _command_registry.set_core(_core)
-
-    logger.info(
-        f"Core components initialized globally in {time.time() - init_start_time:.2f}s"
-    )
 
 
 async def _run_penguin_direct_prompt(prompt_text: str, output_format: str):
@@ -1110,21 +901,10 @@ _previous_main_callback = app.registered_callback
 
 
 def _set_cli_workspace_path(workspace_path: Union[str, Path]) -> Path:
-    """Normalize and propagate a CLI workspace override before core initialization."""
+    """Compatibility wrapper for extracted workspace normalization."""
     global WORKSPACE_PATH
-
-    resolved_workspace = Path(workspace_path).expanduser().resolve()
-    os.environ["PENGUIN_WORKSPACE"] = str(resolved_workspace)
+    resolved_workspace = set_cli_workspace_path(workspace_path)
     WORKSPACE_PATH = resolved_workspace
-
-    try:
-        import importlib
-
-        config_module = importlib.import_module("penguin.config")
-        config_module.WORKSPACE_PATH = resolved_workspace
-    except Exception:
-        logger.debug("Unable to sync workspace override into penguin.config", exc_info=True)
-
     return resolved_workspace
 
 
@@ -1133,45 +913,16 @@ def _preconfigure_cli_environment(
     project: Optional[str],
     root: Optional[str],
 ) -> Tuple[Optional[Path], Path]:
-    """Normalize root/workspace env hints before config- and core-level initialization."""
-    workspace_source: Union[str, Path] = workspace or os.environ.get(
-        "PENGUIN_WORKSPACE", WORKSPACE_PATH
+    """Compatibility wrapper for extracted environment normalization."""
+    global WORKSPACE_PATH
+    result = preconfigure_cli_environment(
+        workspace,
+        project,
+        root,
+        default_workspace=WORKSPACE_PATH,
     )
-    resolved_workspace = _set_cli_workspace_path(workspace_source)
-
-    current_cwd = Path.cwd().resolve()
-    os.environ["PENGUIN_CWD"] = str(current_cwd)
-    os.environ.pop("PENGUIN_PROJECT_ROOT", None)
-
-    resolved_project_path: Optional[Path] = None
-    if project:
-        candidates = []
-        try:
-            candidates.append(Path(project).expanduser())
-        except Exception:
-            pass
-        candidates.append(resolved_workspace / "projects" / project)
-
-        for candidate in candidates:
-            try:
-                if candidate.exists() and candidate.is_dir():
-                    resolved_project_path = candidate.resolve()
-                    os.environ["PENGUIN_PROJECT_ROOT"] = str(resolved_project_path)
-                    os.environ["PENGUIN_CWD"] = str(resolved_project_path)
-                    logger.info("CLI env: PENGUIN_PROJECT_ROOT=%s", resolved_project_path)
-                    break
-            except Exception:
-                continue
-
-    root_mode = (root or "project").lower()
-    if root_mode in ("project", "workspace"):
-        os.environ["PENGUIN_WRITE_ROOT"] = root_mode
-        if root_mode == "workspace":
-            os.environ["PENGUIN_CWD"] = str(resolved_workspace)
-        elif resolved_project_path is not None:
-            os.environ["PENGUIN_CWD"] = str(resolved_project_path)
-
-    return resolved_project_path, resolved_workspace
+    WORKSPACE_PATH = result[1]
+    return result
 
 
 @app.callback(invoke_without_command=True)

--- a/penguin/cli/cli.py
+++ b/penguin/cli/cli.py
@@ -224,6 +224,12 @@ else:
 
 from penguin._version import __version__
 from penguin.cli.bootstrap import bootstrap_cli
+from penguin.cli.command_services import (
+    AmbiguousProjectError,
+    ProjectNotFoundError,
+    parse_task_status,
+    resolve_project_identifier,
+)
 from penguin.cli.environment import (
     preconfigure_cli_environment,
     set_cli_workspace_path,
@@ -233,6 +239,8 @@ from penguin.cli.model_runtime import (
     project_reasoning_config as _project_reasoning_config,
     resolve_reasoning_config as _resolve_cli_reasoning_config,
 )
+from penguin.cli.output_policy import classify_runmode_completion
+from penguin.cli.run_dispatch import DispatchMode, DispatchRequest, select_dispatch_mode
 from penguin.config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -1215,31 +1223,30 @@ def main_entry(
         ctx.obj = ctx.obj or {}
         ctx.obj["project"] = project
 
-        # Check for priority flags in order of precedence:
-        # 1. Task execution (--run)
-        if run_task is not None:
+        dispatch_mode = select_dispatch_mode(
+            DispatchRequest(
+                run_task=run_task,
+                continue_last=continue_last,
+                resume_session=resume_session,
+                prompt=prompt,
+                continuous=continuous,
+                invoked_subcommand=ctx.invoked_subcommand,
+            )
+        )
+        if dispatch_mode is DispatchMode.RUN_MODE:
             await _handle_run_mode(run_task, continuous, time_limit, task_description)
-        # 2. Session management (--continue/--resume)
-        elif continue_last or resume_session:
-            # We'll always go into interactive mode for session management
+        elif dispatch_mode is DispatchMode.SESSION:
             if prompt is not None:
-                # Combine -p with -c/--resume
                 await _handle_session_management(
                     continue_last, resume_session, prompt, output_format
                 )
             else:
-                # Just go into interactive mode with loaded session
                 await _handle_session_management(continue_last, resume_session)
-        # 3. Direct prompt (-p/--prompt)
-        elif prompt is not None:
-            # Standard non-interactive mode if -p or --prompt was used
+        elif dispatch_mode is DispatchMode.DIRECT_PROMPT:
             await _run_penguin_direct_prompt(prompt, output_format)
-        # 4. Continuous mode without task (just --247)
-        elif continuous:
+        elif dispatch_mode is DispatchMode.CONTINUOUS:
             await _handle_run_mode(None, continuous, time_limit, task_description)
-        # 5. Default: interactive chat session
-        elif ctx.invoked_subcommand is None:
-            # No subcommand invoked, default to interactive chat
+        elif dispatch_mode is DispatchMode.INTERACTIVE:
             await _run_interactive_chat()
         # Else: a subcommand was invoked (e.g., `penguin chat`, `penguin profile`).
         # Typer will handle calling the subcommand.
@@ -1441,26 +1448,23 @@ async def _handle_run_mode(
                 ui_update_callback_for_cli=ui_update_callback,
             )
 
-        status_summary = getattr(_core, "current_runmode_status_summary", "") or ""
-        status_summary_lower = status_summary.lower()
-
-        if "clarification" in status_summary_lower or "awaiting input" in status_summary_lower:
+        completion = classify_runmode_completion(
+            getattr(_core, "current_runmode_status_summary", "")
+        )
+        if completion.kind == "waiting_input":
             console.print(
-                f"[yellow]Run mode is waiting for clarification/input.[/yellow] {status_summary}"
+                f"[yellow]Run mode is waiting for clarification/input.[/yellow] {completion.message}"
             )
-        elif (
-            "time limit" in status_summary_lower
-            or "time_limit" in status_summary_lower
-        ):
-            console.print(f"[yellow]Run mode stopped due to time limit.[/yellow] {status_summary}")
-        elif (
-            "idle" in status_summary_lower
-            or "no ready task" in status_summary_lower
-            or "no ready work remained" in status_summary_lower
-        ):
-            console.print(f"[yellow]Run mode stopped because no ready work remained.[/yellow] {status_summary}")
-        elif status_summary:
-            console.print(f"[green]Run mode finished.[/green] {status_summary}")
+        elif completion.kind == "time_limit":
+            console.print(
+                f"[yellow]Run mode stopped due to time limit.[/yellow] {completion.message}"
+            )
+        elif completion.kind == "idle":
+            console.print(
+                f"[yellow]Run mode stopped because no ready work remained.[/yellow] {completion.message}"
+            )
+        elif completion.message:
+            console.print(f"[green]Run mode finished.[/green] {completion.message}")
         else:
             console.print("[green]Run mode finished.[/green]")
 
@@ -2903,26 +2907,18 @@ def _resolve_project_identifier_or_exit(project_identifier: str):
     """Resolve a project by exact ID or unique exact name, failing honestly otherwise."""
     assert _core is not None and _core.project_manager is not None
 
-    project = _core.project_manager.get_project(project_identifier)
-    if project:
-        return project
-
-    exact_name_match = _core.project_manager.get_project_by_name(project_identifier)
-    if exact_name_match:
-        return exact_name_match
-
-    projects = _core.project_manager.list_projects()
-    matching_by_name = [p for p in projects if p.name == project_identifier]
-    if len(matching_by_name) > 1:
+    try:
+        return resolve_project_identifier(_core.project_manager, project_identifier)
+    except AmbiguousProjectError:
         console.print(
             f"[red]Ambiguous project name '{project_identifier}'. Use the project ID instead.[/red]"
         )
         raise typer.Exit(code=1)
-
-    console.print(
-        f"[red]Project '{project_identifier}' was not found by exact ID or exact name.[/red]"
-    )
-    raise typer.Exit(code=1)
+    except ProjectNotFoundError:
+        console.print(
+            f"[red]Project '{project_identifier}' was not found by exact ID or exact name.[/red]"
+        )
+        raise typer.Exit(code=1)
 
 
 async def _delete_project_and_tasks_async(project_id: str) -> None:
@@ -3220,10 +3216,8 @@ def task_list(
             status_filter = None
             if status:
                 from penguin.project.models import TaskStatus
-
                 try:
-                    normalized_status = status.strip().lower()
-                    status_filter = TaskStatus(normalized_status)
+                    status_filter = parse_task_status(status)
                 except ValueError:
                     valid_options = ", ".join(task_status.value for task_status in TaskStatus)
                     console.print(

--- a/penguin/cli/command_services/__init__.py
+++ b/penguin/cli/command_services/__init__.py
@@ -1,0 +1,15 @@
+"""Terminal-independent command execution helpers."""
+
+from penguin.cli.command_services.project import (
+    AmbiguousProjectError,
+    ProjectNotFoundError,
+    resolve_project_identifier,
+)
+from penguin.cli.command_services.task import parse_task_status
+
+__all__ = [
+    "AmbiguousProjectError",
+    "ProjectNotFoundError",
+    "parse_task_status",
+    "resolve_project_identifier",
+]

--- a/penguin/cli/command_services/project.py
+++ b/penguin/cli/command_services/project.py
@@ -1,0 +1,42 @@
+"""Project command domain helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+__all__ = [
+    "AmbiguousProjectError",
+    "ProjectNotFoundError",
+    "resolve_project_identifier",
+]
+
+
+class ProjectNotFoundError(LookupError):
+    """Raised when no exact project ID or name matches."""
+
+
+class AmbiguousProjectError(LookupError):
+    """Raised when an exact project name is not unique."""
+
+
+class ProjectReader(Protocol):
+    def get_project(self, project_id: str) -> Any: ...
+
+    def get_project_by_name(self, name: str) -> Any: ...
+
+    def list_projects(self) -> list[Any]: ...
+
+
+def resolve_project_identifier(manager: ProjectReader, identifier: str) -> Any:
+    """Resolve exact ID or unique exact name without terminal side effects."""
+
+    project = manager.get_project(identifier)
+    if project:
+        return project
+    project = manager.get_project_by_name(identifier)
+    if project:
+        return project
+    matches = [item for item in manager.list_projects() if item.name == identifier]
+    if len(matches) > 1:
+        raise AmbiguousProjectError(identifier)
+    raise ProjectNotFoundError(identifier)

--- a/penguin/cli/command_services/task.py
+++ b/penguin/cli/command_services/task.py
@@ -1,0 +1,15 @@
+"""Task command domain helpers."""
+
+from __future__ import annotations
+
+from penguin.project.models import TaskStatus
+
+__all__ = ["parse_task_status"]
+
+
+def parse_task_status(value: str | None) -> TaskStatus | None:
+    """Parse a case-insensitive task status or return ``None`` when unset."""
+
+    if value is None:
+        return None
+    return TaskStatus(value.strip().lower())

--- a/penguin/cli/environment.py
+++ b/penguin/cli/environment.py
@@ -1,0 +1,70 @@
+"""Environment and path normalization for CLI startup."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from pathlib import Path
+
+__all__ = ["preconfigure_cli_environment", "set_cli_workspace_path"]
+
+logger = logging.getLogger(__name__)
+
+
+def set_cli_workspace_path(workspace_path: str | Path) -> Path:
+    """Normalize and propagate a workspace override before core construction."""
+
+    resolved_workspace = Path(workspace_path).expanduser().resolve()
+    os.environ["PENGUIN_WORKSPACE"] = str(resolved_workspace)
+    try:
+        config_module = importlib.import_module("penguin.config")
+        config_module.WORKSPACE_PATH = resolved_workspace
+    except Exception:
+        logger.debug(
+            "Unable to sync workspace override into penguin.config", exc_info=True
+        )
+    return resolved_workspace
+
+
+def preconfigure_cli_environment(
+    workspace: Path | None,
+    project: str | None,
+    root: str | None,
+    *,
+    default_workspace: str | Path,
+) -> tuple[Path | None, Path]:
+    """Normalize execution-root and workspace hints before loading config."""
+
+    workspace_source = workspace or os.environ.get(
+        "PENGUIN_WORKSPACE", str(default_workspace)
+    )
+    resolved_workspace = set_cli_workspace_path(workspace_source)
+    os.environ["PENGUIN_CWD"] = str(Path.cwd().resolve())
+    os.environ.pop("PENGUIN_PROJECT_ROOT", None)
+
+    resolved_project_path: Path | None = None
+    if project:
+        candidates = [
+            Path(project).expanduser(),
+            resolved_workspace / "projects" / project,
+        ]
+        for candidate in candidates:
+            try:
+                if candidate.exists() and candidate.is_dir():
+                    resolved_project_path = candidate.resolve()
+                    os.environ["PENGUIN_PROJECT_ROOT"] = str(resolved_project_path)
+                    os.environ["PENGUIN_CWD"] = str(resolved_project_path)
+                    break
+            except OSError:
+                continue
+
+    root_mode = (root or "project").lower()
+    if root_mode in {"project", "workspace"}:
+        os.environ["PENGUIN_WRITE_ROOT"] = root_mode
+        if root_mode == "workspace":
+            os.environ["PENGUIN_CWD"] = str(resolved_workspace)
+        elif resolved_project_path is not None:
+            os.environ["PENGUIN_CWD"] = str(resolved_project_path)
+
+    return resolved_project_path, resolved_workspace

--- a/penguin/cli/model_runtime.py
+++ b/penguin/cli/model_runtime.py
@@ -1,0 +1,138 @@
+"""Model configuration projection and resolution for the Python CLI.
+
+This module owns the boundary between the merged Penguin configuration and the
+runtime ``ModelConfig`` used to construct the CLI's API client.  It deliberately
+has no dependency on Typer, terminal state, or CLI module globals.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+from penguin.llm.model_config import ModelConfig
+
+__all__ = [
+    "build_cli_model_config",
+    "project_reasoning_config",
+    "resolve_reasoning_config",
+]
+
+
+def project_reasoning_config(model_config: ModelConfig) -> dict[str, Any]:
+    """Project only explicitly configured reasoning inputs and capabilities."""
+
+    return {
+        "reasoning_enabled": (
+            model_config.reasoning_enabled
+            if model_config.reasoning_enabled_was_explicit
+            else None
+        ),
+        "reasoning_effort": (
+            model_config.reasoning_effort
+            if model_config.reasoning_effort_was_explicit
+            else None
+        ),
+        "reasoning_max_tokens": (
+            model_config.reasoning_max_tokens
+            if model_config.reasoning_max_tokens_was_explicit
+            else None
+        ),
+        "reasoning_exclude": model_config.reasoning_exclude,
+        "supports_reasoning": model_config.supports_reasoning,
+        "supported_reasoning_levels": model_config.supported_reasoning_levels,
+    }
+
+
+def resolve_reasoning_config(model_settings: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve flat or nested reasoning settings without inventing values."""
+
+    nested = model_settings.get("reasoning")
+    reasoning = nested if isinstance(nested, Mapping) else {}
+    if "enabled" in reasoning:
+        reasoning_enabled: bool | None = bool(reasoning.get("enabled"))
+    elif "reasoning_enabled" in model_settings:
+        configured_enabled = model_settings.get("reasoning_enabled")
+        reasoning_enabled = (
+            None if configured_enabled is None else bool(configured_enabled)
+        )
+    else:
+        reasoning_enabled = None
+
+    return {
+        "reasoning_enabled": reasoning_enabled,
+        "reasoning_effort": reasoning.get(
+            "effort", model_settings.get("reasoning_effort")
+        ),
+        "reasoning_max_tokens": reasoning.get(
+            "max_tokens", model_settings.get("reasoning_max_tokens")
+        ),
+        "reasoning_exclude": bool(
+            reasoning.get("exclude", model_settings.get("reasoning_exclude", False))
+        ),
+        "supports_reasoning": model_settings.get("supports_reasoning"),
+        "supported_reasoning_levels": model_settings.get("supported_reasoning_levels"),
+    }
+
+
+def _model_configs(loaded_config: Any) -> dict[str, dict[str, Any]]:
+    raw_configs = getattr(loaded_config, "model_configs", None)
+    if not isinstance(raw_configs, Mapping) and isinstance(loaded_config, Mapping):
+        raw_configs = loaded_config.get("model_configs")
+    if not isinstance(raw_configs, Mapping):
+        return {}
+    return {
+        str(model_id): dict(settings)
+        for model_id, settings in raw_configs.items()
+        if isinstance(settings, Mapping)
+    }
+
+
+def build_cli_model_config(
+    loaded_config: Any,
+    *,
+    model_override: str | None = None,
+    streaming_enabled: bool | None = None,
+) -> ModelConfig:
+    """Return the complete runtime model configuration for CLI startup.
+
+    The already-resolved typed model configuration is retained when there is no
+    model override.  An override is resolved as a new target model so inferred
+    capabilities can never leak from the configured source model.
+    """
+
+    source = getattr(loaded_config, "model_config", None)
+    if not isinstance(source, ModelConfig):
+        raise TypeError("Loaded CLI configuration has no typed model_config")
+
+    if model_override:
+        qualified_provider = (
+            model_override.split("/", 1)[0].strip().lower()
+            if "/" in model_override
+            else None
+        )
+        provider = qualified_provider or source.provider
+        client_preference = (
+            "native"
+            if qualified_provider and qualified_provider != "openrouter"
+            else source.client_preference
+        )
+        result = ModelConfig.for_model(
+            model_name=model_override,
+            provider=provider,
+            client_preference=client_preference,
+            model_configs=_model_configs(loaded_config),
+        )
+        if result.api_base is None:
+            result.api_base = source.api_base
+    else:
+        result = copy.copy(source)
+
+    api_settings = getattr(loaded_config, "api", None)
+    configured_api_base = getattr(api_settings, "base_url", None)
+    if configured_api_base:
+        result.api_base = configured_api_base
+    if streaming_enabled is not None:
+        result.streaming_enabled = streaming_enabled
+    return result

--- a/penguin/cli/output_policy.py
+++ b/penguin/cli/output_policy.py
@@ -1,0 +1,34 @@
+"""Structured output decisions shared by CLI execution surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["RunModeCompletion", "classify_runmode_completion"]
+
+
+@dataclass(frozen=True)
+class RunModeCompletion:
+    """A render-neutral RunMode completion classification."""
+
+    kind: str
+    message: str
+
+
+def classify_runmode_completion(status_summary: str | None) -> RunModeCompletion:
+    """Translate runtime status truth into a stable presentation outcome."""
+
+    summary = status_summary or ""
+    normalized = summary.lower()
+    if "clarification" in normalized or "awaiting input" in normalized:
+        return RunModeCompletion("waiting_input", summary)
+    if "time limit" in normalized or "time_limit" in normalized:
+        return RunModeCompletion("time_limit", summary)
+    if any(
+        phrase in normalized
+        for phrase in ("idle", "no ready task", "no ready work remained")
+    ):
+        return RunModeCompletion("idle", summary)
+    if summary:
+        return RunModeCompletion("finished", summary)
+    return RunModeCompletion("finished", "")

--- a/penguin/cli/run_dispatch.py
+++ b/penguin/cli/run_dispatch.py
@@ -1,0 +1,47 @@
+"""Top-level CLI mode selection independent of Typer and runtime globals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ["DispatchMode", "DispatchRequest", "select_dispatch_mode"]
+
+
+class DispatchMode(str, Enum):
+    """Mutually exclusive top-level CLI execution modes."""
+
+    RUN_MODE = "run_mode"
+    SESSION = "session"
+    DIRECT_PROMPT = "direct_prompt"
+    CONTINUOUS = "continuous"
+    INTERACTIVE = "interactive"
+    SUBCOMMAND = "subcommand"
+
+
+@dataclass(frozen=True)
+class DispatchRequest:
+    """Inputs that determine the CLI execution mode."""
+
+    run_task: str | None
+    continue_last: bool
+    resume_session: str | None
+    prompt: str | None
+    continuous: bool
+    invoked_subcommand: str | None
+
+
+def select_dispatch_mode(request: DispatchRequest) -> DispatchMode:
+    """Select one mode using the CLI's documented precedence contract."""
+
+    if request.run_task is not None:
+        return DispatchMode.RUN_MODE
+    if request.continue_last or request.resume_session:
+        return DispatchMode.SESSION
+    if request.prompt is not None:
+        return DispatchMode.DIRECT_PROMPT
+    if request.continuous:
+        return DispatchMode.CONTINUOUS
+    if request.invoked_subcommand is None:
+        return DispatchMode.INTERACTIVE
+    return DispatchMode.SUBCOMMAND

--- a/penguin/llm/model_config.py
+++ b/penguin/llm/model_config.py
@@ -85,6 +85,7 @@ class ModelConfig:
     supported_reasoning_levels: Optional[list[str]] = None
     _reasoning_enabled_explicit: bool = field(init=False, repr=False, default=False)
     _reasoning_effort_explicit: bool = field(init=False, repr=False, default=False)
+    _reasoning_max_tokens_explicit: bool = field(init=False, repr=False, default=False)
 
     # OpenRouter debug mode - echoes upstream request body (development only)
     debug_upstream: bool = False
@@ -92,6 +93,7 @@ class ModelConfig:
     def __post_init__(self):
         self._reasoning_enabled_explicit = self.reasoning_enabled is not None
         self._reasoning_effort_explicit = self.reasoning_effort is not None
+        self._reasoning_max_tokens_explicit = self.reasoning_max_tokens is not None
         if self.reasoning_enabled is None:
             self.reasoning_enabled = False
         self.service_tier = normalize_openai_service_tier(self.service_tier)
@@ -161,6 +163,24 @@ class ModelConfig:
 
         self.supports_vision = self.vision_enabled
         self.streaming_enabled = self.streaming_enabled
+
+    @property
+    def reasoning_enabled_was_explicit(self) -> bool:
+        """Whether reasoning enablement was supplied by configuration."""
+
+        return self._reasoning_enabled_explicit
+
+    @property
+    def reasoning_effort_was_explicit(self) -> bool:
+        """Whether reasoning effort was supplied by configuration."""
+
+        return self._reasoning_effort_explicit
+
+    @property
+    def reasoning_max_tokens_was_explicit(self) -> bool:
+        """Whether a reasoning token budget was supplied by configuration."""
+
+        return self._reasoning_max_tokens_explicit
 
     @property
     def max_tokens(self) -> Optional[int]:
@@ -330,8 +350,7 @@ class ModelConfig:
         raw_reasoning_enabled = os.getenv("PENGUIN_REASONING_ENABLED")
         reasoning_enabled = (
             raw_reasoning_enabled.strip().lower() == "true"
-            if isinstance(raw_reasoning_enabled, str)
-            and raw_reasoning_enabled.strip()
+            if isinstance(raw_reasoning_enabled, str) and raw_reasoning_enabled.strip()
             else None
         )
         raw_reasoning_effort = os.getenv("PENGUIN_REASONING_EFFORT")
@@ -359,9 +378,8 @@ class ModelConfig:
         max_context_env = os.getenv("PENGUIN_MAX_CONTEXT_WINDOW_TOKENS") or os.getenv(
             "PENGUIN_CONTEXT_WINDOW"
         )
-        service_tier = (
-            os.getenv("PENGUIN_OPENAI_SERVICE_TIER")
-            or os.getenv("OPENAI_SERVICE_TIER")
+        service_tier = os.getenv("PENGUIN_OPENAI_SERVICE_TIER") or os.getenv(
+            "OPENAI_SERVICE_TIER"
         )
 
         return cls(
@@ -568,6 +586,7 @@ class ModelConfig:
 # =============================================================================
 # MODEL SPECS SERVICE - Cached OpenRouter API fetching
 # =============================================================================
+
 
 @dataclass
 class ModelSpecs:

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -1,0 +1,103 @@
+"""Contract tests for extracted CLI startup composition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from penguin.cli.bootstrap import BootstrapDependencies, bootstrap_cli
+from penguin.llm.model_config import ModelConfig
+
+
+def _loaded_config(workspace: Path) -> SimpleNamespace:
+    model_config = ModelConfig(
+        model="gpt-4o",
+        provider="openai",
+        client_preference="native",
+        streaming_enabled=True,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        model_configs={},
+        api=SimpleNamespace(base_url=None),
+        workspace_path=workspace,
+        fast_startup=False,
+        to_dict=lambda: {"model": {"default": "gpt-4o"}},
+    )
+
+
+def test_bootstrap_constructs_complete_result_before_publication(
+    tmp_path: Path,
+) -> None:
+    loaded_config = _loaded_config(tmp_path)
+    api_client = SimpleNamespace(set_system_prompt=Mock())
+    tool_manager = object()
+    core = object()
+    interface = object()
+    dependencies = BootstrapDependencies(
+        config_loader=lambda: loaded_config,
+        api_client_factory=Mock(return_value=api_client),
+        tool_manager_factory=Mock(return_value=tool_manager),
+        core_factory=Mock(return_value=core),
+        interface_factory=Mock(return_value=interface),
+        env_loader=Mock(),
+    )
+
+    result = bootstrap_cli(
+        workspace_override=tmp_path,
+        no_streaming_override=True,
+        fast_startup_override=True,
+        dependencies=dependencies,
+    )
+
+    assert result.core is core
+    assert result.interface is interface
+    assert result.workspace == tmp_path.resolve()
+    assert result.model_config.streaming_enabled is False
+    dependencies.env_loader.assert_called_once_with()
+    dependencies.tool_manager_factory.assert_called_once()
+    assert dependencies.tool_manager_factory.call_args.kwargs["fast_startup"] is True
+    api_client.set_system_prompt.assert_called_once()
+
+
+def test_bootstrap_propagates_factory_failure_without_partial_result(
+    tmp_path: Path,
+) -> None:
+    loaded_config = _loaded_config(tmp_path)
+    dependencies = BootstrapDependencies(
+        config_loader=lambda: loaded_config,
+        api_client_factory=Mock(side_effect=RuntimeError("provider unavailable")),
+        tool_manager_factory=Mock(),
+        core_factory=Mock(),
+        interface_factory=Mock(),
+        env_loader=Mock(),
+    )
+
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        bootstrap_cli(dependencies=dependencies)
+
+    dependencies.tool_manager_factory.assert_not_called()
+    dependencies.core_factory.assert_not_called()
+    dependencies.interface_factory.assert_not_called()
+
+
+def test_bootstrap_model_override_reaches_target_factory(tmp_path: Path) -> None:
+    loaded_config = _loaded_config(tmp_path)
+    api_client_factory = Mock(return_value=SimpleNamespace(set_system_prompt=Mock()))
+    dependencies = BootstrapDependencies(
+        config_loader=lambda: loaded_config,
+        api_client_factory=api_client_factory,
+        tool_manager_factory=Mock(return_value=object()),
+        core_factory=Mock(return_value=object()),
+        interface_factory=Mock(return_value=object()),
+        env_loader=Mock(),
+    )
+
+    result = bootstrap_cli(model_override="gpt-5.6-sol", dependencies=dependencies)
+
+    assert result.model_config.model == "gpt-5.6-sol"
+    assert result.model_config.supports_reasoning is True
+    assert api_client_factory.call_args.kwargs["model_config"] is result.model_config

--- a/tests/cli/test_command_services.py
+++ b/tests/cli/test_command_services.py
@@ -1,0 +1,44 @@
+"""Unit tests for terminal-independent project and task command services."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from penguin.cli.command_services import (
+    AmbiguousProjectError,
+    ProjectNotFoundError,
+    parse_task_status,
+    resolve_project_identifier,
+)
+from penguin.project.models import TaskStatus
+
+
+def test_parse_task_status_is_case_insensitive() -> None:
+    assert parse_task_status(" RUNNING ") is TaskStatus.RUNNING
+    assert parse_task_status(None) is None
+
+
+def test_resolve_project_prefers_exact_id() -> None:
+    project = SimpleNamespace(id="id", name="Demo")
+    manager = SimpleNamespace(
+        get_project=Mock(return_value=project),
+        get_project_by_name=Mock(),
+        list_projects=Mock(),
+    )
+    assert resolve_project_identifier(manager, "id") is project
+    manager.get_project_by_name.assert_not_called()
+
+
+def test_resolve_project_reports_ambiguity_and_missing() -> None:
+    projects = [SimpleNamespace(name="Demo"), SimpleNamespace(name="Demo")]
+    manager = SimpleNamespace(
+        get_project=Mock(return_value=None),
+        get_project_by_name=Mock(return_value=None),
+        list_projects=Mock(return_value=projects),
+    )
+    with pytest.raises(AmbiguousProjectError):
+        resolve_project_identifier(manager, "Demo")
+    manager.list_projects.return_value = []
+    with pytest.raises(ProjectNotFoundError):
+        resolve_project_identifier(manager, "Missing")

--- a/tests/cli/test_environment.py
+++ b/tests/cli/test_environment.py
@@ -1,0 +1,59 @@
+"""Tests for isolated CLI path and environment normalization."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from penguin.cli.environment import preconfigure_cli_environment
+
+
+def test_preconfigure_environment_is_repeatable(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    first = preconfigure_cli_environment(
+        workspace, None, "workspace", default_workspace=tmp_path / "unused"
+    )
+    second = preconfigure_cli_environment(
+        workspace, None, "workspace", default_workspace=tmp_path / "unused"
+    )
+
+    assert first == second == (None, workspace.resolve())
+    assert os.environ["PENGUIN_CWD"] == str(workspace.resolve())
+    assert os.environ["PENGUIN_WRITE_ROOT"] == "workspace"
+
+
+def test_preconfigure_environment_resolves_managed_project(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / "projects" / "demo"
+    project.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    resolved_project, resolved_workspace = preconfigure_cli_environment(
+        workspace, "demo", "project", default_workspace=tmp_path / "unused"
+    )
+
+    assert resolved_project == project.resolve()
+    assert resolved_workspace == workspace.resolve()
+    assert os.environ["PENGUIN_PROJECT_ROOT"] == str(project.resolve())
+    assert os.environ["PENGUIN_CWD"] == str(project.resolve())
+
+
+def test_preconfigure_environment_clears_stale_project(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("PENGUIN_PROJECT_ROOT", str(tmp_path / "stale"))
+    monkeypatch.chdir(tmp_path)
+
+    resolved_project, _ = preconfigure_cli_environment(
+        workspace, None, None, default_workspace=tmp_path / "unused"
+    )
+
+    assert resolved_project is None
+    assert "PENGUIN_PROJECT_ROOT" not in os.environ

--- a/tests/cli/test_output_policy.py
+++ b/tests/cli/test_output_policy.py
@@ -1,0 +1,19 @@
+"""Tests for render-neutral CLI output classification."""
+
+import pytest
+
+from penguin.cli.output_policy import classify_runmode_completion
+
+
+@pytest.mark.parametrize(
+    ("summary", "kind"),
+    [
+        ("Awaiting input for clarification", "waiting_input"),
+        ("Stopped: time_limit", "time_limit"),
+        ("No ready work remained", "idle"),
+        ("Completed successfully", "finished"),
+        (None, "finished"),
+    ],
+)
+def test_runmode_completion_classification(summary: str | None, kind: str) -> None:
+    assert classify_runmode_completion(summary).kind == kind

--- a/tests/cli/test_reasoning_projection.py
+++ b/tests/cli/test_reasoning_projection.py
@@ -1,9 +1,12 @@
-"""Regression tests for reasoning configuration projection in the primary CLI."""
+"""Regression tests for CLI model runtime projection and target resolution."""
+
+from types import SimpleNamespace
 
 from penguin.cli.cli import (
     _project_reasoning_config,
     _resolve_cli_reasoning_config,
 )
+from penguin.cli.model_runtime import build_cli_model_config
 from penguin.llm.model_config import ModelConfig
 
 
@@ -75,3 +78,54 @@ def test_cli_reasoning_projection_preserves_explicit_opt_out() -> None:
     assert rebuilt.reasoning_enabled is False
     assert rebuilt.reasoning_effort is None
     assert rebuilt._reasoning_enabled_explicit is True
+
+
+def test_cli_reasoning_projection_preserves_explicit_token_budget() -> None:
+    """A token budget remains explicit when enablement was omitted."""
+
+    source = ModelConfig(
+        model="anthropic/claude-sonnet-4",
+        provider="anthropic",
+        client_preference="native",
+        reasoning_max_tokens=8000,
+    )
+
+    rebuilt = _rebuild_reasoning_config(source)
+
+    assert rebuilt.reasoning_max_tokens == 8000
+    assert rebuilt.reasoning_max_tokens_was_explicit is True
+
+
+def test_model_override_recomputes_target_reasoning_capability() -> None:
+    """A reasoning target does not inherit a non-reasoning source capability."""
+
+    source = ModelConfig(
+        model="gpt-4o",
+        provider="openai",
+        client_preference="native",
+        supports_reasoning=False,
+    )
+    loaded = SimpleNamespace(model_config=source, model_configs={}, api=None)
+
+    target = build_cli_model_config(loaded, model_override="gpt-5.6-sol")
+
+    assert target.model == "gpt-5.6-sol"
+    assert target.supports_reasoning is True
+    assert target.reasoning_enabled is True
+
+
+def test_model_override_drops_source_reasoning_capability() -> None:
+    """A non-reasoning target does not inherit source reasoning metadata."""
+
+    source = ModelConfig(
+        model="gpt-5.6-sol",
+        provider="openai",
+        client_preference="native",
+    )
+    loaded = SimpleNamespace(model_config=source, model_configs={}, api=None)
+
+    target = build_cli_model_config(loaded, model_override="gpt-4o")
+
+    assert target.model == "gpt-4o"
+    assert target.supports_reasoning is False
+    assert target.reasoning_enabled is False

--- a/tests/cli/test_run_dispatch.py
+++ b/tests/cli/test_run_dispatch.py
@@ -1,0 +1,42 @@
+"""Contract matrix for top-level CLI dispatch precedence."""
+
+import pytest
+
+from penguin.cli.run_dispatch import (
+    DispatchMode,
+    DispatchRequest,
+    select_dispatch_mode,
+)
+
+
+@pytest.mark.parametrize(
+    ("dispatch_request", "expected"),
+    [
+        (
+            DispatchRequest("task", True, "session", "prompt", True, None),
+            DispatchMode.RUN_MODE,
+        ),
+        (DispatchRequest(None, True, None, "prompt", True, None), DispatchMode.SESSION),
+        (
+            DispatchRequest(None, False, "session", "prompt", True, None),
+            DispatchMode.SESSION,
+        ),
+        (
+            DispatchRequest(None, False, None, "prompt", True, None),
+            DispatchMode.DIRECT_PROMPT,
+        ),
+        (DispatchRequest(None, False, None, None, True, None), DispatchMode.CONTINUOUS),
+        (
+            DispatchRequest(None, False, None, None, False, None),
+            DispatchMode.INTERACTIVE,
+        ),
+        (
+            DispatchRequest(None, False, None, None, False, "project"),
+            DispatchMode.SUBCOMMAND,
+        ),
+    ],
+)
+def test_dispatch_precedence(
+    dispatch_request: DispatchRequest, expected: DispatchMode
+) -> None:
+    assert select_dispatch_mode(dispatch_request) is expected


### PR DESCRIPTION
## What changed

- extracts model/runtime projection into `penguin/cli/model_runtime.py`
- extracts environment normalization and atomic dependency composition
- introduces structured dispatch/output services and deterministic tests
- preserves explicit reasoning enablement, effort, and token-budget provenance

## Why

`cli.py` reconstructed model intent and published startup globals while dependencies were still being built. Model overrides could inherit source-model capability metadata, and startup behavior was difficult to test without real providers.

## Impact

CLI startup now constructs a complete result before publishing compatibility globals. Target-model capabilities are resolved from the target, and metadata-only help paths can remain provider-free.

## Validation

- included unit/contract tests for bootstrap, environment, model projection, dispatch, command services, and output policy
- final stacked CLI suite: 134 passed
- installed wheel help smoke passed

Stack base: #82 (`fix/multi-agent-runtime`).

## CI note

The two Link-provider jobs and Python 3.9 goal job also fail on base PR #82 with the same unrelated `RUF043` test-pattern and Python 3.9 union-annotation errors. Python 3.12 goal, TUI, docs, and deployment checks pass.
