### PR TITLE
feat(tools): expose session todo tools

### DIFF
--- a/penguin/tools/core/todo_tools.py
+++ b/penguin/tools/core/todo_tools.py
@@ -1,0 +1,136 @@
+"""Session-scoped todo tools."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any, Callable
+
+__all__ = ["TodoTools", "get_todo_tool_schemas"]
+
+
+def get_todo_tool_schemas() -> list[dict[str, Any]]:
+    """Return model-visible schemas for session todo tools."""
+    return [
+        {
+            "name": "todowrite",
+            "description": "Create or replace the active session's todo list.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "todos": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "content": {"type": "string"},
+                                "status": {
+                                    "type": "string",
+                                    "enum": [
+                                        "pending",
+                                        "in_progress",
+                                        "completed",
+                                        "cancelled",
+                                    ],
+                                },
+                                "priority": {
+                                    "type": "string",
+                                    "enum": ["high", "medium", "low"],
+                                },
+                            },
+                            "required": [
+                                "id",
+                                "content",
+                                "status",
+                                "priority",
+                            ],
+                        },
+                    }
+                },
+                "required": ["todos"],
+            },
+            "x-penguin-permissions": {
+                "mutates_state": True,
+                "requires_approval": False,
+                "parallel_safe": False,
+                "risk": "low",
+            },
+        },
+        {
+            "name": "todoread",
+            "description": "Read the active session's todo list.",
+            "input_schema": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+            "x-penguin-permissions": {
+                "mutates_state": False,
+                "requires_approval": False,
+                "parallel_safe": True,
+                "risk": "low",
+            },
+        },
+    ]
+
+
+class TodoTools:
+    """Read and replace the active session's todo list."""
+
+    def __init__(self, core_getter: Callable[[], Any]) -> None:
+        self._core_getter = core_getter
+
+    def read(self, context: dict[str, Any]) -> str:
+        """Return normalized todos for the active session."""
+        resolved = self._resolve_session(context)
+        if resolved is None:
+            return self._error("Unable to resolve session for todoread")
+
+        core, session_id = resolved
+        from penguin.web.services.session_view import get_session_todo
+
+        todos = get_session_todo(core, session_id)
+        if todos is None:
+            return self._error("Unable to resolve session for todoread")
+        return json.dumps(todos, indent=2)
+
+    async def write(self, todos: Any, context: dict[str, Any]) -> str:
+        """Replace normalized todos for the active session and emit an update."""
+        resolved = self._resolve_session(context)
+        if resolved is None:
+            return self._error("Unable to resolve session for todowrite")
+
+        core, session_id = resolved
+        from penguin.web.services.session_view import update_session_todo
+
+        normalized = update_session_todo(core, session_id, todos)
+        if normalized is None:
+            return self._error("Unable to resolve session for todowrite")
+
+        emit = getattr(core, "emit_ui_event", None)
+        if callable(emit):
+            result = emit(
+                "todo.updated",
+                {
+                    "sessionID": session_id,
+                    "session_id": session_id,
+                    "conversation_id": session_id,
+                    "todos": normalized,
+                },
+            )
+            if inspect.isawaitable(result):
+                await result
+
+        return json.dumps(normalized, indent=2)
+
+    def _resolve_session(self, context: dict[str, Any]) -> tuple[Any, str] | None:
+        core = self._core_getter()
+        session_id = context.get("session_id") or context.get("conversation_id")
+        if core is None or not isinstance(session_id, str) or not session_id:
+            return None
+        return core, session_id
+
+    @staticmethod
+    def _error(message: str) -> str:
+        return json.dumps({"error": message})

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -41,6 +41,7 @@ from penguin.tools.browser_tools import (
 )
 from penguin.tools.core.skill_tools import SkillTools
 from penguin.tools.core.task_tools import TaskTools
+from penguin.tools.core.todo_tools import TodoTools, get_todo_tool_schemas
 from penguin.tools.editing.registry import (
     get_edit_tool_public_names,
     get_edit_tool_schemas,
@@ -280,6 +281,7 @@ class ToolManager:
             self._skill_tools = None
             self._declarative_memory_tool = None
             self._task_tools = None
+            self._todo_tools = TodoTools(lambda: self._core)
             self._grep_search = None
             self._file_map = None
             self._summary_notes_tool = None
@@ -400,6 +402,8 @@ class ToolManager:
                 "finish_response": "self.task_tools.finish_response",
                 "finish_task": "self.task_tools.finish_task",
                 "task_completed": "self.task_tools.task_completed",  # Deprecated alias
+                "todowrite": "self._execute_todo_write",
+                "todoread": "self._execute_todo_read",
             }
 
             # Cached tool instances for performance
@@ -464,6 +468,7 @@ class ToolManager:
                     "required": [],
                 },
             },
+            *get_todo_tool_schemas(),
             {
                 "name": "list_skills",
                 "description": "List discovered Agent Skills and discovery diagnostics. Use this before activating a skill when you need task-specific instructions.",
@@ -2660,6 +2665,11 @@ class ToolManager:
         tools.extend(self._mcp_provider.get_tool_schemas())
         return tools
 
+    @property
+    def todo_tools(self) -> TodoTools:
+        """Return session-scoped todo tools."""
+        return self._todo_tools
+
     def get_model_visible_tools(self) -> List[Dict[str, Any]]:
         """Return tool schemas normalized to Penguin's model-visible contract."""
 
@@ -2769,6 +2779,8 @@ class ToolManager:
             "process_stop",
             ORDERED_TOOL_BATCH_NAME,
             "grep_search",
+            "todowrite",
+            "todoread",
             "finish_response",
             "finish_task",
             "list_skills",
@@ -4573,6 +4585,10 @@ class ToolManager:
                     or effective_context.get("session_id"),
                     load_into_context=tool_input.get("load_into_context", True),
                 ),
+                "todowrite": lambda: self._execute_async_tool(
+                    self.todo_tools.write(tool_input.get("todos"), effective_context)
+                ),
+                "todoread": lambda: self.todo_tools.read(effective_context),
                 "get_repository_status": lambda: get_repository_status(
                     tool_input["repo_owner"], tool_input["repo_name"]
                 ),
@@ -5961,6 +5977,16 @@ class ToolManager:
             return True
         except RuntimeError:
             return False
+
+    def _execute_todo_write(self, todos: Any = None) -> str:
+        """Execute todowrite through the synchronous compatibility API."""
+        return self._execute_async_tool(
+            self.todo_tools.write(todos, self._merged_execution_context(None))
+        )
+
+    def _execute_todo_read(self) -> str:
+        """Execute todoread through the synchronous compatibility API."""
+        return self.todo_tools.read(self._merged_execution_context(None))
 
     def _execute_async_tool(self, coro):
         """Execute an async tool properly depending on the current context."""

--- a/tests/tools/test_todo_tools.py
+++ b/tests/tools/test_todo_tools.py
@@ -1,0 +1,95 @@
+"""Native ToolManager todo tool tests."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from penguin.system.execution_context import ExecutionContext, execution_context_scope
+from penguin.system.state import Session
+from penguin.tools.tool_manager import ToolManager
+
+
+class _SessionManager:
+    def __init__(self, session: Session) -> None:
+        self.sessions = {session.id: (session, 0.0)}
+        self.session_index: dict[str, Any] = {}
+        self.modified: list[str] = []
+        self.saved: list[str] = []
+
+    def mark_session_modified(self, session_id: str) -> None:
+        self.modified.append(session_id)
+
+    def save_session(self, session: Session) -> bool:
+        self.saved.append(session.id)
+        return True
+
+
+def _tool_manager(
+    session: Session,
+    events: list[tuple[str, dict[str, Any]]],
+) -> ToolManager:
+    session_manager = _SessionManager(session)
+
+    async def emit_ui_event(event_type: str, data: dict[str, Any]) -> None:
+        events.append((event_type, data))
+
+    core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=session_manager,
+            agent_session_managers={},
+        ),
+        emit_ui_event=emit_ui_event,
+    )
+    manager = ToolManager({}, lambda *_args, **_kwargs: None, fast_startup=True)
+    manager._permission_enabled = False
+    manager.set_core(core)
+    return manager
+
+
+def test_todo_tools_are_exposed_to_native_providers() -> None:
+    manager = ToolManager({}, lambda *_args, **_kwargs: None, fast_startup=True)
+
+    schemas = manager.get_responses_tools(include_web_search=False)
+    by_name = {schema["name"]: schema for schema in schemas}
+
+    assert {"todowrite", "todoread"} <= by_name.keys()
+    assert by_name["todowrite"]["parameters"]["required"] == ["todos"]
+    assert by_name["todoread"]["parameters"]["required"] == []
+
+
+def test_todo_tools_round_trip_through_tool_manager() -> None:
+    session = Session(id="session_native_todo")
+    events: list[tuple[str, dict[str, Any]]] = []
+    manager = _tool_manager(session, events)
+    context = ExecutionContext(session_id=session.id, conversation_id=session.id)
+    todos = [
+        {
+            "id": "todo_1",
+            "content": "Expose native todo tools",
+            "status": "in_progress",
+            "priority": "high",
+        }
+    ]
+
+    with execution_context_scope(context):
+        write_result = manager.execute_tool("todowrite", {"todos": todos})
+        read_result = manager.execute_tool("todoread", {})
+
+    assert json.loads(write_result) == todos
+    assert json.loads(read_result) == todos
+    assert session.metadata["_opencode_todo_v1"] == todos
+    assert events == [
+        (
+            "todo.updated",
+            {
+                "sessionID": session.id,
+                "session_id": session.id,
+                "conversation_id": session.id,
+                "todos": todos,
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary

- add native `todowrite` and `todoread` ToolManager schemas
- persist session-scoped todos through the existing session-view contract
- emit `todo.updated` after writes and route writes through async dispatch
- add focused schema and round-trip tests

## Why

Todo support existed only in the legacy ActionXML executor and OpenCode TUI compatibility path. Because ToolManager did not register or expose these tools to provider schemas, models using native tool calls could not use them.

## Impact

Native-tool providers can now read and replace the active session todo list. Existing normalization, persistence, and UI event behavior remain shared with the current session todo implementation.

## Validation

- `74 passed` across todo compatibility, async dispatch, tool schema, parser, and session-view tests
- focused Ruff checks passed
- focused Ruff formatting checks passed
- Python compile checks passed

## Base branch

This PR targets `fix/multi-agent-runtime` because its async ToolManager dispatch is a prerequisite. The PR is a single commit and four-file diff against that base.