### PR TITLE
feat(telegram): add durable support through Phase 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,54 @@ jobs:
             tests/api/test_sse_and_status_scoping.py \
             tests/api/test_session_view_service.py
 
+  telegram-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install Penguin Telegram development dependencies
+        run: python -m pip install -e '.[dev,telegram]'
+      - name: Verify Telegram dependency marker
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import sys
+          from importlib.metadata import version
+
+          installed = importlib.util.find_spec("telegram") is not None
+          if sys.version_info >= (3, 10):
+              assert installed, "Telegram extra did not install its runtime"
+              assert version("python-telegram-bot") == "22.6"
+          else:
+              assert not installed, "Telegram runtime must remain Python 3.10+"
+          PY
+      - name: Check Telegram channel modules
+        run: |
+          ruff check \
+            penguin/channels \
+            penguin/integrations/telegram \
+            penguin/web/integrations/telegram.py \
+            tests/channels \
+            tests/integrations/telegram
+          ruff format --check \
+            penguin/channels \
+            penguin/integrations/telegram \
+            penguin/web/integrations/telegram.py \
+            tests/channels \
+            tests/integrations/telegram
+      - name: Run Telegram transport contracts
+        run: pytest -q tests/channels tests/integrations/telegram
+
   tui-goal-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ pip install "penguin-ai[tui]"
 # Legacy Textual prototype / experimental UI support
 pip install "penguin-ai[legacy_tui]"
 
+# Telegram bot integration (Python 3.10+)
+pip install "penguin-ai[telegram]"
+
 # Full feature set
 pip install penguin-ai[all]
 ```
@@ -199,6 +202,7 @@ Under the hood, the `latest` targets override the project default with `--exclud
 | `[memory_lance]` | LanceDB vector database |
 | `[memory_chroma]` | ChromaDB integration |
 | `[mcp]` | Model Context Protocol client/server dependencies (Python 3.10+ for the MCP SDK) |
+| `[telegram]` | Telegram DMs, groups, topics, streaming, approvals, and durable delivery (Python 3.10+). See the [Telegram setup guide](docs/docs/usage/telegram.md). |
 | `[browser]` | Browser automation support. Installs PyDoll fallback; browser-harness must be installed from a local/source checkout because it is not published on PyPI yet. |
 | `[pydoll]` | PyDoll browser automation fallback only |
 | `[all]` | Everything above that is available from PyPI |

--- a/config.yml
+++ b/config.yml
@@ -52,7 +52,14 @@ channels:
 
     permissions:
       mode: workspace  # read_only | workspace | full_access
-      approvals: prompt  # prompt | deny
+      approvals:
+        shell: ask
+        fileWrite: ask
+        fileDelete: ask
+        gitPush: ask
+        network: ask
+        secrets: deny
+        default: ask
       timeout_seconds: 300
       allow_yolo: false
 

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,59 @@ diagnostics:
   enabled: true
   verbose_logging: true
 
+# Optional Telegram bot. Credentials are read from the named environment
+# variables and must never be placed in this file.
+channels:
+  telegram:
+    enabled: false
+    expected_username: Penguin_agent_bot
+    transport: polling  # polling | webhook
+    token_env: TELEGRAM_BOT_TOKEN
+
+    # Empty numeric allowlists deny access by default.
+    dm_policy: allowlist  # pairing | allowlist | open | disabled
+    allow_from: []  # Telegram user IDs
+    group_policy: allowlist  # allowlist | open | disabled
+    group_allow_from: []  # Telegram group/supergroup chat IDs, usually negative
+    group_sender_allow_from: []  # Telegram user IDs allowed inside those groups
+    activation: mention  # mention | always
+    groups: {}  # Optional trusted per-group/topic binding defaults
+    open_access_acknowledged: false
+
+    streaming:
+      mode: progress  # off | edit | progress
+      edit_interval_ms: 750
+      include_reasoning: false
+
+    media:
+      max_download_mb: 20
+      max_document_text_chars: 100000
+
+    permissions:
+      mode: workspace  # read_only | workspace | full_access
+      approvals: prompt  # prompt | deny
+      timeout_seconds: 300
+      allow_yolo: false
+
+    delivery:
+      retry_attempts: 8
+      retry_base_seconds: 1
+      retry_max_seconds: 300
+      dead_letter_after_hours: 24
+
+    runtime:
+      poll_timeout_seconds: 30
+      request_timeout_seconds: 30
+      ingress_workers: 2
+      delivery_workers: 2
+
+    webhook:
+      public_url: null
+      path: /api/v1/integrations/telegram/webhook
+      secret_env: TELEGRAM_WEBHOOK_SECRET
+      timeout_seconds: 10
+      body_limit_bytes: 1048576
+
 # CLI Display Settings
 cli:
   display:

--- a/context/tasks/penguin-telegram.md
+++ b/context/tasks/penguin-telegram.md
@@ -1,0 +1,1223 @@
+# Penguin Telegram Integration Plan
+
+## Status
+
+- Created: 2026-08-11
+- State: active — Phases 0–5 baseline implemented; Phases 6–8 planned
+- Owner: Penguin runtime and integrations
+- Target: basic personal bot through Hermes-level Telegram parity
+- Primary implementation language: Python
+- Recommended Telegram library: `python-telegram-bot`
+
+## Objective
+
+Add Telegram as a first-class Penguin channel, beginning with a secure personal
+DM bot and growing into the practical feature set provided by Hermes:
+
+- DMs, groups, and forum topics
+- stable Penguin session routing
+- streaming responses and progress
+- text, images, documents, voice, and outbound artifacts
+- commands and interactive buttons
+- allowlists, pairing, and remote permission controls
+- polling and webhooks
+- proactive and scheduled delivery
+- restart-safe ingress and outbound delivery
+- status, diagnostics, and recovery behavior
+
+The result should feel like Penguin running through Telegram, not a separate bot
+that happens to call Penguin.
+
+## Executive Recommendation
+
+Build a small channel platform inside Penguin, then implement Telegram as its
+first external adapter.
+
+Do not copy the Hermes adapter into `penguin/` and wire it directly to
+`PenguinCore.process()`. Hermes's Telegram code depends on its gateway, session,
+delivery, command, and platform contracts. Penguin needs equivalent behavior
+through Penguin-owned boundaries.
+
+The recommended sequence is:
+
+1. Extract a transport-neutral chat service from the current HTTP route.
+2. Add channel envelopes, session bindings, authorization policy, and durable
+   ingress/outbound stores.
+3. Port the reusable Telegram-specific mechanics and tests from Hermes.
+4. Borrow OpenClaw's stronger durability and recovery invariants.
+5. Add advanced media, voice, interactivity, and proactive delivery until the
+   Hermes parity checklist is complete.
+
+A basic bot should not wait for every parity feature. Each phase below is
+intended to ship a useful, tested increment.
+
+## Scope
+
+### In Scope
+
+- One configured Telegram bot account.
+- Long polling as the default transport.
+- Webhook transport as an optional production mode.
+- Private chats, groups, supergroups, and forum topics.
+- Numeric Telegram identities for authorization decisions.
+- Stable Telegram address to Penguin session bindings.
+- Session creation, reset, abort, model selection, and status commands.
+- Mention-gated group behavior and bounded group context.
+- Penguin answer streaming through throttled Telegram message edits.
+- Tool progress, questions, approvals, and background completion notices.
+- Inbound and outbound Telegram media supported by the parity phase.
+- Durable ingress, deduplication, ordering, retries, outbound delivery, and
+  restart recovery.
+- Proactive sends and a home-channel destination for scheduled/background work.
+- CLI/web status and diagnostics for configured Telegram support.
+- Deterministic tests with an opt-in live Telegram smoke suite.
+
+### Deferred Or Explicit Non-Goals
+
+- Copying Hermes's entire gateway architecture.
+- Running a second direct `PenguinCore` process beside `penguin-web`.
+- Multiple Telegram bot accounts in the first parity milestone.
+- OpenClaw-only breadth such as a Telegram Mini App/dashboard.
+- Full Telegram Bot API rich-message blocks before ordinary HTML delivery is
+  reliable.
+- Every native Telegram action, including arbitrary polls, stickers, venues,
+  channel posts, and topic administration.
+- Using mutable Telegram usernames as security identities.
+- Treating Telegram as authorization to bypass Penguin tool permissions.
+- Making live Telegram tests the proof of correctness.
+
+These can be revisited after Hermes parity is stable.
+
+## Reference Implementations
+
+### Hermes
+
+Hermes is the primary implementation donor because it is Python-based and uses
+`python-telegram-bot`.
+
+Pinned audit reference:
+
+- Commit:
+  `9829746dfe3d5077f4f076e257505ec7f8feaa65`
+- Telegram guide:
+  <https://github.com/NousResearch/hermes-agent/blob/9829746dfe3d5077f4f076e257505ec7f8feaa65/website/docs/user-guide/messaging/telegram.md>
+- Telegram adapter:
+  <https://github.com/NousResearch/hermes-agent/blob/9829746dfe3d5077f4f076e257505ec7f8feaa65/plugins/platforms/telegram/adapter.py>
+- Gateway tests:
+  <https://github.com/NousResearch/hermes-agent/tree/9829746dfe3d5077f4f076e257505ec7f8feaa65/tests/gateway>
+- License:
+  <https://github.com/NousResearch/hermes-agent/blob/9829746dfe3d5077f4f076e257505ec7f8feaa65/LICENSE>
+
+The local `reference/hermes-agent/` checkout is useful for exploration, but it
+must be compared with the pinned upstream revision before code or tests are
+ported.
+
+### OpenClaw
+
+OpenClaw is the reliability and behavior reference, not a direct code donor. Its
+Telegram implementation is TypeScript and depends heavily on the OpenClaw
+Plugin SDK.
+
+Pinned audit reference:
+
+- Commit:
+  `f788af02383175164bb4562ce358f797fe498d04`
+- Telegram guide:
+  <https://github.com/openclaw/openclaw/blob/f788af02383175164bb4562ce358f797fe498d04/docs/channels/telegram.md>
+- Telegram maintainer invariants:
+  <https://github.com/openclaw/openclaw/blob/f788af02383175164bb4562ce358f797fe498d04/extensions/telegram/AGENTS.md>
+- Telegram source and tests:
+  <https://github.com/openclaw/openclaw/tree/f788af02383175164bb4562ce358f797fe498d04/extensions/telegram>
+- License:
+  <https://github.com/openclaw/openclaw/blob/f788af02383175164bb4562ce358f797fe498d04/LICENSE>
+
+### Copy, Adapt, And Rewrite Policy
+
+Port from Hermes where the code is predominantly Telegram-specific:
+
+- identifier and topic normalization
+- formatting and entity helpers
+- UTF-16-aware length accounting and message splitting
+- caption overflow behavior
+- media classification and Telegram limits
+- retry classification and network fallback helpers
+- webhook and polling setup patterns
+- command parsing and inline-keyboard helpers
+- focused Telegram behavior tests
+
+Rewrite against Penguin contracts:
+
+- process lifecycle and cancellation
+- session creation and persistence
+- execution context and permission propagation
+- questions and approvals
+- tool and artifact events
+- background work and proactive delivery
+- ingress, delivery, and dead-letter persistence
+- diagnostics and configuration
+
+Use OpenClaw as a specification for:
+
+- durable-before-ack ingress
+- `update_id` idempotency
+- per-chat/topic ordered lanes
+- polling-offset safety
+- retry leases and dead letters
+- webhook authentication and body guards
+- outbound fallback behavior
+- restart recovery and poller-conflict handling
+
+Both upstream projects are MIT licensed. Any copied or materially adapted source
+or tests must retain the applicable copyright/license notice. Add a repository
+third-party notice or file-level provenance where appropriate. Do not obscure
+the source of copied tests.
+
+## Current Penguin Substrate
+
+Penguin already has much of the agent-facing runtime required by a channel:
+
+- `PenguinCore` and `Engine` own the reasoning/tool loop.
+- `ConversationManager` and `SessionManager` persist conversations.
+- `get_session_request_gate()` serializes work for one session.
+- direct stream callbacks expose assistant and reasoning chunks.
+- canonical runtime events expose lifecycle, stream, tool, task, error, and
+  user-input events.
+- `ApprovalManager` and `QuestionManager` expose interactive runtime controls.
+- FastAPI lifespan already owns construction and shutdown of the main core.
+- Run Mode and background agents can emit completion state.
+
+Relevant files:
+
+- `penguin/web/app.py`
+- `penguin/web/routes.py`
+- `penguin/core_runtime/process_facade.py`
+- `penguin/core_runtime/process_runtime.py`
+- `penguin/core_runtime/process_lifecycle.py`
+- `penguin/core_runtime/process_streaming.py`
+- `penguin/system/runtime_events.py`
+- `penguin/system/runtime_event_ledger.py`
+- `penguin/security/approval.py`
+- `penguin/security/question.py`
+- `penguin/integrations/integrations.md`
+- `context/rationale/penguin-service-topology.md`
+- `context/tasks/testing-pyramid.md`
+
+## Current Gaps
+
+The current web chat handler in `penguin/web/routes.py` contains important
+business logic that is not available through a channel-neutral service. Calling
+`PenguinCore.process()` directly would skip or duplicate:
+
+- execution-context construction
+- per-session request locking
+- directory and agent binding
+- model and variant selection
+- input/media normalization
+- permission and approval policy
+- request tracking, title refresh, and cleanup
+
+Other material gaps are:
+
+- no external channel envelope or capability contract
+- no durable Telegram address to Penguin session binding
+- no durable inbound update spool or outbound delivery outbox
+- no pairing/authorized-identity store
+- no general voice transcription or speech generation subsystem
+- only limited text/image/document ingestion
+- no complete first-class outbound artifact contract
+- approval resolution does not currently suspend and resume/retry the original
+  tool operation
+- questions suspend execution and require a direct reply path that must bypass
+  the normal session request gate
+- no production gateway-style cron/reminder scheduler
+- Run Mode has process-global state that needs isolation before multiple chats
+  can safely run autonomous work concurrently
+
+The redacted runtime event ledger is not a replacement for a channel ingress or
+delivery store. It intentionally does not retain every private transport payload
+needed to retry external delivery.
+
+## Guiding Principles
+
+1. Keep Telegram mechanics in `penguin/integrations/telegram/`.
+2. Keep channel-neutral routing, state, and delivery semantics in a core channel
+   package.
+3. Keep HTTP and Telegram on the same chat/application service.
+4. Run one main Penguin runtime process until cross-process session and event
+   coordination is designed explicitly.
+5. Default to deny for remote identities and groups.
+6. Treat Telegram metadata and media as untrusted input.
+7. Persist an inbound update before acknowledging it as accepted.
+8. Serialize one chat/topic lane while allowing independent lanes to progress.
+9. Never perform Telegram network calls synchronously inside Penguin's shared
+   event-bus subscribers.
+10. Keep live-provider and live-Telegram checks as opt-in smoke tests.
+11. Prefer behavioral parity over preserving Hermes's internal structure.
+12. Make configured integration failures visible through status and diagnostics.
+
+## Target Architecture
+
+```text
+Telegram Bot API
+  │
+  ├── long polling
+  └── authenticated webhook
+          │
+          ▼
+TelegramAdapter
+  - Bot API lifecycle
+  - Telegram auth/policy projection
+  - media download/upload
+  - commands/callbacks
+  - Telegram formatting
+          │
+          ▼
+ChannelIngressStore
+  - persist before acknowledgement
+  - update_id dedupe
+  - retry/lease/dead-letter state
+  - per-address delivery lanes
+          │
+          ▼
+ChannelManager
+  - normalized inbound envelope
+  - address/session binding
+  - capability and policy enforcement
+          │
+          ▼
+ChatService
+  - execution context
+  - session request gate
+  - input normalization
+  - PenguinCore.process()
+  - cancellation and cleanup
+          │
+          ▼
+PenguinCore → Engine → ConversationManager / ToolManager
+          │
+          ├── direct assistant/reasoning stream callback
+          └── scoped canonical runtime events
+                      │
+                      ▼
+ChannelPresentation + DeliveryStore
+  - progress/final message planning
+  - chunk/edit/media fallback
+  - durable outbound retries
+                      │
+                      ▼
+TelegramAdapter
+```
+
+### Runtime Topology Decision
+
+Start the Telegram manager within the existing FastAPI lifespan in
+`penguin/web/app.py`, sharing the same `PenguinCore` instance as HTTP/SSE.
+
+Initial topology:
+
+```text
+one supervised penguin-web/gateway process
+  ├── FastAPI
+  ├── PenguinCore
+  ├── Telegram polling or webhook adapter
+  ├── channel ingress workers
+  └── channel delivery workers
+```
+
+Only one process may own polling for a bot token. Do not start a second core or
+poller from a standalone `penguin telegram run` command. A future gateway CLI
+may be an alias over this same runtime composition.
+
+## Package And File Layout
+
+Proposed channel-neutral package:
+
+```text
+penguin/channels/
+  __init__.py
+  schema.py             # envelopes, addresses, attachments, deliveries
+  service.py            # shared ChatService/application boundary
+  manager.py            # channel registration, lifecycle, routing
+  policy.py             # normalized identity/access policy
+  presentation.py       # runtime events/results -> channel deliveries
+  session_store.py      # channel address -> Penguin session binding
+  ingress_store.py      # durable inbound work and leases
+  delivery_store.py     # durable outbound outbox and dead letters
+  errors.py             # explicit channel exceptions
+```
+
+Proposed Telegram integration:
+
+```text
+penguin/integrations/telegram/
+  __init__.py
+  config.py             # typed Telegram config and validation
+  manager.py            # adapter lifecycle and account client
+  adapter.py            # python-telegram-bot handlers and Bot API calls
+  auth.py               # DM/group/pairing policy projection
+  commands.py           # native command registration and dispatch
+  callbacks.py          # questions, approvals, model/topic selection
+  formatting.py         # HTML rendering, splitting, plain fallback
+  media.py              # bounded download/upload and media normalization
+  streaming.py          # throttled preview/progress editing
+  network.py            # retry/error classification and proxy behavior
+  webhooks.py           # thin webhook route and secret verification
+  diagnostics.py        # status/probe snapshots
+  errors.py             # explicit Telegram exceptions
+```
+
+Companion surfaces:
+
+```text
+penguin/web/integrations/telegram_webhook.py  # thin status/webhook routes
+penguin/cli/telegram.py                         # setup/status/pairing/diagnostics
+tests/channels/
+tests/integrations/telegram/
+```
+
+Exact filenames may change, but the dependency direction may not:
+
+```text
+Telegram integration → channel facades → Penguin public/runtime services
+```
+
+The Telegram integration must not depend on arbitrary private state scattered
+through `PenguinCore`, `Engine`, or `ToolManager`.
+
+## Configuration Surface
+
+Add a typed schema outside `penguin/config.py`; configuration loading and merge
+logic may remain there, while dataclass/Pydantic definitions belong with the
+channel integration.
+
+Proposed shape:
+
+```yaml
+channels:
+  telegram:
+    enabled: false
+    transport: polling          # polling | webhook
+    token_env: TELEGRAM_BOT_TOKEN
+    token_file: null
+
+    dm_policy: allowlist        # pairing | allowlist | open | disabled
+    allow_from:                 # numeric Telegram user ids only
+      - 123456789
+
+    group_policy: allowlist     # allowlist | open | disabled
+    group_allow_from: []        # numeric Telegram user ids
+    groups:
+      "-1001234567890":
+        enabled: true
+        require_mention: true
+        history_limit: 50
+        prompt: null
+        directory: null
+        agent_id: null
+        topics:
+          "42":
+            enabled: true
+            require_mention: false
+            prompt: null
+            directory: null
+            agent_id: null
+
+    streaming:
+      mode: progress            # off | edit | progress
+      edit_interval_ms: 750
+      include_reasoning: false
+
+    media:
+      max_download_mb: 20
+      max_document_text_chars: 100000
+      voice_transcription: false
+      voice_replies: false
+
+    permissions:
+      mode: workspace           # read_only | workspace | full_access
+      approvals: prompt
+      allow_yolo: false
+
+    delivery:
+      retry_attempts: 8
+      dead_letter_after_hours: 24
+
+    webhook:
+      public_url: null
+      path: /api/v1/integrations/telegram/webhook
+      secret_env: TELEGRAM_WEBHOOK_SECRET
+
+    proxy_url_env: null
+    home_chat_id: null
+    home_topic_id: null
+```
+
+Configuration invariants:
+
+- `enabled: false` is the default.
+- Tokens and webhook secrets come from environment variables, secret references,
+  or guarded regular files. They are never returned through status endpoints.
+- `dm_policy: open` requires an explicit wildcard acknowledgement rather than
+  becoming open because an allowlist is empty.
+- User and group authorization uses numeric IDs, not usernames.
+- Group access and DM pairing are separate grants.
+- Remote permission mode cannot exceed the instance-level permission ceiling.
+- `PENGUIN_YOLO` must not silently make Telegram remote execution unrestricted.
+- Webhook mode requires a secret.
+- Polling and webhook mode cannot own the same token simultaneously.
+
+Add an optional package extra after verifying the supported Python matrix:
+
+```toml
+telegram = [
+  "python-telegram-bot[webhooks]<23",
+]
+```
+
+Pin more tightly while initially porting Hermes tests, then widen only after the
+supported dependency range is exercised in CI.
+
+## Core Data Model
+
+### Channel Address
+
+A normalized destination/source independent of Telegram handler objects:
+
+```text
+ChannelAddress
+  platform: "telegram"
+  account_id: "default"
+  chat_id: str
+  topic_id: str | null
+  peer_id: str | null
+```
+
+Use strings at the Penguin boundary so large signed Telegram IDs survive storage
+and JSON round trips without coercion.
+
+### Inbound Envelope
+
+```text
+InboundEnvelope
+  event_id
+  address
+  sender identity
+  occurred_at
+  text/caption
+  attachments
+  reply/forward metadata
+  command/callback metadata
+  raw transport metadata subset
+```
+
+Do not persist a complete unbounded Telegram update when a normalized bounded
+record is sufficient. Preserve the raw `update_id` and the fields required for
+idempotency, reply routing, diagnostics, and recovery.
+
+### Session Binding
+
+```text
+platform + account_id + chat_id + topic_id + configured DM scope
+    → Penguin session_id + directory + agent_id + agent_mode
+```
+
+Store Penguin-generated UUID session IDs rather than encoding raw Telegram keys
+as filesystem session IDs. `/new` creates a new Penguin session and atomically
+updates the binding.
+
+### Ingress Record
+
+Minimum durable fields:
+
+- platform/account/update ID
+- normalized lane key
+- bounded inbound envelope
+- state: pending, claimed, completed, retry, dead
+- claim owner and lease expiry
+- attempt count and next-attempt time
+- last error class and bounded message
+- created/updated/completed timestamps
+
+### Delivery Record
+
+Minimum durable fields:
+
+- stable delivery ID and idempotency key
+- source session/request/runtime-event ID
+- destination address
+- delivery kind: text, edit, media, reaction, callback update
+- bounded payload or artifact reference
+- reply/topic metadata
+- Telegram message ID after delivery
+- state, lease, attempt count, next-attempt time, and last error
+- created/updated/completed timestamps
+
+### Supporting Caches
+
+Use bounded caches only where Telegram cannot provide later lookup:
+
+- observed messages for reply context
+- sent messages for edit/reaction/topic recovery
+- pairing codes and authorized identities
+- group/topic names for diagnostics
+- last successful home-channel destination
+
+## Session And Topic Semantics
+
+Safe defaults:
+
+- A private chat binds per bot account and peer. Never share one DM session
+  across different users.
+- A group binds per group chat.
+- A forum topic adds `message_thread_id` and receives its own session/lane.
+- Group sender authorization is checked separately from the shared group session.
+- Replies remain in the bound chat/topic session unless a command explicitly
+  changes it.
+- Same-lane work is serialized through the durable lane and Penguin's existing
+  session request gate.
+- Different sessions may execute concurrently within configured capacity.
+
+Commands that change session state must operate on the same binding store as
+ordinary messages. They must not maintain a second Telegram-only session map.
+
+Question replies are exceptional: an answer to a suspended `QuestionManager`
+waiter must resolve that waiter directly. Sending it through a new chat turn can
+deadlock behind the original session gate.
+
+## Security And Permission Model
+
+Telegram exposes a local coding agent to a remote network. The security posture
+must be stricter than the loopback web default.
+
+Required controls:
+
+- default-deny DM and group policies
+- numeric immutable identity checks
+- DM-only pairing grants
+- separate group and sender allowlists
+- mention gating for groups by default
+- callback ownership validation using user, chat, topic, and request identity
+- conservative remote execution context and permission ceiling
+- explicit approvals for destructive/high-risk tools
+- bounded message, callback, and media payloads
+- MIME/magic checks and safe temporary-file handling
+- filenames reduced to safe basenames
+- no arbitrary local path access from Telegram payload metadata
+- token/secret redaction in logs, events, status, and exceptions
+- constant-time webhook secret comparison
+- webhook body/time limits and failed-auth throttling
+- outbound URL and local-file validation where supported
+- rate limits per bot token and destination
+
+Pairing authorizes communication; it does not grant group access, change the
+permission mode, authorize approval callbacks for another person, or establish
+an implicit proactive-delivery destination.
+
+## Reliability Invariants
+
+The channel layer must encode these invariants in tests:
+
+1. Persist a polling/webhook update before acknowledging or advancing beyond it.
+2. The same Telegram `update_id` is admitted at most once per bot identity.
+3. Updates in one chat/topic lane are processed in order.
+4. A failed lane does not block unrelated lanes.
+5. Claims have leases and are recoverable after process death.
+6. Successful completion is durable before an ingress record is discarded.
+7. Outbound deliveries survive process restart.
+8. Delivery retry honors Telegram `retry_after` and bounded backoff.
+9. Retry transient network, `429`, and `5xx` failures.
+10. Treat invalid token/not-found failures as fatal and surface them in status.
+11. Surface `409` polling conflicts rather than hiding duplicate pollers.
+12. Failed formatting retries through a safer representation, eventually plain
+    text, without losing the final answer.
+13. Streaming edits and final durable delivery use the same formatting/chunking
+    rules.
+14. Network calls execute in bounded workers, not shared event-bus callbacks.
+15. Dead letters are visible, inspectable, and manually retryable.
+16. Replaying a crashed inbound request must not silently repeat a known
+    non-idempotent tool operation.
+
+The last invariant requires coordination with Penguin request/tool lifecycle
+records. An ingress record that crashed after starting a turn cannot always be
+blindly replayed. It must either resume from durable Penguin state or surface a
+recoverable/manual-retry outcome.
+
+## Telegram UX And Feature Matrix
+
+| Capability | Basic | Daily Driver | Hermes Parity |
+|---|---:|---:|---:|
+| Private text chat | yes | yes | yes |
+| Stable session binding and `/new` | yes | yes | yes |
+| Default-deny numeric allowlist | yes | yes | yes |
+| Typing indicator | yes | yes | yes |
+| Final text chunking/fallback | yes | yes | yes |
+| Editable streaming answer | no | yes | yes |
+| Tool/progress status | no | yes | yes |
+| `/stop`, `/status`, `/model` | partial | yes | yes |
+| Inbound photos | no | yes | yes |
+| Bounded text documents | no | yes | yes |
+| Groups and mention gating | no | yes | yes |
+| Forum topic sessions | no | yes | yes |
+| Pairing and guest policy | no | optional | yes |
+| Inline questions | no | yes | yes |
+| Resumable tool approvals | no | partial | yes |
+| Webhooks | no | optional | yes |
+| Durable ingress/outbox | minimal | yes | yes |
+| Restart recovery/dead letters | no | yes | yes |
+| Voice transcription | no | no | yes |
+| Voice replies/TTS | no | no | yes |
+| Broad media/file handling | no | partial | yes |
+| Reactions/status reactions | no | optional | yes |
+| Per-topic prompt/agent/skill binding | no | optional | yes |
+| Proactive/background delivery | no | yes | yes |
+| Scheduled/home-channel delivery | no | partial | yes |
+| Polling, webhook, proxy diagnostics | minimal | yes | yes |
+| Startup/recovery notifications | no | optional | yes |
+
+## Implementation Phases
+
+### Phase 0 — Shared Chat Service And Runtime Spike
+
+Objective: establish the correct Penguin integration seam before writing bot
+handlers.
+
+Work:
+
+- [x] Extract the reusable orchestration in
+  `penguin/web/routes.py::handle_chat_message` into a typed application service.
+- [x] Preserve execution context, session binding, request gate, model/variant,
+  media normalization, permission policy, cancellation, and cleanup behavior.
+- [x] Migrate the HTTP route to the new service without changing its contract.
+- [x] Audit the WebSocket chat path and route it through the same service where
+  feasible.
+- [x] Define `ChannelAddress`, `InboundEnvelope`, attachments, stream updates,
+  and delivery requests.
+- [x] Add a minimal in-memory fake channel adapter for contract tests.
+- [x] Verify one direct service call can stream and complete a Penguin response.
+- [x] Verify same-session calls serialize and separate-session calls isolate.
+- [x] Decide and test the supported `python-telegram-bot` version across Penguin's
+  Python 3.9-3.12 package matrix.
+
+Acceptance criteria:
+
+- HTTP chat behavior remains compatible.
+- The new service has no FastAPI request/response types in its public contract.
+- A fake channel can execute, stream, cancel, and complete a Penguin turn.
+- No Telegram-specific code exists inside `PenguinCore` or `Engine`.
+
+### Phase 1 — Basic Personal DM Bot
+
+Objective: ship the smallest secure, genuinely useful Telegram surface.
+
+Work:
+
+- [x] Add the optional `telegram` dependency extra.
+- [x] Add typed disabled-by-default Telegram configuration.
+- [x] Create and stop the Telegram manager from the application lifespan.
+- [x] Support long polling for one bot token.
+- [x] Validate the token and expose bot identity/status without exposing it.
+- [x] Enforce a numeric DM allowlist before admitting work.
+- [x] Normalize text updates into `InboundEnvelope`.
+- [x] Persist a stable DM-to-Penguin session binding.
+- [x] Route text through the shared chat service.
+- [x] Show a typing indicator while Penguin runs.
+- [x] Send final output with conservative 4,000-character chunking.
+- [x] Render Telegram HTML with plain-text fallback.
+- [x] Add `/start`, `/help`, `/new`, `/status`, `/stop`, and `/whoami`.
+- [x] Handle provider/tool/runtime failures as errors, not assistant success text.
+- [x] Add update-ID deduplication before exposing the bot beyond local testing.
+
+Acceptance criteria:
+
+- An allowed user can hold a multi-turn Penguin conversation from Telegram.
+- An unlisted user cannot start a Penguin turn.
+- Restarting Penguin retains the same bound session.
+- `/new` creates and binds a fresh Penguin session.
+- `/stop` cancels the active request for that session.
+- Long responses arrive without parse errors or silent truncation.
+
+### Phase 2 — Daily-Driver Streaming, Commands, And Basic Media
+
+Objective: make Telegram pleasant enough for routine Penguin use.
+
+Work:
+
+- [x] Add throttled editable answer previews.
+- [x] Add `progress` mode with one status/tool message and a clean final answer.
+- [x] Keep reasoning hidden by default; expose only through explicit safe config.
+- [x] Coalesce small deltas and limit edit frequency.
+- [x] Rotate/chunk previews that exceed Telegram limits.
+- [x] Fall back from edit failure to ordinary final delivery.
+- [x] Register a native Telegram command menu.
+- [x] Add `/model`, `/mode`, `/session`, `/goal`, and `/project` where Penguin has
+  stable service contracts for them.
+- [x] Download inbound photos into validated temporary files and pass them as
+  Penguin image inputs.
+- [x] Ingest bounded UTF-8 text documents as context.
+- [x] Add a first-class outbound artifact projection for Penguin-generated images
+  and files.
+- [x] Preserve reply-to context for observed messages.
+- [x] Clean all temporary media on success, failure, and cancellation.
+
+Acceptance criteria:
+
+- Streaming does not create an edit storm or block Penguin event subscribers.
+- Text, tool progress, and final output stay scoped to the originating session.
+- Photos reach Penguin's multimodal input path.
+- Supported text documents are bounded and clearly attributed as untrusted input.
+- Generated artifacts are delivered or produce a visible delivery failure.
+
+### Phase 3 — Groups, Topics, Pairing, And Channel Policy
+
+Objective: support shared Telegram spaces without session or authorization leaks.
+
+Work:
+
+- [x] Add DM policies: pairing, allowlist, open, and disabled.
+- [x] Add one-hour, single-use pairing codes and approval CLI/API.
+- [x] Keep pairing grants DM-only.
+- [x] Add group allowlist and group-sender allowlist policy.
+- [x] Default groups to mention-gated behavior.
+- [x] Handle BotFather privacy-mode limitations clearly in diagnostics/docs.
+- [x] Ignore commands addressed to another bot.
+- [x] Create separate session bindings for groups and forum topics.
+- [x] Preserve topic IDs on typing, replies, edits, and final sends.
+- [x] Add bounded rolling group context for observed messages.
+- [x] Support per-group/topic prompt, directory, agent, mode, and skill binding.
+- [x] Add `/activation mention|always` and `/topic` behavior where appropriate.
+- [x] Handle supergroup ID migration without losing bindings.
+
+Acceptance criteria:
+
+- One DM user cannot see or affect another user's session.
+- Two groups and two topics remain isolated under concurrent load.
+- Unauthorized senders cannot trigger Penguin in an allowed group.
+- Mention gating behaves correctly with Telegram privacy mode enabled and disabled.
+- Group/topic configuration is resolved deterministically and fails closed.
+
+### Phase 4 — Interactive Questions And Resumable Approvals
+
+Objective: make Penguin's interactive safety model usable from Telegram.
+
+Work:
+
+- [x] Project `QuestionManager` prompts as Telegram messages with inline choices.
+- [x] Route free-text question replies directly to the pending waiter.
+- [x] Ensure question replies do not deadlock behind the session request gate.
+- [x] Add callback ownership checks and single-use callback records.
+- [x] Project tool approval requests with approve/deny buttons.
+- [x] Add session/request/tool identity to approval callback payload records.
+- [x] Implement resumable approval semantics so approval can continue or retry the
+  original tool operation safely.
+- [x] Expire stale questions/approvals and update their Telegram messages.
+- [x] Add callback unregister/cleanup behavior for application shutdown.
+- [x] Prevent approval command text from leaking into unauthorized groups/topics.
+
+Acceptance criteria:
+
+- A pending question can be answered with a button or text without creating a
+  second model turn.
+- Only the authorized recipient can resolve a callback.
+- Approve resumes the intended operation at most once; deny does not execute it.
+- Restart or expiry produces a clear terminal state rather than a hanging button.
+
+### Phase 5 — Durable Delivery And Restart Recovery
+
+Objective: make Telegram reliable enough for long-lived/background Penguin work.
+
+Work:
+
+- [x] Implement the SQLite channel session-binding store.
+- [x] Implement durable ingress admission, claims, leases, retry, and dead letters.
+- [x] Persist updates before advancing the polling watermark.
+- [x] Implement per-chat/topic lane scheduling.
+- [x] Implement the durable outbound delivery store and bounded workers.
+- [x] Classify Telegram retryable, fatal, rate-limit, and polling-conflict errors.
+- [x] Honor `retry_after` and use bounded jittered backoff.
+- [x] Recover expired ingress and delivery leases on startup.
+- [x] Add dead-letter list, inspect, retry, and discard operator controls.
+- [x] Detect duplicate token/poller ownership.
+- [x] Add authenticated webhook mode using the same ingress path as polling.
+- [x] Return webhook success only after durable adoption.
+- [x] Add webhook body limits, timeouts, and constant-time secret verification.
+- [x] Define crash behavior for turns that may have started non-idempotent tools.
+
+Acceptance criteria:
+
+- Killing Penguin after ingress admission does not lose the update.
+- Restarting after an outbound network failure eventually delivers or dead-letters
+  the result.
+- Duplicate updates do not execute duplicate completed turns.
+- One blocked lane does not stall unrelated chats.
+- Polling and webhook paths pass the same normalized ingress contract tests.
+
+### Phase 6 — Voice, Files, Reactions, And Media Parity
+
+Objective: reach Hermes-level conversational media support.
+
+Work:
+
+- [ ] Introduce a provider-neutral audio transcription service.
+- [ ] Support a local transcription backend and configured remote providers.
+- [ ] Treat transcripts as machine-generated, untrusted input.
+- [ ] Support voice/audio mention detection only under an explicit policy.
+- [ ] Add optional TTS and Telegram voice-bubble delivery.
+- [ ] Support common document, audio, video, and media-group inputs safely.
+- [ ] Define which binary documents are parsed, attached as artifacts, or rejected.
+- [ ] Expand outbound artifact delivery for photo, document, audio, voice, and
+  video where Penguin can produce them.
+- [ ] Add caption overflow and media fallback behavior.
+- [ ] Add processing/done/error reactions with conservative defaults.
+- [ ] Add reply, edit, pin, and deletion actions required by Hermes parity.
+- [ ] Support proxy configuration and optional local Telegram Bot API deployment.
+
+Acceptance criteria:
+
+- Voice notes can be transcribed into a clearly marked Penguin input.
+- Optional voice replies play as Telegram voice messages.
+- Unsupported or oversized media fails clearly and leaves no temporary files.
+- Media sends use safe fallbacks and do not discard accompanying text.
+- Reaction/status behavior respects authorization and Telegram capabilities.
+
+### Phase 7 — Proactive Delivery And Automation
+
+Objective: make Telegram an outbound Penguin destination, not only a request/
+response surface.
+
+Work:
+
+- [ ] Add an explicit channel destination model usable by Run Mode, goals,
+  projects, background agents, and notifications.
+- [ ] Add `home_chat_id`/`home_topic_id` configuration and validation.
+- [ ] Deliver background completion, failure, and attention-required events.
+- [ ] Persist proactive messages through the same delivery outbox.
+- [ ] Add explicit CLI/API sends to a configured Telegram destination.
+- [ ] Define safe last-used destination semantics without treating pairing as
+  proactive-send consent.
+- [ ] Add a durable scheduler for one-shot reminders, intervals, and cron jobs, or
+  integrate Telegram delivery with Penguin's chosen supervised timer model.
+- [ ] Bind scheduled runs to explicit Penguin session modes and destinations.
+- [ ] Add startup/recovery notification policy and quiet modes.
+- [ ] Ensure concurrent autonomous runs do not share global Run Mode callbacks.
+
+Acceptance criteria:
+
+- A background run can complete after the originating Telegram request and still
+  deliver its result after restart.
+- Scheduled delivery always names an explicit authorized destination.
+- Pairing alone never causes unsolicited scheduled messages.
+- Delivery failures are visible and recoverable through the outbox/dead-letter
+  controls.
+
+### Phase 8 — Hermes Parity Hardening
+
+Objective: close the feature matrix, operational, documentation, and QA gaps.
+
+Work:
+
+- [ ] Audit every capability in the pinned Hermes Telegram documentation.
+- [ ] Port remaining relevant Hermes Telegram tests with attribution.
+- [ ] Test polling, webhook, proxy, and local Bot API configurations.
+- [ ] Add notification modes, edited status, pins, and recovery notices.
+- [ ] Complete command menu validation, help text, and access tiers.
+- [ ] Add model picker, topic skill binding, and per-channel prompt behavior.
+- [ ] Add setup, status, probe, doctor, pairing, and dead-letter CLI flows.
+- [ ] Add actionable diagnostics for token, permissions, privacy mode, webhook,
+  network, polling conflicts, and delivery backlog.
+- [ ] Add systemd-user and launchd guidance using Penguin's single-gateway model.
+- [ ] Complete security audit and fault-injection campaign.
+- [ ] Run opt-in live Telegram smoke tests and capture the verification matrix.
+- [ ] Update README, configuration reference, web docs, and architecture docs.
+- [ ] Produce a final documented list of intentional Hermes divergences.
+
+Acceptance criteria:
+
+- Every Hermes parity matrix row is implemented, explicitly waived, or documented
+  as an intentional Penguin difference.
+- All deterministic channel tests pass without network/provider access.
+- Live smoke tests cover one DM, one group, one topic, media, callback, polling,
+  webhook, restart recovery, and proactive delivery.
+- No business logic has leaked back into HTTP or Telegram route handlers.
+
+## Testing Strategy
+
+Follow `context/tasks/testing-pyramid.md`. Provider and transport reliability must
+be proven with deterministic tests before live checks.
+
+### Unit Tests
+
+- config validation and secret precedence
+- numeric identity and allowlist normalization
+- address/lane/session key resolution
+- group/topic policy inheritance
+- command parsing and callback ownership
+- Markdown-to-HTML rendering and plain fallback
+- UTF-16 length accounting and message/caption splitting
+- media type/size/name validation
+- Telegram error classification and backoff
+- delivery planning from runtime events/results
+
+### Property Tests
+
+- arbitrary Unicode chunks never exceed Telegram limits
+- formatting fallback preserves visible text
+- address normalization is stable across serialization
+- topic/group/DM keys cannot collide
+- configuration merges never broaden access accidentally
+- retry schedules remain bounded and monotonic
+
+### State-Machine Tests
+
+- ingress pending/claim/lease/retry/complete/dead transitions
+- delivery pending/claim/retry/sent/dead transitions
+- crash before and after durable ingress acknowledgement
+- crash before and after Telegram send acknowledgement
+- duplicate updates and delivery idempotency
+- lane ordering and unrelated-lane progress
+- webhook/polling transport replacement and `409` conflicts
+- question and approval pending/resolved/expired transitions
+
+### Contract Tests
+
+- fake `python-telegram-bot` update to normalized `InboundEnvelope`
+- channel address to Penguin session binding
+- ChatService execution-context and permission propagation
+- direct stream callback to throttled Telegram edits
+- canonical runtime event to tool/progress/background delivery
+- media download to Penguin input and artifact to Telegram output
+- polling and webhook parity through the same ingress worker
+
+### Hermetic Integration Tests
+
+Use a fake LLM/provider and fake Telegram Bot API to cover:
+
+- multi-turn DM conversation and `/new`
+- simultaneous isolated chats and serialized same-chat turns
+- group mention and topic routing
+- provider failure and next-turn recovery
+- abort during streaming/tool execution
+- question and approval callbacks
+- restart with pending ingress/outbound work
+- photo/document/voice processing and cleanup
+- proactive delivery after the original request completes
+
+### Fault Injection
+
+- incomplete model streams
+- provider errors and timeouts
+- Telegram `429`, `5xx`, `401`, `404`, and `409`
+- malformed Telegram HTML/entity rejection
+- edit-message failure after partial streaming
+- database busy/I/O failure
+- expired leases and process restart
+- deleted or missing artifact files
+- media download interruption and oversized bodies
+- callback replay and wrong-user callback attempts
+
+### Opt-In Live Telegram Smoke Tests
+
+Live tests require explicit environment variables and are never part of the
+default suite.
+
+Suggested gates:
+
+```text
+PENGUIN_LIVE_TELEGRAM=1
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_TEST_USER_ID=...
+TELEGRAM_TEST_CHAT_ID=...
+TELEGRAM_TEST_TOPIC_ID=...
+```
+
+Live tests should create identifiable messages, clean up when possible, avoid
+destructive tools, and document any Telegram/BotFather setup requirements.
+
+## Observability And Operations
+
+Expose a bounded, redacted status snapshot:
+
+```json
+{
+  "enabled": true,
+  "transport": "polling",
+  "bot_id": "123456789",
+  "bot_username": "penguin_example_bot",
+  "state": "running",
+  "last_update_at": "...",
+  "last_success_at": "...",
+  "ingress_pending": 0,
+  "deliveries_pending": 0,
+  "dead_letters": 0,
+  "last_error": null
+}
+```
+
+The token, webhook secret, proxy credentials, private message bodies, and local
+artifact paths must not appear in status or routine logs.
+
+Recommended operator commands:
+
+```text
+penguin telegram status
+penguin telegram probe
+penguin telegram pairing list
+penguin telegram pairing approve <code>
+penguin telegram deliveries list
+penguin telegram deliveries retry <id>
+penguin telegram doctor
+```
+
+If these commands are implemented under a future generic channel CLI, keep
+equivalent discoverability.
+
+## Documentation And Packaging
+
+Required documentation:
+
+- BotFather bot creation and privacy-mode setup
+- optional dependency installation with `uv`
+- safe token/secret configuration
+- numeric user, group, and topic ID discovery
+- DM allowlist and pairing setup
+- group mention and privacy-mode behavior
+- polling versus webhook operation
+- reverse-proxy and webhook-secret setup
+- permission and approval behavior for a remote bot
+- supported media and configured limits
+- home-channel and scheduled-delivery consent
+- status, logs, recovery, and dead-letter operations
+- launchd/systemd-user single-gateway deployment
+- local Telegram Bot API server limitations and trust boundary
+
+Packaging requirements:
+
+- Telegram remains optional when unconfigured.
+- Missing optional dependencies produce one actionable error.
+- Importing Penguin without the Telegram extra continues to work.
+- The extra participates in supported Python-version CI.
+- Public modules define `__all__`.
+- Upstream MIT notices/provenance are included where code/tests are ported.
+
+## Estimated Effort
+
+These are cumulative one-engineer estimates and assume the core Penguin provider
+and tool runtime remain functional:
+
+| Milestone | Estimate |
+|---|---:|
+| Phase 0-1 basic personal bot | 1-2 weeks |
+| Phase 0-2 daily-driver bot | 3-5 weeks |
+| Through groups, approvals, and durability | 7-10 weeks |
+| Hermes parity, including voice and proactive delivery | 10-14+ weeks |
+
+The scheduler, resumable approvals, voice services, and first-class artifact
+contract are Penguin-wide work. If those become separate generalized projects,
+calendar time may increase even though the Telegram-specific adapter becomes
+smaller.
+
+## Recommended Pull Request Sequence
+
+1. Shared `ChatService` extraction and HTTP contract regression tests.
+2. Channel schemas, fake adapter, session binding, and policy contracts.
+3. Basic Telegram polling DM bot and commands.
+4. Formatting, streaming, photos/documents, and artifact projection.
+5. Groups, topics, mention policy, and pairing.
+6. Questions and resumable approvals.
+7. Durable ingress, outbox, retry/dead-letter state machines, and webhooks.
+8. Voice/media/reactions and network deployment options.
+9. Proactive delivery, scheduler integration, and Run Mode isolation.
+10. Hermes parity audit, diagnostics, packaging, docs, and live smoke evidence.
+
+Each pull request should leave the repository green and independently improve a
+shippable configuration. Avoid a single long-lived parity branch.
+
+## Main Risks
+
+### Architectural Risks
+
+- Duplicating the web chat handler inside Telegram.
+- Calling `PenguinCore.process()` without required request scoping.
+- Running two cores against the same file-backed session state.
+- Blocking the shared event bus on Telegram network I/O.
+- Leaking runtime events between sessions due to missing scope filters.
+- Creating a Telegram-only command/session system that drifts from other clients.
+
+### Reliability Risks
+
+- Duplicate Telegram updates repeating non-idempotent tool work.
+- Advancing polling offsets before durable admission.
+- Losing final output after the Penguin turn commits.
+- Edit storms or rate-limit loops during streaming.
+- Malformed formatting dropping an otherwise valid final answer.
+- Stale callbacks approving the wrong request.
+- Global Run Mode state routing completion to the wrong chat.
+
+### Security Risks
+
+- Open or username-based authorization defaults.
+- Remote Telegram users inheriting permissive local/YOLO execution.
+- Cross-user DM session reuse.
+- Group members resolving another user's question or approval.
+- Unbounded file/media download and unsafe local-path handling.
+- Secrets appearing in config responses or logs.
+- Treating pairing as consent for unsolicited proactive messages.
+
+### Maintenance Risks
+
+- Copying one large Hermes adapter instead of smaller owned modules.
+- Porting tests without recording their upstream revision.
+- Telegram Bot API/library changes invalidating behavior silently.
+- Coupling parity to optional features without a stable Penguin-wide contract.
+
+## Open Questions
+
+Resolve these before or during the named phase, not all before Phase 1:
+
+1. Should the shared application boundary be named `ChatService`,
+   `InteractionService`, or a broader `ChannelExecutionService`?
+2. Should channel SQLite state use one database with multiple tables or separate
+   binding/ingress/delivery databases?
+3. Which workspace path owns channel state and retention configuration?
+4. Is pairing necessary for the first public release, or is an explicit numeric
+   allowlist sufficient until Phase 3?
+5. Which STT/TTS providers are acceptable defaults, and which remain extras?
+6. What exact tool operation record is required to resume approved work safely?
+7. Which Penguin artifacts are stable enough for reliable outbound delivery?
+8. Should cron live inside Penguin or remain supervised through launchd/systemd
+   timers that call a Penguin command?
+9. Which commands are channel-neutral and which remain Telegram-specific?
+10. What portion of group history belongs in persisted conversation context versus
+    ephemeral Telegram context?
+11. Should per-topic agent/directory/skill bindings be config-only initially or
+    mutable through owner commands?
+12. What retention and redaction policy applies to inbound/outbound channel rows?
+
+## Definition Of Done
+
+Hermes-level Penguin Telegram support is complete when:
+
+- [ ] A fresh user can install the optional extra, create/configure a bot, and
+  diagnose setup using documented commands.
+- [ ] DMs, allowed groups, and forum topics route to isolated durable Penguin
+  sessions.
+- [ ] Text, images, bounded documents, voice, and supported files work with clear
+  limits and cleanup.
+- [ ] Streaming, tool progress, formatting fallback, replies, and final artifacts
+  behave reliably.
+- [ ] Commands, model selection, questions, and resumable approvals use Penguin's
+  canonical services.
+- [ ] Authorization fails closed and remote permissions cannot exceed configured
+  Penguin policy.
+- [ ] Polling and authenticated webhooks share durable ingress semantics.
+- [ ] Duplicate updates, restarts, rate limits, and network failures cannot
+  silently lose committed results.
+- [ ] Background and scheduled work can deliver through an explicit authorized
+  home destination.
+- [ ] Status, probe, doctor, pairing, outbox, and dead-letter controls are usable.
+- [ ] Deterministic unit, property, state-machine, contract, integration, and
+  fault-injection suites pass.
+- [ ] Opt-in live smoke evidence covers the critical Telegram surfaces.
+- [ ] Upstream attribution is preserved for copied/adapted Hermes/OpenClaw work.
+- [ ] README, user docs, architecture docs, and configuration references match
+  runtime truth.
+- [ ] Any intentional difference from the pinned Hermes behavior is documented.

--- a/context/tasks/penguin-telegram.md
+++ b/context/tasks/penguin-telegram.md
@@ -435,7 +435,15 @@ channels:
 
     permissions:
       mode: workspace           # read_only | workspace | full_access
-      approvals: prompt
+      approvals:
+        shell: ask
+        fileWrite: ask
+        fileDelete: ask
+        gitPush: ask
+        network: ask
+        secrets: deny
+        default: ask
+      timeout_seconds: 300
       allow_yolo: false
 
     delivery:

--- a/docs/docs/usage/telegram.md
+++ b/docs/docs/usage/telegram.md
@@ -88,7 +88,14 @@ channels:
 
     permissions:
       mode: workspace
-      approvals: prompt
+      approvals:
+        shell: ask
+        fileWrite: ask
+        fileDelete: ask
+        gitPush: ask
+        network: ask
+        secrets: deny
+        default: ask
       timeout_seconds: 300
       allow_yolo: false
 
@@ -272,6 +279,7 @@ The bot registers this command menu:
 | `/model` | Show the active model. |
 | `/goal ...` | Use Penguin's session-goal command for the bound session. |
 | `/project` | Show the bound project directory. |
+| `/permissions` | Show Telegram's capped permission policy and timeout. |
 
 Additional policy commands are `/pair CODE`, `/activation mention|always`, and
 `/topic`. A command explicitly addressed to another bot is ignored.
@@ -313,20 +321,34 @@ video, media groups, and general file ingestion are not implemented in Phases
 
 Penguin projects pending questions into Telegram with inline choices; the
 authorized user may also answer with text. Tool approval prompts have
-`Approve once` and `Deny` buttons. Callback records are scoped to the originating
-bot account, chat, topic, and user, expire after the configured timeout, and can
-be completed only once. An approved waiter resumes the intended tool operation
-at most once. When Penguin asks several questions together, answer with exactly
-one non-empty line per question; inline choices are offered only for a single
-question. Resolution, expiry, shutdown, and restart replace active controls with
-a terminal state so stale buttons cannot resume work.
+`Approve once`, `Approve for session`, and `Deny` buttons. Callback records are
+scoped to the originating bot account, chat, topic, and user, expire after the
+configured timeout, and can be completed only once. An approved waiter resumes
+the intended tool operation at most once. When Penguin asks several questions
+together, answer with exactly one non-empty line per question; inline choices
+are offered only for a single question. Resolution, expiry, shutdown, and
+restart replace active controls with a terminal state so stale buttons cannot
+resume work.
 
 Remote permissions remain subordinate to Penguin's instance security mode:
 
 - `permissions.mode` accepts `read_only`, `workspace`, or `full_access`, but is
   capped by the instance-level `security.mode`.
-- `permissions.approvals: prompt` waits for Telegram approval; `deny` refuses
-  operations requiring approval.
+- `permissions.approvals` accepts category decisions for `shell`, `fileWrite`,
+  `fileDelete`, `gitPush`, `network`, `secrets`, and `default`. Each decision is
+  `allow`, `ask`, or `deny`. `allow` skips only the Telegram prompt; Penguin's
+  instance security, workspace boundaries, and child-tool checks still apply.
+- Legacy scalar `permissions.approvals: prompt` and
+  `permissions.approvals: deny` remain supported.
+- `/permissions` reports Telegram's mode cap, category decisions, and approval
+  timeout without changing configuration or exposing credentials. An `allow`
+  decision removes only Telegram's own prompt; instance or agent policy may
+  still ask, and any instance, agent, or workspace denial still blocks.
+- `secrets` applies in addition to the tool's normal category when a tool targets
+  common credential files, private-key paths, or secret-bearing process
+  environment names and references.
+- Sub-agent creation and resumption use the conservative `shell` category.
+  Approving orchestration never pre-approves tools subsequently used by a child.
 - `publish_artifact` is an explicit, approval-gated network operation; Penguin
   never infers outbound files from ordinary path-looking tool output.
 - `allow_yolo: true` is rejected.

--- a/docs/docs/usage/telegram.md
+++ b/docs/docs/usage/telegram.md
@@ -1,0 +1,446 @@
+---
+title: Telegram
+---
+
+# Telegram bot
+
+Penguin can run `@Penguin_agent_bot` as an optional Telegram surface over the
+same core used by `penguin-web`. The current implementation covers Phases 0–5:
+DMs, allowlisted groups and forum topics, stable Penguin sessions, streaming,
+basic media, questions and approvals, polling or authenticated webhooks, and
+restart-safe SQLite ingress and delivery.
+
+Voice transcription, TTS, audio/video and broad media support, reactions,
+scheduled delivery, and general proactive/background sends are later phases.
+
+## Requirements and installation
+
+Telegram uses `python-telegram-bot==22.6` as an optional dependency.
+That dependency is enabled only on Python 3.10 or newer; use Python 3.10–3.12
+for Penguin's Telegram integration.
+
+```bash
+# Published package
+pip install "penguin-ai[telegram]"
+
+# Source checkout
+uv sync --extra telegram
+```
+
+The base Penguin install does not install or start Telegram support.
+
+## Create and secure the bot
+
+1. Open Telegram's official [BotFather](https://t.me/BotFather).
+2. Create or manage the bot whose username is `@Penguin_agent_bot`.
+3. Keep its HTTP API token in a secret manager or process environment.
+4. If a token is ever exposed, revoke it with BotFather and issue a new one.
+
+With `expected_username: Penguin_agent_bot`, Penguin verifies the username
+returned by Telegram at startup and refuses to start the integration if it does
+not match (case-insensitive).
+
+Never paste a live bot token or webhook secret into YAML, source control,
+documentation, logs, issue trackers, or chat. Penguin accepts the bot token only
+from `TELEGRAM_BOT_TOKEN` and the webhook secret only from
+`TELEGRAM_WEBHOOK_SECRET`.
+
+For an interactive local shell, this reads the bot token without echoing it:
+
+```bash
+read -s TELEGRAM_BOT_TOKEN
+export TELEGRAM_BOT_TOKEN
+```
+
+For a service, inject the variable through the service manager or secret store.
+
+## Start with default-deny configuration
+
+Add a `channels.telegram` block to the YAML configuration Penguin loads. Start
+disabled with empty numeric allowlists:
+
+```yaml
+channels:
+  telegram:
+    enabled: false
+    expected_username: Penguin_agent_bot
+    transport: polling
+    token_env: TELEGRAM_BOT_TOKEN
+
+    dm_policy: allowlist
+    allow_from: []
+
+    group_policy: allowlist
+    group_allow_from: []
+    group_sender_allow_from: []
+    activation: mention
+    groups: {}
+    open_access_acknowledged: false
+
+    streaming:
+      mode: progress
+      edit_interval_ms: 750
+      include_reasoning: false
+
+    media:
+      max_download_mb: 20
+      max_document_text_chars: 100000
+
+    permissions:
+      mode: workspace
+      approvals: prompt
+      timeout_seconds: 300
+      allow_yolo: false
+
+    delivery:
+      retry_attempts: 8
+      retry_base_seconds: 1
+      retry_max_seconds: 300
+      dead_letter_after_hours: 24
+
+    runtime:
+      poll_timeout_seconds: 30
+      request_timeout_seconds: 30
+      ingress_workers: 2
+      delivery_workers: 2
+
+    webhook:
+      public_url: null
+      path: /api/v1/integrations/telegram/webhook
+      secret_env: TELEGRAM_WEBHOOK_SECRET
+      timeout_seconds: 10
+      body_limit_bytes: 1048576
+```
+
+Use `/whoami` to obtain numeric Telegram IDs after temporarily authorizing a
+known account, or inspect them with Telegram's normal bot administration tools.
+Usernames are never authorization identities.
+
+For a personal polling bot:
+
+1. Put your positive numeric user ID in `allow_from`.
+2. Leave both group allowlists empty until group access is needed.
+3. Export `TELEGRAM_BOT_TOKEN`.
+4. Change `enabled` to `true` and start `penguin-web`.
+
+```bash
+HOST=127.0.0.1 PORT=9000 penguin-web
+```
+
+The manager starts and stops with the web application's lifespan; it does not
+create a second Penguin core.
+
+## Authorization policies
+
+DM policy choices are:
+
+- `allowlist`: only positive IDs in `allow_from` are admitted.
+- `pairing`: an operator creates a one-hour, single-use code; the user sends
+  `/pair CODE` in a private chat.
+- `disabled`: no DMs are admitted.
+- `open`: all DMs are admitted, but only when
+  `open_access_acknowledged: true` is also present. This is discouraged for a
+  tool-using coding agent.
+
+Group access requires two independent checks when `group_policy: allowlist`:
+
+- `group_allow_from` contains the numeric group or supergroup chat ID, normally
+  a negative number.
+- `group_sender_allow_from` contains each positive user ID allowed to invoke
+  Penguin in those groups.
+
+An allowed group with an unlisted sender still cannot start a Penguin turn.
+`group_policy` also accepts `disabled` or explicitly acknowledged `open`.
+
+Trusted execution defaults can be bound to a group and refined per forum topic:
+
+```yaml
+channels:
+  telegram:
+    groups:
+      "-1001234567890":
+        enabled: true
+        require_mention: true
+        history_limit: 50
+        prompt: Keep answers concise and operational.
+        directory: /absolute/path/to/project
+        agent_id: null
+        mode: plan
+        skills: [ponytail]
+        topics:
+          "42":
+            require_mention: false
+            history_limit: 10
+            prompt: null
+            mode: build
+            skills: []
+```
+
+Group and topic rules inherit deterministically. A disabled group cannot be
+re-enabled by a topic. Directories must already exist and be absolute; invalid
+configuration stops startup. A configured skill that is unavailable in
+Penguin's trusted skill catalog fails that turn instead of being ignored.
+
+These trusted defaults are copied into the durable address binding when that
+group or topic is first used. `/new` creates a fresh session and reloads the
+configured directory, agent, mode, prompt, skills, activation, and history
+limit. `/mode` and `/activation` intentionally change the current binding until
+the next `/new`.
+
+Updates that fail authorization are dropped before durable admission and do not
+receive a denial message. The only pre-authorization exception is a valid,
+single-use `/pair` code in a private chat.
+
+## Groups, privacy mode, and forum topics
+
+Groups default to `activation: mention`. Penguin runs only when a message
+mentions `@Penguin_agent_bot`, addresses a command to it, or replies to the bot.
+An authorized user can change a group's or topic's binding with
+`/activation mention` or `/activation always`.
+
+Telegram's [privacy mode](https://core.telegram.org/bots/features#privacy-mode)
+controls which group updates Telegram sends to a bot. Mention activation works
+with privacy mode. `activation: always` can act only on updates Telegram actually
+delivers; if ambient group context is required, review the risk and change the
+bot's privacy setting with BotFather. Numeric group and sender authorization
+still applies when privacy mode is disabled.
+
+Each private chat, group, and forum topic has a separate durable address and
+Penguin session binding. Replies, typing indicators, previews, callbacks, and
+final messages preserve the topic ID. `/topic` shows the current topic and
+session binding. Group history supplied to a turn is bounded and includes only
+messages visible to the bot.
+
+Commands addressed to another bot are ignored. Supergroup ID migrations move
+the stored binding to the new chat ID.
+
+## Polling and webhooks
+
+### Polling
+
+`transport: polling` is the default. Penguin durably stores each normalized
+update before advancing the Telegram polling offset. A token fingerprint and
+lease prevent two Penguin pollers from owning the same bot; a polling conflict
+stops the poller and appears in status instead of being hidden.
+
+Use one running polling instance per bot token.
+
+### Webhook
+
+Webhook mode uses the same durable ingress path. Set an externally reachable
+HTTPS base URL and generate a strong secret in the environment:
+
+```bash
+TELEGRAM_WEBHOOK_SECRET="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+export TELEGRAM_WEBHOOK_SECRET
+```
+
+```yaml
+channels:
+  telegram:
+    enabled: true
+    transport: webhook
+    webhook:
+      public_url: https://penguin.example.com
+      path: /api/v1/integrations/telegram/webhook
+      secret_env: TELEGRAM_WEBHOOK_SECRET
+```
+
+Route that path through the reverse proxy to `penguin-web`. Penguin registers
+the webhook with Telegram's `secret_token`; the route compares
+`X-Telegram-Bot-Api-Secret-Token` in constant time, applies configured body and
+adoption time limits, and returns success only after durable adoption. See
+Telegram's official [setWebhook documentation](https://core.telegram.org/bots/api#setwebhook)
+for network requirements.
+
+Polling and webhook ownership are mutually exclusive. Change `transport` and
+restart Penguin rather than running both for one token.
+
+## Commands
+
+The bot registers this command menu:
+
+| Command | Behavior |
+| --- | --- |
+| `/start`, `/help` | Show the available Telegram commands. |
+| `/new` | Create and bind a fresh Penguin session for this chat or topic. |
+| `/status` | Show the bound session and mode. |
+| `/stop` | Abort the active Penguin turn for the bound session. |
+| `/whoami` | Show numeric user, chat, and topic IDs. |
+| `/session` | Show the bound Penguin session ID. |
+| `/mode plan`, `/mode build` | Show or change the binding's agent mode. |
+| `/model` | Show the active model. |
+| `/goal ...` | Use Penguin's session-goal command for the bound session. |
+| `/project` | Show the bound project directory. |
+
+Additional policy commands are `/pair CODE`, `/activation mention|always`, and
+`/topic`. A command explicitly addressed to another bot is ignored.
+
+## Streaming and media
+
+Text is rendered as safe Telegram HTML with plain-text fallback and split at a
+conservative 4,000 UTF-16 code units. The streaming modes are:
+
+- `off`: typing indicator followed by the final response.
+- `progress`: one `Penguin is working…` message, replaced by the final response.
+- `edit`: throttled, coalesced assistant previews followed by the final response.
+
+Reasoning is hidden by default. Enable `include_reasoning` only when everyone
+with access to the destination is allowed to see model reasoning.
+
+Current inbound media support is deliberately narrow:
+
+- validated Telegram photos, passed through Penguin's image input path;
+- bounded UTF-8 text documents with supported text, JSON, XML, YAML, CSV, or
+  Markdown MIME types;
+- captions and reply-to text as untrusted input context.
+
+The default download limit is 20 MiB and can be configured from 1–50 MiB.
+Document text defaults to 100,000 characters and is capped at 1,000,000.
+Temporary downloads are removed after success, failure, or cancellation.
+Files explicitly marked with Penguin's `publish_artifact` tool are delivered as
+photos or documents when they exist under the bound project, fit the same size
+limit, and remain safe at send time. Ordinary reads and writes are never
+auto-attached.
+
+Unsupported or oversized media receives a visible rejection and leaves no
+temporary file. Transport or delivery failures remain available through the
+operator dead-letter diagnostics. Voice messages, transcription, TTS, audio,
+video, media groups, and general file ingestion are not implemented in Phases
+0–5.
+
+## Questions, approvals, and remote permissions
+
+Penguin projects pending questions into Telegram with inline choices; the
+authorized user may also answer with text. Tool approval prompts have
+`Approve once` and `Deny` buttons. Callback records are scoped to the originating
+bot account, chat, topic, and user, expire after the configured timeout, and can
+be completed only once. An approved waiter resumes the intended tool operation
+at most once. When Penguin asks several questions together, answer with exactly
+one non-empty line per question; inline choices are offered only for a single
+question. Resolution, expiry, shutdown, and restart replace active controls with
+a terminal state so stale buttons cannot resume work.
+
+Remote permissions remain subordinate to Penguin's instance security mode:
+
+- `permissions.mode` accepts `read_only`, `workspace`, or `full_access`, but is
+  capped by the instance-level `security.mode`.
+- `permissions.approvals: prompt` waits for Telegram approval; `deny` refuses
+  operations requiring approval.
+- `publish_artifact` is an explicit, approval-gated network operation; Penguin
+  never infers outbound files from ordinary path-looking tool output.
+- `allow_yolo: true` is rejected.
+- An enabled Telegram integration refuses to start when `PENGUIN_YOLO` is true
+  or Penguin security enforcement is disabled.
+
+Telegram access is not permission to bypass Penguin's tool policy.
+
+## Persistence, recovery, and delivery semantics
+
+Channel state lives in
+`{PENGUIN_WORKSPACE}/channels/channel_state.db` and includes address/session
+bindings, hashed pairing codes, DM grants, single-use callbacks, ingress,
+deliveries, and polling ownership. Protect this database: bounded payloads may
+contain private message text, error details, and local artifact paths. Raw bot
+tokens and webhook secrets are not stored.
+
+Set `PENGUIN_WORKSPACE` or `workspace.path` to a durable, private location.
+An ephemeral workspace such as `/tmp` defeats restart recovery.
+
+Completed rows are retained to preserve deduplication and diagnostics. Individual
+payloads and unauthorized admission are bounded, but Phases 0–5 do not expose
+automatic age-based pruning; monitor the channel database on long-lived
+installations and protect it with the same retention discipline as conversation
+data.
+
+The Phase 5 reliability contract is:
+
+- update IDs are deduplicated before execution;
+- polling admission and offset advancement are one SQLite transaction;
+- one chat/topic lane stays ordered while independent lanes can progress;
+- completion and final-delivery enqueue are atomic;
+- retryable Telegram failures honor `retry_after` and bounded backoff;
+- expired unstarted claims retry after restart;
+- expired delivery leases return to the outbox;
+- fatal or exhausted work becomes an inspectable dead letter.
+
+:::warning Execution-uncertain ingress
+
+If Penguin crashes after a turn is marked started, a non-idempotent tool may
+already have run. Recovery marks that ingress dead with
+`error_class: execution_uncertain` instead of executing it automatically.
+Inspect the original request and its effects before manually retrying; retrying
+runs the turn again.
+
+Likewise, an outbound retry can rarely duplicate a Telegram message if Telegram
+accepted it but the local process died before recording the acknowledgement.
+
+:::
+
+## Operator API
+
+The status, pairing, and dead-letter routes use Penguin's normal web API
+authentication. The webhook route is the only Telegram route authenticated by
+the separate Telegram webhook secret. The examples below assume an API key in
+`PENGUIN_API_KEY`.
+
+```bash
+# Redacted status: never returns bot/webhook credentials
+curl http://127.0.0.1:9000/api/v1/integrations/telegram/status \
+  -H "X-API-Key: $PENGUIN_API_KEY"
+```
+
+For `dm_policy: pairing`, create a one-hour, single-use code, optionally pinned
+to one expected numeric user ID:
+
+```bash
+curl -X POST http://127.0.0.1:9000/api/v1/integrations/telegram/pairings \
+  -H "X-API-Key: $PENGUIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"expected_user_id":"123456789","ttl_seconds":3600}'
+```
+
+Send the returned code to the intended user through a trusted channel. They
+complete pairing by sending `/pair CODE` privately to the bot. Revoke the grant
+with:
+
+```bash
+curl -X DELETE \
+  http://127.0.0.1:9000/api/v1/integrations/telegram/pairings/123456789 \
+  -H "X-API-Key: $PENGUIN_API_KEY"
+```
+
+List dead ingress or delivery records:
+
+```bash
+curl "http://127.0.0.1:9000/api/v1/integrations/telegram/dead-letters?kind=ingress&limit=50" \
+  -H "X-API-Key: $PENGUIN_API_KEY"
+```
+
+Dead-letter payloads can contain private input and paths; expose this operator
+API only to trusted administrators. Retry or discard one reviewed record:
+
+```bash
+curl -X POST \
+  http://127.0.0.1:9000/api/v1/integrations/telegram/dead-letters/retry \
+  -H "X-API-Key: $PENGUIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"ingress","record_id":"RECORD_ID"}'
+
+curl -X POST \
+  http://127.0.0.1:9000/api/v1/integrations/telegram/dead-letters/discard \
+  -H "X-API-Key: $PENGUIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"kind":"delivery","record_id":"RECORD_ID"}'
+```
+
+Discard is allowed only for terminal records that no retained delivery still
+references.
+
+## Current boundaries
+
+Phases 0–5 support one configured bot account in the `penguin-web` process.
+They do not yet provide voice/TTS, broad Telegram media parity, reactions,
+scheduled/home-channel delivery, proactive background delivery, or a Telegram
+operator CLI. Use the authenticated operator API for status, pairing, and dead
+letters until later phases add broader operational surfaces.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
         'usage/skills',
         'usage/project_management',
         'usage/api_usage',
+        'usage/telegram',
         'usage/python_api_reference'
       ],
     },

--- a/penguin/channels/__init__.py
+++ b/penguin/channels/__init__.py
@@ -1,0 +1,20 @@
+"""Transport-neutral channel primitives."""
+
+from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
+from penguin.channels.schema import (
+    Attachment,
+    ChannelAddress,
+    DeliveryRequest,
+    InboundEnvelope,
+    StreamUpdate,
+)
+
+__all__ = [
+    "Attachment",
+    "ChannelAddress",
+    "ChatProcessRequest",
+    "DeliveryRequest",
+    "InboundEnvelope",
+    "StreamUpdate",
+    "execute_chat_turn",
+]

--- a/penguin/channels/_store_callbacks.py
+++ b/penguin/channels/_store_callbacks.py
@@ -1,0 +1,485 @@
+"""Interactive callback persistence mixed into :mod:`penguin.channels.store`."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Mapping
+
+from penguin.channels.store_models import (
+    CallbackRecord,
+    IdempotencyConflictError,
+    LeaseLostError,
+    callback_record_from_row,
+)
+
+
+class CallbackStoreMixin:
+    """SQLite callback transitions and their ordered terminal deliveries."""
+
+    def _callback_values(
+        self,
+        callback_id: str,
+        *,
+        account_id: str,
+        chat_id: str,
+        topic_id: str | None,
+        user_id: str,
+        request_id: str,
+        payload: Mapping[str, Any],
+        expires_at: float,
+        tool_call_id: str | None,
+        now: float | None,
+    ) -> dict[str, Any]:
+        timestamp = self._now(now)
+        if expires_at <= timestamp:
+            raise ValueError("expires_at must be in the future")
+        return {
+            "callback_id": self._required(callback_id, "callback_id", 128),
+            "account_id": self._required(account_id, "account_id"),
+            "chat_id": self._required(chat_id, "chat_id"),
+            "topic_id": self._optional(topic_id, "topic_id") or "",
+            "user_id": self._required(user_id, "user_id"),
+            "request_id": self._required(request_id, "request_id"),
+            "tool_call_id": self._optional(tool_call_id, "tool_call_id"),
+            "payload_json": self._encode_payload(payload),
+            "expires_at": expires_at,
+            "timestamp": timestamp,
+        }
+
+    @staticmethod
+    def _insert_callback_conn(
+        conn: sqlite3.Connection, values: Mapping[str, Any]
+    ) -> None:
+        try:
+            conn.execute(
+                """
+                INSERT INTO channel_callbacks (
+                    callback_id, account_id, chat_id, topic_id, user_id,
+                    request_id, tool_call_id, payload_json, state,
+                    expires_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                """,
+                (
+                    values["callback_id"],
+                    values["account_id"],
+                    values["chat_id"],
+                    values["topic_id"],
+                    values["user_id"],
+                    values["request_id"],
+                    values["tool_call_id"],
+                    values["payload_json"],
+                    values["expires_at"],
+                    values["timestamp"],
+                    values["timestamp"],
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise IdempotencyConflictError(
+                f"callback {values['callback_id']!r} already exists"
+            ) from exc
+
+    def create_callback(
+        self,
+        callback_id: str,
+        *,
+        account_id: str,
+        chat_id: str,
+        topic_id: str | None,
+        user_id: str,
+        request_id: str,
+        payload: Mapping[str, Any],
+        expires_at: float,
+        tool_call_id: str | None = None,
+        now: float | None = None,
+    ) -> CallbackRecord:
+        """Create a bounded callback addressed to exactly one recipient."""
+
+        values = self._callback_values(
+            callback_id,
+            account_id=account_id,
+            chat_id=chat_id,
+            topic_id=topic_id,
+            user_id=user_id,
+            request_id=request_id,
+            payload=payload,
+            expires_at=expires_at,
+            tool_call_id=tool_call_id,
+            now=now,
+        )
+        with self._write() as conn:
+            self._insert_callback_conn(conn, values)
+            row = conn.execute(
+                "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                (values["callback_id"],),
+            ).fetchone()
+            assert row is not None
+            return callback_record_from_row(row)
+
+    def create_callback_with_delivery(
+        self,
+        callback_id: str,
+        *,
+        account_id: str,
+        chat_id: str,
+        topic_id: str | None,
+        user_id: str,
+        request_id: str,
+        payload: Mapping[str, Any],
+        expires_at: float,
+        projection_delivery_id: str,
+        lane_key: str,
+        delivery_payload: Mapping[str, Any],
+        platform: str,
+        source_session_id: str | None,
+        tool_call_id: str | None = None,
+        now: float | None = None,
+    ) -> CallbackRecord:
+        """Atomically create a callback and its preceding prompt delivery."""
+
+        values = self._callback_values(
+            callback_id,
+            account_id=account_id,
+            chat_id=chat_id,
+            topic_id=topic_id,
+            user_id=user_id,
+            request_id=request_id,
+            payload=payload,
+            expires_at=expires_at,
+            tool_call_id=tool_call_id,
+            now=now,
+        )
+        delivery = self._delivery_values(
+            delivery_id=projection_delivery_id,
+            idempotency_key=projection_delivery_id,
+            lane_key=lane_key,
+            payload=delivery_payload,
+            platform=platform,
+            account_id=account_id,
+            kind="text",
+            source_event_id=None,
+            source_session_id=source_session_id,
+            source_request_id=request_id,
+        )
+        with self._write() as conn:
+            self._insert_callback_conn(conn, values)
+            self._insert_delivery_conn(
+                conn,
+                **delivery,
+                ready_at=values["timestamp"],
+                timestamp=values["timestamp"],
+            )
+            row = conn.execute(
+                "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                (values["callback_id"],),
+            ).fetchone()
+            assert row is not None
+            return callback_record_from_row(row)
+
+    def claim_callback(
+        self,
+        callback_id: str,
+        *,
+        account_id: str,
+        chat_id: str,
+        topic_id: str | None,
+        user_id: str,
+        owner_id: str,
+        lease_seconds: float = 30.0,
+        platform: str | None = None,
+        now: float | None = None,
+    ) -> CallbackRecord | None:
+        """Claim a callback once, only when all recipient fields match."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            expired = conn.execute(
+                """
+                UPDATE channel_callbacks
+                SET state = 'expired', updated_at = ?, completed_at = ?
+                WHERE callback_id = ? AND state = 'pending' AND expires_at <= ?
+                """,
+                (timestamp, timestamp, callback_id, timestamp),
+            ).rowcount
+            if expired:
+                row = conn.execute(
+                    "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                    (callback_id,),
+                ).fetchone()
+                assert row is not None
+                self._enqueue_callback_terminal_conn(
+                    conn,
+                    callback_record_from_row(row),
+                    "Expired",
+                    platform,
+                    timestamp,
+                )
+            cursor = conn.execute(
+                """
+                UPDATE channel_callbacks
+                SET state = 'claimed', claim_owner = ?, lease_expires_at = ?,
+                    updated_at = ?
+                WHERE callback_id = ? AND state = 'pending' AND expires_at > ?
+                  AND account_id = ? AND chat_id = ? AND topic_id = ?
+                  AND user_id = ?
+                """,
+                (
+                    owner_id,
+                    timestamp + lease_seconds,
+                    timestamp,
+                    callback_id,
+                    timestamp,
+                    account_id,
+                    chat_id,
+                    topic_id or "",
+                    user_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                return None
+            row = conn.execute(
+                "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                (callback_id,),
+            ).fetchone()
+            assert row is not None
+            return callback_record_from_row(row)
+
+    def complete_callback(
+        self,
+        callback_id: str,
+        *,
+        owner_id: str,
+        now: float | None = None,
+    ) -> None:
+        """Mark an owned callback complete; replays cannot claim it again."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_callbacks
+                SET state = 'completed', claim_owner = NULL,
+                    lease_expires_at = NULL, updated_at = ?, completed_at = ?
+                WHERE callback_id = ? AND state = 'claimed'
+                  AND claim_owner = ?
+                """,
+                (timestamp, timestamp, callback_id, owner_id),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"callback {callback_id!r} is not owned")
+
+    def complete_callback_with_terminal(
+        self,
+        callback_id: str,
+        *,
+        owner_id: str,
+        label: str,
+        platform: str,
+        now: float | None = None,
+    ) -> CallbackRecord:
+        """Complete an owned callback and durably enqueue its terminal edit."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_callbacks
+                SET state = 'completed', claim_owner = NULL,
+                    lease_expires_at = NULL, updated_at = ?, completed_at = ?
+                WHERE callback_id = ? AND state = 'claimed'
+                  AND claim_owner = ?
+                """,
+                (timestamp, timestamp, callback_id, owner_id),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"callback {callback_id!r} is not owned")
+            row = conn.execute(
+                "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                (callback_id,),
+            ).fetchone()
+            assert row is not None
+            record = callback_record_from_row(row)
+            self._enqueue_callback_terminal_conn(
+                conn, record, label, platform, timestamp
+            )
+            return record
+
+    def terminalize_callbacks(
+        self,
+        request_id: str,
+        *,
+        account_id: str,
+        label: str,
+        platform: str,
+        expired: bool = False,
+        now: float | None = None,
+    ) -> list[CallbackRecord]:
+        """Terminalize pending callbacks for an externally resolved request."""
+
+        timestamp = self._now(now)
+        terminal_state = "expired" if expired else "completed"
+        records: list[CallbackRecord] = []
+        with self._write() as conn:
+            rows = conn.execute(
+                """SELECT * FROM channel_callbacks
+                WHERE account_id = ? AND request_id = ? AND state = 'pending'
+                ORDER BY created_at, callback_id""",
+                (account_id, request_id),
+            ).fetchall()
+            for row in rows:
+                cursor = conn.execute(
+                    """UPDATE channel_callbacks
+                    SET state = ?, updated_at = ?, completed_at = ?
+                    WHERE callback_id = ? AND state = 'pending'""",
+                    (terminal_state, timestamp, timestamp, row["callback_id"]),
+                )
+                if cursor.rowcount != 1:
+                    continue
+                updated = conn.execute(
+                    "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                    (row["callback_id"],),
+                ).fetchone()
+                assert updated is not None
+                record = callback_record_from_row(updated)
+                self._enqueue_callback_terminal_conn(
+                    conn, record, label, platform, timestamp
+                )
+                records.append(record)
+        return records
+
+    def recover_expired_callbacks(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        now: float | None = None,
+    ) -> list[CallbackRecord]:
+        """Surface newly expired or uncertain callbacks exactly once."""
+
+        timestamp = self._now(now)
+        recovered: list[CallbackRecord] = []
+        with self._write() as conn:
+            rows = conn.execute(
+                """SELECT * FROM channel_callbacks
+                WHERE account_id = ? AND (
+                    (state = 'pending' AND expires_at <= ?)
+                    OR (state = 'claimed' AND lease_expires_at <= ?)
+                ) ORDER BY created_at, callback_id""",
+                (account_id, timestamp, timestamp),
+            ).fetchall()
+            for row in rows:
+                terminal_state = "expired" if row["state"] == "pending" else "dead"
+                cursor = conn.execute(
+                    """UPDATE channel_callbacks
+                    SET state = ?, claim_owner = NULL, lease_expires_at = NULL,
+                        updated_at = ?, completed_at = ?
+                    WHERE callback_id = ? AND state = ?""",
+                    (
+                        terminal_state,
+                        timestamp,
+                        timestamp,
+                        row["callback_id"],
+                        row["state"],
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    continue
+                updated = conn.execute(
+                    "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                    (row["callback_id"],),
+                ).fetchone()
+                assert updated is not None
+                record = callback_record_from_row(updated)
+                self._enqueue_callback_terminal_conn(
+                    conn, record, "Expired", platform, timestamp
+                )
+                recovered.append(record)
+        return recovered
+
+    def recover_orphaned_callbacks(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        now: float | None = None,
+    ) -> list[CallbackRecord]:
+        """Close callbacks whose in-memory waiter was lost across a restart."""
+
+        timestamp = self._now(now)
+        recovered: list[CallbackRecord] = []
+        with self._write() as conn:
+            rows = conn.execute(
+                """SELECT * FROM channel_callbacks
+                WHERE account_id = ? AND state IN ('pending', 'claimed')
+                ORDER BY created_at, callback_id""",
+                (account_id,),
+            ).fetchall()
+            for row in rows:
+                terminal_state = "expired" if row["state"] == "pending" else "dead"
+                cursor = conn.execute(
+                    """UPDATE channel_callbacks
+                    SET state = ?, claim_owner = NULL, lease_expires_at = NULL,
+                        updated_at = ?, completed_at = ?
+                    WHERE callback_id = ? AND state = ?""",
+                    (
+                        terminal_state,
+                        timestamp,
+                        timestamp,
+                        row["callback_id"],
+                        row["state"],
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    continue
+                updated = conn.execute(
+                    "SELECT * FROM channel_callbacks WHERE callback_id = ?",
+                    (row["callback_id"],),
+                ).fetchone()
+                assert updated is not None
+                record = callback_record_from_row(updated)
+                self._enqueue_callback_terminal_conn(
+                    conn, record, "Expired", platform, timestamp
+                )
+                recovered.append(record)
+        return recovered
+
+    def _enqueue_callback_terminal_conn(
+        self,
+        conn: sqlite3.Connection,
+        callback: CallbackRecord,
+        label: str,
+        platform: str | None,
+        timestamp: float,
+    ) -> None:
+        payload = callback.payload
+        projection_id = str(payload.get("projection_delivery_id") or "")
+        lane_key = str(payload.get("lane_key") or "")
+        platform = str(platform or payload.get("platform") or "")
+        if not projection_id or not lane_key or not platform:
+            return
+        delivery_id = f"{platform}:callback-terminal:{callback.callback_id}"
+        terminal_payload = {
+            "chat_id": callback.chat_id,
+            "topic_id": callback.topic_id or "",
+            "projection_delivery_id": projection_id,
+            "label": label,
+        }
+        delivery = self._delivery_values(
+            delivery_id=delivery_id,
+            idempotency_key=delivery_id,
+            lane_key=lane_key,
+            payload=terminal_payload,
+            platform=platform,
+            account_id=callback.account_id,
+            kind="callback_terminal",
+            source_event_id=None,
+            source_session_id=str(payload.get("session_id") or "") or None,
+            source_request_id=callback.request_id,
+        )
+        self._insert_delivery_conn(
+            conn,
+            **delivery,
+            ready_at=timestamp,
+            timestamp=timestamp,
+        )

--- a/penguin/channels/_store_helpers.py
+++ b/penguin/channels/_store_helpers.py
@@ -1,0 +1,60 @@
+"""Small validation and hashing helpers for the channel store."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from penguin.channels.store_models import PayloadTooLargeError
+
+
+def fingerprint_token(token: str) -> str:
+    """Return a non-reversible bot-token identity safe for persistence."""
+
+    if not token:
+        raise ValueError("token must not be empty")
+    material = b"penguin-channel-token-v1\0" + token.encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def pairing_hash(code: str) -> str:
+    if not code or len(code) > 256:
+        raise ValueError("pairing code must contain 1-256 characters")
+    material = b"penguin-channel-pairing-v1\0" + code.encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def dead_letter_limit(limit: int) -> int:
+    if isinstance(limit, bool) or not 1 <= limit <= 100:
+        raise ValueError("limit must be an integer from 1 through 100")
+    return limit
+
+
+def required_text(value: str, name: str, max_chars: int = 512) -> str:
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+    if len(value) > max_chars:
+        raise ValueError(f"{name} exceeds {max_chars} characters")
+    return value
+
+
+def optional_text(value: str | None, name: str, max_chars: int = 2_048) -> str | None:
+    if value is not None and len(value) > max_chars:
+        raise ValueError(f"{name} exceeds {max_chars} characters")
+    return value
+
+
+def encode_payload(payload: Mapping[str, Any], max_bytes: int) -> str:
+    try:
+        encoded = json.dumps(
+            dict(payload),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("payload must be JSON serializable") from exc
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise PayloadTooLargeError(f"payload exceeds {max_bytes} UTF-8 bytes")
+    return encoded

--- a/penguin/channels/chat.py
+++ b/penguin/channels/chat.py
@@ -1,0 +1,109 @@
+"""Shared execution seam for interactive chat transports."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+from penguin.core_runtime import process_lifecycle
+from penguin.system.execution_context import ExecutionContext, execution_context_scope
+
+__all__ = ["ChatProcessRequest", "ChatStreamCallback", "execute_chat_turn"]
+
+logger = logging.getLogger(__name__)
+
+ChatStreamCallback = Callable[[str, str], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ChatProcessRequest:
+    """A fully normalized request ready for :meth:`PenguinCore.process`.
+
+    HTTP, Telegram, and future transports retain responsibility for authentication,
+    parsing, and presentation. This request owns the concurrency and authority
+    boundary that every interactive transport must share.
+    """
+
+    input_data: str | Mapping[str, Any]
+    execution_context: ExecutionContext
+    session_id: str | None = None
+    context: Mapping[str, Any] | None = None
+    agent_id: str | None = None
+    max_iterations: int | None = None
+    context_files: Sequence[str] = field(default_factory=tuple)
+    streaming: bool = True
+    stream_callback: ChatStreamCallback | None = None
+    api_client_override: Any = None
+    model_config_override: Any = None
+
+
+def _track_request(core: Any, session_id: str | None) -> asyncio.Task[Any] | None:
+    """Register a turn before it waits for the per-session execution gate."""
+
+    if not session_id:
+        return None
+    task = asyncio.current_task()
+    if task is None:
+        return None
+    tasks_map = getattr(core, "_opencode_process_tasks", None)
+    if not isinstance(tasks_map, dict):
+        tasks_map = {}
+        setattr(core, "_opencode_process_tasks", tasks_map)
+    tasks = tasks_map.get(session_id)
+    if not isinstance(tasks, set):
+        tasks = set()
+        tasks_map[session_id] = tasks
+    tasks.add(task)
+    return task
+
+
+def _untrack_request(
+    core: Any,
+    session_id: str | None,
+    task: asyncio.Task[Any] | None,
+) -> None:
+    if not session_id or task is None:
+        return
+    tasks_map = getattr(core, "_opencode_process_tasks", None)
+    if not isinstance(tasks_map, dict):
+        return
+    tasks = tasks_map.get(session_id)
+    if not isinstance(tasks, set):
+        return
+    tasks.discard(task)
+    if not tasks:
+        tasks_map.pop(session_id, None)
+
+
+async def execute_chat_turn(
+    core: Any,
+    request: ChatProcessRequest,
+) -> dict[str, Any]:
+    """Run one normalized turn with request scope and per-session serialization."""
+
+    task = _track_request(core, request.session_id)
+    gate = process_lifecycle.get_session_request_gate(core, request.session_id)
+    try:
+        with execution_context_scope(request.execution_context):
+            async with gate:
+                result = await core.process(
+                    input_data=request.input_data,
+                    context=dict(request.context)
+                    if request.context is not None
+                    else None,
+                    conversation_id=request.session_id,
+                    agent_id=request.agent_id,
+                    max_iterations=request.max_iterations,
+                    context_files=list(request.context_files),
+                    streaming=request.streaming,
+                    stream_callback=request.stream_callback,
+                    api_client_override=request.api_client_override,
+                    model_config_override=request.model_config_override,
+                )
+        if not isinstance(result, dict):
+            raise TypeError("PenguinCore.process() must return a dictionary")
+        return result
+    finally:
+        _untrack_request(core, request.session_id, task)

--- a/penguin/channels/fake.py
+++ b/penguin/channels/fake.py
@@ -1,0 +1,70 @@
+"""In-memory channel adapter used by transport contract tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
+from penguin.channels.schema import DeliveryRequest, StreamUpdate
+
+__all__ = ["FakeChannel"]
+
+
+class FakeChannel:
+    """Capture streams and deliveries without I/O."""
+
+    def __init__(self) -> None:
+        self.streams: list[StreamUpdate] = []
+        self.deliveries: list[DeliveryRequest] = []
+        self._active: set[asyncio.Task[Any]] = set()
+
+    async def execute(self, core: Any, request: ChatProcessRequest) -> dict[str, Any]:
+        """Execute and capture stream deltas through the public chat seam."""
+
+        outer_callback = request.stream_callback
+
+        async def capture(text: str, kind: str = "assistant") -> None:
+            self.streams.append(StreamUpdate(text=text, kind=kind))
+            if outer_callback is not None:
+                await outer_callback(text, kind)
+
+        captured_request = ChatProcessRequest(
+            input_data=request.input_data,
+            execution_context=request.execution_context,
+            session_id=request.session_id,
+            context=request.context,
+            agent_id=request.agent_id,
+            max_iterations=request.max_iterations,
+            context_files=request.context_files,
+            streaming=request.streaming,
+            stream_callback=capture,
+            api_client_override=request.api_client_override,
+            model_config_override=request.model_config_override,
+        )
+        task = asyncio.current_task()
+        if task is not None:
+            self._active.add(task)
+        try:
+            result = await execute_chat_turn(core, captured_request)
+            self.streams.append(
+                StreamUpdate(
+                    text=str(result.get("assistant_response") or ""),
+                    final=True,
+                )
+            )
+            return result
+        finally:
+            if task is not None:
+                self._active.discard(task)
+
+    def cancel_all(self) -> int:
+        """Cancel every active fake transport request."""
+
+        tasks = tuple(self._active)
+        for task in tasks:
+            task.cancel()
+        return len(tasks)
+
+    async def deliver(self, request: DeliveryRequest) -> None:
+        self.deliveries.append(request)

--- a/penguin/channels/schema.py
+++ b/penguin/channels/schema.py
@@ -1,0 +1,78 @@
+"""Small, transport-neutral contracts shared by channel adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "Attachment",
+    "ChannelAddress",
+    "DeliveryRequest",
+    "InboundEnvelope",
+    "StreamUpdate",
+]
+
+
+@dataclass(frozen=True)
+class ChannelAddress:
+    """Stable destination and session-binding identity for one channel scope."""
+
+    platform: str
+    account_id: str
+    chat_id: str
+    topic_id: str = ""
+
+    @property
+    def lane_key(self) -> str:
+        """Return a collision-resistant per-chat/topic scheduling lane."""
+
+        return "\x1f".join(
+            (self.platform, self.account_id, self.chat_id, self.topic_id)
+        )
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """Bounded external media metadata; payload bytes are never embedded."""
+
+    kind: str
+    file_id: str
+    file_name: str | None = None
+    mime_type: str | None = None
+    size: int | None = None
+
+
+@dataclass(frozen=True)
+class InboundEnvelope:
+    """Normalized channel input admitted before Penguin execution."""
+
+    event_id: str
+    source_sequence: int
+    address: ChannelAddress
+    sender_id: str
+    text: str = ""
+    sender_username: str | None = None
+    reply_to_message_id: str | None = None
+    attachments: Sequence[Attachment] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StreamUpdate:
+    """One assistant, reasoning, or progress delta from a Penguin turn."""
+
+    text: str
+    kind: str = "assistant"
+    final: bool = False
+
+
+@dataclass(frozen=True)
+class DeliveryRequest:
+    """A durable outbound request addressed to a channel lane."""
+
+    delivery_id: str
+    address: ChannelAddress
+    kind: str
+    payload: Mapping[str, Any]
+    reply_to_message_id: str | None = None

--- a/penguin/channels/store.py
+++ b/penguin/channels/store.py
@@ -1,0 +1,1935 @@
+"""Durable SQLite state for remote channel integrations.
+
+The store deliberately keeps transport payloads bounded and uses short,
+explicit compare-and-swap transitions.  Each operation opens its own SQLite
+connection so workers may safely use one :class:`ChannelStore` from different
+threads.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping
+
+from penguin.channels._store_callbacks import CallbackStoreMixin
+from penguin.channels._store_helpers import (
+    dead_letter_limit,
+    encode_payload,
+    fingerprint_token,
+    optional_text,
+    pairing_hash,
+    required_text,
+)
+from penguin.channels.store_models import (
+    BindingRecord,
+    CallbackRecord,
+    ChannelStoreError,
+    CompareAndSwapError,
+    DeliveryRecord,
+    IdempotencyConflictError,
+    IngressRecord,
+    LeaseLostError,
+    PairingRecord,
+    PayloadTooLargeError,
+    PollerLease,
+    PollerLeaseConflictError,
+    RecoveryCounts,
+    binding_record_from_row,
+    delivery_record_from_row,
+    ingress_record_from_row,
+    pairing_record_from_row,
+    poller_record_from_row,
+)
+from penguin.channels.store_schema import SCHEMA_SQL
+
+DEFAULT_MAX_PAYLOAD_BYTES = 1_048_576
+DEFAULT_MAX_ERROR_CHARS = 4_096
+DEFAULT_BUSY_TIMEOUT_MS = 30_000
+
+
+class ChannelStore(CallbackStoreMixin):
+    """Production-oriented SQLite persistence for channel integrations."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
+        max_error_chars: int = DEFAULT_MAX_ERROR_CHARS,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if max_payload_bytes <= 0:
+            raise ValueError("max_payload_bytes must be positive")
+        if max_error_chars <= 0:
+            raise ValueError("max_error_chars must be positive")
+        if busy_timeout_ms <= 0:
+            raise ValueError("busy_timeout_ms must be positive")
+
+        self.path = Path(path)
+        self.max_payload_bytes = max_payload_bytes
+        self.max_error_chars = max_error_chars
+        self.busy_timeout_ms = busy_timeout_ms
+        self._clock = clock
+        self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name == "posix":
+            descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(descriptor)
+            self.path.chmod(0o600)
+        self._initialize()
+        if os.name == "posix":
+            self.path.chmod(0o600)
+
+    fingerprint_token = staticmethod(fingerprint_token)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self.path),
+            timeout=self.busy_timeout_ms / 1000,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute(f"PRAGMA busy_timeout={self.busy_timeout_ms}")
+        conn.execute("PRAGMA synchronous=FULL")
+        return conn
+
+    @contextmanager
+    def _write(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            yield conn
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @contextmanager
+    def _read(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _initialize(self) -> None:
+        conn = self._connect()
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(SCHEMA_SQL)
+        finally:
+            conn.close()
+
+    def _now(self, now: float | None) -> float:
+        return self._clock() if now is None else now
+
+    _dead_letter_limit = staticmethod(dead_letter_limit)
+    _required = staticmethod(required_text)
+    _optional = staticmethod(optional_text)
+
+    def _encode_payload(self, payload: Mapping[str, Any]) -> str:
+        return encode_payload(payload, self.max_payload_bytes)
+
+    def _error_fields(self, error_class: str, error_message: str) -> tuple[str, str]:
+        bounded_class = self._required(error_class, "error_class", 256)
+        return bounded_class, error_message[: self.max_error_chars]
+
+    _pairing_hash = staticmethod(pairing_hash)
+
+    # Bindings -------------------------------------------------------------
+
+    def get_binding(self, address_key: str) -> BindingRecord | None:
+        """Return the current binding for an address, if one exists."""
+
+        self._required(address_key, "address_key", 1_024)
+        with self._read() as conn:
+            row = conn.execute(
+                "SELECT * FROM channel_bindings WHERE address_key = ?",
+                (address_key,),
+            ).fetchone()
+        return binding_record_from_row(row) if row is not None else None
+
+    def upsert_binding(
+        self,
+        address_key: str,
+        session_id: str,
+        *,
+        directory: str | None = None,
+        agent_id: str | None = None,
+        agent_mode: str | None = None,
+        settings: Mapping[str, Any] | None = None,
+        expected_version: int | None = None,
+        now: float | None = None,
+    ) -> BindingRecord:
+        """Create or replace a binding, optionally using a version CAS."""
+
+        address_key = self._required(address_key, "address_key", 1_024)
+        session_id = self._required(session_id, "session_id")
+        directory = self._optional(directory, "directory", 4_096)
+        agent_id = self._optional(agent_id, "agent_id")
+        agent_mode = self._optional(agent_mode, "agent_mode")
+        settings_json = self._encode_payload(settings) if settings is not None else None
+        timestamp = self._now(now)
+
+        with self._write() as conn:
+            if expected_version is None:
+                conn.execute(
+                    """
+                    INSERT INTO channel_bindings (
+                        address_key, session_id, directory, agent_id, agent_mode,
+                        settings_json, version, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+                    ON CONFLICT(address_key) DO UPDATE SET
+                        session_id = excluded.session_id,
+                        directory = excluded.directory,
+                        agent_id = excluded.agent_id,
+                        agent_mode = excluded.agent_mode,
+                        settings_json = CASE WHEN ?
+                            THEN excluded.settings_json
+                            ELSE channel_bindings.settings_json END,
+                        version = channel_bindings.version + 1,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        address_key,
+                        session_id,
+                        directory,
+                        agent_id,
+                        agent_mode,
+                        settings_json or "{}",
+                        timestamp,
+                        timestamp,
+                        settings_json is not None,
+                    ),
+                )
+            elif expected_version == 0:
+                try:
+                    conn.execute(
+                        """
+                        INSERT INTO channel_bindings (
+                            address_key, session_id, directory, agent_id,
+                            agent_mode, settings_json, version, created_at,
+                            updated_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+                        """,
+                        (
+                            address_key,
+                            session_id,
+                            directory,
+                            agent_id,
+                            agent_mode,
+                            settings_json or "{}",
+                            timestamp,
+                            timestamp,
+                        ),
+                    )
+                except sqlite3.IntegrityError as exc:
+                    raise CompareAndSwapError(
+                        f"binding {address_key!r} already exists"
+                    ) from exc
+            elif expected_version > 0:
+                cursor = conn.execute(
+                    """
+                    UPDATE channel_bindings
+                    SET session_id = ?, directory = ?, agent_id = ?,
+                        agent_mode = ?,
+                        settings_json = COALESCE(?, settings_json),
+                        version = version + 1, updated_at = ?
+                    WHERE address_key = ? AND version = ?
+                    """,
+                    (
+                        session_id,
+                        directory,
+                        agent_id,
+                        agent_mode,
+                        settings_json,
+                        timestamp,
+                        address_key,
+                        expected_version,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise CompareAndSwapError(
+                        f"binding {address_key!r} changed before replacement"
+                    )
+            else:
+                raise ValueError("expected_version must be non-negative")
+
+            row = conn.execute(
+                "SELECT * FROM channel_bindings WHERE address_key = ?",
+                (address_key,),
+            ).fetchone()
+            assert row is not None
+            return binding_record_from_row(row)
+
+    def migrate_binding_prefix(
+        self,
+        old_prefix: str,
+        new_prefix: str,
+        *,
+        separator: str = "\x1f",
+        expected_versions: Mapping[str, int] | None = None,
+        group_authorization: tuple[str, str, str, str] | None = None,
+        now: float | None = None,
+    ) -> list[BindingRecord]:
+        """Atomically migrate bindings and optionally authorize the new group."""
+
+        old_prefix = self._required(old_prefix, "old_prefix", 1_024)
+        new_prefix = self._required(new_prefix, "new_prefix", 1_024)
+        if old_prefix == new_prefix:
+            raise ValueError("binding prefixes must differ")
+        if not separator or len(separator) > 8:
+            raise ValueError("separator must contain 1-8 characters")
+        if old_prefix.startswith(new_prefix + separator) or new_prefix.startswith(
+            old_prefix + separator
+        ):
+            raise ValueError("binding prefixes must not overlap")
+        authorization = self._group_authorization(group_authorization)
+        timestamp = self._now(now)
+
+        with self._write() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM channel_bindings
+                WHERE address_key = ? OR address_key LIKE ? ESCAPE '\\'
+                ORDER BY address_key
+                """,
+                (old_prefix, self._like_prefix(old_prefix + separator) + "%"),
+            ).fetchall()
+            if not rows and group_authorization is None:
+                raise CompareAndSwapError(f"binding prefix {old_prefix!r} not found")
+
+            migrations = [
+                (row, new_prefix + row["address_key"][len(old_prefix) :])
+                for row in rows
+            ]
+            old_keys = {row["address_key"] for row in rows}
+            if expected_versions is not None and {
+                key: int(value) for key, value in expected_versions.items()
+            } != {row["address_key"]: row["version"] for row in rows}:
+                raise CompareAndSwapError("binding versions changed before migration")
+
+            for _, destination in migrations:
+                collision = conn.execute(
+                    "SELECT 1 FROM channel_bindings WHERE address_key = ?",
+                    (destination,),
+                ).fetchone()
+                if collision is not None and destination not in old_keys:
+                    raise CompareAndSwapError(
+                        f"binding destination {destination!r} already exists"
+                    )
+
+            for row, destination in migrations:
+                cursor = conn.execute(
+                    """
+                    UPDATE channel_bindings
+                    SET address_key = ?, version = version + 1, updated_at = ?
+                    WHERE address_key = ? AND version = ?
+                    """,
+                    (
+                        destination,
+                        timestamp,
+                        row["address_key"],
+                        row["version"],
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise CompareAndSwapError("binding changed during migration")
+
+            if authorization is not None:
+                self._upsert_group_authorization(conn, authorization, timestamp)
+
+            migrated = conn.execute(
+                """
+                SELECT * FROM channel_bindings
+                WHERE address_key = ? OR address_key LIKE ? ESCAPE '\\'
+                ORDER BY address_key
+                """,
+                (new_prefix, self._like_prefix(new_prefix + separator) + "%"),
+            ).fetchall()
+            return [binding_record_from_row(row) for row in migrated]
+
+    def is_group_authorized(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        chat_id: str,
+        allowed_source_chat_ids: frozenset[str],
+    ) -> bool:
+        """Check whether migration lineage reaches a currently allowed source."""
+
+        if not allowed_source_chat_ids:
+            return False
+        with self._read() as conn:
+            rows = conn.execute(
+                """WITH RECURSIVE lineage(chat_id, source_chat_id) AS (
+                    SELECT chat_id, source_chat_id
+                    FROM channel_group_authorizations
+                    WHERE platform = ? AND account_id = ? AND chat_id = ?
+                    UNION
+                    SELECT parent.chat_id, parent.source_chat_id
+                    FROM channel_group_authorizations AS parent
+                    JOIN lineage AS child
+                      ON parent.chat_id = child.source_chat_id
+                    WHERE parent.platform = ? AND parent.account_id = ?
+                )
+                SELECT source_chat_id FROM lineage""",
+                (platform, account_id, chat_id, platform, account_id),
+            ).fetchall()
+        return any(row["source_chat_id"] in allowed_source_chat_ids for row in rows)
+
+    @staticmethod
+    def _like_prefix(value: str) -> str:
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    def _group_authorization(
+        self, value: tuple[str, str, str, str] | None
+    ) -> tuple[str, str, str, str] | None:
+        if value is None:
+            return None
+        platform, account_id, source_chat_id, chat_id = (
+            self._required(item, "group authorization") for item in value
+        )
+        if source_chat_id == chat_id:
+            raise ValueError("group migration chat IDs must differ")
+        return platform, account_id, source_chat_id, chat_id
+
+    @staticmethod
+    def _upsert_group_authorization(
+        conn: sqlite3.Connection,
+        value: tuple[str, str, str, str],
+        timestamp: float,
+    ) -> None:
+        platform, account_id, source_chat_id, chat_id = value
+        conn.execute(
+            """INSERT INTO channel_group_authorizations (
+                platform, account_id, chat_id, source_chat_id, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(platform, account_id, chat_id) DO UPDATE SET
+                source_chat_id = excluded.source_chat_id""",
+            (platform, account_id, chat_id, source_chat_id, timestamp),
+        )
+
+    def resolve_group_source(
+        self, *, platform: str, account_id: str, chat_id: str
+    ) -> str:
+        """Resolve a migrated group ID back to its stable scheduling source."""
+
+        current = self._required(chat_id, "chat_id")
+        with self._read() as conn:
+            for _ in range(64):
+                row = conn.execute(
+                    """SELECT source_chat_id FROM channel_group_authorizations
+                    WHERE platform = ? AND account_id = ? AND chat_id = ?""",
+                    (platform, account_id, current),
+                ).fetchone()
+                if row is None or row["source_chat_id"] == current:
+                    return current
+                current = row["source_chat_id"]
+        raise ChannelStoreError("group migration lineage is cyclic or too deep")
+
+    def resolve_group_destination(
+        self, *, platform: str, account_id: str, chat_id: str
+    ) -> str:
+        """Resolve an obsolete group ID to its latest known destination."""
+
+        current = self._required(chat_id, "chat_id")
+        with self._read() as conn:
+            for _ in range(64):
+                row = conn.execute(
+                    """SELECT chat_id FROM channel_group_authorizations
+                    WHERE platform = ? AND account_id = ? AND source_chat_id = ?
+                    ORDER BY created_at DESC, chat_id DESC LIMIT 1""",
+                    (platform, account_id, current),
+                ).fetchone()
+                if row is None or row["chat_id"] == current:
+                    return current
+                current = row["chat_id"]
+        raise ChannelStoreError("group migration lineage is cyclic or too deep")
+
+    # Pairing and DM grants -----------------------------------------------
+
+    def create_pairing(
+        self,
+        code: str,
+        *,
+        account_id: str,
+        expires_at: float,
+        expected_user_id: str | None = None,
+        now: float | None = None,
+    ) -> PairingRecord:
+        """Persist only a hash of a short-lived, single-use pairing code."""
+
+        code_hash = self._pairing_hash(code)
+        account_id = self._required(account_id, "account_id")
+        expected_user_id = self._optional(expected_user_id, "expected_user_id")
+        timestamp = self._now(now)
+        if expires_at <= timestamp:
+            raise ValueError("expires_at must be in the future")
+
+        with self._write() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO channel_pairings (
+                        code_hash, account_id, expected_user_id, state,
+                        expires_at, created_at, updated_at
+                    ) VALUES (?, ?, ?, 'active', ?, ?, ?)
+                    """,
+                    (
+                        code_hash,
+                        account_id,
+                        expected_user_id,
+                        expires_at,
+                        timestamp,
+                        timestamp,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise IdempotencyConflictError("pairing code already exists") from exc
+            row = conn.execute(
+                "SELECT * FROM channel_pairings WHERE code_hash = ?", (code_hash,)
+            ).fetchone()
+            assert row is not None
+            return pairing_record_from_row(row)
+
+    def consume_pairing(
+        self,
+        code: str,
+        *,
+        account_id: str,
+        user_id: str,
+        chat_id: str,
+        now: float | None = None,
+    ) -> PairingRecord | None:
+        """Consume a pairing in a matching DM and atomically grant DM access."""
+
+        code_hash = self._pairing_hash(code)
+        account_id = self._required(account_id, "account_id")
+        user_id = self._required(user_id, "user_id")
+        chat_id = self._required(chat_id, "chat_id")
+        timestamp = self._now(now)
+        if chat_id != user_id:
+            return None
+
+        with self._write() as conn:
+            conn.execute(
+                """
+                UPDATE channel_pairings
+                SET state = 'expired', updated_at = ?
+                WHERE code_hash = ? AND state = 'active' AND expires_at <= ?
+                """,
+                (timestamp, code_hash, timestamp),
+            )
+            cursor = conn.execute(
+                """
+                UPDATE channel_pairings
+                SET state = 'consumed', consumed_by_user_id = ?,
+                    consumed_chat_id = ?, updated_at = ?
+                WHERE code_hash = ? AND account_id = ? AND state = 'active'
+                  AND expires_at > ?
+                  AND (expected_user_id IS NULL OR expected_user_id = ?)
+                """,
+                (
+                    user_id,
+                    chat_id,
+                    timestamp,
+                    code_hash,
+                    account_id,
+                    timestamp,
+                    user_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                return None
+            conn.execute(
+                """
+                INSERT INTO channel_dm_authorizations (
+                    account_id, user_id, pairing_code_hash, created_at, revoked_at
+                ) VALUES (?, ?, ?, ?, NULL)
+                ON CONFLICT(account_id, user_id) DO UPDATE SET
+                    pairing_code_hash = excluded.pairing_code_hash,
+                    created_at = excluded.created_at,
+                    revoked_at = NULL
+                """,
+                (account_id, user_id, code_hash, timestamp),
+            )
+            row = conn.execute(
+                "SELECT * FROM channel_pairings WHERE code_hash = ?", (code_hash,)
+            ).fetchone()
+            assert row is not None
+            return pairing_record_from_row(row)
+
+    def can_consume_pairing(
+        self,
+        code: str,
+        *,
+        account_id: str,
+        user_id: str,
+        chat_id: str,
+        now: float | None = None,
+    ) -> bool:
+        """Return whether a pairing may be consumed without changing state."""
+
+        code_hash = self._pairing_hash(code)
+        account_id = self._required(account_id, "account_id")
+        user_id = self._required(user_id, "user_id")
+        chat_id = self._required(chat_id, "chat_id")
+        if chat_id != user_id:
+            return False
+        with self._read() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM channel_pairings
+                WHERE code_hash = ? AND account_id = ? AND state = 'active'
+                  AND expires_at > ?
+                  AND (expected_user_id IS NULL OR expected_user_id = ?)
+                """,
+                (code_hash, account_id, self._now(now), user_id),
+            ).fetchone()
+        return row is not None
+
+    def revoke_pairing(
+        self, code: str, *, account_id: str, now: float | None = None
+    ) -> bool:
+        """Revoke an unused pairing code."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_pairings
+                SET state = 'revoked', updated_at = ?
+                WHERE code_hash = ? AND account_id = ? AND state = 'active'
+                """,
+                (timestamp, self._pairing_hash(code), account_id),
+            )
+            return cursor.rowcount == 1
+
+    def is_dm_authorized(self, *, account_id: str, user_id: str) -> bool:
+        """Return whether pairing currently grants this user DM access."""
+
+        with self._read() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM channel_dm_authorizations
+                WHERE account_id = ? AND user_id = ? AND revoked_at IS NULL
+                """,
+                (account_id, user_id),
+            ).fetchone()
+        return row is not None
+
+    def revoke_dm_authorization(
+        self, *, account_id: str, user_id: str, now: float | None = None
+    ) -> bool:
+        """Revoke a previously paired DM identity."""
+
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_dm_authorizations SET revoked_at = ?
+                WHERE account_id = ? AND user_id = ? AND revoked_at IS NULL
+                """,
+                (self._now(now), account_id, user_id),
+            )
+            return cursor.rowcount == 1
+
+    # Durable inbound work ------------------------------------------------
+
+    def admit_ingress(
+        self,
+        event_id: str,
+        lane_key: str,
+        payload: Mapping[str, Any],
+        *,
+        platform: str,
+        account_id: str,
+        group_authorization: tuple[str, str, str, str] | None = None,
+        now: float | None = None,
+    ) -> bool:
+        """Durably admit an event, returning ``False`` for an exact duplicate."""
+
+        platform = self._required(platform, "platform", 64)
+        account_id = self._required(account_id, "account_id")
+        event_id = self._required(event_id, "event_id")
+        lane_key = self._required(lane_key, "lane_key", 1_024)
+        payload_json = self._encode_payload(payload)
+        authorization = self._group_authorization(group_authorization)
+        timestamp = self._now(now)
+        with self._write() as conn:
+            if authorization is not None:
+                self._upsert_group_authorization(conn, authorization, timestamp)
+            return self._admit_ingress_conn(
+                conn,
+                platform=platform,
+                account_id=account_id,
+                event_id=event_id,
+                lane_key=lane_key,
+                payload_json=payload_json,
+                timestamp=timestamp,
+            )
+
+    def _admit_ingress_conn(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        platform: str,
+        account_id: str,
+        event_id: str,
+        lane_key: str,
+        payload_json: str,
+        timestamp: float,
+    ) -> bool:
+        cursor = conn.execute(
+            """
+            INSERT OR IGNORE INTO channel_ingress (
+                platform, account_id, event_id, lane_key, payload_json,
+                state, attempt_count, next_attempt_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)
+            """,
+            (
+                platform,
+                account_id,
+                event_id,
+                lane_key,
+                payload_json,
+                timestamp,
+                timestamp,
+                timestamp,
+            ),
+        )
+        if cursor.rowcount == 1:
+            return True
+        row = conn.execute(
+            """
+            SELECT lane_key, payload_json FROM channel_ingress
+            WHERE platform = ? AND account_id = ? AND event_id = ?
+            """,
+            (platform, account_id, event_id),
+        ).fetchone()
+        if (
+            row is None
+            or row["lane_key"] != lane_key
+            or row["payload_json"] != payload_json
+        ):
+            raise IdempotencyConflictError(
+                f"ingress event {event_id!r} was reused for different work"
+            )
+        return False
+
+    def get_ingress(
+        self, event_id: str, *, platform: str, account_id: str
+    ) -> IngressRecord | None:
+        """Return one ingress record for diagnostics or state transitions."""
+
+        with self._read() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM channel_ingress
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                """,
+                (platform, account_id, event_id),
+            ).fetchone()
+        return ingress_record_from_row(row) if row is not None else None
+
+    def claim_ingress(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        lease_seconds: float,
+        lane_suffix: str | None = None,
+        exclude_lane_suffix: str | None = None,
+        now: float | None = None,
+    ) -> IngressRecord | None:
+        """Claim the oldest ready event whose lane has no earlier live work."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        if lane_suffix is not None and exclude_lane_suffix is not None:
+            raise ValueError("lane suffix filters are mutually exclusive")
+        owner_id = self._required(owner_id, "owner_id")
+        timestamp = self._now(now)
+        lease_expires = timestamp + lease_seconds
+        lane_filter = ""
+        parameters: list[Any] = [platform, account_id, timestamp]
+        suffix = lane_suffix if lane_suffix is not None else exclude_lane_suffix
+        if suffix is not None:
+            suffix = self._required(suffix, "lane_suffix", 128)
+            comparison = "=" if lane_suffix is not None else "!="
+            lane_filter = f"AND substr(item.lane_key, -?) {comparison} ?"
+            parameters.extend((len(suffix), suffix))
+        with self._write() as conn:
+            row = conn.execute(
+                f"""
+                SELECT item.*
+                FROM channel_ingress AS item
+                WHERE item.platform = ? AND item.account_id = ?
+                  AND item.state IN ('pending', 'retry')
+                  AND item.next_attempt_at <= ?
+                  {lane_filter}
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM channel_ingress AS prior
+                      WHERE prior.platform = item.platform
+                        AND prior.account_id = item.account_id
+                        AND prior.lane_key = item.lane_key
+                        AND prior.sequence < item.sequence
+                        AND prior.state IN (
+                            'pending', 'retry', 'claimed', 'started'
+                        )
+                  )
+                ORDER BY item.sequence
+                LIMIT 1
+                """,
+                parameters,
+            ).fetchone()
+            if row is None:
+                return None
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'claimed', claim_owner = ?, lease_expires_at = ?,
+                    attempt_count = attempt_count + 1, updated_at = ?
+                WHERE sequence = ? AND state IN ('pending', 'retry')
+                """,
+                (owner_id, lease_expires, timestamp, row["sequence"]),
+            )
+            if cursor.rowcount != 1:
+                return None
+            claimed = conn.execute(
+                "SELECT * FROM channel_ingress WHERE sequence = ?",
+                (row["sequence"],),
+            ).fetchone()
+            assert claimed is not None
+            return ingress_record_from_row(claimed)
+
+    def start_ingress(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        now: float | None = None,
+    ) -> IngressRecord:
+        """Record that execution is beginning, before invoking Penguin."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'started', started_at = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    timestamp,
+                    timestamp,
+                    platform,
+                    account_id,
+                    event_id,
+                    owner_id,
+                    timestamp,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"ingress event {event_id!r} is not owned")
+            row = conn.execute(
+                """
+                SELECT * FROM channel_ingress
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                """,
+                (platform, account_id, event_id),
+            ).fetchone()
+            assert row is not None
+            return ingress_record_from_row(row)
+
+    def renew_ingress_lease(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> bool:
+        """Extend a live ingress claim with an owner CAS."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET lease_expires_at = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state IN ('claimed', 'started') AND claim_owner = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    timestamp + lease_seconds,
+                    timestamp,
+                    platform,
+                    account_id,
+                    event_id,
+                    owner_id,
+                    timestamp,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def complete_ingress(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        now: float | None = None,
+    ) -> None:
+        """Complete a started ingress record using an owner CAS."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            self._complete_ingress_conn(
+                conn,
+                event_id=event_id,
+                platform=platform,
+                account_id=account_id,
+                owner_id=owner_id,
+                timestamp=timestamp,
+            )
+
+    def _complete_ingress_conn(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        event_id: str,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        timestamp: float,
+    ) -> None:
+        cursor = conn.execute(
+            """
+            UPDATE channel_ingress
+            SET state = 'completed', claim_owner = NULL,
+                lease_expires_at = NULL, updated_at = ?, completed_at = ?
+            WHERE platform = ? AND account_id = ? AND event_id = ?
+              AND state = 'started' AND claim_owner = ?
+            """,
+            (timestamp, timestamp, platform, account_id, event_id, owner_id),
+        )
+        if cursor.rowcount != 1:
+            raise LeaseLostError(f"ingress event {event_id!r} is not owned")
+
+    def retry_ingress(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        retry_at: float,
+        error_class: str,
+        error_message: str,
+        now: float | None = None,
+    ) -> None:
+        """Release owned ingress work for a bounded, explicit retry."""
+
+        timestamp = self._now(now)
+        bounded_class, bounded_message = self._error_fields(error_class, error_message)
+        if retry_at < timestamp:
+            retry_at = timestamp
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'retry', next_attempt_at = ?, claim_owner = NULL,
+                    lease_expires_at = NULL, started_at = NULL,
+                    last_error_class = ?, last_error_message = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state IN ('claimed', 'started') AND claim_owner = ?
+                """,
+                (
+                    retry_at,
+                    bounded_class,
+                    bounded_message,
+                    timestamp,
+                    platform,
+                    account_id,
+                    event_id,
+                    owner_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"ingress event {event_id!r} is not owned")
+
+    def dead_letter_ingress(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        error_class: str,
+        error_message: str,
+        now: float | None = None,
+    ) -> None:
+        """Move owned ingress work to a terminal, inspectable state."""
+
+        timestamp = self._now(now)
+        bounded_class, bounded_message = self._error_fields(error_class, error_message)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'dead', claim_owner = NULL,
+                    lease_expires_at = NULL, last_error_class = ?,
+                    last_error_message = ?, updated_at = ?, completed_at = ?
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state IN ('claimed', 'started') AND claim_owner = ?
+                """,
+                (
+                    bounded_class,
+                    bounded_message,
+                    timestamp,
+                    timestamp,
+                    platform,
+                    account_id,
+                    event_id,
+                    owner_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"ingress event {event_id!r} is not owned")
+
+    def recover_expired_ingress(self, *, now: float | None = None) -> RecoveryCounts:
+        """Retry unstarted claims and dead-letter uncertain started turns."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            retried = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'retry', next_attempt_at = ?, claim_owner = NULL,
+                    lease_expires_at = NULL, started_at = NULL,
+                    last_error_class = 'lease_expired',
+                    last_error_message = 'worker lease expired before execution',
+                    updated_at = ?
+                WHERE state = 'claimed' AND lease_expires_at <= ?
+                """,
+                (timestamp, timestamp, timestamp),
+            ).rowcount
+            dead = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'dead', claim_owner = NULL,
+                    lease_expires_at = NULL,
+                    last_error_class = 'execution_uncertain',
+                    last_error_message =
+                        'worker lease expired after execution started',
+                    updated_at = ?, completed_at = ?
+                WHERE state = 'started' AND lease_expires_at <= ?
+                """,
+                (timestamp, timestamp, timestamp),
+            ).rowcount
+            return RecoveryCounts(retried=retried, dead=dead)
+
+    def requeue_dead_ingress(
+        self,
+        event_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        now: float | None = None,
+    ) -> bool:
+        """Explicitly requeue a dead ingress record for operator recovery."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_ingress
+                SET state = 'retry', next_attempt_at = ?, started_at = NULL,
+                    last_error_class = NULL, last_error_message = NULL,
+                    completed_at = NULL, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state = 'dead'
+                """,
+                (timestamp, timestamp, platform, account_id, event_id),
+            )
+            return cursor.rowcount == 1
+
+    def list_dead_ingress(
+        self, *, platform: str, account_id: str, limit: int = 100
+    ) -> list[IngressRecord]:
+        """List a bounded oldest-first page of inbound dead letters."""
+
+        with self._read() as conn:
+            rows = conn.execute(
+                """SELECT * FROM channel_ingress
+                WHERE platform = ? AND account_id = ? AND state = 'dead'
+                ORDER BY sequence LIMIT ?""",
+                (platform, account_id, self._dead_letter_limit(limit)),
+            ).fetchall()
+        return [ingress_record_from_row(row) for row in rows]
+
+    def discard_dead_ingress(
+        self, event_id: str, *, platform: str, account_id: str
+    ) -> bool:
+        """Delete only a dead ingress record with no referenced deliveries."""
+
+        with self._write() as conn:
+            cursor = conn.execute(
+                """DELETE FROM channel_ingress AS item
+                WHERE platform = ? AND account_id = ? AND event_id = ?
+                  AND state = 'dead' AND NOT EXISTS (
+                    SELECT 1 FROM channel_deliveries AS delivery
+                    WHERE delivery.platform = item.platform
+                      AND delivery.account_id = item.account_id
+                      AND delivery.source_event_id = item.event_id
+                  )""",
+                (platform, account_id, event_id),
+            )
+            return cursor.rowcount == 1
+
+    # Durable outbound work -----------------------------------------------
+
+    def enqueue_delivery(
+        self,
+        delivery_id: str,
+        idempotency_key: str,
+        lane_key: str,
+        payload: Mapping[str, Any],
+        *,
+        platform: str,
+        account_id: str,
+        kind: str = "text",
+        source_event_id: str | None = None,
+        source_session_id: str | None = None,
+        source_request_id: str | None = None,
+        available_at: float | None = None,
+        now: float | None = None,
+    ) -> bool:
+        """Idempotently enqueue a bounded outbound delivery."""
+
+        timestamp = self._now(now)
+        ready_at = timestamp if available_at is None else max(available_at, timestamp)
+        values = self._delivery_values(
+            delivery_id=delivery_id,
+            idempotency_key=idempotency_key,
+            lane_key=lane_key,
+            payload=payload,
+            platform=platform,
+            account_id=account_id,
+            kind=kind,
+            source_event_id=source_event_id,
+            source_session_id=source_session_id,
+            source_request_id=source_request_id,
+        )
+        with self._write() as conn:
+            return self._insert_delivery_conn(
+                conn, **values, ready_at=ready_at, timestamp=timestamp
+            )
+
+    def _delivery_values(
+        self,
+        *,
+        delivery_id: str,
+        idempotency_key: str,
+        lane_key: str,
+        payload: Mapping[str, Any],
+        platform: str,
+        account_id: str,
+        kind: str,
+        source_event_id: str | None,
+        source_session_id: str | None,
+        source_request_id: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "delivery_id": self._required(delivery_id, "delivery_id"),
+            "idempotency_key": self._required(
+                idempotency_key, "idempotency_key", 1_024
+            ),
+            "lane_key": self._required(lane_key, "lane_key", 1_024),
+            "payload_json": self._encode_payload(payload),
+            "platform": self._required(platform, "platform", 64),
+            "account_id": self._required(account_id, "account_id"),
+            "kind": self._required(kind, "kind", 64),
+            "source_event_id": self._optional(source_event_id, "source_event_id"),
+            "source_session_id": self._optional(source_session_id, "source_session_id"),
+            "source_request_id": self._optional(source_request_id, "source_request_id"),
+        }
+
+    def _insert_delivery_conn(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        delivery_id: str,
+        idempotency_key: str,
+        lane_key: str,
+        payload_json: str,
+        platform: str,
+        account_id: str,
+        kind: str,
+        source_event_id: str | None,
+        source_session_id: str | None,
+        source_request_id: str | None,
+        ready_at: float,
+        timestamp: float,
+    ) -> bool:
+        existing = conn.execute(
+            """
+            SELECT * FROM channel_deliveries
+            WHERE platform = ? AND account_id = ?
+              AND (delivery_id = ? OR idempotency_key = ?)
+            ORDER BY sequence
+            """,
+            (platform, account_id, delivery_id, idempotency_key),
+        ).fetchall()
+        if existing:
+            if len(existing) != 1:
+                raise IdempotencyConflictError(
+                    "delivery id and idempotency key identify different records"
+                )
+            row = existing[0]
+            expected = (
+                delivery_id,
+                idempotency_key,
+                lane_key,
+                kind,
+                payload_json,
+                source_event_id,
+                source_session_id,
+                source_request_id,
+            )
+            actual = (
+                row["delivery_id"],
+                row["idempotency_key"],
+                row["lane_key"],
+                row["kind"],
+                row["payload_json"],
+                row["source_event_id"],
+                row["source_session_id"],
+                row["source_request_id"],
+            )
+            if actual != expected:
+                raise IdempotencyConflictError(
+                    f"delivery {delivery_id!r} was reused for different work"
+                )
+            return False
+
+        conn.execute(
+            """
+            INSERT INTO channel_deliveries (
+                platform, account_id, delivery_id, idempotency_key, lane_key,
+                kind, payload_json, source_event_id, source_session_id,
+                source_request_id, state, attempt_count, next_attempt_at,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)
+            """,
+            (
+                platform,
+                account_id,
+                delivery_id,
+                idempotency_key,
+                lane_key,
+                kind,
+                payload_json,
+                source_event_id,
+                source_session_id,
+                source_request_id,
+                ready_at,
+                timestamp,
+                timestamp,
+            ),
+        )
+        return True
+
+    def complete_ingress_and_enqueue_delivery(
+        self,
+        event_id: str,
+        *,
+        ingress_owner_id: str,
+        delivery_id: str,
+        idempotency_key: str,
+        lane_key: str,
+        payload: Mapping[str, Any],
+        platform: str,
+        account_id: str,
+        kind: str = "text",
+        source_session_id: str | None = None,
+        source_request_id: str | None = None,
+        now: float | None = None,
+    ) -> bool:
+        """Atomically adopt the final delivery and complete its ingress turn."""
+
+        timestamp = self._now(now)
+        values = self._delivery_values(
+            delivery_id=delivery_id,
+            idempotency_key=idempotency_key,
+            lane_key=lane_key,
+            payload=payload,
+            platform=platform,
+            account_id=account_id,
+            kind=kind,
+            source_event_id=event_id,
+            source_session_id=source_session_id,
+            source_request_id=source_request_id,
+        )
+        with self._write() as conn:
+            inserted = self._insert_delivery_conn(
+                conn, **values, ready_at=timestamp, timestamp=timestamp
+            )
+            self._complete_ingress_conn(
+                conn,
+                event_id=event_id,
+                platform=platform,
+                account_id=account_id,
+                owner_id=ingress_owner_id,
+                timestamp=timestamp,
+            )
+            return inserted
+
+    def get_delivery(
+        self, delivery_id: str, *, platform: str, account_id: str
+    ) -> DeliveryRecord | None:
+        """Return one delivery for diagnostics or state transitions."""
+
+        with self._read() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM channel_deliveries
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                """,
+                (platform, account_id, delivery_id),
+            ).fetchone()
+        return delivery_record_from_row(row) if row is not None else None
+
+    def claim_delivery(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> DeliveryRecord | None:
+        """Claim the oldest ready delivery with lane ordering."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        owner_id = self._required(owner_id, "owner_id")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            row = conn.execute(
+                """
+                SELECT item.*
+                FROM channel_deliveries AS item
+                WHERE item.platform = ? AND item.account_id = ?
+                  AND item.state IN ('pending', 'retry')
+                  AND item.next_attempt_at <= ?
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM channel_deliveries AS prior
+                      WHERE prior.platform = item.platform
+                        AND prior.account_id = item.account_id
+                        AND prior.lane_key = item.lane_key
+                        AND prior.sequence < item.sequence
+                        AND prior.state IN ('pending', 'retry', 'claimed')
+                  )
+                ORDER BY item.sequence
+                LIMIT 1
+                """,
+                (platform, account_id, timestamp),
+            ).fetchone()
+            if row is None:
+                return None
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'claimed', claim_owner = ?, lease_expires_at = ?,
+                    attempt_count = attempt_count + 1, updated_at = ?
+                WHERE sequence = ? AND state IN ('pending', 'retry')
+                """,
+                (
+                    owner_id,
+                    timestamp + lease_seconds,
+                    timestamp,
+                    row["sequence"],
+                ),
+            )
+            if cursor.rowcount != 1:
+                return None
+            claimed = conn.execute(
+                "SELECT * FROM channel_deliveries WHERE sequence = ?",
+                (row["sequence"],),
+            ).fetchone()
+            assert claimed is not None
+            return delivery_record_from_row(claimed)
+
+    def renew_delivery_lease(
+        self,
+        delivery_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> bool:
+        """Extend an owned delivery lease before it expires."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET lease_expires_at = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    timestamp + lease_seconds,
+                    timestamp,
+                    platform,
+                    account_id,
+                    delivery_id,
+                    owner_id,
+                    timestamp,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def complete_delivery(
+        self,
+        delivery_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        external_message_id: str | None = None,
+        now: float | None = None,
+    ) -> None:
+        """Mark an owned delivery successfully sent."""
+
+        external_message_id = self._optional(external_message_id, "external_message_id")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'delivered', claim_owner = NULL,
+                    lease_expires_at = NULL, external_message_id = ?,
+                    updated_at = ?, completed_at = ?
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                """,
+                (
+                    external_message_id,
+                    timestamp,
+                    timestamp,
+                    platform,
+                    account_id,
+                    delivery_id,
+                    owner_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"delivery {delivery_id!r} is not owned")
+
+    def retry_delivery(
+        self,
+        delivery_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        retry_at: float,
+        error_class: str,
+        error_message: str,
+        now: float | None = None,
+    ) -> None:
+        """Release an owned delivery for a later retry."""
+
+        timestamp = self._now(now)
+        bounded_class, bounded_message = self._error_fields(error_class, error_message)
+        if retry_at < timestamp:
+            retry_at = timestamp
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'retry', next_attempt_at = ?, claim_owner = NULL,
+                    lease_expires_at = NULL, last_error_class = ?,
+                    last_error_message = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                """,
+                (
+                    retry_at,
+                    bounded_class,
+                    bounded_message,
+                    timestamp,
+                    platform,
+                    account_id,
+                    delivery_id,
+                    owner_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"delivery {delivery_id!r} is not owned")
+
+    def dead_letter_delivery(
+        self,
+        delivery_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        error_class: str,
+        error_message: str,
+        now: float | None = None,
+    ) -> None:
+        """Move an owned delivery to a terminal, inspectable state."""
+
+        timestamp = self._now(now)
+        bounded_class, bounded_message = self._error_fields(error_class, error_message)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'dead', claim_owner = NULL,
+                    lease_expires_at = NULL, last_error_class = ?,
+                    last_error_message = ?, updated_at = ?, completed_at = ?
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                """,
+                (
+                    bounded_class,
+                    bounded_message,
+                    timestamp,
+                    timestamp,
+                    platform,
+                    account_id,
+                    delivery_id,
+                    owner_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise LeaseLostError(f"delivery {delivery_id!r} is not owned")
+
+    def recover_expired_deliveries(self, *, now: float | None = None) -> int:
+        """Requeue deliveries abandoned by expired workers."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'retry', next_attempt_at = ?, claim_owner = NULL,
+                    lease_expires_at = NULL,
+                    last_error_class = 'lease_expired',
+                    last_error_message = 'delivery worker lease expired',
+                    updated_at = ?
+                WHERE state = 'claimed' AND lease_expires_at <= ?
+                """,
+                (timestamp, timestamp, timestamp),
+            )
+            return cursor.rowcount
+
+    def requeue_dead_delivery(
+        self,
+        delivery_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        now: float | None = None,
+    ) -> bool:
+        """Explicitly requeue a dead delivery for operator recovery."""
+
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_deliveries
+                SET state = 'retry', next_attempt_at = ?,
+                    last_error_class = NULL, last_error_message = NULL,
+                    completed_at = NULL, updated_at = ?
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'dead'
+                """,
+                (timestamp, timestamp, platform, account_id, delivery_id),
+            )
+            return cursor.rowcount == 1
+
+    def list_dead_deliveries(
+        self, *, platform: str, account_id: str, limit: int = 100
+    ) -> list[DeliveryRecord]:
+        """List a bounded oldest-first page of outbound dead letters."""
+
+        with self._read() as conn:
+            rows = conn.execute(
+                """SELECT * FROM channel_deliveries
+                WHERE platform = ? AND account_id = ? AND state = 'dead'
+                ORDER BY sequence LIMIT ?""",
+                (platform, account_id, self._dead_letter_limit(limit)),
+            ).fetchall()
+        return [delivery_record_from_row(row) for row in rows]
+
+    def discard_dead_delivery(
+        self, delivery_id: str, *, platform: str, account_id: str
+    ) -> bool:
+        """Delete only a terminal dead delivery."""
+
+        with self._write() as conn:
+            cursor = conn.execute(
+                """DELETE FROM channel_deliveries
+                WHERE platform = ? AND account_id = ? AND delivery_id = ?
+                  AND state = 'dead'""",
+                (platform, account_id, delivery_id),
+            )
+            return cursor.rowcount == 1
+
+    # Poller ownership and durable watermark ------------------------------
+
+    def acquire_poller(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> PollerLease:
+        """Acquire exclusive polling ownership or surface a conflict."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        platform = self._required(platform, "platform", 64)
+        account_id = self._required(account_id, "account_id")
+        token_fingerprint = self._required(token_fingerprint, "token_fingerprint", 128)
+        owner_id = self._required(owner_id, "owner_id")
+        timestamp = self._now(now)
+        expires_at = timestamp + lease_seconds
+
+        with self._write() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM channel_pollers
+                WHERE platform = ? AND account_id = ?
+                """,
+                (platform, account_id),
+            ).fetchone()
+            if row is None:
+                conn.execute(
+                    """
+                    INSERT INTO channel_pollers (
+                        platform, account_id, token_fingerprint, lease_owner,
+                        lease_expires_at, update_offset, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+                    """,
+                    (
+                        platform,
+                        account_id,
+                        token_fingerprint,
+                        owner_id,
+                        expires_at,
+                        timestamp,
+                    ),
+                )
+            else:
+                active = (
+                    row["lease_owner"] is not None
+                    and row["lease_expires_at"] is not None
+                    and row["lease_expires_at"] > timestamp
+                )
+                same_owner = (
+                    row["lease_owner"] == owner_id
+                    and row["token_fingerprint"] == token_fingerprint
+                )
+                if active and not same_owner:
+                    raise PollerLeaseConflictError(
+                        f"polling is already owned for {platform}/{account_id}"
+                    )
+                offset = (
+                    row["update_offset"]
+                    if row["token_fingerprint"] == token_fingerprint
+                    else None
+                )
+                conn.execute(
+                    """
+                    UPDATE channel_pollers
+                    SET token_fingerprint = ?, lease_owner = ?,
+                        lease_expires_at = ?, update_offset = ?, updated_at = ?
+                    WHERE platform = ? AND account_id = ?
+                    """,
+                    (
+                        token_fingerprint,
+                        owner_id,
+                        expires_at,
+                        offset,
+                        timestamp,
+                        platform,
+                        account_id,
+                    ),
+                )
+
+            current = conn.execute(
+                """
+                SELECT * FROM channel_pollers
+                WHERE platform = ? AND account_id = ?
+                """,
+                (platform, account_id),
+            ).fetchone()
+            assert current is not None
+            return poller_record_from_row(current)
+
+    def renew_poller(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> bool:
+        """Renew a polling lease while it is still live."""
+
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_pollers
+                SET lease_expires_at = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ?
+                  AND token_fingerprint = ? AND lease_owner = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    timestamp + lease_seconds,
+                    timestamp,
+                    platform,
+                    account_id,
+                    token_fingerprint,
+                    owner_id,
+                    timestamp,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def release_poller(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        now: float | None = None,
+    ) -> bool:
+        """Release polling ownership while retaining the matching offset."""
+
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_pollers
+                SET lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+                WHERE platform = ? AND account_id = ?
+                  AND token_fingerprint = ? AND lease_owner = ?
+                """,
+                (
+                    self._now(now),
+                    platform,
+                    account_id,
+                    token_fingerprint,
+                    owner_id,
+                ),
+            )
+            return cursor.rowcount == 1
+
+    def get_poller_offset(
+        self,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+    ) -> int | None:
+        """Return only the offset belonging to this exact bot fingerprint."""
+
+        with self._read() as conn:
+            row = conn.execute(
+                """
+                SELECT token_fingerprint, update_offset FROM channel_pollers
+                WHERE platform = ? AND account_id = ?
+                """,
+                (platform, account_id),
+            ).fetchone()
+        if row is None:
+            return None
+        if row["token_fingerprint"] != token_fingerprint:
+            raise PollerLeaseConflictError(
+                f"stored offset belongs to another token for {platform}/{account_id}"
+            )
+        return row["update_offset"]
+
+    def advance_poller_offset(
+        self,
+        new_offset: int,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        now: float | None = None,
+    ) -> int:
+        """Advance a live poller's watermark monotonically."""
+
+        if new_offset < 0:
+            raise ValueError("new_offset must be non-negative")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            row = self._require_poller_conn(
+                conn,
+                platform=platform,
+                account_id=account_id,
+                token_fingerprint=token_fingerprint,
+                owner_id=owner_id,
+                timestamp=timestamp,
+            )
+            current_offset = row["update_offset"]
+            if current_offset is not None and new_offset < current_offset:
+                raise CompareAndSwapError("poller offset cannot move backwards")
+            conn.execute(
+                """
+                UPDATE channel_pollers SET update_offset = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ?
+                """,
+                (new_offset, timestamp, platform, account_id),
+            )
+            return new_offset
+
+    def admit_ingress_and_advance_poller(
+        self,
+        event_id: str,
+        lane_key: str,
+        payload: Mapping[str, Any],
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        new_offset: int,
+        group_authorization: tuple[str, str, str, str] | None = None,
+        now: float | None = None,
+    ) -> bool:
+        """Atomically persist an update before advancing its poll watermark."""
+
+        if new_offset < 0:
+            raise ValueError("new_offset must be non-negative")
+        platform = self._required(platform, "platform", 64)
+        account_id = self._required(account_id, "account_id")
+        event_id = self._required(event_id, "event_id")
+        lane_key = self._required(lane_key, "lane_key", 1_024)
+        payload_json = self._encode_payload(payload)
+        authorization = self._group_authorization(group_authorization)
+        timestamp = self._now(now)
+        with self._write() as conn:
+            poller = self._require_poller_conn(
+                conn,
+                platform=platform,
+                account_id=account_id,
+                token_fingerprint=token_fingerprint,
+                owner_id=owner_id,
+                timestamp=timestamp,
+            )
+            current_offset = poller["update_offset"]
+            if current_offset is not None and new_offset < current_offset:
+                raise CompareAndSwapError("poller offset cannot move backwards")
+            if authorization is not None:
+                self._upsert_group_authorization(conn, authorization, timestamp)
+            inserted = self._admit_ingress_conn(
+                conn,
+                platform=platform,
+                account_id=account_id,
+                event_id=event_id,
+                lane_key=lane_key,
+                payload_json=payload_json,
+                timestamp=timestamp,
+            )
+            conn.execute(
+                """
+                UPDATE channel_pollers SET update_offset = ?, updated_at = ?
+                WHERE platform = ? AND account_id = ?
+                """,
+                (new_offset, timestamp, platform, account_id),
+            )
+            return inserted
+
+    @staticmethod
+    def _require_poller_conn(
+        conn: sqlite3.Connection,
+        *,
+        platform: str,
+        account_id: str,
+        token_fingerprint: str,
+        owner_id: str,
+        timestamp: float,
+    ) -> sqlite3.Row:
+        row = conn.execute(
+            """
+            SELECT * FROM channel_pollers
+            WHERE platform = ? AND account_id = ?
+            """,
+            (platform, account_id),
+        ).fetchone()
+        if (
+            row is None
+            or row["token_fingerprint"] != token_fingerprint
+            or row["lease_owner"] != owner_id
+            or row["lease_expires_at"] is None
+            or row["lease_expires_at"] <= timestamp
+        ):
+            raise LeaseLostError(
+                f"poller lease is not owned for {platform}/{account_id}"
+            )
+        return row
+
+
+__all__ = [
+    "BindingRecord",
+    "CallbackRecord",
+    "ChannelStore",
+    "ChannelStoreError",
+    "CompareAndSwapError",
+    "DeliveryRecord",
+    "IdempotencyConflictError",
+    "IngressRecord",
+    "LeaseLostError",
+    "PairingRecord",
+    "PayloadTooLargeError",
+    "PollerLease",
+    "PollerLeaseConflictError",
+    "RecoveryCounts",
+]

--- a/penguin/channels/store_models.py
+++ b/penguin/channels/store_models.py
@@ -1,0 +1,278 @@
+"""Value records and explicit errors returned by the channel state store."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+class ChannelStoreError(RuntimeError):
+    """Base error for durable channel state operations."""
+
+
+class CompareAndSwapError(ChannelStoreError):
+    """Raised when a caller tries to replace stale state."""
+
+
+class LeaseLostError(ChannelStoreError):
+    """Raised when a worker no longer owns a claimed record."""
+
+
+class IdempotencyConflictError(ChannelStoreError):
+    """Raised when one idempotency key is reused for different work."""
+
+
+class PollerLeaseConflictError(ChannelStoreError):
+    """Raised when another process currently owns a polling lease."""
+
+
+class PayloadTooLargeError(ChannelStoreError, ValueError):
+    """Raised when a persisted JSON payload exceeds its configured bound."""
+
+
+@dataclass(frozen=True)
+class BindingRecord:
+    """A channel address bound to one Penguin session."""
+
+    address_key: str
+    session_id: str
+    directory: str | None
+    agent_id: str | None
+    agent_mode: str | None
+    settings: dict[str, Any]
+    version: int
+    created_at: float
+    updated_at: float
+
+
+@dataclass(frozen=True)
+class PairingRecord:
+    """A pairing attempt without the plaintext pairing code."""
+
+    code_hash: str
+    account_id: str
+    expected_user_id: str | None
+    state: str
+    expires_at: float
+    consumed_by_user_id: str | None
+    consumed_chat_id: str | None
+    created_at: float
+    updated_at: float
+
+
+@dataclass(frozen=True)
+class CallbackRecord:
+    """A single-use interactive callback scoped to its intended recipient."""
+
+    callback_id: str
+    account_id: str
+    chat_id: str
+    topic_id: str | None
+    user_id: str
+    request_id: str
+    tool_call_id: str | None
+    payload: dict[str, Any]
+    state: str
+    claim_owner: str | None
+    lease_expires_at: float | None
+    expires_at: float
+    created_at: float
+    updated_at: float
+
+
+@dataclass(frozen=True)
+class IngressRecord:
+    """A durable inbound event and its processing state."""
+
+    sequence: int
+    platform: str
+    account_id: str
+    event_id: str
+    lane_key: str
+    payload: dict[str, Any]
+    state: str
+    attempt_count: int
+    next_attempt_at: float
+    claim_owner: str | None
+    lease_expires_at: float | None
+    started_at: float | None
+    last_error_class: str | None
+    last_error_message: str | None
+    created_at: float
+    updated_at: float
+    completed_at: float | None
+
+
+@dataclass(frozen=True)
+class DeliveryRecord:
+    """A durable outbound delivery and its retry state."""
+
+    sequence: int
+    platform: str
+    account_id: str
+    delivery_id: str
+    idempotency_key: str
+    lane_key: str
+    kind: str
+    payload: dict[str, Any]
+    source_event_id: str | None
+    source_session_id: str | None
+    source_request_id: str | None
+    state: str
+    attempt_count: int
+    next_attempt_at: float
+    claim_owner: str | None
+    lease_expires_at: float | None
+    external_message_id: str | None
+    last_error_class: str | None
+    last_error_message: str | None
+    created_at: float
+    updated_at: float
+    completed_at: float | None
+
+
+@dataclass(frozen=True)
+class PollerLease:
+    """Exclusive ownership and durable update offset for one bot identity."""
+
+    platform: str
+    account_id: str
+    token_fingerprint: str
+    owner_id: str
+    lease_expires_at: float
+    update_offset: int | None
+
+
+@dataclass(frozen=True)
+class RecoveryCounts:
+    """Counts of safely retried and terminal uncertain records."""
+
+    retried: int
+    dead: int
+
+
+def binding_record_from_row(row: Any) -> BindingRecord:
+    return BindingRecord(
+        address_key=row["address_key"],
+        session_id=row["session_id"],
+        directory=row["directory"],
+        agent_id=row["agent_id"],
+        agent_mode=row["agent_mode"],
+        settings=json.loads(row["settings_json"]),
+        version=row["version"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def pairing_record_from_row(row: Any) -> PairingRecord:
+    return PairingRecord(
+        code_hash=row["code_hash"],
+        account_id=row["account_id"],
+        expected_user_id=row["expected_user_id"],
+        state=row["state"],
+        expires_at=row["expires_at"],
+        consumed_by_user_id=row["consumed_by_user_id"],
+        consumed_chat_id=row["consumed_chat_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def callback_record_from_row(row: Any) -> CallbackRecord:
+    return CallbackRecord(
+        callback_id=row["callback_id"],
+        account_id=row["account_id"],
+        chat_id=row["chat_id"],
+        topic_id=row["topic_id"] or None,
+        user_id=row["user_id"],
+        request_id=row["request_id"],
+        tool_call_id=row["tool_call_id"],
+        payload=json.loads(row["payload_json"]),
+        state=row["state"],
+        claim_owner=row["claim_owner"],
+        lease_expires_at=row["lease_expires_at"],
+        expires_at=row["expires_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def ingress_record_from_row(row: Any) -> IngressRecord:
+    return IngressRecord(
+        sequence=row["sequence"],
+        platform=row["platform"],
+        account_id=row["account_id"],
+        event_id=row["event_id"],
+        lane_key=row["lane_key"],
+        payload=json.loads(row["payload_json"]),
+        state=row["state"],
+        attempt_count=row["attempt_count"],
+        next_attempt_at=row["next_attempt_at"],
+        claim_owner=row["claim_owner"],
+        lease_expires_at=row["lease_expires_at"],
+        started_at=row["started_at"],
+        last_error_class=row["last_error_class"],
+        last_error_message=row["last_error_message"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        completed_at=row["completed_at"],
+    )
+
+
+def delivery_record_from_row(row: Any) -> DeliveryRecord:
+    return DeliveryRecord(
+        sequence=row["sequence"],
+        platform=row["platform"],
+        account_id=row["account_id"],
+        delivery_id=row["delivery_id"],
+        idempotency_key=row["idempotency_key"],
+        lane_key=row["lane_key"],
+        kind=row["kind"],
+        payload=json.loads(row["payload_json"]),
+        source_event_id=row["source_event_id"],
+        source_session_id=row["source_session_id"],
+        source_request_id=row["source_request_id"],
+        state=row["state"],
+        attempt_count=row["attempt_count"],
+        next_attempt_at=row["next_attempt_at"],
+        claim_owner=row["claim_owner"],
+        lease_expires_at=row["lease_expires_at"],
+        external_message_id=row["external_message_id"],
+        last_error_class=row["last_error_class"],
+        last_error_message=row["last_error_message"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        completed_at=row["completed_at"],
+    )
+
+
+def poller_record_from_row(row: Any) -> PollerLease:
+    assert row["lease_owner"] is not None
+    assert row["lease_expires_at"] is not None
+    return PollerLease(
+        platform=row["platform"],
+        account_id=row["account_id"],
+        token_fingerprint=row["token_fingerprint"],
+        owner_id=row["lease_owner"],
+        lease_expires_at=row["lease_expires_at"],
+        update_offset=row["update_offset"],
+    )
+
+
+__all__ = [
+    "BindingRecord",
+    "CallbackRecord",
+    "ChannelStoreError",
+    "CompareAndSwapError",
+    "DeliveryRecord",
+    "IdempotencyConflictError",
+    "IngressRecord",
+    "LeaseLostError",
+    "PairingRecord",
+    "PayloadTooLargeError",
+    "PollerLease",
+    "PollerLeaseConflictError",
+    "RecoveryCounts",
+]

--- a/penguin/channels/store_schema.py
+++ b/penguin/channels/store_schema.py
@@ -1,0 +1,152 @@
+"""SQLite schema for durable channel state."""
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS channel_bindings (
+    address_key TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    directory TEXT,
+    agent_id TEXT,
+    agent_mode TEXT,
+    settings_json TEXT NOT NULL DEFAULT '{}',
+    version INTEGER NOT NULL CHECK (version > 0),
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS channel_pairings (
+    code_hash TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    expected_user_id TEXT,
+    state TEXT NOT NULL CHECK (
+        state IN ('active', 'consumed', 'revoked', 'expired')
+    ),
+    expires_at REAL NOT NULL,
+    consumed_by_user_id TEXT,
+    consumed_chat_id TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS channel_pairings_expiry
+    ON channel_pairings(state, expires_at);
+
+CREATE TABLE IF NOT EXISTS channel_dm_authorizations (
+    account_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    pairing_code_hash TEXT,
+    created_at REAL NOT NULL,
+    revoked_at REAL,
+    PRIMARY KEY (account_id, user_id),
+    FOREIGN KEY (pairing_code_hash) REFERENCES channel_pairings(code_hash)
+);
+
+CREATE TABLE IF NOT EXISTS channel_group_authorizations (
+    platform TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    chat_id TEXT NOT NULL,
+    source_chat_id TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (platform, account_id, chat_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS channel_group_authorizations_source
+    ON channel_group_authorizations(platform, account_id, source_chat_id);
+
+CREATE TABLE IF NOT EXISTS channel_callbacks (
+    callback_id TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    chat_id TEXT NOT NULL,
+    topic_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    tool_call_id TEXT,
+    payload_json TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'claimed', 'completed', 'dead', 'expired')
+    ),
+    claim_owner TEXT,
+    lease_expires_at REAL,
+    expires_at REAL NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL
+);
+CREATE INDEX IF NOT EXISTS channel_callbacks_expiry
+    ON channel_callbacks(state, expires_at, lease_expires_at);
+
+CREATE TABLE IF NOT EXISTS channel_ingress (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    lane_key TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'retry', 'claimed', 'started', 'completed', 'dead')
+    ),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at REAL NOT NULL,
+    claim_owner TEXT,
+    lease_expires_at REAL,
+    started_at REAL,
+    last_error_class TEXT,
+    last_error_message TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL,
+    UNIQUE (platform, account_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS channel_ingress_claim
+    ON channel_ingress(platform, account_id, state, next_attempt_at, sequence);
+CREATE INDEX IF NOT EXISTS channel_ingress_lane
+    ON channel_ingress(platform, account_id, lane_key, sequence, state);
+
+CREATE TABLE IF NOT EXISTS channel_deliveries (
+    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+    platform TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    delivery_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    lane_key TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    source_event_id TEXT,
+    source_session_id TEXT,
+    source_request_id TEXT,
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'retry', 'claimed', 'delivered', 'dead')
+    ),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at REAL NOT NULL,
+    claim_owner TEXT,
+    lease_expires_at REAL,
+    external_message_id TEXT,
+    last_error_class TEXT,
+    last_error_message TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL,
+    UNIQUE (platform, account_id, delivery_id),
+    UNIQUE (platform, account_id, idempotency_key),
+    FOREIGN KEY (platform, account_id, source_event_id)
+        REFERENCES channel_ingress(platform, account_id, event_id)
+);
+CREATE INDEX IF NOT EXISTS channel_deliveries_claim
+    ON channel_deliveries(platform, account_id, state, next_attempt_at, sequence);
+CREATE INDEX IF NOT EXISTS channel_deliveries_lane
+    ON channel_deliveries(platform, account_id, lane_key, sequence, state);
+
+CREATE TABLE IF NOT EXISTS channel_pollers (
+    platform TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    token_fingerprint TEXT NOT NULL,
+    lease_owner TEXT,
+    lease_expires_at REAL,
+    update_offset INTEGER,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (platform, account_id)
+);
+
+PRAGMA user_version=1;
+"""
+
+
+__all__ = ["SCHEMA_SQL"]

--- a/penguin/engine.py
+++ b/penguin/engine.py
@@ -71,6 +71,7 @@ from penguin.tools.runtime import (
     tool_results_loop_identity,
 )
 from penguin.config import TASK_COMPLETION_PHRASE  # Add this import
+from penguin.skills.renderer import render_activation
 from penguin.system.execution_context import get_current_execution_context
 
 import logging
@@ -2638,6 +2639,15 @@ class Engine:
         if agent_id:
             if self.get_agent(agent_id) is not None:
                 return agent_id, None
+            execution_context = get_current_execution_context()
+            if (
+                execution_context is not None
+                and execution_context.require_registered_agent
+                and execution_context.agent_id == agent_id
+            ):
+                raise ValueError(
+                    f"Configured request agent is unavailable: {agent_id}"
+                )
             logger.warning(
                 "Unknown requested agent '%s'; using default agent '%s'",
                 agent_id,
@@ -3559,38 +3569,114 @@ class Engine:
         self,
         messages: List[Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
-        """Append a plan-mode system notice for the current request context."""
+        """Append trusted request-only notices without mutating conversation state."""
         execution_context = get_current_execution_context()
         if execution_context is None:
             return messages
 
+        additions: List[Dict[str, Any]] = []
+
+        def has_marker(marker: str) -> bool:
+            for message in [*messages, *additions]:
+                if not isinstance(message, dict) or message.get("role") != "system":
+                    continue
+                content = message.get("content")
+                if isinstance(content, str) and marker in content:
+                    return True
+            return False
+
         raw_mode = execution_context.agent_mode
         mode = raw_mode.strip().lower() if isinstance(raw_mode, str) else None
-        if mode != "plan":
-            return messages
+        mode_marker = "[PENGUIN_AGENT_MODE_PLAN]"
+        if mode == "plan" and not has_marker(mode_marker):
+            notice = (
+                f"{mode_marker} Plan mode is active for this session. You must stay "
+                "read-only and avoid mutating operations. Do not attempt file writes, "
+                "destructive shell commands, or process execution intended to modify "
+                "state. If implementation is required, provide a plan and request "
+                "build mode."
+            )
+            additions.append({"role": "system", "content": notice})
+            logger.info(
+                "agent.mode.notice_applied mode=plan session=%s agent=%s",
+                execution_context.session_id,
+                execution_context.agent_id,
+            )
 
-        marker = "[PENGUIN_AGENT_MODE_PLAN]"
-        for message in messages:
-            if not isinstance(message, dict):
-                continue
-            if message.get("role") != "system":
-                continue
-            content = message.get("content")
-            if isinstance(content, str) and marker in content:
-                return messages
+        request_prompt = execution_context.request_system_prompt
+        prompt_marker = "[PENGUIN_TRUSTED_REQUEST_PROMPT]"
+        if request_prompt is not None:
+            if (
+                not isinstance(request_prompt, str)
+                or not request_prompt.strip()
+                or "\x00" in request_prompt
+                or len(request_prompt) > 16_000
+            ):
+                raise ValueError("request_system_prompt is invalid")
+            if not has_marker(prompt_marker):
+                additions.append(
+                    {
+                        "role": "system",
+                        "content": f"{prompt_marker}\n{request_prompt.strip()}",
+                    }
+                )
 
-        notice = (
-            f"{marker} Plan mode is active for this session. You must stay read-only "
-            "and avoid mutating operations. Do not attempt file writes, destructive "
-            "shell commands, or process execution intended to modify state. "
-            "If implementation is required, provide a plan and request build mode."
+        skill_names = execution_context.request_skills
+        if skill_names:
+            manager = self._request_skill_manager(execution_context.agent_id)
+            for name in skill_names:
+                if (
+                    not isinstance(name, str)
+                    or re.fullmatch(
+                        r"[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?", name
+                    )
+                    is None
+                ):
+                    raise ValueError("request_skills contains an invalid skill name")
+                marker = f"[PENGUIN_REQUEST_SKILL:{name}]"
+                if has_marker(marker):
+                    continue
+                skill = manager.get(name)
+                if skill is None:
+                    raise ValueError(f"Configured request skill is unavailable: {name}")
+                additions.append(
+                    {
+                        "role": "system",
+                        "content": f"{marker}\n{render_activation(skill)}",
+                    }
+                )
+
+        return [*messages, *additions]
+
+    def _request_skill_manager(self, agent_id: Optional[str]) -> Any:
+        """Return an existing skill catalog without activating session state."""
+
+        agent = self.get_agent(agent_id) if agent_id else None
+        conversation_manager = (
+            agent.conversation_manager
+            if agent is not None
+            else self.conversation_manager
         )
-        logger.info(
-            "agent.mode.notice_applied mode=plan session=%s agent=%s",
-            execution_context.session_id,
-            execution_context.agent_id,
+        manager = getattr(conversation_manager, "skill_manager", None)
+        if manager is not None:
+            return manager
+
+        tool_manager = (
+            agent.tool_manager
+            if agent is not None and agent.tool_manager is not None
+            else self.tool_manager
         )
-        return [*messages, {"role": "system", "content": notice}]
+        manager = getattr(tool_manager, "skill_manager", None)
+        if manager is None:
+            try:
+                manager = tool_manager.skill_tools.manager
+            except Exception as exc:
+                raise RuntimeError(
+                    "Agent Skills are unavailable for this request"
+                ) from exc
+        if manager is None:
+            raise RuntimeError("Agent Skills are unavailable for this request")
+        return manager
 
     async def _llm_step(
         self,

--- a/penguin/integrations/telegram/__init__.py
+++ b/penguin/integrations/telegram/__init__.py
@@ -1,0 +1,15 @@
+"""Optional Telegram channel integration."""
+
+from penguin.integrations.telegram.binding_policy import (
+    TelegramBinding,
+    TelegramBindingPolicy,
+)
+from penguin.integrations.telegram.config import TelegramConfig
+from penguin.integrations.telegram.manager import TelegramManager
+
+__all__ = [
+    "TelegramBinding",
+    "TelegramBindingPolicy",
+    "TelegramConfig",
+    "TelegramManager",
+]

--- a/penguin/integrations/telegram/_approval_ui.py
+++ b/penguin/integrations/telegram/_approval_ui.py
@@ -1,0 +1,122 @@
+"""Telegram approval presentation and terminal-delivery helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Mapping
+
+from penguin.integrations.telegram._helpers import message_id
+from penguin.integrations.telegram.formatting import (
+    TELEGRAM_TEXT_LIMIT,
+    plain_text,
+    render_html,
+    utf16_length,
+)
+
+__all__ = ["approval_buttons", "send_terminal_edit", "terminal_edit_payload"]
+
+
+def approval_buttons(callback_id: str, prefix: str) -> list[list[dict[str, str]]]:
+    """Build bounded approval controls for one durable callback."""
+
+    return [
+        [
+            {"text": "Approve once", "data": f"{prefix}{callback_id}:approve"},
+            {
+                "text": "Approve for session",
+                "data": f"{prefix}{callback_id}:approve_session",
+            },
+        ],
+        [{"text": "Deny", "data": f"{prefix}{callback_id}:deny"}],
+    ]
+
+
+def terminal_edit_payload(
+    projection_payload: Mapping[str, Any],
+    *,
+    label: str,
+    chat_id: Any,
+    message_id: str,
+) -> tuple[dict[str, Any], str]:
+    """Preserve an interactive prompt while removing its active controls."""
+
+    original = str(projection_payload.get("text") or "")
+    text, fallback = _fit_terminal_text(original, label)
+    return (
+        {
+            "chat_id": chat_id,
+            "message_id": int(message_id),
+            "text": text,
+            "parse_mode": "HTML",
+            "reply_markup": None,
+        },
+        fallback,
+    )
+
+
+def _fit_terminal_text(original: str, label: str) -> tuple[str, str]:
+    """Fit the prompt prefix and terminal marker into one Telegram message."""
+
+    suffix = f"\n\n**{label}**"
+
+    def render(prefix_end: int) -> tuple[str, str]:
+        source = f"{original[:prefix_end]}{suffix}"
+        return render_html(source), plain_text(source)
+
+    text, fallback = render(len(original))
+    if max(utf16_length(text), utf16_length(fallback)) <= TELEGRAM_TEXT_LIMIT:
+        return text, fallback
+
+    lower = 0
+    upper = len(original)
+    best = render(0)
+    if max(utf16_length(best[0]), utf16_length(best[1])) > TELEGRAM_TEXT_LIMIT:
+        raise ValueError("terminal approval marker exceeds Telegram's text limit")
+
+    while lower <= upper:
+        midpoint = (lower + upper) // 2
+        candidate = render(midpoint)
+        if (
+            max(utf16_length(candidate[0]), utf16_length(candidate[1]))
+            <= TELEGRAM_TEXT_LIMIT
+        ):
+            best = candidate
+            lower = midpoint + 1
+        else:
+            upper = midpoint - 1
+    return best
+
+
+async def send_terminal_edit(
+    *,
+    store: Any,
+    bot: Any,
+    api_call: Callable[[Any], Awaitable[Any]],
+    account_id: str,
+    payload: Mapping[str, Any],
+    chat_id: Any,
+) -> str | None:
+    """Replace an already-delivered approval prompt with its terminal state."""
+
+    projection = await asyncio.to_thread(
+        store.get_delivery,
+        str(payload.get("projection_delivery_id") or ""),
+        platform="telegram",
+        account_id=account_id,
+    )
+    if projection is None or not projection.external_message_id:
+        return None
+    kwargs, fallback = terminal_edit_payload(
+        projection.payload,
+        label=str(payload.get("label") or "Expired"),
+        chat_id=chat_id,
+        message_id=projection.external_message_id,
+    )
+    try:
+        response = await api_call(bot.edit_message_text(**kwargs))
+    except Exception as exc:
+        if type(exc).__name__ != "BadRequest":
+            raise
+        kwargs.update(text=fallback, parse_mode=None)
+        response = await api_call(bot.edit_message_text(**kwargs))
+    return message_id(response) or projection.external_message_id

--- a/penguin/integrations/telegram/_artifacts.py
+++ b/penguin/integrations/telegram/_artifacts.py
@@ -1,0 +1,59 @@
+"""Artifact discovery and send-time path validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def validated_artifact_path(payload: Mapping[str, Any], max_bytes: int) -> Path:
+    """Revalidate a queued artifact against its enqueue-time canonical root."""
+
+    path = Path(str(payload.get("path") or ""))
+    root = Path(str(payload.get("allowed_root") or ""))
+    try:
+        if not path.is_absolute() or not root.is_absolute():
+            raise ValueError("artifact paths must be absolute")
+        if path.is_symlink() or root.is_symlink():
+            raise ValueError("artifact paths must not be symlinks")
+        resolved = path.resolve(strict=True)
+        resolved_root = root.resolve(strict=True)
+        if resolved != path or resolved_root != root or not resolved_root.is_dir():
+            raise ValueError("artifact path changed after enqueue")
+        resolved.relative_to(resolved_root)
+        if not resolved.is_file() or resolved.stat().st_size > max_bytes:
+            raise ValueError("artifact is unavailable or exceeds the size limit")
+    except (OSError, ValueError) as exc:
+        raise ValueError("Telegram artifact is unsafe or unavailable") from exc
+    return resolved
+
+
+def artifact_paths(result: Mapping[str, Any]) -> list[str]:
+    """Find paths exposed through explicit artifact projection fields only."""
+
+    found: list[str] = []
+
+    def visit(value: Any) -> None:
+        if isinstance(value, str):
+            found.append(value)
+            return
+        if isinstance(value, Mapping):
+            for key in ("path", "file_path", "image_path"):
+                child = value.get(key)
+                if isinstance(child, str):
+                    found.append(child)
+            visit(value.get("artifact"))
+            visit(value.get("artifacts"))
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(result.get("artifact"))
+    visit(result.get("artifacts"))
+    actions = result.get("action_results")
+    if isinstance(actions, list):
+        for action in actions:
+            if isinstance(action, Mapping):
+                visit(action.get("artifact"))
+                visit(action.get("artifacts"))
+    return list(dict.fromkeys(found))[:20]

--- a/penguin/integrations/telegram/_authorization.py
+++ b/penguin/integrations/telegram/_authorization.py
@@ -1,0 +1,78 @@
+"""Narrow authorization helpers for Telegram group migrations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import InboundEnvelope
+    from penguin.channels.store import ChannelStore
+    from penguin.integrations.telegram.config import TelegramConfig
+
+
+def migration_chat_ids(envelope: InboundEnvelope) -> tuple[str, str] | None:
+    """Return the trusted old/new IDs carried by a migration service update."""
+
+    migrate_to = str(envelope.metadata.get("migrate_to_chat_id") or "")
+    if migrate_to:
+        return envelope.address.chat_id, migrate_to
+    migrate_from = str(envelope.metadata.get("migrate_from_chat_id") or "")
+    if migrate_from:
+        return migrate_from, envelope.address.chat_id
+    return None
+
+
+async def group_event_is_authorized(
+    envelope: InboundEnvelope,
+    *,
+    config: TelegramConfig,
+    store: ChannelStore,
+    account_id: str,
+) -> bool:
+    """Authorize normal group traffic or a narrowly scoped migration event."""
+
+    migration = migration_chat_ids(envelope)
+    candidate_chat_id = (
+        migration[0] if migration is not None else envelope.address.chat_id
+    )
+    destination_chat_id = (
+        migration[1] if migration is not None else envelope.address.chat_id
+    )
+    try:
+        numeric_chat_id = int(candidate_chat_id)
+    except ValueError:
+        return False
+    topic_id = envelope.address.topic_id or None
+    try:
+        destination_enabled = config.binding_for(destination_chat_id, topic_id).enabled
+        candidate_enabled = config.binding_for(candidate_chat_id, topic_id).enabled
+    except ValueError:
+        return False
+    if not destination_enabled or not candidate_enabled:
+        return False
+
+    allowed = config.allows_group(numeric_chat_id)
+    if not allowed and config.group_policy == "allowlist":
+        allowed_sources = frozenset(
+            str(chat_id)
+            for chat_id in config.allowed_group_ids
+            if config.binding_for(chat_id, topic_id).enabled
+        )
+        allowed = await asyncio.to_thread(
+            store.is_group_authorized,
+            platform="telegram",
+            account_id=account_id,
+            chat_id=candidate_chat_id,
+            allowed_source_chat_ids=allowed_sources,
+        )
+    if migration is not None:
+        return allowed
+    try:
+        numeric_sender_id = int(envelope.sender_id)
+    except ValueError:
+        return False
+    return allowed and config.allows_group_sender(numeric_sender_id)
+
+
+__all__ = ["group_event_is_authorized", "migration_chat_ids"]

--- a/penguin/integrations/telegram/_commands.py
+++ b/penguin/integrations/telegram/_commands.py
@@ -25,8 +25,8 @@ async def handle_command(
     if command in {"start", "help"}:
         return (
             "Penguin is ready. Send a message or use /new, /status, /stop, "
-            "/session, /mode, /model, /goal, /project, /activation, /topic, "
-            "/pair, or /whoami."
+            "/session, /mode, /model, /goal, /project, /permissions, "
+            "/activation, /topic, /pair, or /whoami."
         )
     if command == "whoami":
         return (
@@ -96,6 +96,8 @@ async def handle_command(
     if command == "project":
         directory = getattr(binding, "directory", None) or WORKSPACE_PATH
         return f"Project directory: {directory}"
+    if command == "permissions":
+        return manager.config.permissions_summary
     if command == "goal":
         from penguin.web.services.session_goal_command import (
             execute_session_goal_command,

--- a/penguin/integrations/telegram/_commands.py
+++ b/penguin/integrations/telegram/_commands.py
@@ -1,0 +1,123 @@
+"""Telegram command handling kept outside the gateway lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from penguin.config import WORKSPACE_PATH
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import InboundEnvelope
+
+
+async def handle_command(
+    manager: Any,
+    command: str,
+    arguments: str,
+    envelope: InboundEnvelope,
+    binding: Any,
+) -> str | None:
+    """Execute one already-authorized Telegram command."""
+
+    store = manager.store
+    assert store is not None
+    if command in {"start", "help"}:
+        return (
+            "Penguin is ready. Send a message or use /new, /status, /stop, "
+            "/session, /mode, /model, /goal, /project, /activation, /topic, "
+            "/pair, or /whoami."
+        )
+    if command == "whoami":
+        return (
+            f"Telegram user ID: {envelope.sender_id}\n"
+            f"Chat ID: {envelope.address.chat_id}\n"
+            f"Topic ID: {envelope.address.topic_id or 'none'}"
+        )
+    if command == "status":
+        return (
+            f"Penguin Telegram: running\nSession: {binding.session_id}\n"
+            f"Mode: {getattr(binding, 'agent_mode', None) or 'build'}"
+        )
+    if command == "session":
+        return f"Penguin session: {binding.session_id}"
+    if command == "new":
+        replacement = await manager._new_binding(envelope.address, binding)
+        return f"Started a new Penguin session: {replacement.session_id}"
+    if command == "stop":
+        abort = getattr(manager.core, "abort_session", None)
+        stopped = bool(await abort(binding.session_id)) if callable(abort) else False
+        return "Stopped the active Penguin turn." if stopped else "No active turn."
+    if command == "mode":
+        normalized = arguments.strip().lower()
+        if not normalized:
+            return f"Mode: {getattr(binding, 'agent_mode', None) or 'build'}"
+        if normalized not in {"plan", "build"}:
+            return "Usage: /mode plan|build"
+        updated = await asyncio.to_thread(
+            store.upsert_binding,
+            envelope.address.lane_key,
+            binding.session_id,
+            directory=getattr(binding, "directory", None),
+            agent_id=getattr(binding, "agent_id", None),
+            agent_mode=normalized,
+            settings=getattr(binding, "settings", {}),
+            expected_version=binding.version,
+        )
+        return f"Mode set to {updated.agent_mode}."
+    if command == "activation":
+        if envelope.metadata.get("chat_type") == "private":
+            return "/activation is only available in groups and topics."
+        activation = arguments.strip().lower()
+        if activation not in {"mention", "always"}:
+            return "Usage: /activation mention|always"
+        settings = dict(getattr(binding, "settings", {}) or {})
+        settings["activation"] = activation
+        await asyncio.to_thread(
+            store.upsert_binding,
+            envelope.address.lane_key,
+            binding.session_id,
+            directory=getattr(binding, "directory", None),
+            agent_id=getattr(binding, "agent_id", None),
+            agent_mode=getattr(binding, "agent_mode", None),
+            settings=settings,
+            expected_version=binding.version,
+        )
+        return f"Activation set to {activation}."
+    if command == "topic":
+        return (
+            f"Topic binding: {envelope.address.topic_id or 'none'}\n"
+            f"Session: {binding.session_id}"
+        )
+    if command == "model":
+        model_config = getattr(manager.core, "model_config", None)
+        model = getattr(model_config, "model", None) or "not configured"
+        return f"Active Penguin model: {model}"
+    if command == "project":
+        directory = getattr(binding, "directory", None) or WORKSPACE_PATH
+        return f"Project directory: {directory}"
+    if command == "goal":
+        from penguin.web.services.session_goal_command import (
+            execute_session_goal_command,
+            parse_session_goal_command,
+        )
+
+        parsed = parse_session_goal_command(f"/goal {arguments}".rstrip())
+        if parsed is None:
+            return "Invalid /goal command."
+        result = await execute_session_goal_command(
+            manager.core,
+            binding.session_id,
+            parsed,
+            directory=getattr(binding, "directory", None),
+        )
+        if result.get("assistant_response"):
+            return str(result["assistant_response"])
+        goal = result.get("goal")
+        return "No active goal." if goal is None else f"Goal: {goal}"
+    if command == "pair":
+        return "This Telegram identity is already authorized."
+    return "Unknown command. Use /help for supported commands."
+
+
+__all__ = ["handle_command"]

--- a/penguin/integrations/telegram/_helpers.py
+++ b/penguin/integrations/telegram/_helpers.py
@@ -1,0 +1,70 @@
+"""Small presentation helpers shared by the Telegram manager."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import ChannelAddress
+
+
+def delivery_payload(
+    address: ChannelAddress,
+    text: str,
+    *,
+    reply_to_message_id: str | None = None,
+    edit_message_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "chat_id": address.chat_id,
+        "topic_id": address.topic_id,
+        "text": text,
+        "reply_to_message_id": reply_to_message_id,
+        "edit_message_id": edit_message_id,
+    }
+
+
+def value(item: Any, key: str) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(key)
+    return getattr(item, key, None)
+
+
+def message_id(message: Any) -> str | None:
+    identifier = value(message, "message_id")
+    return str(identifier) if identifier is not None else None
+
+
+def interactive_terminal_label(request: Any) -> str | None:
+    status = getattr(getattr(request, "status", None), "value", "")
+    return {
+        "answered": "Answered",
+        "rejected": "Denied",
+        "approved": "Approved",
+        "denied": "Denied",
+        "expired": "Expired",
+    }.get(str(status).casefold())
+
+
+def inline_markup(raw: Any) -> Any:
+    if not isinstance(raw, list) or not raw:
+        return None
+    try:
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+    except ImportError:
+        return raw
+    rows = []
+    for raw_row in raw:
+        if not isinstance(raw_row, list):
+            continue
+        row = []
+        for item in raw_row:
+            if isinstance(item, Mapping) and item.get("text") and item.get("data"):
+                row.append(
+                    InlineKeyboardButton(
+                        text=str(item["text"]), callback_data=str(item["data"])
+                    )
+                )
+        if row:
+            rows.append(row)
+    return InlineKeyboardMarkup(rows) if rows else None

--- a/penguin/integrations/telegram/_history.py
+++ b/penguin/integrations/telegram/_history.py
@@ -1,0 +1,38 @@
+"""Bounded in-memory context for Telegram group lanes."""
+
+from __future__ import annotations
+
+from collections import OrderedDict, deque
+
+
+class GroupHistory:
+    """A small LRU of independently bounded group/topic histories."""
+
+    def __init__(self, *, max_lanes: int = 256, max_messages: int = 200) -> None:
+        self.max_lanes = max_lanes
+        self.max_messages = max_messages
+        self._lanes: OrderedDict[str, deque[str]] = OrderedDict()
+
+    def append(self, lane_key: str, text: str) -> None:
+        lane = self._lanes.pop(lane_key, None)
+        if lane is None:
+            lane = deque(maxlen=self.max_messages)
+        lane.append(text)
+        self._lanes[lane_key] = lane
+        while len(self._lanes) > self.max_lanes:
+            self._lanes.popitem(last=False)
+
+    def recent(self, lane_key: str, limit: int) -> list[str]:
+        lane = self._lanes.pop(lane_key, None)
+        if lane is None:
+            return []
+        self._lanes[lane_key] = lane
+        if limit <= 0:
+            return []
+        return list(lane)[-limit:]
+
+    def __len__(self) -> int:
+        return len(self._lanes)
+
+
+__all__ = ["GroupHistory"]

--- a/penguin/integrations/telegram/_leases.py
+++ b/penguin/integrations/telegram/_leases.py
@@ -1,0 +1,81 @@
+"""Lease renewal for long-running Telegram ingress and delivery work."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable, TypeVar
+
+from penguin.channels.store_models import LeaseLostError
+
+_T = TypeVar("_T")
+
+
+async def lease_heartbeat(
+    renew: Callable[..., bool],
+    record_id: str,
+    *,
+    platform: str,
+    account_id: str,
+    owner_id: str,
+    lease_seconds: float,
+) -> None:
+    """Renew one owned record until it completes or ownership is lost."""
+
+    while True:
+        await asyncio.sleep(lease_seconds / 3)
+        renewed = await asyncio.to_thread(
+            renew,
+            record_id,
+            platform=platform,
+            account_id=account_id,
+            owner_id=owner_id,
+            lease_seconds=lease_seconds,
+        )
+        if not renewed:
+            return
+
+
+async def run_with_lease_heartbeat(
+    operation: Awaitable[_T],
+    renew: Callable[..., bool],
+    record_id: str,
+    *,
+    platform: str,
+    account_id: str,
+    owner_id: str,
+    lease_seconds: float,
+) -> _T:
+    """Cancel an in-flight operation if its durable ownership is lost."""
+
+    operation_task = asyncio.ensure_future(operation)
+    heartbeat = asyncio.create_task(
+        lease_heartbeat(
+            renew,
+            record_id,
+            platform=platform,
+            account_id=account_id,
+            owner_id=owner_id,
+            lease_seconds=lease_seconds,
+        )
+    )
+    try:
+        done, _pending = await asyncio.wait(
+            {operation_task, heartbeat}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if heartbeat in done:
+            error = heartbeat.exception()
+            operation_task.cancel()
+            await asyncio.gather(operation_task, return_exceptions=True)
+            if error is not None:
+                raise LeaseLostError(
+                    f"lease renewal for {record_id!r} became uncertain"
+                ) from error
+            raise LeaseLostError(f"lease for {record_id!r} was lost")
+        return await operation_task
+    finally:
+        heartbeat.cancel()
+        operation_task.cancel()
+        await asyncio.gather(heartbeat, operation_task, return_exceptions=True)
+
+
+__all__ = ["lease_heartbeat", "run_with_lease_heartbeat"]

--- a/penguin/integrations/telegram/_migration.py
+++ b/penguin/integrations/telegram/_migration.py
@@ -1,0 +1,61 @@
+"""Durable Telegram group migration address helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from penguin.channels.schema import ChannelAddress
+
+if TYPE_CHECKING:
+    from penguin.channels.store import ChannelStore
+
+
+def migration_authorization(
+    account_id: str, migration: tuple[str, str] | None
+) -> tuple[str, str, str, str] | None:
+    """Return the durable Telegram migration edge accepted by the store."""
+
+    return ("telegram", account_id, *migration) if migration is not None else None
+
+
+async def stable_lane(
+    store: ChannelStore,
+    address: ChannelAddress,
+    *,
+    chat_id: str | None = None,
+) -> str:
+    """Return one scheduling lane shared by every ID in a migration chain."""
+
+    source = await asyncio.to_thread(
+        store.resolve_group_source,
+        platform=address.platform,
+        account_id=address.account_id,
+        chat_id=chat_id or address.chat_id,
+    )
+    return ChannelAddress(
+        address.platform,
+        address.account_id,
+        source,
+        address.topic_id,
+    ).lane_key
+
+
+async def latest_chat_id(
+    store: ChannelStore,
+    *,
+    platform: str,
+    account_id: str,
+    chat_id: str,
+) -> str:
+    """Return the latest durable destination for a possibly obsolete chat ID."""
+
+    return await asyncio.to_thread(
+        store.resolve_group_destination,
+        platform=platform,
+        account_id=account_id,
+        chat_id=chat_id,
+    )
+
+
+__all__ = ["latest_chat_id", "migration_authorization", "stable_lane"]

--- a/penguin/integrations/telegram/_preview.py
+++ b/penguin/integrations/telegram/_preview.py
@@ -1,0 +1,126 @@
+"""Per-turn Telegram typing and streaming preview lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
+
+from penguin.integrations.telegram._helpers import message_id
+from penguin.integrations.telegram.formatting import StreamingCoalescer, html_chunks
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import InboundEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+class Preview:
+    """Per-turn typing/progress task; stream callbacks only mutate memory."""
+
+    def __init__(self, manager: Any, envelope: InboundEnvelope) -> None:
+        self.manager = manager
+        self.envelope = envelope
+        self.coalescer = StreamingCoalescer(
+            interval_seconds=manager.config.edit_interval_ms / 1000
+        )
+        self.message_id: str | None = None
+        self._event = asyncio.Event()
+        self._closed = asyncio.Event()
+        self._tasks: list[asyncio.Task[Any]] = []
+
+    async def start(self) -> None:
+        self._tasks.append(asyncio.create_task(self._typing_loop()))
+        if self.manager.config.streaming_mode == "progress":
+            await self._send_or_edit("Penguin is working…")
+        if self.manager.config.streaming_mode in {"edit", "progress"}:
+            self._tasks.append(asyncio.create_task(self._preview_loop()))
+
+    async def push(self, chunk: str, message_type: str = "assistant") -> None:
+        if message_type == "reasoning" and not self.manager.config.include_reasoning:
+            return
+        if chunk:
+            self.coalescer.push(chunk)
+            self._event.set()
+
+    async def finish(self) -> str | None:
+        self._closed.set()
+        self._event.set()
+        for task in self._tasks:
+            if task.get_name() == "telegram-typing":
+                task.cancel()
+        await asyncio.sleep(0)
+        return self.message_id
+
+    async def close(self) -> None:
+        self._closed.set()
+        self._event.set()
+        for task in self._tasks:
+            task.cancel()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+
+    async def _typing_loop(self) -> None:
+        asyncio.current_task().set_name("telegram-typing")
+        while not self._closed.is_set():
+            kwargs: dict[str, Any] = {
+                "chat_id": self.envelope.address.chat_id,
+                "action": "typing",
+            }
+            if self.envelope.address.topic_id:
+                kwargs["message_thread_id"] = int(self.envelope.address.topic_id)
+            with suppress(Exception):
+                await self.manager._api_call(
+                    self.manager.bot.send_chat_action(**kwargs)
+                )
+            try:
+                await asyncio.wait_for(self._closed.wait(), timeout=4.0)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _preview_loop(self) -> None:
+        mode = self.manager.config.streaming_mode
+        while not self._closed.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._event.wait(),
+                    timeout=self.manager.config.edit_interval_ms / 1000,
+                )
+            except asyncio.TimeoutError:
+                pass
+            self._event.clear()
+            if mode != "edit":
+                continue
+            preview = self.coalescer.take(time.monotonic())
+            if preview:
+                await self._send_or_edit(preview)
+
+    async def _send_or_edit(self, text: str) -> None:
+        chunks = html_chunks(text)
+        rendered = chunks[-1] if chunks else "…"
+        try:
+            if self.message_id:
+                await self.manager._api_call(
+                    self.manager.bot.edit_message_text(
+                        chat_id=self.envelope.address.chat_id,
+                        message_id=int(self.message_id),
+                        text=rendered,
+                        parse_mode="HTML",
+                    )
+                )
+                return
+            kwargs: dict[str, Any] = {
+                "chat_id": self.envelope.address.chat_id,
+                "text": rendered,
+                "parse_mode": "HTML",
+            }
+            if self.envelope.address.topic_id:
+                kwargs["message_thread_id"] = int(self.envelope.address.topic_id)
+            message = await self.manager._api_call(
+                self.manager.bot.send_message(**kwargs)
+            )
+            self.message_id = message_id(message)
+        except Exception:
+            logger.debug("Telegram preview update failed", exc_info=True)

--- a/penguin/integrations/telegram/binding_policy.py
+++ b/penguin/integrations/telegram/binding_policy.py
@@ -1,0 +1,382 @@
+"""Validated per-group and per-topic Telegram execution bindings."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, cast
+
+_MISSING = object()
+_BINDING_KEYS = {
+    "enabled",
+    "require_mention",
+    "activation",
+    "history_limit",
+    "prompt",
+    "directory",
+    "agent_id",
+    "mode",
+    "skills",
+}
+_GROUP_KEYS = _BINDING_KEYS | {"topics"}
+_SKILL_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+_AGENT_ID = re.compile(r"^[a-z0-9_-]{1,64}$")
+_MAX_GROUPS = 1_000
+_MAX_TOPICS_PER_GROUP = 1_000
+_MAX_HISTORY = 200
+_MAX_PROMPT_CHARS = 16_000
+_MAX_SKILLS = 16
+
+
+@dataclass(frozen=True)
+class TelegramBinding:
+    """Fully resolved settings for one Telegram group or topic."""
+
+    enabled: bool = True
+    activation: str = "mention"
+    history_limit: int = 20
+    prompt: str | None = None
+    directory: str | None = None
+    agent_id: str | None = None
+    mode: str = "build"
+    skills: tuple[str, ...] = ()
+
+    def durable_settings(self) -> dict[str, Any]:
+        """Return bounded execution settings stored with a new session binding."""
+
+        return {
+            "activation": self.activation,
+            "history_limit": self.history_limit,
+            "prompt": self.prompt,
+            "skills": list(self.skills),
+        }
+
+
+@dataclass(frozen=True)
+class _BindingOverride:
+    enabled: bool | object = _MISSING
+    activation: str | object = _MISSING
+    history_limit: int | object = _MISSING
+    prompt: str | object | None = _MISSING
+    directory: str | object | None = _MISSING
+    agent_id: str | object | None = _MISSING
+    mode: str | object = _MISSING
+    skills: tuple[str, ...] | object = _MISSING
+
+    def apply(self, parent: TelegramBinding) -> TelegramBinding:
+        """Apply this override without allowing a topic to re-enable its group."""
+
+        enabled = parent.enabled
+        if self.enabled is not _MISSING:
+            enabled = parent.enabled and bool(self.enabled)
+        return TelegramBinding(
+            enabled=enabled,
+            activation=(
+                parent.activation
+                if self.activation is _MISSING
+                else str(self.activation)
+            ),
+            history_limit=(
+                parent.history_limit
+                if self.history_limit is _MISSING
+                else int(self.history_limit)
+            ),
+            prompt=(
+                parent.prompt if self.prompt is _MISSING else _optional(self.prompt)
+            ),
+            directory=(
+                parent.directory
+                if self.directory is _MISSING
+                else _optional(self.directory)
+            ),
+            agent_id=(
+                parent.agent_id
+                if self.agent_id is _MISSING
+                else _optional(self.agent_id)
+            ),
+            mode=parent.mode if self.mode is _MISSING else str(self.mode),
+            skills=(
+                parent.skills
+                if self.skills is _MISSING
+                else cast("tuple[str, ...]", self.skills)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class _GroupRule:
+    override: _BindingOverride
+    topics: Mapping[int, _BindingOverride]
+
+
+@dataclass(frozen=True)
+class TelegramBindingPolicy:
+    """Resolve trusted config overrides using global → group → topic order."""
+
+    default: TelegramBinding
+    groups: Mapping[int, _GroupRule]
+
+    def with_default_activation(self, activation: str) -> TelegramBindingPolicy:
+        """Return this policy rebased onto the configured global activation."""
+
+        if activation not in {"always", "mention"}:
+            raise ValueError("default activation must be always or mention")
+        return TelegramBindingPolicy(
+            default=replace(self.default, activation=activation),
+            groups=self.groups,
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Any,
+        *,
+        default_activation: str = "mention",
+    ) -> TelegramBindingPolicy:
+        """Parse the ``groups`` config mapping and reject ambiguous input."""
+
+        if value is None:
+            raw_groups: Mapping[Any, Any] = {}
+        elif isinstance(value, Mapping):
+            raw_groups = value
+        else:
+            raise ValueError("groups must be a mapping keyed by numeric chat ids")
+        if len(raw_groups) > _MAX_GROUPS:
+            raise ValueError(f"groups must contain at most {_MAX_GROUPS} entries")
+        if default_activation not in {"always", "mention"}:
+            raise ValueError("default activation must be always or mention")
+
+        groups: dict[int, _GroupRule] = {}
+        for raw_group_id, raw_rule in raw_groups.items():
+            group_id = _numeric_id(raw_group_id, "groups key", positive_only=False)
+            if group_id in groups:
+                raise ValueError(f"duplicate Telegram group id: {group_id}")
+            if not isinstance(raw_rule, Mapping):
+                raise ValueError(f"groups.{group_id} must be a mapping")
+            _reject_unknown_keys(raw_rule, _GROUP_KEYS, f"groups.{group_id}")
+
+            raw_topics = raw_rule.get("topics", {})
+            if raw_topics is None:
+                raw_topics = {}
+            if not isinstance(raw_topics, Mapping):
+                raise ValueError(f"groups.{group_id}.topics must be a mapping")
+            if len(raw_topics) > _MAX_TOPICS_PER_GROUP:
+                raise ValueError(
+                    f"groups.{group_id}.topics must contain at most "
+                    f"{_MAX_TOPICS_PER_GROUP} entries"
+                )
+            topics: dict[int, _BindingOverride] = {}
+            for raw_topic_id, raw_topic in raw_topics.items():
+                topic_id = _numeric_id(
+                    raw_topic_id,
+                    f"groups.{group_id}.topics key",
+                    positive_only=True,
+                )
+                if topic_id in topics:
+                    raise ValueError(
+                        f"duplicate Telegram topic id {topic_id} in group {group_id}"
+                    )
+                if not isinstance(raw_topic, Mapping):
+                    raise ValueError(
+                        f"groups.{group_id}.topics.{topic_id} must be a mapping"
+                    )
+                _reject_unknown_keys(
+                    raw_topic,
+                    _BINDING_KEYS,
+                    f"groups.{group_id}.topics.{topic_id}",
+                )
+                topics[topic_id] = _parse_override(
+                    raw_topic,
+                    f"groups.{group_id}.topics.{topic_id}",
+                )
+
+            groups[group_id] = _GroupRule(
+                override=_parse_override(raw_rule, f"groups.{group_id}"),
+                topics=MappingProxyType(topics),
+            )
+
+        return cls(
+            default=TelegramBinding(activation=default_activation),
+            groups=MappingProxyType(groups),
+        )
+
+    def resolve(
+        self, chat_id: int | str, topic_id: int | str | None = None
+    ) -> TelegramBinding:
+        """Return the deterministic binding for a numeric Telegram address."""
+
+        group_id = _numeric_id(chat_id, "chat_id", positive_only=False)
+        parsed_topic_id = (
+            None
+            if topic_id in (None, "")
+            else _numeric_id(topic_id, "topic_id", positive_only=True)
+        )
+        group = self.groups.get(group_id)
+        resolved = self.default if group is None else group.override.apply(self.default)
+        if parsed_topic_id is None or group is None:
+            return resolved
+        topic = group.topics.get(parsed_topic_id)
+        return resolved if topic is None else topic.apply(resolved)
+
+
+def _parse_override(value: Mapping[str, Any], path: str) -> _BindingOverride:
+    activation = _MISSING
+    if "activation" in value:
+        activation = _choice(
+            value["activation"], {"always", "mention"}, f"{path}.activation"
+        )
+    if "require_mention" in value:
+        require_mention = _bool(value["require_mention"], f"{path}.require_mention")
+        alias_activation = "mention" if require_mention else "always"
+        if activation is not _MISSING and activation != alias_activation:
+            raise ValueError(f"{path}.activation conflicts with {path}.require_mention")
+        activation = alias_activation
+
+    return _BindingOverride(
+        enabled=(
+            _bool(value["enabled"], f"{path}.enabled")
+            if "enabled" in value
+            else _MISSING
+        ),
+        activation=activation,
+        history_limit=(
+            _bounded_int(
+                value["history_limit"], 0, _MAX_HISTORY, f"{path}.history_limit"
+            )
+            if "history_limit" in value
+            else _MISSING
+        ),
+        prompt=(
+            _prompt(value["prompt"], f"{path}.prompt")
+            if "prompt" in value
+            else _MISSING
+        ),
+        directory=(
+            _directory(value["directory"], f"{path}.directory")
+            if "directory" in value
+            else _MISSING
+        ),
+        agent_id=(
+            _agent(value["agent_id"], f"{path}.agent_id")
+            if "agent_id" in value
+            else _MISSING
+        ),
+        mode=(
+            _choice(value["mode"], {"build", "plan"}, f"{path}.mode")
+            if "mode" in value
+            else _MISSING
+        ),
+        skills=(
+            _skills(value["skills"], f"{path}.skills")
+            if "skills" in value
+            else _MISSING
+        ),
+    )
+
+
+def _reject_unknown_keys(
+    value: Mapping[str, Any], allowed: set[str], path: str
+) -> None:
+    unknown = sorted(str(key) for key in value if key not in allowed)
+    if unknown:
+        raise ValueError(f"{path} contains unknown fields: {', '.join(unknown)}")
+
+
+def _numeric_id(value: Any, name: str, *, positive_only: bool) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a numeric Telegram id")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a numeric Telegram id") from exc
+    if (
+        parsed == 0
+        or (positive_only and parsed < 0)
+        or str(value).strip() != str(parsed)
+    ):
+        raise ValueError(f"{name} must be a canonical numeric Telegram id")
+    return parsed
+
+
+def _bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _choice(value: Any, choices: set[str], name: str) -> str:
+    if not isinstance(value, str) or value.strip().lower() not in choices:
+        raise ValueError(f"{name} must be one of: {', '.join(sorted(choices))}")
+    return value.strip().lower()
+
+
+def _bounded_int(value: Any, minimum: int, maximum: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+def _prompt(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string or null")
+    prompt = value.strip()
+    if not prompt or "\x00" in prompt or len(prompt) > _MAX_PROMPT_CHARS:
+        raise ValueError(
+            f"{name} must contain 1-{_MAX_PROMPT_CHARS} characters without NUL"
+        )
+    return prompt
+
+
+def _directory(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be an absolute existing directory or null")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise ValueError(f"{name} must be an absolute existing directory or null")
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(
+            f"{name} must be an absolute existing directory or null"
+        ) from exc
+    if not resolved.is_dir():
+        raise ValueError(f"{name} must be an absolute existing directory or null")
+    return str(resolved)
+
+
+def _agent(value: Any, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or _AGENT_ID.fullmatch(value.strip()) is None:
+        raise ValueError(f"{name} must match ^[a-z0-9_-]{{1,64}}$ or be null")
+    return value.strip()
+
+
+def _skills(value: Any, name: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or len(value) > _MAX_SKILLS:
+        raise ValueError(f"{name} must be a list of at most {_MAX_SKILLS} skill names")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or _SKILL_NAME.fullmatch(item.strip()) is None:
+            raise ValueError(f"{name} must contain lowercase kebab-case skill names")
+        normalized = item.strip()
+        if normalized not in result:
+            result.append(normalized)
+    return tuple(result)
+
+
+def _optional(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+__all__ = ["TelegramBinding", "TelegramBindingPolicy"]

--- a/penguin/integrations/telegram/config.py
+++ b/penguin/integrations/telegram/config.py
@@ -1,0 +1,482 @@
+"""Validated configuration for the optional Telegram integration."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from penguin.integrations.telegram.binding_policy import (
+    TelegramBinding,
+    TelegramBindingPolicy,
+)
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+_PERMISSION_RANK = {"read_only": 0, "workspace": 1, "full_access": 2}
+_APPROVAL_ACTIONS = (
+    "shell",
+    "fileWrite",
+    "fileDelete",
+    "gitPush",
+    "network",
+    "secrets",
+)
+
+
+@dataclass(frozen=True)
+class TelegramConfig:
+    """Fail-closed Telegram settings loaded from Penguin config and the environment."""
+
+    enabled: bool = False
+    token: str | None = field(default=None, repr=False)
+    expected_username: str = "Penguin_agent_bot"
+    transport: str = "polling"
+    dm_policy: str = "allowlist"
+    allow_from: frozenset[int] = frozenset()
+    group_policy: str = "allowlist"
+    allowed_group_ids: frozenset[int] = frozenset()
+    allowed_group_sender_ids: frozenset[int] = frozenset()
+    activation: str = "mention"
+    binding_policy: TelegramBindingPolicy = field(
+        default_factory=lambda: TelegramBindingPolicy.from_mapping(None)
+    )
+    streaming_mode: str = "progress"
+    edit_interval_ms: int = 750
+    include_reasoning: bool = False
+    max_download_bytes: int = 20 * 1024 * 1024
+    max_document_text_chars: int = 100_000
+    permission_mode: str = "workspace"
+    approvals: str = "prompt"
+    approval_timeout_seconds: float = 300.0
+    allow_yolo: bool = False
+    retry_attempts: int = 8
+    retry_base_seconds: float = 1.0
+    retry_max_seconds: float = 300.0
+    dead_letter_after_hours: int = 24
+    poll_timeout_seconds: float = 30.0
+    request_timeout_seconds: float = 30.0
+    webhook_timeout_seconds: float = 10.0
+    webhook_body_limit_bytes: int = 1024 * 1024
+    ingress_workers: int = 2
+    delivery_workers: int = 2
+    webhook_public_url: str | None = None
+    webhook_path: str = "/api/v1/integrations/telegram/webhook"
+    webhook_secret: str | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        """Keep direct construction consistent with parsed configuration."""
+
+        if self.binding_policy.default.activation != self.activation:
+            object.__setattr__(
+                self,
+                "binding_policy",
+                self.binding_policy.with_default_activation(self.activation),
+            )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        raw_config: Mapping[str, Any] | None,
+        environ: Mapping[str, str] | None = None,
+    ) -> TelegramConfig:
+        """Load a config without ever accepting an inline bot token."""
+        raw = raw_config or {}
+        data = _telegram_section(raw)
+        env = os.environ if environ is None else environ
+
+        _reject_inline_secrets(data)
+        enabled = _as_bool(data.get("enabled"), default=False, name="enabled")
+        transport = _choice(
+            data.get("transport", "polling"),
+            {"polling", "webhook"},
+            "transport",
+        )
+        token = _secret(env.get("TELEGRAM_BOT_TOKEN")) if enabled else None
+        if enabled and token is None:
+            raise ValueError("Telegram is enabled but TELEGRAM_BOT_TOKEN is not set")
+
+        webhook = _mapping(data.get("webhook"), "webhook")
+        secret = (
+            _secret(env.get("TELEGRAM_WEBHOOK_SECRET"))
+            if enabled and transport == "webhook"
+            else None
+        )
+        if enabled and transport == "webhook" and secret is None:
+            raise ValueError("Telegram webhook mode requires TELEGRAM_WEBHOOK_SECRET")
+
+        dm_policy = _choice(
+            data.get("dm_policy", "allowlist"),
+            {"pairing", "allowlist", "open", "disabled"},
+            "dm_policy",
+        )
+        group_policy = _choice(
+            data.get("group_policy", "allowlist"),
+            {"allowlist", "open", "disabled"},
+            "group_policy",
+        )
+        open_acknowledged = _as_bool(
+            data.get("open_access_acknowledged"),
+            default=False,
+            name="open_access_acknowledged",
+        )
+        if "open" in {dm_policy, group_policy} and not open_acknowledged:
+            raise ValueError(
+                "Open Telegram access requires open_access_acknowledged: true"
+            )
+
+        permissions = _mapping(data.get("permissions"), "permissions")
+        requested_mode = _choice(
+            permissions.get("mode", "workspace"),
+            set(_PERMISSION_RANK),
+            "permissions.mode",
+        )
+        permission_mode = _cap_permission_mode(requested_mode, raw)
+        approvals = _choice(
+            permissions.get("approvals", "prompt"),
+            {"prompt", "deny"},
+            "permissions.approvals",
+        )
+        allow_yolo = _as_bool(
+            permissions.get("allow_yolo"),
+            default=False,
+            name="permissions.allow_yolo",
+        )
+        if allow_yolo:
+            raise ValueError("Telegram cannot opt in to PENGUIN_YOLO")
+        if enabled and _as_bool(
+            env.get("PENGUIN_YOLO"), default=False, name="PENGUIN_YOLO"
+        ):
+            raise ValueError("Telegram cannot run while PENGUIN_YOLO is enabled")
+        security = _mapping(raw.get("security"), "security")
+        if enabled and not _as_bool(
+            security.get("enabled"), default=True, name="security.enabled"
+        ):
+            raise ValueError("Telegram requires Penguin security enforcement")
+
+        streaming = _mapping(data.get("streaming"), "streaming")
+        media = _mapping(data.get("media"), "media")
+        delivery = _mapping(data.get("delivery"), "delivery")
+        runtime = _mapping(data.get("runtime"), "runtime")
+        activation = _choice(
+            data.get("activation", "mention"),
+            {"always", "mention"},
+            "activation",
+        )
+        binding_policy = TelegramBindingPolicy.from_mapping(
+            data.get("groups"),
+            default_activation=activation,
+        )
+
+        max_download_mb = _bounded_int(
+            media.get("max_download_mb", 20),
+            1,
+            50,
+            "media.max_download_mb",
+        )
+        retry_base = _bounded_float(
+            delivery.get("retry_base_seconds", 1.0),
+            0.1,
+            60.0,
+            "delivery.retry_base_seconds",
+        )
+        retry_max = _bounded_float(
+            delivery.get("retry_max_seconds", 300.0),
+            retry_base,
+            3600.0,
+            "delivery.retry_max_seconds",
+        )
+
+        username = str(data.get("expected_username") or "Penguin_agent_bot")
+        username = username.removeprefix("@")
+        if not re.fullmatch(
+            r"[A-Za-z0-9_]{5,32}", username
+        ) or not username.lower().endswith("bot"):
+            raise ValueError("expected_username is not a valid Telegram bot username")
+
+        webhook_path = str(
+            webhook.get("path") or "/api/v1/integrations/telegram/webhook"
+        )
+        if webhook_path != "/api/v1/integrations/telegram/webhook":
+            raise ValueError(
+                "webhook.path must be /api/v1/integrations/telegram/webhook"
+            )
+
+        return cls(
+            enabled=enabled,
+            token=token,
+            expected_username=username,
+            transport=transport,
+            dm_policy=dm_policy,
+            allow_from=_numeric_ids(data.get("allow_from"), "allow_from"),
+            group_policy=group_policy,
+            allowed_group_ids=_numeric_ids(
+                data.get("allowed_group_ids", data.get("group_allow_from")),
+                "group_allow_from",
+                positive_only=False,
+            ),
+            allowed_group_sender_ids=_numeric_ids(
+                data.get(
+                    "allowed_group_sender_ids",
+                    data.get("group_sender_allow_from"),
+                ),
+                "group_sender_allow_from",
+            ),
+            activation=activation,
+            binding_policy=binding_policy,
+            streaming_mode=_choice(
+                streaming.get("mode", "progress"),
+                {"off", "edit", "progress"},
+                "streaming.mode",
+            ),
+            edit_interval_ms=_bounded_int(
+                streaming.get("edit_interval_ms", 750),
+                250,
+                10_000,
+                "streaming.edit_interval_ms",
+            ),
+            include_reasoning=_as_bool(
+                streaming.get("include_reasoning"),
+                default=False,
+                name="streaming.include_reasoning",
+            ),
+            max_download_bytes=max_download_mb * 1024 * 1024,
+            max_document_text_chars=_bounded_int(
+                media.get("max_document_text_chars", 100_000),
+                1,
+                1_000_000,
+                "media.max_document_text_chars",
+            ),
+            permission_mode=permission_mode,
+            approvals=approvals,
+            approval_timeout_seconds=_bounded_float(
+                permissions.get("timeout_seconds", 300.0),
+                30.0,
+                3600.0,
+                "permissions.timeout_seconds",
+            ),
+            allow_yolo=False,
+            retry_attempts=_bounded_int(
+                delivery.get("retry_attempts", 8),
+                1,
+                20,
+                "delivery.retry_attempts",
+            ),
+            retry_base_seconds=retry_base,
+            retry_max_seconds=retry_max,
+            dead_letter_after_hours=_bounded_int(
+                delivery.get("dead_letter_after_hours", 24),
+                1,
+                720,
+                "delivery.dead_letter_after_hours",
+            ),
+            poll_timeout_seconds=_bounded_float(
+                runtime.get("poll_timeout_seconds", 30.0),
+                1.0,
+                50.0,
+                "runtime.poll_timeout_seconds",
+            ),
+            request_timeout_seconds=_bounded_float(
+                runtime.get("request_timeout_seconds", 30.0),
+                1.0,
+                120.0,
+                "runtime.request_timeout_seconds",
+            ),
+            webhook_timeout_seconds=_bounded_float(
+                webhook.get("timeout_seconds", 10.0),
+                1.0,
+                30.0,
+                "webhook.timeout_seconds",
+            ),
+            webhook_body_limit_bytes=_bounded_int(
+                webhook.get("body_limit_bytes", 1024 * 1024),
+                1024,
+                10 * 1024 * 1024,
+                "webhook.body_limit_bytes",
+            ),
+            ingress_workers=_bounded_int(
+                runtime.get("ingress_workers", 2),
+                1,
+                16,
+                "runtime.ingress_workers",
+            ),
+            delivery_workers=_bounded_int(
+                runtime.get("delivery_workers", 2),
+                1,
+                16,
+                "runtime.delivery_workers",
+            ),
+            webhook_public_url=_optional_string(webhook.get("public_url")),
+            webhook_path=webhook_path,
+            webhook_secret=secret,
+        )
+
+    @property
+    def approval_policy(self) -> dict[str, Any]:
+        """Return the request policy consumed by Penguin's permission checks."""
+        decision = "ask" if self.approvals == "prompt" else "deny"
+        policy = {
+            **{action: decision for action in _APPROVAL_ACTIONS},
+            "default": decision,
+            "allowLists": {},
+            "timeout_seconds": self.approval_timeout_seconds,
+        }
+        if self.approvals == "prompt":
+            policy["wait_for_resolution"] = True
+        return policy
+
+    def allows_dm(self, user_id: int) -> bool:
+        """Return whether policy alone admits a DM; pairing grants live elsewhere."""
+        return self.dm_policy == "open" or (
+            self.dm_policy == "allowlist" and user_id in self.allow_from
+        )
+
+    def allows_group_sender(self, user_id: int) -> bool:
+        """Return whether policy alone admits a sender in a group."""
+        return self.group_policy == "open" or (
+            self.group_policy == "allowlist"
+            and user_id in self.allowed_group_sender_ids
+        )
+
+    def allows_group(self, chat_id: int) -> bool:
+        """Return whether policy alone admits a Telegram group chat."""
+        return self.group_policy == "open" or (
+            self.group_policy == "allowlist" and chat_id in self.allowed_group_ids
+        )
+
+    def binding_for(
+        self,
+        chat_id: int | str,
+        topic_id: int | str | None = None,
+    ) -> TelegramBinding:
+        """Resolve trusted execution settings for a Telegram group or topic."""
+
+        return self.binding_policy.resolve(chat_id, topic_id)
+
+
+def _telegram_section(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+    channels = raw.get("channels")
+    if isinstance(channels, Mapping):
+        telegram = channels.get("telegram")
+        if isinstance(telegram, Mapping):
+            return telegram
+    telegram = raw.get("telegram")
+    return telegram if isinstance(telegram, Mapping) else {}
+
+
+def _reject_inline_secrets(data: Mapping[str, Any]) -> None:
+    for name in ("token", "bot_token", "token_file", "proxy_url"):
+        if data.get(name) not in (None, ""):
+            raise ValueError(f"Telegram {name} must not be stored in config")
+    token_env = data.get("token_env")
+    if token_env not in (None, "", "TELEGRAM_BOT_TOKEN"):
+        raise ValueError("Telegram token_env must be TELEGRAM_BOT_TOKEN")
+    webhook = _mapping(data.get("webhook"), "webhook")
+    for name in ("secret", "secret_token"):
+        if webhook.get(name) not in (None, ""):
+            raise ValueError("Telegram webhook secret must not be stored in config")
+    secret_env = webhook.get("secret_env")
+    if secret_env not in (None, "", "TELEGRAM_WEBHOOK_SECRET"):
+        raise ValueError("Telegram webhook.secret_env must be TELEGRAM_WEBHOOK_SECRET")
+
+
+def _cap_permission_mode(requested: str, raw: Mapping[str, Any]) -> str:
+    security = _mapping(raw.get("security"), "security")
+    instance = str(security.get("mode", "workspace")).strip().lower()
+    if instance == "full":
+        instance = "full_access"
+    if instance not in _PERMISSION_RANK:
+        instance = "workspace"
+    ceiling = min(_PERMISSION_RANK[requested], _PERMISSION_RANK[instance])
+    return next(mode for mode, rank in _PERMISSION_RANK.items() if rank == ceiling)
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return value
+
+
+def _as_bool(value: Any, *, default: bool, name: str) -> bool:
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in _TRUE:
+        return True
+    if normalized in _FALSE:
+        return False
+    raise ValueError(f"{name} must be a boolean")
+
+
+def _choice(value: Any, choices: set[str], name: str) -> str:
+    normalized = str(value).strip().lower()
+    if normalized not in choices:
+        allowed = ", ".join(sorted(choices))
+        raise ValueError(f"{name} must be one of: {allowed}")
+    return normalized
+
+
+def _bounded_int(value: Any, minimum: int, maximum: int, name: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if isinstance(value, bool) or not minimum <= parsed <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return parsed
+
+
+def _bounded_float(value: Any, minimum: float, maximum: float, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a number") from exc
+    if isinstance(value, bool) or not minimum <= parsed <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return parsed
+
+
+def _numeric_ids(
+    value: Any, name: str, *, positive_only: bool = True
+) -> frozenset[int]:
+    if value in (None, ""):
+        return frozenset()
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        raise ValueError(f"{name} must be a list of numeric Telegram user ids")
+    parsed: set[int] = set()
+    for item in value:
+        if isinstance(item, bool):
+            raise ValueError(f"{name} must contain only numeric Telegram user ids")
+        try:
+            user_id = int(item)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{name} must contain only numeric Telegram user ids"
+            ) from exc
+        if (
+            user_id == 0
+            or (positive_only and user_id < 0)
+            or str(item).strip() != str(user_id)
+        ):
+            raise ValueError(f"{name} must contain only numeric Telegram user ids")
+        parsed.add(user_id)
+    return frozenset(parsed)
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _secret(value: Any) -> str | None:
+    return _optional_string(value)
+
+
+__all__ = ["TelegramConfig"]

--- a/penguin/integrations/telegram/config.py
+++ b/penguin/integrations/telegram/config.py
@@ -23,6 +23,7 @@ _APPROVAL_ACTIONS = (
     "network",
     "secrets",
 )
+_APPROVAL_DECISIONS = {"allow", "ask", "deny"}
 
 
 @dataclass(frozen=True)
@@ -48,7 +49,7 @@ class TelegramConfig:
     max_download_bytes: int = 20 * 1024 * 1024
     max_document_text_chars: int = 100_000
     permission_mode: str = "workspace"
-    approvals: str = "prompt"
+    approvals: str | Mapping[str, str] = "prompt"
     approval_timeout_seconds: float = 300.0
     allow_yolo: bool = False
     retry_attempts: int = 8
@@ -133,11 +134,7 @@ class TelegramConfig:
             "permissions.mode",
         )
         permission_mode = _cap_permission_mode(requested_mode, raw)
-        approvals = _choice(
-            permissions.get("approvals", "prompt"),
-            {"prompt", "deny"},
-            "permissions.approvals",
-        )
+        approvals = _approval_setting(permissions.get("approvals", "prompt"))
         allow_yolo = _as_bool(
             permissions.get("allow_yolo"),
             default=False,
@@ -315,16 +312,50 @@ class TelegramConfig:
     @property
     def approval_policy(self) -> dict[str, Any]:
         """Return the request policy consumed by Penguin's permission checks."""
-        decision = "ask" if self.approvals == "prompt" else "deny"
+        if isinstance(self.approvals, Mapping):
+            configured = dict(self.approvals)
+            default_decision = configured.get("default", "ask")
+            decisions = {
+                action: configured.get(action, default_decision)
+                for action in _APPROVAL_ACTIONS
+            }
+            decisions["default"] = default_decision
+        else:
+            decision = "ask" if self.approvals == "prompt" else "deny"
+            decisions = {
+                **{action: decision for action in _APPROVAL_ACTIONS},
+                "default": decision,
+            }
         policy = {
-            **{action: decision for action in _APPROVAL_ACTIONS},
-            "default": decision,
+            **decisions,
             "allowLists": {},
             "timeout_seconds": self.approval_timeout_seconds,
         }
-        if self.approvals == "prompt":
+        if "ask" in decisions.values():
             policy["wait_for_resolution"] = True
         return policy
+
+    @property
+    def permissions_summary(self) -> str:
+        """Return a credential-free description of Telegram's policy layer."""
+
+        policy = self.approval_policy
+        timeout = self.approval_timeout_seconds
+        timeout_text = f"{timeout:g} seconds"
+        decisions = "\n".join(
+            f"- {category}: {policy[category]}"
+            for category in (*_APPROVAL_ACTIONS, "default")
+        )
+        return (
+            "Telegram permission policy\n"
+            f"Mode cap: {self.permission_mode} "
+            "(cannot exceed Penguin security.mode)\n"
+            f"Approval timeout: {timeout_text}\n"
+            f"Telegram category decisions:\n{decisions}\n"
+            "allow means Telegram adds no prompt; Penguin instance or agent "
+            "policy can still ASK, and any instance, agent, or workspace DENY "
+            "still blocks. YOLO is unavailable."
+        )
 
     def allows_dm(self, user_id: int) -> bool:
         """Return whether policy alone admits a DM; pairing grants live elsewhere."""
@@ -390,6 +421,29 @@ def _cap_permission_mode(requested: str, raw: Mapping[str, Any]) -> str:
         instance = "workspace"
     ceiling = min(_PERMISSION_RANK[requested], _PERMISSION_RANK[instance])
     return next(mode for mode, rank in _PERMISSION_RANK.items() if rank == ceiling)
+
+
+def _approval_setting(value: Any) -> str | Mapping[str, str]:
+    """Parse legacy scalar or granular Telegram approval decisions."""
+
+    if not isinstance(value, Mapping):
+        return _choice(value, {"prompt", "deny"}, "permissions.approvals")
+
+    allowed_keys = {*_APPROVAL_ACTIONS, "default"}
+    unknown = sorted(str(key) for key in value if key not in allowed_keys)
+    if unknown:
+        raise ValueError(
+            "permissions.approvals contains unknown categories: " + ", ".join(unknown)
+        )
+
+    parsed: dict[str, str] = {}
+    for category, decision in value.items():
+        parsed[str(category)] = _choice(
+            decision,
+            _APPROVAL_DECISIONS,
+            f"permissions.approvals.{category}",
+        )
+    return parsed
 
 
 def _mapping(value: Any, name: str) -> Mapping[str, Any]:

--- a/penguin/integrations/telegram/formatting.py
+++ b/penguin/integrations/telegram/formatting.py
@@ -1,0 +1,202 @@
+"""Pure Telegram text formatting and streaming helpers."""
+
+from __future__ import annotations
+
+import html
+import re
+from dataclasses import dataclass, field
+
+TELEGRAM_TEXT_LIMIT = 4000
+
+_FENCED_CODE = re.compile(r"```(?:[A-Za-z0-9_+.-]+\n)?(.*?)```", re.DOTALL)
+_INLINE_CODE = re.compile(r"`([^`\n]*)`")
+_LINK = re.compile(r"\[([^\]\n]+)\]\((https?://[^\s)]+)\)")
+
+
+def utf16_length(text: str) -> int:
+    """Return Telegram's UTF-16 code-unit length for text."""
+    return len(text.encode("utf-16-le", errors="surrogatepass")) // 2
+
+
+def split_text(text: str, limit: int = TELEGRAM_TEXT_LIMIT) -> list[str]:
+    """Split text without losing content, keeping each chunk within ``limit``."""
+    if limit < 1:
+        raise ValueError("limit must be positive")
+    if not text:
+        return []
+
+    chunks: list[str] = []
+    remaining = text
+    while remaining:
+        end = _utf16_prefix_end(remaining, limit)
+        if end == 0:
+            raise ValueError("limit is smaller than one Unicode character")
+        if end == len(remaining):
+            chunks.append(remaining)
+            break
+
+        candidate = remaining[:end]
+        newline = candidate.rfind("\n")
+        space = candidate.rfind(" ")
+        preferred = max(newline, space)
+        if preferred >= end // 2:
+            end = preferred + 1
+        chunks.append(remaining[:end])
+        remaining = remaining[end:]
+    return chunks
+
+
+def render_html(markdown: str) -> str:
+    """Render a small, safe Markdown subset as Telegram HTML."""
+    if not markdown:
+        return ""
+
+    marker = "\ue000"
+    while marker in markdown:
+        marker += "\ue000"
+    protected: list[str] = []
+
+    def stash(value: str) -> str:
+        token = f"{marker}{len(protected)}{marker}"
+        protected.append(value)
+        return token
+
+    text = _FENCED_CODE.sub(
+        lambda match: stash(
+            f"<pre><code>{html.escape(match.group(1), quote=False)}</code></pre>"
+        ),
+        markdown,
+    )
+    text = _INLINE_CODE.sub(
+        lambda match: stash(f"<code>{html.escape(match.group(1), quote=False)}</code>"),
+        text,
+    )
+    text = _LINK.sub(
+        lambda match: stash(
+            f'<a href="{html.escape(match.group(2), quote=True)}">'
+            f"{html.escape(match.group(1), quote=False)}</a>"
+        ),
+        text,
+    )
+
+    text = html.escape(text, quote=False)
+    text = re.sub(r"(?m)^#{1,6}[ \t]+(.+)$", r"<b>\1</b>", text)
+    text = re.sub(r"\*\*([^*\n]+)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"__([^_\n]+)__", r"<b>\1</b>", text)
+    text = re.sub(r"~~([^~\n]+)~~", r"<s>\1</s>", text)
+    text = re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"<i>\1</i>", text)
+
+    for index, value in enumerate(protected):
+        text = text.replace(f"{marker}{index}{marker}", value)
+    return text
+
+
+def plain_text(markdown: str) -> str:
+    """Return a clean plain-text fallback for the supported Markdown subset."""
+    text = _FENCED_CODE.sub(lambda match: match.group(1), markdown)
+    text = _INLINE_CODE.sub(lambda match: match.group(1), text)
+    text = _LINK.sub(lambda match: match.group(1), text)
+    text = re.sub(r"(?m)^#{1,6}[ \t]+", "", text)
+    text = re.sub(r"\*\*([^*\n]+)\*\*", r"\1", text)
+    text = re.sub(r"__([^_\n]+)__", r"\1", text)
+    text = re.sub(r"~~([^~\n]+)~~", r"\1", text)
+    return re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"\1", text)
+
+
+def html_chunks(markdown: str, limit: int = TELEGRAM_TEXT_LIMIT) -> list[str]:
+    """Render independently valid HTML chunks under Telegram's length limit."""
+    return [rendered for rendered, _fallback in formatted_chunks(markdown, limit)]
+
+
+def formatted_chunks(
+    markdown: str, limit: int = TELEGRAM_TEXT_LIMIT
+) -> list[tuple[str, str]]:
+    """Return aligned HTML and plain-text chunks for delivery fallback."""
+    if limit < 16:
+        raise ValueError("HTML chunk limit must be at least 16")
+
+    pending = split_text(markdown, limit)
+    chunks: list[tuple[str, str]] = []
+    while pending:
+        source = pending.pop(0)
+        rendered = render_html(source)
+        fallback = plain_text(source)
+        if utf16_length(rendered) <= limit and utf16_length(fallback) <= limit:
+            chunks.append((rendered, fallback))
+            continue
+        half = max(1, utf16_length(source) // 2)
+        parts = split_text(source, half)
+        if len(parts) == 1:
+            raise ValueError("text cannot be represented within the HTML limit")
+        pending[0:0] = parts
+    return chunks
+
+
+def plain_chunks(markdown: str, limit: int = TELEGRAM_TEXT_LIMIT) -> list[str]:
+    """Return plain fallback chunks under Telegram's length limit."""
+    return split_text(plain_text(markdown), limit)
+
+
+@dataclass
+class StreamingCoalescer:
+    """Coalesce streaming deltas and expose deterministic throttled previews."""
+
+    interval_seconds: float = 0.75
+    _text: str = field(default="", init=False, repr=False)
+    _last_emitted: str = field(default="", init=False, repr=False)
+    _last_emit_at: float | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+
+    @property
+    def text(self) -> str:
+        """Return all content received so far."""
+        return self._text
+
+    @property
+    def has_pending(self) -> bool:
+        """Return whether the latest content has not been emitted."""
+        return self._text != self._last_emitted
+
+    def push(self, delta: str) -> None:
+        """Append a stream delta."""
+        self._text += delta
+
+    def take(self, now: float, *, force: bool = False) -> str | None:
+        """Return the latest cumulative preview when due, otherwise ``None``."""
+        if not self.has_pending:
+            return None
+        if (
+            not force
+            and self._last_emit_at is not None
+            and now - self._last_emit_at < self.interval_seconds
+        ):
+            return None
+        self._last_emitted = self._text
+        self._last_emit_at = now
+        return self._text
+
+
+def _utf16_prefix_end(text: str, limit: int) -> int:
+    units = 0
+    for index, char in enumerate(text):
+        char_units = utf16_length(char)
+        if units + char_units > limit:
+            return index
+        units += char_units
+    return len(text)
+
+
+__all__ = [
+    "TELEGRAM_TEXT_LIMIT",
+    "StreamingCoalescer",
+    "formatted_chunks",
+    "html_chunks",
+    "plain_chunks",
+    "plain_text",
+    "render_html",
+    "split_text",
+    "utf16_length",
+]

--- a/penguin/integrations/telegram/manager.py
+++ b/penguin/integrations/telegram/manager.py
@@ -1,0 +1,1992 @@
+"""In-process Telegram gateway sharing one PenguinCore with penguin-web."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import secrets
+import tempfile
+import time
+import uuid
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Mapping
+
+from PIL import Image, UnidentifiedImageError
+
+from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
+from penguin.channels.store import (
+    ChannelStore,
+    CompareAndSwapError,
+    DeliveryRecord,
+    IngressRecord,
+    LeaseLostError,
+    PollerLeaseConflictError,
+)
+from penguin.config import WORKSPACE_PATH
+from penguin.integrations.telegram import _migration
+from penguin.integrations.telegram._artifacts import (
+    artifact_paths,
+    validated_artifact_path,
+)
+from penguin.integrations.telegram._authorization import (
+    group_event_is_authorized,
+    migration_chat_ids,
+)
+from penguin.integrations.telegram._commands import handle_command
+from penguin.integrations.telegram._helpers import (
+    delivery_payload as _delivery_payload,
+    inline_markup as _inline_markup,
+    interactive_terminal_label,
+    message_id as _message_id,
+    value as _value,
+)
+from penguin.integrations.telegram._history import GroupHistory
+from penguin.integrations.telegram._leases import run_with_lease_heartbeat
+from penguin.integrations.telegram._preview import Preview
+from penguin.integrations.telegram.formatting import formatted_chunks
+from penguin.integrations.telegram.transport import classify_failure, retry_delay
+from penguin.integrations.telegram.updates import (
+    envelope_from_dict,
+    envelope_to_dict,
+    is_addressed_to_bot,
+    normalize_update,
+    parse_command,
+    strip_bot_mention,
+    update_to_dict,
+)
+from penguin.system.execution_context import ExecutionContext, normalize_directory
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import ChannelAddress, InboundEnvelope
+    from penguin.integrations.telegram.config import TelegramConfig
+
+__all__ = ["TelegramManager"]
+
+logger = logging.getLogger(__name__)
+
+_PLATFORM = "telegram"
+_LEASE_SECONDS = 120.0
+_POLL_LEASE_SECONDS = 90.0
+_RECOVERY_INTERVAL_SECONDS = 30.0
+_INTERACTIVE_PREFIX = "penguin:"
+_INTERACTIVE_LANE_SUFFIX = "\x1finteractive"
+_TOKEN_PATTERN = re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b")
+_TEXT_DOCUMENT_MIMES = frozenset(
+    {
+        "application/json",
+        "application/xml",
+        "application/x-yaml",
+        "text/csv",
+        "text/markdown",
+        "text/plain",
+        "text/yaml",
+    }
+)
+
+
+class TelegramManager:
+    """Own polling/webhook admission, Penguin routing, and durable delivery."""
+
+    def __init__(
+        self,
+        core: Any,
+        config: TelegramConfig,
+        *,
+        store: ChannelStore | None = None,
+        bot: Any = None,
+        store_path: Path | None = None,
+        bot_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.core = core
+        self.config = config
+        self.store = store
+        self._store_path = store_path or (
+            Path(WORKSPACE_PATH) / "channels" / "channel_state.db"
+        )
+        self.bot = bot
+        self._bot_factory = bot_factory
+        self.account_id = ""
+        self.bot_username = config.expected_username
+        self.owner_id = f"telegram-{uuid.uuid4().hex}"
+        self._fingerprint = ""
+        self._tasks: list[asyncio.Task[Any]] = []
+        self._projection_tasks: set[asyncio.Task[Any]] = set()
+        self._stop = asyncio.Event()
+        self._work_available = asyncio.Event()
+        self._running = False
+        self._status_error: str | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._admission_lock = asyncio.Lock()
+        self._session_create_lock = asyncio.Lock()
+        self._request_targets: dict[str, tuple[ChannelAddress, str]] = {}
+        self._session_targets: dict[str, tuple[ChannelAddress, str]] = {}
+        self._pending_questions: dict[tuple[str, str], str] = {}
+        self._group_context = GroupHistory()
+        self._question_created_callback = self._on_question_created
+        self._question_resolved_callback = self._on_question_resolved
+        self._approval_created_callback = self._on_approval_created
+        self._approval_resolved_callback = self._on_approval_resolved
+
+    async def start(self) -> None:
+        """Validate identity, recover leases, and start bounded workers."""
+
+        if not self.config.enabled or self._running:
+            return
+        try:
+            await self._start_enabled()
+        except BaseException as exc:
+            self._status_error = f"{type(exc).__name__}: {self._safe_error(exc)}"
+            await self.stop()
+            raise
+
+    async def _start_enabled(self) -> None:
+        """Start an enabled manager; :meth:`start` owns failure rollback."""
+
+        if not self.config.token:
+            raise RuntimeError("Telegram token is unavailable")
+        self._loop = asyncio.get_running_loop()
+        self.bot = self.bot or self._create_bot(self.config.token)
+        initializer = getattr(self.bot, "initialize", None)
+        if callable(initializer):
+            await self._api_call(initializer())
+        identity = await self._api_call(self.bot.get_me())
+        self.account_id = str(_value(identity, "id") or "")
+        actual_username = str(_value(identity, "username") or "").lstrip("@")
+        if not self.account_id or not actual_username:
+            raise RuntimeError("Telegram getMe returned an incomplete bot identity")
+        if actual_username.casefold() != self.config.expected_username.casefold():
+            raise RuntimeError(
+                "Configured Telegram bot identity does not match expected_username"
+            )
+        self.bot_username = actual_username
+        if self.store is None:
+            self.store = ChannelStore(self._store_path)
+        self._fingerprint = self.store.fingerprint_token(self.config.token)
+        await asyncio.to_thread(
+            self.store.acquire_poller,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+            token_fingerprint=self._fingerprint,
+            owner_id=self.owner_id,
+            lease_seconds=_POLL_LEASE_SECONDS,
+        )
+        await asyncio.to_thread(self.store.recover_expired_ingress)
+        await asyncio.to_thread(self.store.recover_expired_deliveries)
+        recovered_callbacks = await asyncio.to_thread(
+            self.store.recover_orphaned_callbacks,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+        )
+        if recovered_callbacks:
+            self._work_available.set()
+        self._register_interactive_callbacks()
+        await self._set_commands()
+
+        if self.config.transport == "polling":
+            deleter = getattr(self.bot, "delete_webhook", None)
+            if callable(deleter):
+                await self._api_call(deleter(drop_pending_updates=False))
+        else:
+            if not self.config.webhook_public_url:
+                raise RuntimeError("Telegram webhook mode requires webhook.public_url")
+            setter = getattr(self.bot, "set_webhook", None)
+            if not callable(setter):
+                raise RuntimeError("Telegram bot client does not support webhooks")
+            url = self.config.webhook_public_url.rstrip("/") + self.config.webhook_path
+            await self._api_call(
+                setter(
+                    url=url,
+                    secret_token=self.config.webhook_secret,
+                    allowed_updates=["message", "callback_query"],
+                )
+            )
+
+        self._stop.clear()
+        self._running = True
+        self._tasks.extend(
+            asyncio.create_task(
+                self._ingress_worker(index), name=f"telegram-in-{index}"
+            )
+            for index in range(self.config.ingress_workers)
+        )
+        self._tasks.append(
+            asyncio.create_task(
+                self._ingress_worker("control", interactive=True),
+                name="telegram-in-control",
+            )
+        )
+        self._tasks.extend(
+            asyncio.create_task(
+                self._delivery_worker(index), name=f"telegram-out-{index}"
+            )
+            for index in range(self.config.delivery_workers)
+        )
+        self._tasks.append(
+            asyncio.create_task(self._recovery_loop(), name="telegram-lease-recovery")
+        )
+        if self.config.transport == "polling":
+            self._tasks.append(
+                asyncio.create_task(self._polling_loop(), name="telegram-poller")
+            )
+        logger.info(
+            "Telegram integration started username=@%s transport=%s",
+            self.bot_username,
+            self.config.transport,
+        )
+
+    async def stop(self) -> None:
+        """Stop workers, release polling ownership, and unregister callbacks."""
+
+        self._stop.set()
+        self._work_available.set()
+        tasks, self._tasks = self._tasks, []
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        projection_tasks, self._projection_tasks = self._projection_tasks, set()
+        for task in projection_tasks:
+            task.cancel()
+        if projection_tasks:
+            await asyncio.gather(*projection_tasks, return_exceptions=True)
+        self._unregister_interactive_callbacks()
+        if self.store is not None and self.account_id and self._fingerprint:
+            with suppress(Exception):
+                await asyncio.to_thread(
+                    self.store.release_poller,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    token_fingerprint=self._fingerprint,
+                    owner_id=self.owner_id,
+                )
+        shutdown = getattr(self.bot, "shutdown", None)
+        if callable(shutdown):
+            with suppress(Exception):
+                await self._api_call(shutdown())
+        self._running = False
+        logger.info("Telegram integration stopped")
+
+    def status(self) -> dict[str, Any]:
+        """Return diagnostics with no credentials or secrets."""
+
+        return {
+            "enabled": self.config.enabled,
+            "running": self._running,
+            "transport": self.config.transport,
+            "username": f"@{self.bot_username}",
+            "account_id": self.account_id or None,
+            "workers": len([task for task in self._tasks if not task.done()]),
+            "error": self._status_error,
+        }
+
+    def _safe_error(self, value: Any) -> str:
+        text = str(value)[:1000]
+        for secret in (self.config.token, self.config.webhook_secret):
+            if secret:
+                text = text.replace(secret, "[redacted]")
+        return _TOKEN_PATTERN.sub("[redacted-telegram-token]", text)
+
+    async def create_pairing(
+        self,
+        *,
+        expected_user_id: str | None = None,
+        ttl_seconds: int = 3600,
+    ) -> str:
+        """Create a one-hour, single-use DM pairing code for an operator."""
+
+        if self.store is None or not self.account_id:
+            raise RuntimeError("Telegram integration is not running")
+        if ttl_seconds < 60 or ttl_seconds > 3600:
+            raise ValueError("pairing TTL must be between 60 and 3600 seconds")
+        code = secrets.token_hex(8).upper()
+        await asyncio.to_thread(
+            self.store.create_pairing,
+            code,
+            account_id=self.account_id,
+            expected_user_id=expected_user_id,
+            expires_at=time.time() + ttl_seconds,
+        )
+        return code
+
+    async def revoke_dm(self, user_id: str) -> bool:
+        """Revoke one pairing-derived DM grant."""
+
+        if self.store is None or not self.account_id:
+            raise RuntimeError("Telegram integration is not running")
+        return bool(
+            await asyncio.to_thread(
+                self.store.revoke_dm_authorization,
+                account_id=self.account_id,
+                user_id=str(user_id),
+            )
+        )
+
+    async def list_dead_letters(
+        self, *, kind: str, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """Return bounded inspectable dead-letter records."""
+
+        if self.store is None or not self.account_id:
+            raise RuntimeError("Telegram integration is not running")
+        if kind == "ingress":
+            records = await asyncio.to_thread(
+                self.store.list_dead_ingress,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                limit=limit,
+            )
+        elif kind == "delivery":
+            records = await asyncio.to_thread(
+                self.store.list_dead_deliveries,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                limit=limit,
+            )
+        else:
+            raise ValueError("dead-letter kind must be ingress or delivery")
+        return [
+            {
+                "id": getattr(record, "event_id", None)
+                or getattr(record, "delivery_id", None),
+                "lane_key": record.lane_key,
+                "attempt_count": record.attempt_count,
+                "error_class": record.last_error_class,
+                "error_message": record.last_error_message,
+                "created_at": record.created_at,
+                "updated_at": record.updated_at,
+                "payload": record.payload,
+            }
+            for record in records
+        ]
+
+    async def retry_dead_letter(self, *, kind: str, record_id: str) -> bool:
+        """Explicitly requeue one terminal record."""
+
+        if self.store is None or not self.account_id:
+            raise RuntimeError("Telegram integration is not running")
+        method = (
+            self.store.requeue_dead_ingress
+            if kind == "ingress"
+            else self.store.requeue_dead_delivery
+            if kind == "delivery"
+            else None
+        )
+        if method is None:
+            raise ValueError("dead-letter kind must be ingress or delivery")
+        result = await asyncio.to_thread(
+            method,
+            record_id,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+        )
+        if result:
+            self._work_available.set()
+        return bool(result)
+
+    async def discard_dead_letter(self, *, kind: str, record_id: str) -> bool:
+        """Delete one terminal record after an explicit operator request."""
+
+        if self.store is None or not self.account_id:
+            raise RuntimeError("Telegram integration is not running")
+        method = (
+            self.store.discard_dead_ingress
+            if kind == "ingress"
+            else self.store.discard_dead_delivery
+            if kind == "delivery"
+            else None
+        )
+        if method is None:
+            raise ValueError("dead-letter kind must be ingress or delivery")
+        return bool(
+            await asyncio.to_thread(
+                method,
+                record_id,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+            )
+        )
+
+    async def admit_webhook_update(self, update: Any) -> bool:
+        """Durably adopt one webhook update before acknowledging it."""
+
+        if not self._running or self.store is None:
+            raise RuntimeError("Telegram integration is not running")
+        envelope = normalize_update(update, account_id=self.account_id)
+        if envelope is None:
+            return False
+        async with self._admission_lock:
+            if not await self._may_admit(envelope):
+                return False
+            migration = migration_chat_ids(envelope)
+            lane = await self._ingress_lane(envelope)
+            inserted = await asyncio.to_thread(
+                self.store.admit_ingress,
+                envelope.event_id,
+                lane,
+                envelope_to_dict(envelope),
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                group_authorization=_migration.migration_authorization(
+                    self.account_id, migration
+                ),
+            )
+        self._work_available.set()
+        return bool(inserted)
+
+    async def _polling_loop(self) -> None:
+        assert self.store is not None
+        offset = await asyncio.to_thread(
+            self.store.get_poller_offset,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+            token_fingerprint=self._fingerprint,
+        )
+        failures = 0
+        while not self._stop.is_set():
+            try:
+                renewed = await asyncio.to_thread(
+                    self.store.renew_poller,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    token_fingerprint=self._fingerprint,
+                    owner_id=self.owner_id,
+                    lease_seconds=_POLL_LEASE_SECONDS,
+                )
+                if not renewed:
+                    raise PollerLeaseConflictError("Telegram poller lease was lost")
+                updates = await self._api_call(
+                    self.bot.get_updates(
+                        offset=offset,
+                        timeout=self.config.poll_timeout_seconds,
+                        allowed_updates=["message", "callback_query"],
+                    ),
+                    timeout=min(
+                        self.config.poll_timeout_seconds
+                        + self.config.request_timeout_seconds,
+                        _POLL_LEASE_SECONDS * 2 / 3,
+                    ),
+                )
+                failures = 0
+                for update in updates:
+                    raw = update_to_dict(update)
+                    update_id = int(raw["update_id"])
+                    next_offset = update_id + 1
+                    envelope = normalize_update(raw, account_id=self.account_id)
+                    if envelope is None:
+                        await asyncio.to_thread(
+                            self.store.advance_poller_offset,
+                            next_offset,
+                            platform=_PLATFORM,
+                            account_id=self.account_id,
+                            token_fingerprint=self._fingerprint,
+                            owner_id=self.owner_id,
+                        )
+                    elif not await self._may_admit(envelope):
+                        await asyncio.to_thread(
+                            self.store.advance_poller_offset,
+                            next_offset,
+                            platform=_PLATFORM,
+                            account_id=self.account_id,
+                            token_fingerprint=self._fingerprint,
+                            owner_id=self.owner_id,
+                        )
+                    else:
+                        migration = migration_chat_ids(envelope)
+                        lane = await self._ingress_lane(envelope)
+                        await asyncio.to_thread(
+                            self.store.admit_ingress_and_advance_poller,
+                            envelope.event_id,
+                            lane,
+                            envelope_to_dict(envelope),
+                            platform=_PLATFORM,
+                            account_id=self.account_id,
+                            token_fingerprint=self._fingerprint,
+                            owner_id=self.owner_id,
+                            new_offset=next_offset,
+                            group_authorization=_migration.migration_authorization(
+                                self.account_id, migration
+                            ),
+                        )
+                        self._work_available.set()
+                    offset = next_offset
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                failure = classify_failure(exc)
+                self._status_error = (
+                    f"{failure.error_class}: {self._safe_error(failure.message)}"
+                )
+                if failure.polling_conflict or not failure.retryable:
+                    logger.error("Telegram polling stopped: %s", self._status_error)
+                    self._running = False
+                    self._stop.set()
+                    return
+                failures += 1
+                delay = retry_delay(
+                    failures,
+                    base_seconds=self.config.retry_base_seconds,
+                    max_seconds=self.config.retry_max_seconds,
+                    retry_after=failure.retry_after,
+                )
+                await self._wait_or_stop(delay)
+
+    async def _ingress_worker(
+        self, index: int | str, *, interactive: bool = False
+    ) -> None:
+        assert self.store is not None
+        worker_id = f"{self.owner_id}:in:{index}"
+        while not self._stop.is_set():
+            record = await asyncio.to_thread(
+                self.store.claim_ingress,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                owner_id=worker_id,
+                lease_seconds=_LEASE_SECONDS,
+                lane_suffix=_INTERACTIVE_LANE_SUFFIX if interactive else None,
+                exclude_lane_suffix=(None if interactive else _INTERACTIVE_LANE_SUFFIX),
+            )
+            if record is None:
+                await self._wait_for_work()
+                continue
+            try:
+                await run_with_lease_heartbeat(
+                    self._handle_ingress(record, worker_id),
+                    self.store.renew_ingress_lease,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                    lease_seconds=_LEASE_SECONDS,
+                )
+            except asyncio.CancelledError:
+                if self._stop.is_set():
+                    raise
+                logger.info("Telegram ingress was cancelled event=%s", record.event_id)
+            except Exception:
+                logger.exception("Unhandled Telegram ingress worker error")
+
+    async def _delivery_worker(self, index: int) -> None:
+        assert self.store is not None
+        worker_id = f"{self.owner_id}:out:{index}"
+        while not self._stop.is_set():
+            record = await asyncio.to_thread(
+                self.store.claim_delivery,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                owner_id=worker_id,
+                lease_seconds=_LEASE_SECONDS,
+            )
+            if record is None:
+                await self._wait_for_work()
+                continue
+            try:
+                try:
+                    remote_id = await run_with_lease_heartbeat(
+                        self._send_delivery(record),
+                        self.store.renew_delivery_lease,
+                        record.delivery_id,
+                        platform=_PLATFORM,
+                        account_id=self.account_id,
+                        owner_id=worker_id,
+                        lease_seconds=_LEASE_SECONDS,
+                    )
+                    await asyncio.to_thread(
+                        self.store.complete_delivery,
+                        record.delivery_id,
+                        platform=_PLATFORM,
+                        account_id=self.account_id,
+                        owner_id=worker_id,
+                        external_message_id=remote_id,
+                    )
+                except LeaseLostError:
+                    logger.warning(
+                        "Telegram delivery ownership lost id=%s",
+                        record.delivery_id,
+                    )
+                except Exception as exc:
+                    await self._handle_delivery_failure(record, worker_id, exc)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "Telegram delivery persistence failed id=%s; left for recovery",
+                    record.delivery_id,
+                )
+
+    async def _recovery_loop(self) -> None:
+        """Recover leases that expire after this process has already started."""
+
+        assert self.store is not None
+        while not self._stop.is_set():
+            await self._wait_or_stop(_RECOVERY_INTERVAL_SECONDS)
+            if self._stop.is_set():
+                return
+            try:
+                if self.config.transport == "webhook":
+                    renewed = await asyncio.to_thread(
+                        self.store.renew_poller,
+                        platform=_PLATFORM,
+                        account_id=self.account_id,
+                        token_fingerprint=self._fingerprint,
+                        owner_id=self.owner_id,
+                        lease_seconds=_POLL_LEASE_SECONDS,
+                    )
+                    if not renewed:
+                        self._status_error = "Telegram transport lease was lost"
+                        self._running = False
+                        self._stop.set()
+                        return
+                ingress = await asyncio.to_thread(self.store.recover_expired_ingress)
+                deliveries = await asyncio.to_thread(
+                    self.store.recover_expired_deliveries
+                )
+                callbacks = await asyncio.to_thread(
+                    self.store.recover_expired_callbacks,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                )
+                if ingress.retried or deliveries or callbacks:
+                    self._work_available.set()
+            except Exception:
+                logger.exception("Telegram lease recovery failed")
+
+    async def _handle_ingress(self, record: IngressRecord, worker_id: str) -> None:
+        assert self.store is not None
+        envelope = envelope_from_dict(record.payload)
+        started = False
+        completed = False
+        try:
+            if not await self._is_authorized(envelope):
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_without_delivery(record, worker_id)
+                return
+
+            migration = migration_chat_ids(envelope)
+            if migration is not None:
+                await self._migrate_binding(*migration)
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_without_delivery(record, worker_id)
+                return
+
+            callback_data = str(envelope.metadata.get("callback_data") or "")
+            if callback_data.startswith(_INTERACTIVE_PREFIX):
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._resolve_callback(envelope, callback_data, worker_id)
+                await self._complete_without_delivery(record, worker_id)
+                return
+
+            pending_key = (
+                record.lane_key.removesuffix(_INTERACTIVE_LANE_SUFFIX),
+                envelope.sender_id,
+            )
+            pending_question = self._pending_questions.get(pending_key)
+            if pending_question and envelope.text.strip():
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                answer_result = await self._reply_to_question(
+                    pending_question, envelope.text
+                )
+                if answer_result is True:
+                    self._pending_questions.pop(pending_key, None)
+                    await self._complete_with_text(
+                        record, worker_id, envelope, "Answer received."
+                    )
+                elif answer_result is None:
+                    await self._complete_with_text(
+                        record,
+                        worker_id,
+                        envelope,
+                        "Please reply with one non-empty answer per question, "
+                        "one per line.",
+                    )
+                else:
+                    self._pending_questions.pop(pending_key, None)
+                    await self._complete_with_text(
+                        record,
+                        worker_id,
+                        envelope,
+                        "That question is no longer pending.",
+                    )
+                return
+
+            command, arguments, target = parse_command(envelope.text)
+            if target and target.casefold() != self.bot_username.casefold():
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_without_delivery(record, worker_id)
+                return
+
+            binding = await self._binding_for(envelope.address)
+            if command is not None:
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                response = await handle_command(
+                    self, command, arguments, envelope, binding
+                )
+                if response is None:
+                    await self._complete_without_delivery(record, worker_id)
+                else:
+                    await self._complete_with_text(
+                        record,
+                        worker_id,
+                        envelope,
+                        response,
+                        session_id=getattr(binding, "session_id", None),
+                    )
+                return
+
+            if not self._is_activated(envelope, binding):
+                self._observe_group_message(envelope)
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_without_delivery(record, worker_id)
+                return
+
+            bound_directory = getattr(binding, "directory", None)
+            directory = normalize_directory(bound_directory)
+            if bound_directory and directory is None:
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_with_text(
+                    record,
+                    worker_id,
+                    envelope,
+                    "Bound project unavailable. Update or recreate this Telegram "
+                    "session binding before retrying.",
+                )
+                return
+            directory = directory or normalize_directory(WORKSPACE_PATH)
+            settings = getattr(binding, "settings", {})
+            raw_history_limit = (
+                settings.get("history_limit") if isinstance(settings, Mapping) else None
+            )
+            history_limit = (
+                raw_history_limit
+                if isinstance(raw_history_limit, int)
+                and not isinstance(raw_history_limit, bool)
+                and 0 <= raw_history_limit <= 200
+                else self.config.binding_for(
+                    envelope.address.chat_id, envelope.address.topic_id or None
+                ).history_limit
+            )
+            history = self._group_context.recent(
+                envelope.address.lane_key, history_limit
+            )
+            self._observe_group_message(envelope)
+            with tempfile.TemporaryDirectory(prefix="penguin-telegram-") as temp_dir:
+                try:
+                    image_paths, document_inputs = await self._download_attachments(
+                        envelope, Path(temp_dir)
+                    )
+                except ValueError as exc:
+                    await asyncio.to_thread(
+                        self.store.start_ingress,
+                        record.event_id,
+                        platform=_PLATFORM,
+                        account_id=self.account_id,
+                        owner_id=worker_id,
+                    )
+                    started = True
+                    await self._complete_with_text(
+                        record,
+                        worker_id,
+                        envelope,
+                        f"Telegram attachment rejected: {exc}",
+                    )
+                    return
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                result, preview_id = await self._execute_turn(
+                    envelope,
+                    binding,
+                    image_paths=image_paths,
+                    document_inputs=document_inputs,
+                    group_history=history,
+                    directory=directory,
+                )
+            if result.get("error") or result.get("status") in {"error", "failed"}:
+                error = result.get("error")
+                error_text = (
+                    str(error.get("message") or error)
+                    if isinstance(error, Mapping)
+                    else str(error or "Penguin could not complete the request.")
+                )
+                final_text = f"Penguin error: {error_text}"
+            else:
+                final_text = str(result.get("assistant_response") or "")
+                if not final_text:
+                    final_text = "Penguin completed the turn without a text response."
+            try:
+                await self._enqueue_artifacts(
+                    envelope,
+                    binding.session_id,
+                    record,
+                    result,
+                    allowed_root=Path(
+                        getattr(binding, "directory", None) or WORKSPACE_PATH
+                    ),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue Telegram artifacts event=%s",
+                    record.event_id,
+                )
+                final_text += (
+                    "\n\nPenguin could not queue one or more generated artifacts."
+                )
+            await self._complete_with_text(
+                record,
+                worker_id,
+                envelope,
+                final_text,
+                session_id=binding.session_id,
+                request_id=envelope.event_id,
+                edit_message_id=preview_id,
+            )
+            completed = True
+        except asyncio.CancelledError:
+            if started and not completed:
+                with suppress(Exception):
+                    await asyncio.to_thread(
+                        self.store.dead_letter_ingress,
+                        record.event_id,
+                        platform=_PLATFORM,
+                        account_id=self.account_id,
+                        owner_id=worker_id,
+                        error_class="execution_cancelled",
+                        error_message=(
+                            "Telegram turn was cancelled after execution began"
+                        ),
+                    )
+            raise
+        except Exception as exc:
+            if completed:
+                logger.exception(
+                    "Telegram post-completion work failed event=%s", record.event_id
+                )
+            elif started:
+                await asyncio.to_thread(
+                    self.store.dead_letter_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                    error_class="execution_uncertain",
+                    error_message=self._safe_error(exc),
+                )
+            elif record.attempt_count < self.config.retry_attempts:
+                delay = retry_delay(
+                    record.attempt_count,
+                    base_seconds=self.config.retry_base_seconds,
+                    max_seconds=self.config.retry_max_seconds,
+                )
+                await asyncio.to_thread(
+                    self.store.retry_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                    retry_at=time.time() + delay,
+                    error_class=type(exc).__name__,
+                    error_message=self._safe_error(exc),
+                )
+            else:
+                await asyncio.to_thread(
+                    self.store.dead_letter_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                    error_class=type(exc).__name__,
+                    error_message=self._safe_error(exc),
+                )
+            logger.error(
+                "Telegram ingress failed event=%s class=%s message=%s",
+                record.event_id,
+                type(exc).__name__,
+                self._safe_error(exc),
+            )
+
+    def _create_bot(self, token: str) -> Any:
+        if self._bot_factory is not None:
+            return self._bot_factory(token)
+        try:
+            from telegram import Bot
+        except ImportError as exc:
+            raise RuntimeError(
+                "Telegram support requires Python 3.10+ and "
+                "`pip install penguin-ai[telegram]`"
+            ) from exc
+        return Bot(token=token)
+
+    async def _set_commands(self) -> None:
+        setter = getattr(self.bot, "set_my_commands", None)
+        if not callable(setter):
+            return
+        commands = [
+            ("start", "Start or resume Penguin"),
+            ("help", "Show Telegram commands"),
+            ("new", "Start a fresh Penguin session"),
+            ("status", "Show bot and session status"),
+            ("stop", "Stop the active Penguin turn"),
+            ("whoami", "Show your numeric Telegram identity"),
+            ("session", "Show the bound Penguin session"),
+            ("mode", "Show or set plan/build mode"),
+            ("model", "Show the active Penguin model"),
+            ("goal", "Show or update the session goal"),
+            ("project", "Show the bound project directory"),
+            ("activation", "Set group mention activation"),
+            ("topic", "Show the current topic binding"),
+            ("pair", "Authorize this private chat"),
+        ]
+        with suppress(Exception):
+            await self._api_call(setter(commands))
+
+    async def _api_call(self, operation: Any, *, timeout: float | None = None) -> Any:
+        """Run one Bot API operation within its configured wall-clock budget."""
+
+        return await asyncio.wait_for(
+            operation,
+            timeout=self.config.request_timeout_seconds if timeout is None else timeout,
+        )
+
+    async def _wait_for_work(self) -> None:
+        self._work_available.clear()
+        try:
+            await asyncio.wait_for(self._work_available.wait(), timeout=0.25)
+        except asyncio.TimeoutError:
+            return
+
+    async def _wait_or_stop(self, delay: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=max(0.0, delay))
+        except asyncio.TimeoutError:
+            return
+
+    async def _ingress_lane(self, envelope: InboundEnvelope) -> str:
+        migration = migration_chat_ids(envelope)
+        lane = envelope.address.lane_key
+        if envelope.metadata.get("chat_type") != "private":
+            lane = await _migration.stable_lane(
+                self.store,
+                envelope.address,
+                chat_id=migration[0] if migration else None,
+            )
+        interactive = (
+            str(envelope.metadata.get("callback_data") or "").startswith(
+                _INTERACTIVE_PREFIX
+            )
+            or (lane, envelope.sender_id) in self._pending_questions
+            or parse_command(envelope.text)[0] == "stop"
+        )
+        return f"{lane}{_INTERACTIVE_LANE_SUFFIX}" if interactive else lane
+
+    async def _is_authorized(self, envelope: InboundEnvelope) -> bool:
+        assert self.store is not None
+        chat_type = str(envelope.metadata.get("chat_type") or "private")
+        if chat_type != "private":
+            return await group_event_is_authorized(
+                envelope,
+                config=self.config,
+                store=self.store,
+                account_id=self.account_id,
+            )
+        try:
+            user_id = int(envelope.sender_id)
+        except ValueError:
+            return False
+        if self.config.dm_policy == "pairing":
+            if await asyncio.to_thread(
+                self.store.is_dm_authorized,
+                account_id=self.account_id,
+                user_id=envelope.sender_id,
+            ):
+                return True
+            command, arguments, target = parse_command(envelope.text)
+            if (
+                command == "pair"
+                and arguments
+                and (
+                    target is None or target.casefold() == self.bot_username.casefold()
+                )
+            ):
+                paired = await asyncio.to_thread(
+                    self.store.consume_pairing,
+                    arguments.split()[0],
+                    account_id=self.account_id,
+                    user_id=envelope.sender_id,
+                    chat_id=envelope.address.chat_id,
+                )
+                return paired is not None
+            return False
+        return self.config.allows_dm(user_id)
+
+    async def _may_admit(self, envelope: InboundEnvelope) -> bool:
+        """Reject unauthorized updates before they enter durable work queues."""
+
+        assert self.store is not None
+        chat_type = str(envelope.metadata.get("chat_type") or "private")
+        if chat_type != "private":
+            return await group_event_is_authorized(
+                envelope,
+                config=self.config,
+                store=self.store,
+                account_id=self.account_id,
+            )
+        try:
+            user_id = int(envelope.sender_id)
+        except ValueError:
+            return False
+        if self.config.dm_policy != "pairing":
+            return self.config.allows_dm(user_id)
+        if await asyncio.to_thread(
+            self.store.is_dm_authorized,
+            account_id=self.account_id,
+            user_id=envelope.sender_id,
+        ):
+            return True
+        command, arguments, target = parse_command(envelope.text)
+        if (
+            command != "pair"
+            or not arguments
+            or (
+                target is not None and target.casefold() != self.bot_username.casefold()
+            )
+        ):
+            return False
+        try:
+            return await asyncio.to_thread(
+                self.store.can_consume_pairing,
+                arguments.split()[0],
+                account_id=self.account_id,
+                user_id=envelope.sender_id,
+                chat_id=envelope.address.chat_id,
+            )
+        except ValueError:
+            return False
+
+    def _is_activated(self, envelope: InboundEnvelope, binding: Any) -> bool:
+        if envelope.metadata.get("chat_type") == "private":
+            return True
+        settings = getattr(binding, "settings", {})
+        activation = (
+            settings.get("activation") if isinstance(settings, Mapping) else None
+        ) or self.config.binding_for(
+            envelope.address.chat_id, envelope.address.topic_id or None
+        ).activation
+        if activation == "always":
+            return True
+        return (
+            is_addressed_to_bot(envelope.text, self.bot_username)
+            or str(envelope.metadata.get("reply_sender_id") or "") == self.account_id
+        )
+
+    def _observe_group_message(self, envelope: InboundEnvelope) -> None:
+        if envelope.metadata.get("chat_type") == "private" or not envelope.text:
+            return
+        username = envelope.sender_username or envelope.sender_id
+        self._group_context.append(
+            envelope.address.lane_key, f"{username}: {envelope.text[:1000]}"
+        )
+
+    async def _binding_for(self, address: ChannelAddress) -> Any:
+        assert self.store is not None
+        binding = await asyncio.to_thread(self.store.get_binding, address.lane_key)
+        if binding is not None:
+            return binding
+        async with self._session_create_lock:
+            binding = await asyncio.to_thread(self.store.get_binding, address.lane_key)
+            if binding is not None:
+                return binding
+            policy = self._configured_group_binding(address)
+            session_id = await asyncio.to_thread(self.core.create_conversation)
+            try:
+                return await asyncio.to_thread(
+                    self.store.upsert_binding,
+                    address.lane_key,
+                    session_id,
+                    directory=(
+                        policy.directory
+                        if policy is not None and policy.directory is not None
+                        else normalize_directory(WORKSPACE_PATH)
+                    ),
+                    agent_id=policy.agent_id if policy is not None else None,
+                    agent_mode=policy.mode if policy is not None else "build",
+                    settings=(
+                        policy.durable_settings() if policy is not None else None
+                    ),
+                    expected_version=0,
+                )
+            except CompareAndSwapError:
+                existing = await asyncio.to_thread(
+                    self.store.get_binding, address.lane_key
+                )
+                if existing is None:
+                    raise
+                return existing
+
+    async def _new_binding(self, address: ChannelAddress, binding: Any) -> Any:
+        assert self.store is not None
+        async with self._session_create_lock:
+            policy = self._configured_group_binding(address)
+            session_id = await asyncio.to_thread(self.core.create_conversation)
+            return await asyncio.to_thread(
+                self.store.upsert_binding,
+                address.lane_key,
+                session_id,
+                directory=(
+                    policy.directory or normalize_directory(WORKSPACE_PATH)
+                    if policy is not None
+                    else getattr(binding, "directory", None)
+                ),
+                agent_id=(
+                    policy.agent_id
+                    if policy is not None
+                    else getattr(binding, "agent_id", None)
+                ),
+                agent_mode=(
+                    policy.mode
+                    if policy is not None
+                    else getattr(binding, "agent_mode", None)
+                ),
+                settings=(
+                    policy.durable_settings()
+                    if policy is not None
+                    else getattr(binding, "settings", {})
+                ),
+                expected_version=getattr(binding, "version", None),
+            )
+
+    def _configured_group_binding(self, address: ChannelAddress) -> Any:
+        """Return trusted defaults for a Telegram group/topic address."""
+
+        try:
+            if int(address.chat_id) >= 0:
+                return None
+        except ValueError:
+            return None
+        return self.config.binding_for(address.chat_id, address.topic_id or None)
+
+    async def _migrate_binding(self, old_chat_id: str, new_chat_id: str) -> None:
+        assert self.store is not None
+        old_prefix = "\x1f".join((_PLATFORM, self.account_id, old_chat_id))
+        new_prefix = "\x1f".join((_PLATFORM, self.account_id, new_chat_id))
+        await asyncio.to_thread(
+            self.store.migrate_binding_prefix,
+            old_prefix,
+            new_prefix,
+            group_authorization=(
+                _PLATFORM,
+                self.account_id,
+                old_chat_id,
+                new_chat_id,
+            ),
+        )
+
+    async def _execute_turn(
+        self,
+        envelope: InboundEnvelope,
+        binding: Any,
+        *,
+        image_paths: list[str],
+        document_inputs: list[str],
+        group_history: list[str],
+        directory: str | None,
+    ) -> tuple[dict[str, Any], str | None]:
+        text = strip_bot_mention(envelope.text, self.bot_username)
+        if envelope.metadata.get("reply_text"):
+            text = (
+                f"[Replying to Telegram message]\n"
+                f"{str(envelope.metadata['reply_text'])[:2000]}\n\n{text}"
+            )
+        if document_inputs:
+            text = "\n\n".join([*document_inputs, text])
+        if group_history:
+            observed = "\n".join(group_history)
+            text = (
+                "[Untrusted recent Telegram group context]\n"
+                f"{observed}\n"
+                "[End untrusted Telegram group context]\n\n"
+                f"{text}"
+            )
+        input_data: dict[str, Any] = {
+            "text": text,
+            "client_message_id": envelope.event_id,
+        }
+        if image_paths:
+            input_data["image_paths"] = image_paths
+        request_id = str(uuid.uuid4())
+        context = {
+            "channel": "telegram",
+            "sender_id": envelope.sender_id,
+            "reply_to_message_id": envelope.reply_to_message_id,
+        }
+        if group_history:
+            context["observed_group_context"] = group_history
+        settings = getattr(binding, "settings", {})
+        if not isinstance(settings, Mapping):
+            settings = {}
+        configured = (
+            self.config.binding_for(
+                envelope.address.chat_id, envelope.address.topic_id or None
+            )
+            if envelope.metadata.get("chat_type") != "private"
+            else None
+        )
+        prompt = settings.get(
+            "prompt", configured.prompt if configured is not None else None
+        )
+        raw_skills = settings.get(
+            "skills", configured.skills if configured is not None else ()
+        )
+        skills = (
+            tuple(item for item in raw_skills if isinstance(item, str))
+            if isinstance(raw_skills, (list, tuple))
+            else ()
+        )
+        agent_id = getattr(binding, "agent_id", None)
+        execution_context = ExecutionContext(
+            session_id=binding.session_id,
+            conversation_id=binding.session_id,
+            agent_id=agent_id,
+            agent_mode=getattr(binding, "agent_mode", None) or "build",
+            directory=directory,
+            project_root=directory,
+            workspace_root=directory,
+            request_id=request_id,
+            permission_mode=self.config.permission_mode,
+            approval_policy=self.config.approval_policy,
+            request_system_prompt=prompt if isinstance(prompt, str) else None,
+            request_skills=skills,
+            require_registered_agent=bool(agent_id),
+        )
+        target = (envelope.address, envelope.sender_id)
+        self._request_targets[request_id] = target
+        self._session_targets[binding.session_id] = target
+        preview = Preview(self, envelope)
+        try:
+            await preview.start()
+            result = await execute_chat_turn(
+                self.core,
+                ChatProcessRequest(
+                    input_data=input_data,
+                    execution_context=execution_context,
+                    session_id=binding.session_id,
+                    context=context,
+                    agent_id=agent_id,
+                    streaming=self.config.streaming_mode != "off",
+                    stream_callback=preview.push
+                    if self.config.streaming_mode != "off"
+                    else None,
+                ),
+            )
+            return result, await preview.finish()
+        finally:
+            await preview.close()
+            self._request_targets.pop(request_id, None)
+            if self._session_targets.get(binding.session_id) == target:
+                self._session_targets.pop(binding.session_id, None)
+
+    async def _download_attachments(
+        self, envelope: InboundEnvelope, directory: Path
+    ) -> tuple[list[str], list[str]]:
+        image_paths: list[str] = []
+        document_inputs: list[str] = []
+        for attachment in envelope.attachments:
+            if (
+                attachment.size is not None
+                and attachment.size > self.config.max_download_bytes
+            ):
+                raise ValueError(
+                    "Telegram attachment exceeds the configured size limit"
+                )
+            remote_file = await self._api_call(self.bot.get_file(attachment.file_id))
+            safe_name = Path(
+                attachment.file_name or f"{attachment.kind}-{uuid.uuid4().hex}"
+            ).name
+            target = directory / safe_name
+            downloader = getattr(remote_file, "download_to_drive", None)
+            if not callable(downloader):
+                raise RuntimeError("Telegram file cannot be downloaded")
+            await self._api_call(downloader(custom_path=str(target)))
+            size = target.stat().st_size
+            if size > self.config.max_download_bytes:
+                raise ValueError(
+                    "Downloaded Telegram attachment exceeds the size limit"
+                )
+            if attachment.kind == "photo":
+                await asyncio.to_thread(_validate_image, target)
+                image_paths.append(str(target))
+                continue
+            mime = (attachment.mime_type or "").lower()
+            if not (mime.startswith("text/") or mime in _TEXT_DOCUMENT_MIMES):
+                raise ValueError(
+                    f"Unsupported Telegram document type: {mime or 'unknown'}"
+                )
+            text = await asyncio.to_thread(target.read_text, "utf-8")
+            if len(text) > self.config.max_document_text_chars:
+                raise ValueError("Telegram text document exceeds the character limit")
+            document_inputs.append(
+                f"[Begin untrusted Telegram document {safe_name!r}]\n{text}\n"
+                "[End untrusted Telegram document]"
+            )
+        return image_paths, document_inputs
+
+    async def _complete_with_text(
+        self,
+        record: IngressRecord,
+        worker_id: str,
+        envelope: InboundEnvelope,
+        text: str,
+        *,
+        session_id: str | None = None,
+        request_id: str | None = None,
+        edit_message_id: str | None = None,
+    ) -> None:
+        assert self.store is not None
+        delivery_id = f"{record.event_id}:final"
+        payload = _delivery_payload(
+            envelope.address,
+            text,
+            reply_to_message_id=envelope.reply_to_message_id,
+            edit_message_id=edit_message_id,
+        )
+        await asyncio.to_thread(
+            self.store.complete_ingress_and_enqueue_delivery,
+            record.event_id,
+            ingress_owner_id=worker_id,
+            delivery_id=delivery_id,
+            idempotency_key=delivery_id,
+            lane_key=record.lane_key.removesuffix(_INTERACTIVE_LANE_SUFFIX),
+            payload=payload,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+            kind="text",
+            source_session_id=session_id,
+            source_request_id=request_id,
+        )
+        self._work_available.set()
+
+    async def _complete_without_delivery(
+        self, record: IngressRecord, worker_id: str
+    ) -> None:
+        assert self.store is not None
+        await asyncio.to_thread(
+            self.store.complete_ingress,
+            record.event_id,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+            owner_id=worker_id,
+        )
+
+    async def _send_delivery(self, record: DeliveryRecord) -> str | None:
+        assert self.store is not None
+        payload = record.payload
+        chat_id = await _migration.latest_chat_id(
+            self.store,
+            platform=record.platform,
+            account_id=record.account_id,
+            chat_id=str(payload["chat_id"]),
+        )
+        topic_id = payload.get("topic_id") or None
+        if record.kind == "text":
+            return await self._send_text_payload(payload, chat_id, topic_id)
+        if record.kind == "callback_terminal":
+            return await self._send_callback_terminal(payload, chat_id)
+        path = validated_artifact_path(payload, self.config.max_download_bytes)
+        kwargs = {"chat_id": chat_id}
+        if topic_id is not None:
+            kwargs["message_thread_id"] = int(topic_id)
+        with path.open("rb") as file_obj:
+            if record.kind == "photo":
+                message = await self._api_call(
+                    self.bot.send_photo(photo=file_obj, **kwargs)
+                )
+            else:
+                message = await self._api_call(
+                    self.bot.send_document(document=file_obj, **kwargs)
+                )
+        return _message_id(message)
+
+    async def _send_text_payload(
+        self, payload: Mapping[str, Any], chat_id: Any, topic_id: Any
+    ) -> str | None:
+        text = str(payload.get("text") or "")
+        chunks = formatted_chunks(text) or [("", "")]
+        edit_id = payload.get("edit_message_id")
+        last_id: str | None = None
+        button_message_id: str | None = None
+        for index, (chunk, fallback) in enumerate(chunks):
+            try:
+                if index == 0 and edit_id:
+                    message = await self._api_call(
+                        self.bot.edit_message_text(
+                            chat_id=chat_id,
+                            message_id=int(edit_id),
+                            text=chunk,
+                            parse_mode="HTML",
+                        )
+                    )
+                else:
+                    kwargs: dict[str, Any] = {
+                        "chat_id": chat_id,
+                        "text": chunk,
+                        "parse_mode": "HTML",
+                    }
+                    if topic_id:
+                        kwargs["message_thread_id"] = int(topic_id)
+                    if index == 0 and payload.get("reply_to_message_id"):
+                        kwargs["reply_to_message_id"] = int(
+                            payload["reply_to_message_id"]
+                        )
+                    markup = _inline_markup(payload.get("buttons"))
+                    if markup is not None and index == 0:
+                        kwargs["reply_markup"] = markup
+                    message = await self._api_call(self.bot.send_message(**kwargs))
+            except Exception as exc:
+                if type(exc).__name__ != "BadRequest":
+                    raise
+                kwargs = {"chat_id": chat_id, "text": fallback}
+                if topic_id:
+                    kwargs["message_thread_id"] = int(topic_id)
+                if index == 0 and payload.get("reply_to_message_id"):
+                    kwargs["reply_to_message_id"] = int(payload["reply_to_message_id"])
+                markup = _inline_markup(payload.get("buttons"))
+                if markup is not None and index == 0:
+                    kwargs["reply_markup"] = markup
+                message = await self._api_call(self.bot.send_message(**kwargs))
+            current_id = _message_id(message)
+            if index == 0 and payload.get("buttons"):
+                button_message_id = current_id
+            last_id = current_id or last_id
+        return button_message_id or last_id
+
+    async def _send_callback_terminal(
+        self, payload: Mapping[str, Any], chat_id: Any
+    ) -> str | None:
+        assert self.store is not None
+        projection_id = str(payload.get("projection_delivery_id") or "")
+        projection = await asyncio.to_thread(
+            self.store.get_delivery,
+            projection_id,
+            platform=_PLATFORM,
+            account_id=self.account_id,
+        )
+        if projection is None or not projection.external_message_id:
+            return None
+        label = str(payload.get("label") or "Expired")
+        message = await self._api_call(
+            self.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=int(projection.external_message_id),
+                text=f"<b>{label}</b>",
+                parse_mode="HTML",
+                reply_markup=None,
+            )
+        )
+        return _message_id(message) or projection.external_message_id
+
+    async def _handle_delivery_failure(
+        self, record: DeliveryRecord, worker_id: str, exc: BaseException
+    ) -> None:
+        assert self.store is not None
+        failure = classify_failure(exc)
+        age = time.time() - record.created_at
+        retryable = (
+            failure.retryable
+            and record.attempt_count < self.config.retry_attempts
+            and age < self.config.dead_letter_after_hours * 3600
+        )
+        if retryable:
+            delay = retry_delay(
+                record.attempt_count,
+                base_seconds=self.config.retry_base_seconds,
+                max_seconds=self.config.retry_max_seconds,
+                retry_after=failure.retry_after,
+            )
+            await asyncio.to_thread(
+                self.store.retry_delivery,
+                record.delivery_id,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                owner_id=worker_id,
+                retry_at=time.time() + delay,
+                error_class=failure.error_class,
+                error_message=self._safe_error(failure.message),
+            )
+        else:
+            self._status_error = (
+                f"{failure.error_class}: {self._safe_error(failure.message)}"
+            )
+            await asyncio.to_thread(
+                self.store.dead_letter_delivery,
+                record.delivery_id,
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                owner_id=worker_id,
+                error_class=failure.error_class,
+                error_message=self._safe_error(failure.message),
+            )
+            if failure.error_class.casefold() == "invalidtoken":
+                self._running = False
+                self._stop.set()
+                self._work_available.set()
+        logger.warning(
+            "Telegram delivery failed id=%s retryable=%s class=%s",
+            record.delivery_id,
+            retryable,
+            failure.error_class,
+        )
+
+    async def _enqueue_artifacts(
+        self,
+        envelope: InboundEnvelope,
+        session_id: str,
+        ingress: IngressRecord,
+        result: Mapping[str, Any],
+        *,
+        allowed_root: Path,
+    ) -> None:
+        assert self.store is not None
+        root = allowed_root.expanduser().resolve()
+        skipped = 0
+        for index, path in enumerate(artifact_paths(result)):
+            try:
+                resolved = Path(path).expanduser().resolve(strict=True)
+                resolved.relative_to(root)
+            except (OSError, ValueError):
+                skipped += 1
+                continue
+            if not resolved.is_file() or (
+                resolved.stat().st_size > self.config.max_download_bytes
+            ):
+                skipped += 1
+                continue
+            kind = (
+                "photo"
+                if resolved.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
+                else "document"
+            )
+            delivery_id = f"{ingress.event_id}:artifact:{index}"
+            await asyncio.to_thread(
+                self.store.enqueue_delivery,
+                delivery_id,
+                delivery_id,
+                ingress.lane_key.removesuffix(_INTERACTIVE_LANE_SUFFIX),
+                {
+                    "chat_id": envelope.address.chat_id,
+                    "topic_id": envelope.address.topic_id,
+                    "path": str(resolved),
+                    "allowed_root": str(root),
+                },
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                kind=kind,
+                source_event_id=ingress.event_id,
+                source_session_id=session_id,
+            )
+        if skipped:
+            warning_id = f"{ingress.event_id}:artifact-warning"
+            await asyncio.to_thread(
+                self.store.enqueue_delivery,
+                warning_id,
+                warning_id,
+                ingress.lane_key.removesuffix(_INTERACTIVE_LANE_SUFFIX),
+                _delivery_payload(
+                    envelope.address,
+                    f"Penguin skipped {skipped} unsafe or unavailable artifact(s).",
+                ),
+                platform=_PLATFORM,
+                account_id=self.account_id,
+                kind="text",
+                source_event_id=ingress.event_id,
+                source_session_id=session_id,
+            )
+        self._work_available.set()
+
+    def _register_interactive_callbacks(self) -> None:
+        from penguin.security.approval import get_approval_manager
+        from penguin.security.question import get_question_manager
+
+        get_question_manager().on_request_created(self._question_created_callback)
+        get_question_manager().on_request_answered(self._question_resolved_callback)
+        get_question_manager().on_request_rejected(self._question_resolved_callback)
+        get_approval_manager().on_request_created(self._approval_created_callback)
+        get_approval_manager().on_request_resolved(self._approval_resolved_callback)
+
+    def _unregister_interactive_callbacks(self) -> None:
+        from penguin.security.approval import get_approval_manager
+        from penguin.security.question import get_question_manager
+
+        get_question_manager().remove_callback(self._question_created_callback)
+        get_question_manager().remove_callback(self._question_resolved_callback)
+        get_approval_manager().remove_callback(self._approval_created_callback)
+        get_approval_manager().remove_callback(self._approval_resolved_callback)
+
+    def _on_question_created(self, request: Any) -> None:
+        target = self._projection_target(request)
+        if target is not None:
+            self._schedule_projection(self._project_question(request, target))
+
+    def _on_approval_created(self, request: Any) -> None:
+        target = self._projection_target(request)
+        if target is not None:
+            self._schedule_projection(self._project_approval(request, target))
+
+    def _projection_target(self, request: Any) -> tuple[ChannelAddress, str] | None:
+        context = getattr(request, "context", {})
+        request_id = context.get("request_id") if isinstance(context, Mapping) else None
+        if request_id:
+            return self._request_targets.get(str(request_id))
+        return self._session_targets.get(str(request.session_id))
+
+    def _on_question_resolved(self, request: Any) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        loop.call_soon_threadsafe(
+            self._discard_pending_question,
+            str(request.id),
+        )
+        label = interactive_terminal_label(request)
+        if label is not None:
+            self._schedule_projection(self._terminalize_request(request, label))
+
+    def _on_approval_resolved(self, request: Any) -> None:
+        label = interactive_terminal_label(request)
+        if label is not None:
+            self._schedule_projection(self._terminalize_request(request, label))
+
+    async def _terminalize_request(self, request: Any, label: str) -> None:
+        if self.store is None:
+            return
+        records = await asyncio.to_thread(
+            self.store.terminalize_callbacks,
+            str(request.id),
+            account_id=self.account_id,
+            label=label,
+            platform=_PLATFORM,
+            expired=label == "Expired",
+        )
+        if records:
+            self._work_available.set()
+
+    def _discard_pending_question(self, request_id: str) -> None:
+        stale = [
+            key
+            for key, pending_request_id in self._pending_questions.items()
+            if pending_request_id == request_id
+        ]
+        for key in stale:
+            self._pending_questions.pop(key, None)
+
+    def _schedule_projection(self, coroutine: Any) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            close = getattr(coroutine, "close", None)
+            if callable(close):
+                close()
+            return
+
+        def schedule() -> None:
+            task = asyncio.create_task(coroutine)
+            self._projection_tasks.add(task)
+            task.add_done_callback(self._projection_tasks.discard)
+
+        loop.call_soon_threadsafe(schedule)
+
+    async def _project_question(
+        self, request: Any, target: tuple[ChannelAddress, str]
+    ) -> None:
+        if self.store is None:
+            return
+        address, user_id = target
+        callback_id = uuid.uuid4().hex
+        questions = list(getattr(request, "questions", []) or [])
+        text_lines = ["Penguin needs your input:"]
+        buttons: list[list[dict[str, str]]] = []
+        if len(questions) == 1:
+            first = questions[0]
+            text_lines.append(str(first.get("question") or "Choose an answer"))
+            for index, option in enumerate(first.get("options") or []):
+                label = str(option.get("label") or option.get("description") or index)
+                buttons.append(
+                    [
+                        {
+                            "text": label[:40],
+                            "data": f"{_INTERACTIVE_PREFIX}{callback_id}:q{index}",
+                        }
+                    ]
+                )
+            text_lines.append("You may also reply with text.")
+        elif questions:
+            for index, question in enumerate(questions, start=1):
+                text_lines.append(
+                    f"{index}. {question.get('question') or 'Provide an answer'}"
+                )
+            text_lines.append(
+                "Reply with exactly one non-empty answer per line, in the same order."
+            )
+        self._pending_questions[(address.lane_key, user_id)] = str(request.id)
+        await self._create_projection(
+            address,
+            f"question:{request.id}",
+            "\n\n".join(text_lines),
+            buttons,
+            session_id=str(request.session_id),
+            user_id=user_id,
+            callback_id=callback_id,
+            request_id=str(request.id),
+            callback_payload={"kind": "question", "questions": questions},
+        )
+        label = interactive_terminal_label(request)
+        if label is not None:
+            await self._terminalize_request(request, label)
+
+    async def _project_approval(
+        self, request: Any, target: tuple[ChannelAddress, str]
+    ) -> None:
+        if self.store is None:
+            return
+        address, user_id = target
+        callback_id = uuid.uuid4().hex
+        buttons = [
+            [
+                {
+                    "text": "Approve once",
+                    "data": f"{_INTERACTIVE_PREFIX}{callback_id}:approve",
+                },
+                {"text": "Deny", "data": f"{_INTERACTIVE_PREFIX}{callback_id}:deny"},
+            ]
+        ]
+        if address.chat_id == user_id:
+            text = (
+                f"Tool approval required\nTool: {request.tool_name}\n"
+                f"Operation: {request.operation}\nResource: {request.resource}\n"
+                f"Reason: {request.reason}"
+            )
+        else:
+            text = (
+                "Tool approval required\n"
+                "Sensitive operation details are hidden in shared chats."
+            )
+        await self._create_projection(
+            address,
+            f"approval:{request.id}",
+            text,
+            buttons,
+            session_id=str(request.session_id or ""),
+            user_id=user_id,
+            callback_id=callback_id,
+            request_id=str(request.id),
+            callback_payload={"kind": "approval"},
+            tool_call_id=str(getattr(request, "context", {}).get("tool_call_id") or "")
+            or None,
+        )
+        label = interactive_terminal_label(request)
+        if label is not None:
+            await self._terminalize_request(request, label)
+
+    async def _create_projection(
+        self,
+        address: ChannelAddress,
+        key: str,
+        text: str,
+        buttons: list[list[dict[str, str]]],
+        *,
+        session_id: str,
+        user_id: str,
+        callback_id: str,
+        request_id: str,
+        callback_payload: Mapping[str, Any],
+        tool_call_id: str | None = None,
+    ) -> None:
+        assert self.store is not None
+        delivery_id = f"telegram:{key}"
+        delivery = _delivery_payload(address, text)
+        delivery["buttons"] = buttons
+        callback = {
+            **callback_payload,
+            "projection_delivery_id": delivery_id,
+            "lane_key": address.lane_key,
+            "platform": _PLATFORM,
+            "session_id": session_id,
+        }
+        await asyncio.to_thread(
+            self.store.create_callback_with_delivery,
+            callback_id,
+            account_id=self.account_id,
+            chat_id=address.chat_id,
+            topic_id=address.topic_id or None,
+            user_id=user_id,
+            request_id=request_id,
+            payload=callback,
+            expires_at=time.time() + self.config.approval_timeout_seconds,
+            projection_delivery_id=delivery_id,
+            lane_key=address.lane_key,
+            delivery_payload=delivery,
+            platform=_PLATFORM,
+            source_session_id=session_id,
+            tool_call_id=tool_call_id,
+        )
+        self._work_available.set()
+
+    async def _resolve_callback(
+        self, envelope: InboundEnvelope, callback_data: str, worker_id: str
+    ) -> None:
+        assert self.store is not None
+        parts = callback_data.split(":", 2)
+        if len(parts) != 3:
+            return
+        _prefix, callback_id, action = parts
+        callback = await asyncio.to_thread(
+            self.store.claim_callback,
+            callback_id,
+            account_id=self.account_id,
+            chat_id=envelope.address.chat_id,
+            topic_id=envelope.address.topic_id or None,
+            user_id=envelope.sender_id,
+            owner_id=worker_id,
+            platform=_PLATFORM,
+        )
+        if callback is None:
+            await self._answer_callback(envelope, "This action is unavailable.")
+            return
+        kind = callback.payload.get("kind")
+        resolved = False
+        label = "Expired"
+        if kind == "approval":
+            from penguin.security.approval import ApprovalScope, get_approval_manager
+
+            manager = get_approval_manager()
+            if action == "approve":
+                resolved = (
+                    manager.approve(callback.request_id, scope=ApprovalScope.ONCE)
+                    is not None
+                )
+                if resolved:
+                    label = "Approved"
+            elif action == "deny":
+                resolved = manager.deny(callback.request_id) is not None
+                if resolved:
+                    label = "Denied"
+        elif kind == "question" and action.startswith("q"):
+            try:
+                index = int(action[1:])
+            except ValueError:
+                index = -1
+            questions = callback.payload.get("questions") or []
+            options = questions[0].get("options") if questions else []
+            if 0 <= index < len(options):
+                option = options[index]
+                answer = str(option.get("label") or option.get("description") or "")
+                resolved = await self._reply_to_question(callback.request_id, answer)
+                if resolved:
+                    label = "Answered"
+                    self._pending_questions.pop(
+                        (envelope.address.lane_key, envelope.sender_id), None
+                    )
+        await asyncio.to_thread(
+            self.store.complete_callback_with_terminal,
+            callback_id,
+            owner_id=worker_id,
+            label=label,
+            platform=_PLATFORM,
+        )
+        self._work_available.set()
+        await self._answer_callback(
+            envelope,
+            "Recorded." if resolved else "This request is no longer pending.",
+        )
+
+    async def _reply_to_question(self, request_id: str, text: str) -> bool | None:
+        from penguin.security.question import get_question_manager
+
+        request = get_question_manager().get_request(request_id)
+        if request is None or request.status.value != "pending":
+            return False
+        questions = list(request.questions or [])
+        if len(questions) <= 1:
+            answers = [[text.strip()]]
+        else:
+            values = [line.strip() for line in text.splitlines() if line.strip()]
+            if len(values) != len(questions):
+                return None
+            answers = [[value] for value in values]
+        return get_question_manager().reply(request_id, answers) is not None
+
+    async def _answer_callback(self, envelope: InboundEnvelope, text: str) -> None:
+        callback_id = envelope.metadata.get("callback_id")
+        answer = getattr(self.bot, "answer_callback_query", None)
+        if callback_id and callable(answer):
+            with suppress(Exception):
+                await self._api_call(
+                    answer(callback_query_id=callback_id, text=text[:200])
+                )
+
+
+def _validate_image(path: Path) -> None:
+    try:
+        with Image.open(path) as image:
+            image.verify()
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ValueError("Telegram photo is not a valid supported image") from exc

--- a/penguin/integrations/telegram/manager.py
+++ b/penguin/integrations/telegram/manager.py
@@ -26,6 +26,10 @@ from penguin.channels.store import (
 )
 from penguin.config import WORKSPACE_PATH
 from penguin.integrations.telegram import _migration
+from penguin.integrations.telegram._approval_ui import (
+    approval_buttons,
+    send_terminal_edit,
+)
 from penguin.integrations.telegram._artifacts import (
     artifact_paths,
     validated_artifact_path,
@@ -992,6 +996,7 @@ class TelegramManager:
             ("session", "Show the bound Penguin session"),
             ("mode", "Show or set plan/build mode"),
             ("model", "Show the active Penguin model"),
+            ("permissions", "Show Telegram tool permissions"),
             ("goal", "Show or update the session goal"),
             ("project", "Show the bound project directory"),
             ("activation", "Set group mention activation"),
@@ -1524,26 +1529,14 @@ class TelegramManager:
         self, payload: Mapping[str, Any], chat_id: Any
     ) -> str | None:
         assert self.store is not None
-        projection_id = str(payload.get("projection_delivery_id") or "")
-        projection = await asyncio.to_thread(
-            self.store.get_delivery,
-            projection_id,
-            platform=_PLATFORM,
+        return await send_terminal_edit(
+            store=self.store,
+            bot=self.bot,
+            api_call=self._api_call,
             account_id=self.account_id,
+            payload=payload,
+            chat_id=chat_id,
         )
-        if projection is None or not projection.external_message_id:
-            return None
-        label = str(payload.get("label") or "Expired")
-        message = await self._api_call(
-            self.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=int(projection.external_message_id),
-                text=f"<b>{label}</b>",
-                parse_mode="HTML",
-                reply_markup=None,
-            )
-        )
-        return _message_id(message) or projection.external_message_id
 
     async def _handle_delivery_failure(
         self, record: DeliveryRecord, worker_id: str, exc: BaseException
@@ -1713,8 +1706,22 @@ class TelegramManager:
 
     def _on_approval_resolved(self, request: Any) -> None:
         label = interactive_terminal_label(request)
-        if label is not None:
-            self._schedule_projection(self._terminalize_request(request, label))
+        if label is not None and self._projection_target(request) is not None:
+            self._schedule_projection(self._finish_approval(request, label))
+
+    async def _finish_approval(self, request: Any, label: str) -> None:
+        abort = getattr(self.core, "abort_session", None)
+        session_id = str(getattr(request, "session_id", "") or "")
+        if label in {"Denied", "Expired"} and session_id and callable(abort):
+            try:
+                await abort(session_id)
+            except Exception:
+                logger.exception(
+                    "Failed to stop Telegram turn after %s approval session=%s",
+                    label.casefold(),
+                    session_id,
+                )
+        await self._terminalize_request(request, label)
 
     async def _terminalize_request(self, request: Any, label: str) -> None:
         if self.store is None:
@@ -1809,15 +1816,7 @@ class TelegramManager:
             return
         address, user_id = target
         callback_id = uuid.uuid4().hex
-        buttons = [
-            [
-                {
-                    "text": "Approve once",
-                    "data": f"{_INTERACTIVE_PREFIX}{callback_id}:approve",
-                },
-                {"text": "Deny", "data": f"{_INTERACTIVE_PREFIX}{callback_id}:deny"},
-            ]
-        ]
+        buttons = approval_buttons(callback_id, _INTERACTIVE_PREFIX)
         if address.chat_id == user_id:
             text = (
                 f"Tool approval required\nTool: {request.tool_name}\n"
@@ -1925,6 +1924,13 @@ class TelegramManager:
                 )
                 if resolved:
                     label = "Approved"
+            elif action == "approve_session":
+                resolved = (
+                    manager.approve(callback.request_id, scope=ApprovalScope.SESSION)
+                    is not None
+                )
+                if resolved:
+                    label = "Approved for session"
             elif action == "deny":
                 resolved = manager.deny(callback.request_id) is not None
                 if resolved:

--- a/penguin/integrations/telegram/transport.py
+++ b/penguin/integrations/telegram/transport.py
@@ -1,0 +1,77 @@
+"""Telegram network error and retry policy helpers."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Callable
+
+__all__ = ["TelegramFailure", "classify_failure", "retry_delay"]
+
+
+@dataclass(frozen=True)
+class TelegramFailure:
+    """Sanitized delivery failure classification."""
+
+    error_class: str
+    message: str
+    retryable: bool
+    retry_after: float | None = None
+    polling_conflict: bool = False
+
+
+def classify_failure(exc: BaseException) -> TelegramFailure:
+    """Classify PTB errors without importing the optional dependency."""
+
+    name = type(exc).__name__
+    message = str(exc)[:1000]
+    lowered = name.casefold()
+    retry_after = _seconds(getattr(exc, "retry_after", None))
+    if retry_after is not None or lowered == "retryafter":
+        return TelegramFailure(name, message, True, retry_after=retry_after)
+    if lowered in {
+        "timedout",
+        "timeouterror",
+        "networkerror",
+        "connecterror",
+        "readerror",
+    }:
+        return TelegramFailure(name, message, True)
+    if lowered == "conflict":
+        return TelegramFailure(name, message, False, polling_conflict=True)
+    if lowered in {"forbidden", "invalidtoken", "badrequest"}:
+        return TelegramFailure(name, message, False)
+    return TelegramFailure(name, message, False)
+
+
+def retry_delay(
+    attempt: int,
+    *,
+    base_seconds: float,
+    max_seconds: float,
+    retry_after: float | None = None,
+    random_value: Callable[[], float] = random.random,
+) -> float:
+    """Return bounded exponential backoff with equal jitter."""
+
+    if attempt < 1:
+        raise ValueError("attempt must be positive")
+    if base_seconds <= 0 or max_seconds < base_seconds:
+        raise ValueError("invalid retry bounds")
+    if retry_after is not None:
+        return min(max_seconds, max(0.0, retry_after))
+    ceiling = min(max_seconds, base_seconds * (2 ** (attempt - 1)))
+    jitter = min(1.0, max(0.0, float(random_value())))
+    return ceiling / 2 + (ceiling / 2 * jitter)
+
+
+def _seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, timedelta):
+        return max(0.0, value.total_seconds())
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return None

--- a/penguin/integrations/telegram/updates.py
+++ b/penguin/integrations/telegram/updates.py
@@ -1,0 +1,263 @@
+"""Pure normalization for Telegram Bot API updates."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Mapping
+
+from penguin.channels.schema import Attachment, ChannelAddress, InboundEnvelope
+
+__all__ = [
+    "envelope_from_dict",
+    "envelope_to_dict",
+    "is_addressed_to_bot",
+    "normalize_update",
+    "parse_command",
+    "strip_bot_mention",
+    "update_to_dict",
+]
+
+
+def update_to_dict(update: Any) -> dict[str, Any]:
+    """Return a plain update dictionary without retaining PTB objects."""
+
+    if isinstance(update, Mapping):
+        return dict(update)
+    converter = getattr(update, "to_dict", None)
+    if callable(converter):
+        converted = converter()
+        if isinstance(converted, Mapping):
+            return dict(converted)
+    raise TypeError("Telegram update must be a mapping or expose to_dict()")
+
+
+def normalize_update(update: Any, *, account_id: str) -> InboundEnvelope | None:
+    """Normalize a message or callback update into the channel contract."""
+
+    raw = update_to_dict(update)
+    update_id = _int(raw.get("update_id"))
+    if update_id is None:
+        return None
+
+    callback = _mapping(raw.get("callback_query"))
+    message = _mapping(callback.get("message")) if callback else {}
+    if not message:
+        message = _mapping(
+            raw.get("message") or raw.get("edited_message") or raw.get("channel_post")
+        )
+    if not message:
+        return None
+
+    chat = _mapping(message.get("chat"))
+    sender = _mapping(callback.get("from")) if callback else {}
+    if not sender:
+        sender = _mapping(message.get("from"))
+    chat_id = _identifier(chat.get("id"))
+    sender_id = _identifier(sender.get("id"))
+    if not chat_id:
+        return None
+
+    topic_id = _identifier(message.get("message_thread_id"))
+    text = str(message.get("text") or message.get("caption") or "")
+    reply = _mapping(message.get("reply_to_message"))
+    reply_sender = _mapping(reply.get("from"))
+    callback_data = callback.get("data")
+    callback_id = callback.get("id")
+
+    metadata: dict[str, Any] = {
+        "chat_type": str(chat.get("type") or "private"),
+        "message_id": _identifier(message.get("message_id")),
+        "chat_title": _bounded(chat.get("title"), 256),
+        "callback_id": _bounded(callback_id, 256),
+        "callback_data": _bounded(callback_data, 512),
+        "reply_text": _bounded(reply.get("text") or reply.get("caption"), 2000),
+        "reply_sender_id": _identifier(reply_sender.get("id")),
+        "migrate_to_chat_id": _identifier(message.get("migrate_to_chat_id")),
+        "migrate_from_chat_id": _identifier(message.get("migrate_from_chat_id")),
+    }
+    metadata = {
+        key: value for key, value in metadata.items() if value not in (None, "")
+    }
+    is_migration = bool(
+        metadata.get("migrate_to_chat_id") or metadata.get("migrate_from_chat_id")
+    )
+    if not sender_id and not is_migration:
+        return None
+    attachments = tuple(_attachments(message))
+    if not (
+        text
+        or attachments
+        or metadata.get("callback_data")
+        or metadata.get("migrate_to_chat_id")
+        or metadata.get("migrate_from_chat_id")
+    ):
+        return None
+
+    return InboundEnvelope(
+        event_id=f"telegram:{account_id}:{update_id}",
+        source_sequence=update_id,
+        address=ChannelAddress(
+            platform="telegram",
+            account_id=str(account_id),
+            chat_id=chat_id,
+            topic_id=topic_id,
+        ),
+        sender_id=sender_id or "",
+        sender_username=_bounded(sender.get("username"), 64),
+        text=text,
+        reply_to_message_id=_identifier(reply.get("message_id")) or None,
+        attachments=attachments,
+        metadata=metadata,
+    )
+
+
+def parse_command(text: str) -> tuple[str | None, str, str | None]:
+    """Return command name, arguments, and optional addressed bot username."""
+
+    stripped = (text or "").strip()
+    if not stripped.startswith("/"):
+        return None, stripped, None
+    head, _, arguments = stripped.partition(" ")
+    command_and_target = head[1:].split("@", 1)
+    command = command_and_target[0].strip().lower()
+    target = command_and_target[1].strip() if len(command_and_target) == 2 else None
+    if not command:
+        return None, arguments.strip(), target
+    return command, arguments.strip(), target
+
+
+def is_addressed_to_bot(text: str, username: str) -> bool:
+    """Return whether a command or mention is addressed to this bot."""
+
+    command, _arguments, target = parse_command(text)
+    if command is not None:
+        return target is None or target.casefold() == username.lstrip("@").casefold()
+    return f"@{username.lstrip('@')}".casefold() in (text or "").casefold()
+
+
+def strip_bot_mention(text: str, username: str) -> str:
+    """Remove this bot's explicit mention without altering other usernames."""
+
+    mention = f"@{username.lstrip('@')}"
+    source = text or ""
+    index = source.casefold().find(mention.casefold())
+    if index < 0:
+        return source.strip()
+    return (source[:index] + source[index + len(mention) :]).strip()
+
+
+def envelope_to_dict(envelope: InboundEnvelope) -> dict[str, Any]:
+    """Serialize an envelope for the durable ingress store."""
+
+    return {
+        "event_id": envelope.event_id,
+        "source_sequence": envelope.source_sequence,
+        "address": asdict(envelope.address),
+        "sender_id": envelope.sender_id,
+        "sender_username": envelope.sender_username,
+        "text": envelope.text,
+        "reply_to_message_id": envelope.reply_to_message_id,
+        "attachments": [asdict(item) for item in envelope.attachments],
+        "metadata": dict(envelope.metadata),
+    }
+
+
+def envelope_from_dict(payload: Mapping[str, Any]) -> InboundEnvelope:
+    """Deserialize a validated store payload."""
+
+    address = _mapping(payload.get("address"))
+    attachments: list[Attachment] = []
+    raw_attachments = payload.get("attachments")
+    if isinstance(raw_attachments, list):
+        for item in raw_attachments:
+            data = _mapping(item)
+            if data.get("kind") and data.get("file_id"):
+                attachments.append(
+                    Attachment(
+                        kind=str(data["kind"]),
+                        file_id=str(data["file_id"]),
+                        file_name=_optional_string(data.get("file_name")),
+                        mime_type=_optional_string(data.get("mime_type")),
+                        size=_int(data.get("size")),
+                    )
+                )
+    return InboundEnvelope(
+        event_id=str(payload["event_id"]),
+        source_sequence=int(payload["source_sequence"]),
+        address=ChannelAddress(
+            platform=str(address["platform"]),
+            account_id=str(address["account_id"]),
+            chat_id=str(address["chat_id"]),
+            topic_id=str(address.get("topic_id") or ""),
+        ),
+        sender_id=str(payload["sender_id"]),
+        sender_username=_optional_string(payload.get("sender_username")),
+        text=str(payload.get("text") or ""),
+        reply_to_message_id=_optional_string(payload.get("reply_to_message_id")),
+        attachments=tuple(attachments),
+        metadata=dict(_mapping(payload.get("metadata"))),
+    )
+
+
+def _attachments(message: Mapping[str, Any]) -> list[Attachment]:
+    result: list[Attachment] = []
+    photos = message.get("photo")
+    if isinstance(photos, list) and photos:
+        photo = max(
+            (_mapping(item) for item in photos),
+            key=lambda item: int(item.get("file_size") or 0),
+        )
+        if photo.get("file_id"):
+            result.append(
+                Attachment(
+                    kind="photo",
+                    file_id=str(photo["file_id"]),
+                    mime_type="image/jpeg",
+                    size=_int(photo.get("file_size")),
+                )
+            )
+    document = _mapping(message.get("document"))
+    if document.get("file_id"):
+        result.append(
+            Attachment(
+                kind="document",
+                file_id=str(document["file_id"]),
+                file_name=_bounded(document.get("file_name"), 255),
+                mime_type=_bounded(document.get("mime_type"), 127),
+                size=_int(document.get("file_size")),
+            )
+        )
+    return result
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _identifier(value: Any) -> str:
+    if isinstance(value, bool) or value is None:
+        return ""
+    return str(value).strip()
+
+
+def _int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bounded(value: Any, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:limit] if text else None
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None

--- a/penguin/prompt_actions.py
+++ b/penguin/prompt_actions.py
@@ -366,6 +366,18 @@ or artifacts from MCP/browser/test tools that returned a local image path.
 **Important:** Use `read_image` when you need to actually see an image. Reading a
 filename or JSON artifact path is not enough; promote the image into conversation
 context with this tool.
+
+### publish_artifact
+Mark one existing project/workspace file for delivery to the requesting channel.
+Use this only when the user explicitly asked to receive that file. Writing or
+reading a file does not publish it automatically.
+
+**Native tool call:** call `publish_artifact` with `{"path":"path/to/report.pdf"}`.
+
+**ActionXML fallback example:**
+```actionxml
+<publish_artifact>{"path":"path/to/report.pdf"}</publish_artifact>
+```
 """
 
 

--- a/penguin/security/action_policy.py
+++ b/penguin/security/action_policy.py
@@ -1,0 +1,334 @@
+"""Request-scoped authorization for model-emitted ActionXML actions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from typing import Any, Mapping
+
+from penguin.security.approval import ApprovalStatus, get_approval_manager
+from penguin.system.execution_context import get_current_execution_context
+
+logger = logging.getLogger(__name__)
+
+
+# ActionXML handlers in this table mutate state without a complete ToolManager
+# permission route, so they need an equivalent request-scoped gate at the
+# dispatch boundary. Tool-backed actions with a canonical permission mapping
+# are intentionally omitted: their normal ToolManager dispatch owns approval
+# resumption.
+DIRECT_ACTION_POLICY_KEYS: dict[str, str] = {
+    "add_summary_note": "fileWrite",
+    "process_start": "shell",
+    "process_list": "shell",
+    "process_enter": "shell",
+    "process_stop": "shell",
+    "process_send": "shell",
+    "process_exit": "fileWrite",
+    "project_create": "fileWrite",
+    "project_update": "fileWrite",
+    "project_delete": "fileDelete",
+    "task_create": "fileWrite",
+    "task_update": "fileWrite",
+    "task_complete": "fileWrite",
+    "task_delete": "fileDelete",
+    "finish_task": "fileWrite",
+    "task_completed": "fileWrite",
+    "todowrite": "fileWrite",
+    "send_message": "network",
+    "spawn_sub_agent": "default",
+    "stop_sub_agent": "default",
+    "resume_sub_agent": "default",
+    "delegate": "network",
+    "delegate_explore_task": "network",
+    "browser_navigate": "network",
+    "browser_interact": "network",
+    "browser_screenshot": "fileWrite",
+    "pydoll_browser_navigate": "network",
+    "pydoll_browser_interact": "network",
+    "pydoll_browser_screenshot": "fileWrite",
+    "pydoll_browser_scroll": "network",
+    "pydoll_debug_toggle": "default",
+}
+
+
+SAFE_ACTION_NAMES = frozenset(
+    {
+        "memory_search",
+        "process_status",
+        "todoread",
+        "question",
+        "task_list",
+        "task_display",
+        "finish_response",
+        "list_skills",
+        "activate_skill",
+        "project_list",
+        "project_display",
+        "dependency_display",
+        "wait_for_agents",
+    }
+)
+
+
+TOOL_MANAGED_ACTION_NAMES = frozenset(
+    {
+        "execute",
+        "execute_command",
+        "search",
+        "add_declarative_note",
+        "list_files_filtered",
+        "find_files_enhanced",
+        "enhanced_diff",
+        "analyze_project",
+        "read_file",
+        "read_image",
+        "publish_artifact",
+        "enhanced_read",
+        "enhanced_write",
+        "write_file",
+        "edit_file",
+        "apply_patch",
+        "apply_diff",
+        "patch_file",
+        "multiedit",
+        "patch_files",
+        "edit_with_pattern",
+        "replace_lines",
+        "insert_lines",
+        "delete_lines",
+        "perplexity_search",
+        "workspace_search",
+        "analyze_codebase",
+        "reindex_workspace",
+        "browser_status",
+        "browser_cleanup",
+        "browser_open_tab",
+        "browser_page_info",
+        "browser_harness_screenshot",
+        "browser_click",
+        "browser_type",
+        "browser_key",
+        "browser_fill",
+        "browser_wait",
+        "browser_js",
+        "browser_list_tabs",
+        "browser_switch_tab",
+        "get_agent_status",
+        "get_context_info",
+        "sync_context",
+        "get_repository_status",
+        "create_and_switch_branch",
+        "commit_and_push_changes",
+        "create_improvement_pr",
+        "create_feature_pr",
+        "create_bugfix_pr",
+    }
+)
+
+
+def policy_timeout_seconds(policy: Mapping[str, Any]) -> float | None:
+    """Return a bounded policy timeout, preserving a missing timeout."""
+    raw_timeout = policy.get("timeout_seconds")
+    if raw_timeout is None:
+        return None
+    if isinstance(raw_timeout, bool):
+        return 0.0
+    try:
+        parsed_timeout = float(raw_timeout)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(parsed_timeout):
+        return 0.0
+    return min(3600.0, max(0.0, parsed_timeout))
+
+
+async def authorize_direct_action(action_name: str, params: Any) -> str | None:
+    """Authorize a direct ActionXML mutation under the active request policy."""
+    context = get_current_execution_context()
+    if context is None:
+        return None
+    if action_name in SAFE_ACTION_NAMES:
+        return None
+    if action_name in TOOL_MANAGED_ACTION_NAMES:
+        return None
+
+    policy_key = DIRECT_ACTION_POLICY_KEYS.get(action_name, "default")
+
+    if str(context.permission_mode or "").strip().lower() == "read_only":
+        return json.dumps(
+            {
+                "error": "permission_denied",
+                "action": action_name,
+                "reason": "Request-scoped read-only mode blocks mutating actions",
+            }
+        )
+
+    approval_policy = context.approval_policy
+    if not isinstance(approval_policy, dict):
+        return None
+    decision = (
+        str(
+            approval_policy.get(
+                policy_key,
+                approval_policy.get("default", ""),
+            )
+        )
+        .strip()
+        .lower()
+    )
+    if decision == "deny":
+        return json.dumps(
+            {
+                "error": "permission_denied",
+                "action": action_name,
+                "reason": "Request-scoped approval policy denies this action",
+            }
+        )
+    if decision != "ask":
+        return None
+
+    if approval_policy.get("default") == "deny":
+        return json.dumps(
+            {
+                "error": "permission_denied",
+                "action": action_name,
+                "reason": "Remote approval policy denies prompted actions",
+            }
+        )
+
+    try:
+        manager = get_approval_manager()
+        operation = f"action.{action_name}"
+        resource = str(params or "").strip()[:500]
+        session_id = context.session_id or context.conversation_id
+        if manager.check_pre_approved(operation, resource, session_id):
+            return None
+
+        timeout_seconds = policy_timeout_seconds(approval_policy)
+        request = manager.create_request(
+            tool_name=action_name,
+            operation=operation,
+            resource=resource,
+            reason="Request-scoped approval policy requires approval",
+            session_id=session_id,
+            context={
+                "action": action_name,
+                "agent_id": context.agent_id,
+                "request_id": context.request_id,
+            },
+            ttl_seconds=timeout_seconds,
+        )
+
+        if approval_policy.get("wait_for_resolution") is not True:
+            return json.dumps(
+                {
+                    "status": "pending_approval",
+                    "approval_id": request.id,
+                    "action": action_name,
+                    "operation": operation,
+                    "resource": resource,
+                }
+            )
+
+        try:
+            resolved = await asyncio.to_thread(
+                manager.wait_for_resolution,
+                request.id,
+                timeout_seconds,
+            )
+        except asyncio.CancelledError:
+            await asyncio.to_thread(manager.deny, request.id)
+            raise
+
+        if resolved is not None and resolved.status == ApprovalStatus.APPROVED:
+            consumed = await asyncio.to_thread(
+                manager.consume_approved_request,
+                request.id,
+                tool_name=action_name,
+                operation=operation,
+                resource=resource,
+                session_id=session_id,
+            )
+            if consumed:
+                return None
+            return json.dumps(
+                {
+                    "error": "approval_grant_invalid",
+                    "approval_id": request.id,
+                    "action": action_name,
+                }
+            )
+
+        status = resolved.status if resolved is not None else None
+        error = {
+            ApprovalStatus.DENIED: "approval_denied",
+            ApprovalStatus.EXPIRED: "approval_expired",
+        }.get(status, "approval_unavailable")
+        return json.dumps(
+            {
+                "error": error,
+                "status": status.value if status is not None else "unavailable",
+                "approval_id": request.id,
+                "action": action_name,
+            }
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        logger.error(
+            "Failed to authorize direct ActionXML action %s: %s",
+            action_name,
+            error,
+        )
+        return json.dumps(
+            {
+                "error": "approval_error",
+                "action": action_name,
+                "message": str(error),
+            }
+        )
+
+
+async def deny_pending_approvals_for_current_request() -> None:
+    """Deny this turn's pending approvals after ActionXML cancellation."""
+    context = get_current_execution_context()
+    if context is None:
+        return
+    request_id = context.request_id
+    session_id = context.session_id or context.conversation_id
+    if not request_id or not session_id:
+        return
+
+    def _deny_matching() -> int:
+        manager = get_approval_manager()
+        denied = 0
+        for request in manager.get_pending(session_id=session_id):
+            request_context = getattr(request, "context", None)
+            if not isinstance(request_context, dict):
+                continue
+            if request_context.get("request_id") != request_id:
+                continue
+            if manager.deny(request.id) is not None:
+                denied += 1
+        return denied
+
+    try:
+        await asyncio.to_thread(_deny_matching)
+    except Exception:
+        logger.exception(
+            "Failed to deny cancelled ActionXML approvals request=%s",
+            request_id,
+        )
+
+
+__all__ = [
+    "DIRECT_ACTION_POLICY_KEYS",
+    "SAFE_ACTION_NAMES",
+    "TOOL_MANAGED_ACTION_NAMES",
+    "authorize_direct_action",
+    "deny_pending_approvals_for_current_request",
+    "policy_timeout_seconds",
+]

--- a/penguin/security/action_policy.py
+++ b/penguin/security/action_policy.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from penguin.security.approval import ApprovalStatus, get_approval_manager
+from penguin.security.tool_permissions import is_sensitive_resource
 from penguin.system.execution_context import get_current_execution_context
 
 logger = logging.getLogger(__name__)
@@ -38,9 +39,12 @@ DIRECT_ACTION_POLICY_KEYS: dict[str, str] = {
     "task_completed": "fileWrite",
     "todowrite": "fileWrite",
     "send_message": "network",
-    "spawn_sub_agent": "default",
-    "stop_sub_agent": "default",
-    "resume_sub_agent": "default",
+    # Starting or resuming autonomous work is intentionally as sensitive as
+    # process control. Approval covers orchestration only; child tools are still
+    # checked independently under the active execution context.
+    "spawn_sub_agent": "shell",
+    "stop_sub_agent": "shell",
+    "resume_sub_agent": "shell",
     "delegate": "network",
     "delegate_explore_task": "network",
     "browser_navigate": "network",
@@ -145,6 +149,13 @@ def policy_timeout_seconds(policy: Mapping[str, Any]) -> float | None:
     return min(3600.0, max(0.0, parsed_timeout))
 
 
+def _approval_operation(action_name: str, ask_policy_keys: set[str]) -> tuple[str, str]:
+    """Return category-exact and caller-compatible action operation names."""
+    base_operation = f"action.{action_name}"
+    fingerprint = ",".join(sorted(ask_policy_keys))
+    return f"{base_operation}[ask={fingerprint}]", base_operation
+
+
 async def authorize_direct_action(action_name: str, params: Any) -> str | None:
     """Authorize a direct ActionXML mutation under the active request policy."""
     context = get_current_execution_context()
@@ -155,7 +166,9 @@ async def authorize_direct_action(action_name: str, params: Any) -> str | None:
     if action_name in TOOL_MANAGED_ACTION_NAMES:
         return None
 
-    policy_key = DIRECT_ACTION_POLICY_KEYS.get(action_name, "default")
+    policy_keys = {DIRECT_ACTION_POLICY_KEYS.get(action_name, "default")}
+    if is_sensitive_resource(str(params or "")):
+        policy_keys.add("secrets")
 
     if str(context.permission_mode or "").strip().lower() == "read_only":
         return json.dumps(
@@ -169,17 +182,13 @@ async def authorize_direct_action(action_name: str, params: Any) -> str | None:
     approval_policy = context.approval_policy
     if not isinstance(approval_policy, dict):
         return None
-    decision = (
-        str(
-            approval_policy.get(
-                policy_key,
-                approval_policy.get("default", ""),
-            )
-        )
+    policy_decisions = {
+        key: str(approval_policy.get(key, approval_policy.get("default", "")))
         .strip()
         .lower()
-    )
-    if decision == "deny":
+        for key in policy_keys
+    }
+    if "deny" in policy_decisions.values():
         return json.dumps(
             {
                 "error": "permission_denied",
@@ -187,24 +196,21 @@ async def authorize_direct_action(action_name: str, params: Any) -> str | None:
                 "reason": "Request-scoped approval policy denies this action",
             }
         )
-    if decision != "ask":
+    ask_policy_keys = {
+        key for key, decision in policy_decisions.items() if decision == "ask"
+    }
+    if not ask_policy_keys:
         return None
-
-    if approval_policy.get("default") == "deny":
-        return json.dumps(
-            {
-                "error": "permission_denied",
-                "action": action_name,
-                "reason": "Remote approval policy denies prompted actions",
-            }
-        )
 
     try:
         manager = get_approval_manager()
-        operation = f"action.{action_name}"
+        operation, base_operation = _approval_operation(action_name, ask_policy_keys)
         resource = str(params or "").strip()[:500]
         session_id = context.session_id or context.conversation_id
-        if manager.check_pre_approved(operation, resource, session_id):
+        if manager.check_pre_approved(operation, resource, session_id) or (
+            operation != base_operation
+            and manager.check_pre_approved(base_operation, resource, session_id)
+        ):
             return None
 
         timeout_seconds = policy_timeout_seconds(approval_policy)

--- a/penguin/security/approval.py
+++ b/penguin/security/approval.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import math
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -177,6 +179,9 @@ class ApprovalManager:
         
         # Resolved requests (kept for history/audit)
         self._resolved: Dict[str, ApprovalRequest] = {}
+
+        # Approved requests whose one-shot execution grant has been consumed.
+        self._consumed_approvals: Set[str] = set()
         
         # Session approvals by session_id
         self._session_approvals: Dict[str, List[SessionApproval]] = {}
@@ -190,17 +195,20 @@ class ApprovalManager:
         
         # Lock for thread-safe operations
         self._data_lock = threading.RLock()
+        self._resolution_condition = threading.Condition(self._data_lock)
         
         self._initialized = True
         logger.info(f"ApprovalManager initialized with TTL={default_ttl_seconds}s")
     
     def reset(self) -> None:
         """Reset the manager state. Mainly for testing."""
-        with self._data_lock:
+        with self._resolution_condition:
             self._pending.clear()
             self._resolved.clear()
+            self._consumed_approvals.clear()
             self._session_approvals.clear()
             self._global_approvals.clear()
+            self._resolution_condition.notify_all()
     
     # --- Request Creation ---
     
@@ -212,7 +220,7 @@ class ApprovalManager:
         reason: str,
         session_id: Optional[str] = None,
         context: Optional[Dict[str, Any]] = None,
-        ttl_seconds: Optional[int] = None,
+        ttl_seconds: Optional[float] = None,
     ) -> ApprovalRequest:
         """Create a new approval request.
         
@@ -228,7 +236,11 @@ class ApprovalManager:
         Returns:
             The created ApprovalRequest
         """
-        ttl = timedelta(seconds=ttl_seconds) if ttl_seconds else self._default_ttl
+        ttl = (
+            timedelta(seconds=ttl_seconds)
+            if ttl_seconds is not None
+            else self._default_ttl
+        )
         
         request = ApprovalRequest(
             tool_name=tool_name,
@@ -275,41 +287,52 @@ class ApprovalManager:
         Returns:
             The resolved request, or None if not found/already resolved
         """
-        with self._data_lock:
-            request = self._pending.pop(request_id, None)
-            if request is None:
-                logger.warning(f"Approval request not found or already resolved: {request_id}")
-                return None
-            
-            request.status = ApprovalStatus.APPROVED
-            request.resolved_at = datetime.utcnow()
-            request.resolution_scope = scope
-            
-            self._resolved[request_id] = request
-            
-            # Create session/pattern approval if scope warrants
-            if scope == ApprovalScope.SESSION and request.session_id:
-                self._add_session_approval(
-                    request.session_id,
-                    request.operation,
-                    pattern=None,
-                )
-            elif scope == ApprovalScope.PATTERN and pattern:
-                session_id = request.session_id or "__global__"
-                self._add_session_approval(
-                    session_id,
-                    request.operation,
-                    pattern=pattern,
-                )
+        expired_request: Optional[ApprovalRequest] = None
+        request: Optional[ApprovalRequest] = None
+        with self._resolution_condition:
+            existing = self._pending.get(request_id)
+            if existing is not None and existing.is_expired():
+                expired_request = self._expire_pending_locked(request_id)
+            else:
+                request = self._pending.pop(request_id, None)
+                if request is not None:
+                    request.status = ApprovalStatus.APPROVED
+                    request.resolved_at = datetime.utcnow()
+                    request.resolution_scope = scope
+                    self._resolved[request_id] = request
+
+                    # Create session/pattern approval if scope warrants.
+                    if scope == ApprovalScope.SESSION and request.session_id:
+                        self._add_session_approval(
+                            request.session_id,
+                            request.operation,
+                            pattern=None,
+                        )
+                    elif scope == ApprovalScope.PATTERN and pattern:
+                        session_id = request.session_id or "__global__"
+                        self._add_session_approval(
+                            session_id,
+                            request.operation,
+                            pattern=pattern,
+                        )
+
+                    self._resolution_condition.notify_all()
+
+        if expired_request is not None:
+            self._notify_resolved_callbacks(expired_request)
+            logger.warning("Approval request expired before approval: %s", request_id)
+            return None
+        if request is None:
+            logger.warning(
+                "Approval request not found or already resolved: %s",
+                request_id,
+            )
+            return None
         
         logger.info(f"Approval granted: id={request_id}, scope={scope.value}")
         
         # Notify listeners
-        for callback in self._on_request_resolved:
-            try:
-                callback(request)
-            except Exception as e:
-                logger.error(f"Error in approval resolved callback: {e}")
+        self._notify_resolved_callbacks(request)
         
         return request
     
@@ -322,27 +345,129 @@ class ApprovalManager:
         Returns:
             The resolved request, or None if not found/already resolved
         """
-        with self._data_lock:
-            request = self._pending.pop(request_id, None)
-            if request is None:
-                logger.warning(f"Approval request not found or already resolved: {request_id}")
-                return None
-            
-            request.status = ApprovalStatus.DENIED
-            request.resolved_at = datetime.utcnow()
-            
-            self._resolved[request_id] = request
+        expired_request: Optional[ApprovalRequest] = None
+        request: Optional[ApprovalRequest] = None
+        with self._resolution_condition:
+            existing = self._pending.get(request_id)
+            if existing is not None and existing.is_expired():
+                expired_request = self._expire_pending_locked(request_id)
+            else:
+                request = self._pending.pop(request_id, None)
+                if request is not None:
+                    request.status = ApprovalStatus.DENIED
+                    request.resolved_at = datetime.utcnow()
+                    self._resolved[request_id] = request
+                    self._resolution_condition.notify_all()
+
+        if expired_request is not None:
+            self._notify_resolved_callbacks(expired_request)
+            logger.warning("Approval request expired before denial: %s", request_id)
+            return None
+        if request is None:
+            logger.warning(
+                "Approval request not found or already resolved: %s",
+                request_id,
+            )
+            return None
         
         logger.info(f"Approval denied: id={request_id}")
         
         # Notify listeners
-        for callback in self._on_request_resolved:
-            try:
-                callback(request)
-            except Exception as e:
-                logger.error(f"Error in approval resolved callback: {e}")
+        self._notify_resolved_callbacks(request)
         
         return request
+
+    def wait_for_resolution(
+        self,
+        request_id: str,
+        timeout_seconds: Optional[float] = None,
+    ) -> Optional[ApprovalRequest]:
+        """Block until an approval is resolved or its wait expires.
+
+        This method is intentionally synchronous. Async callers must run it in
+        a worker thread so the event loop remains available to receive the
+        approval response.
+
+        Args:
+            request_id: ID of the request to wait for.
+            timeout_seconds: Optional maximum wait. A timeout expires the
+                request so a later approval cannot resume stale work.
+
+        Returns:
+            The resolved request, or ``None`` if it was reset or not found.
+        """
+        deadline: Optional[float] = None
+        if timeout_seconds is not None:
+            timeout = float(timeout_seconds)
+            if not math.isfinite(timeout):
+                timeout = 0.0
+            deadline = time.monotonic() + max(timeout, 0.0)
+
+        while True:
+            expired_request: Optional[ApprovalRequest] = None
+            callbacks: List[Callable[[ApprovalRequest], None]] = []
+            with self._resolution_condition:
+                resolved = self._resolved.get(request_id)
+                if resolved is not None:
+                    return resolved
+
+                request = self._pending.get(request_id)
+                if request is None:
+                    return None
+
+                now = datetime.utcnow()
+                wait_limits: List[float] = []
+                if request.expires_at is not None:
+                    wait_limits.append((request.expires_at - now).total_seconds())
+                if deadline is not None:
+                    wait_limits.append(deadline - time.monotonic())
+
+                if wait_limits and min(wait_limits) <= 0:
+                    expired_request = self._expire_pending_locked(request_id)
+                    callbacks = list(self._on_request_resolved)
+                else:
+                    wait_for = min(wait_limits) if wait_limits else None
+                    self._resolution_condition.wait(timeout=wait_for)
+                    continue
+
+            if expired_request is not None:
+                self._invoke_callbacks(
+                    callbacks,
+                    expired_request,
+                    "approval expired",
+                )
+                return expired_request
+
+    def consume_approved_request(
+        self,
+        request_id: str,
+        *,
+        tool_name: str,
+        operation: str,
+        resource: str,
+        session_id: Optional[str],
+    ) -> bool:
+        """Atomically consume one matching approved execution grant.
+
+        Returns ``True`` exactly once for an approved request whose protected
+        operation matches the resumed call. Duplicate or mismatched claims are
+        rejected without replaying the tool.
+        """
+        with self._data_lock:
+            request = self._resolved.get(request_id)
+            if request is None or request.status != ApprovalStatus.APPROVED:
+                return False
+            if request_id in self._consumed_approvals:
+                return False
+            if (
+                request.tool_name != tool_name
+                or request.operation != operation
+                or request.resource != resource
+                or request.session_id != session_id
+            ):
+                return False
+            self._consumed_approvals.add(request_id)
+            return True
     
     # --- Pre-approval & Session Approvals ---
     
@@ -507,33 +632,62 @@ class ApprovalManager:
             return [a for a in approvals if not a.is_expired()]
     
     # --- Expiration Handling ---
+
+    def _expire_pending_locked(
+        self,
+        request_id: str,
+    ) -> Optional[ApprovalRequest]:
+        """Move one pending request to expired state while holding the lock."""
+        request = self._pending.pop(request_id, None)
+        if request is None:
+            return None
+        request.status = ApprovalStatus.EXPIRED
+        request.resolved_at = datetime.utcnow()
+        self._resolved[request_id] = request
+        self._resolution_condition.notify_all()
+        return request
+
+    @staticmethod
+    def _invoke_callbacks(
+        callbacks: List[Callable[[ApprovalRequest], None]],
+        request: ApprovalRequest,
+        event_name: str,
+    ) -> None:
+        """Invoke a callback snapshot without holding manager state locks."""
+        for callback in callbacks:
+            try:
+                callback(request)
+            except Exception as exc:
+                logger.error("Error in %s callback: %s", event_name, exc)
+
+    def _notify_resolved_callbacks(self, request: ApprovalRequest) -> None:
+        """Notify current resolution listeners outside the manager lock."""
+        with self._data_lock:
+            callbacks = list(self._on_request_resolved)
+        self._invoke_callbacks(callbacks, request, "approval resolved")
     
     def _expire_old_requests(self) -> int:
         """Expire old pending requests. Returns count of expired."""
-        expired_ids = []
-        
-        with self._data_lock:
-            for request_id, request in self._pending.items():
-                if request.is_expired():
-                    expired_ids.append(request_id)
-            
+        expired_requests: List[ApprovalRequest] = []
+
+        with self._resolution_condition:
+            expired_ids = [
+                request_id
+                for request_id, request in self._pending.items()
+                if request.is_expired()
+            ]
             for request_id in expired_ids:
-                request = self._pending.pop(request_id)
-                request.status = ApprovalStatus.EXPIRED
-                request.resolved_at = datetime.utcnow()
-                self._resolved[request_id] = request
-                
-                # Notify listeners
-                for callback in self._on_request_resolved:
-                    try:
-                        callback(request)
-                    except Exception as e:
-                        logger.error(f"Error in approval expired callback: {e}")
+                request = self._expire_pending_locked(request_id)
+                if request is not None:
+                    expired_requests.append(request)
+
+        for request in expired_requests:
+            self._notify_resolved_callbacks(request)
         
-        if expired_ids:
-            logger.info(f"Expired {len(expired_ids)} approval requests")
+        if expired_requests:
+            logger.info(f"Expired {len(expired_requests)} approval requests")
         
-        return len(expired_ids)
+        return len(expired_requests)
     
     def cleanup_expired_sessions(self) -> int:
         """Clean up expired session approvals. Returns count removed."""
@@ -588,4 +742,3 @@ class ApprovalManager:
 def get_approval_manager() -> ApprovalManager:
     """Get the singleton ApprovalManager instance."""
     return ApprovalManager()
-

--- a/penguin/security/question.py
+++ b/penguin/security/question.py
@@ -93,7 +93,16 @@ class QuestionManager:
             for waiter in group:
                 if waiter.done():
                     continue
-                waiter.cancel()
+                try:
+                    waiter.get_loop().call_soon_threadsafe(self._cancel_waiter, waiter)
+                except RuntimeError:
+                    logger.debug("Question waiter loop was already closed")
+
+    @staticmethod
+    def _cancel_waiter(waiter: asyncio.Future[QuestionRequest]) -> None:
+        """Cancel a waiter on its owning event loop."""
+        if not waiter.done():
+            waiter.cancel()
 
     def _notify_waiters(self, request: QuestionRequest) -> None:
         """Resolve any async waiters for a request."""
@@ -152,7 +161,9 @@ class QuestionManager:
             self._pending[request.id] = request
             self._waiters.setdefault(request.id, [])
 
-        for callback in self._on_request_created:
+        with self._data_lock:
+            callbacks = list(self._on_request_created)
+        for callback in callbacks:
             try:
                 callback(request)
             except Exception:
@@ -177,7 +188,9 @@ class QuestionManager:
 
         self._notify_waiters(request)
 
-        for callback in self._on_request_answered:
+        with self._data_lock:
+            callbacks = list(self._on_request_answered)
+        for callback in callbacks:
             try:
                 callback(request)
             except Exception:
@@ -197,13 +210,42 @@ class QuestionManager:
 
         self._notify_waiters(request)
 
-        for callback in self._on_request_rejected:
+        with self._data_lock:
+            callbacks = list(self._on_request_rejected)
+        for callback in callbacks:
             try:
                 callback(request)
             except Exception:
                 logger.debug("Question rejected callback failed", exc_info=True)
 
         return request
+
+    def shutdown(self) -> int:
+        """Reject all pending questions and wake their async waiters.
+
+        Returns:
+            Number of pending requests rejected during shutdown.
+        """
+        with self._data_lock:
+            requests = list(self._pending.values())
+            self._pending.clear()
+            for request in requests:
+                request.status = QuestionStatus.REJECTED
+                request.resolved_at = datetime.utcnow()
+                self._resolved[request.id] = request
+            callbacks = list(self._on_request_rejected)
+
+        for request in requests:
+            self._notify_waiters(request)
+            for callback in callbacks:
+                try:
+                    callback(request)
+                except Exception:
+                    logger.debug(
+                        "Question shutdown callback failed",
+                        exc_info=True,
+                    )
+        return len(requests)
 
     def list_pending(self, session_id: str | None = None) -> list[QuestionRequest]:
         """List pending question requests, optionally filtered by session."""
@@ -252,21 +294,39 @@ class QuestionManager:
                 return await waiter
             return await asyncio.wait_for(waiter, timeout=timeout_seconds)
         except asyncio.TimeoutError:
+            self.reject(request_id)
             return None
+        except asyncio.CancelledError:
+            self.reject(request_id)
+            raise
         finally:
             self._remove_waiter(request_id, waiter)
 
     def on_request_created(self, callback: Callable[[QuestionRequest], None]) -> None:
         """Register callback for request creation."""
-        self._on_request_created.append(callback)
+        with self._data_lock:
+            self._on_request_created.append(callback)
 
     def on_request_answered(self, callback: Callable[[QuestionRequest], None]) -> None:
         """Register callback for answered requests."""
-        self._on_request_answered.append(callback)
+        with self._data_lock:
+            self._on_request_answered.append(callback)
 
     def on_request_rejected(self, callback: Callable[[QuestionRequest], None]) -> None:
         """Register callback for rejected requests."""
-        self._on_request_rejected.append(callback)
+        with self._data_lock:
+            self._on_request_rejected.append(callback)
+
+    def remove_callback(self, callback: Callable[[QuestionRequest], None]) -> None:
+        """Unregister a callback from every question lifecycle event."""
+        with self._data_lock:
+            for callbacks in (
+                self._on_request_created,
+                self._on_request_answered,
+                self._on_request_rejected,
+            ):
+                while callback in callbacks:
+                    callbacks.remove(callback)
 
 
 def get_question_manager() -> QuestionManager:

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -29,6 +29,7 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     "find_file": [Operation.FILESYSTEM_LIST],
     "get_file_map": [Operation.FILESYSTEM_LIST],
     "read_image": [Operation.FILESYSTEM_READ],
+    "publish_artifact": [Operation.FILESYSTEM_READ, Operation.NETWORK_POST],
     "enhanced_read": [Operation.FILESYSTEM_READ],
     # File write operations
     "create_folder": [Operation.FILESYSTEM_MKDIR],

--- a/penguin/security/tool_permissions.py
+++ b/penguin/security/tool_permissions.py
@@ -19,6 +19,29 @@ from penguin.security.permission_engine import Operation, PermissionResult
 
 logger = logging.getLogger(__name__)
 
+_SECRET_PATH_PATTERN = re.compile(
+    r"(?:^|[/\\\s'\"`])(?:"
+    r"\.env(?:\.[A-Za-z0-9_-]+)?|"
+    r"\.netrc|\.npmrc|\.pypirc|"
+    r"credentials(?:\.[A-Za-z0-9_-]+)?|"
+    r"id_(?:rsa|dsa|ecdsa|ed25519)|"
+    r"[^/\\\s'\"`]+\.(?:pem|key|p12|pfx)"
+    r")(?:$|[/\\\s'\"`;])|"
+    r"(?:^|[/\\])(?:secrets?|\.ssh)(?:[/\\]|$)",
+    re.IGNORECASE,
+)
+_SECRET_ENV_PATTERN = re.compile(
+    r"\$(?:\{)?[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY)"
+    r"[A-Z0-9_]*(?:\})?|"
+    r"\b(?:os\.environ|os\.getenv|process\.env|printenv)\b|"
+    r"(?:^|[;&|]\s*)env(?:\s|$)",
+    re.IGNORECASE,
+)
+_SECRET_ENV_NAME_PATTERN = re.compile(
+    r"(?:TOKEN|SECRET|PASSWORD|PASSWD|API_KEY|PRIVATE_KEY|ACCESS_KEY|CREDENTIAL)",
+    re.IGNORECASE,
+)
+
 
 # Map tool names to their required operations
 # Tools can require multiple operations (e.g., apply_diff needs read + write)
@@ -31,6 +54,10 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     "read_image": [Operation.FILESYSTEM_READ],
     "publish_artifact": [Operation.FILESYSTEM_READ, Operation.NETWORK_POST],
     "enhanced_read": [Operation.FILESYSTEM_READ],
+    # Skill discovery and activation only read local instruction files. Activating a
+    # skill changes model context, but it does not mutate the host or external state.
+    "list_skills": [Operation.FILESYSTEM_LIST],
+    "activate_skill": [Operation.FILESYSTEM_READ],
     # File write operations
     "create_folder": [Operation.FILESYSTEM_MKDIR],
     "create_file": [Operation.FILESYSTEM_WRITE],
@@ -50,6 +77,11 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     # Code execution
     "code_execution": [Operation.PROCESS_EXECUTE],
     "execute_command": [Operation.PROCESS_EXECUTE],
+    "process_start": [Operation.PROCESS_SPAWN],
+    # Polling reads Penguin's bounded process buffer without changing the process.
+    "process_poll": [Operation.MEMORY_READ],
+    "process_write_stdin": [Operation.PROCESS_EXECUTE],
+    "process_stop": [Operation.PROCESS_KILL],
     # Search operations (generally safe)
     "grep_search": [Operation.FILESYSTEM_READ],
     "memory_search": [Operation.MEMORY_READ],
@@ -61,11 +93,12 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     "add_summary_note": [Operation.MEMORY_WRITE],
     # Browser operations
     "browser_navigate": [Operation.NETWORK_FETCH],
-    "browser_interact": [Operation.NETWORK_FETCH],
+    "browser_interact": [Operation.NETWORK_POST],
     "browser_screenshot": [Operation.FILESYSTEM_WRITE],  # Saves screenshot
     "pydoll_browser_navigate": [Operation.NETWORK_FETCH],
-    "pydoll_browser_interact": [Operation.NETWORK_FETCH],
+    "pydoll_browser_interact": [Operation.NETWORK_POST],
     "pydoll_browser_screenshot": [Operation.FILESYSTEM_WRITE],
+    "pydoll_browser_scroll": [Operation.NETWORK_POST],
     "browser_status": [Operation.NETWORK_FETCH],
     "browser_cleanup": [Operation.NETWORK_POST],
     "browser_open_tab": [Operation.NETWORK_FETCH],
@@ -85,12 +118,71 @@ TOOL_OPERATION_MAP: dict[str, list[Operation]] = {
     "git_log": [Operation.GIT_READ],
     "git_commit": [Operation.GIT_WRITE],
     "git_push": [Operation.GIT_PUSH],
-    # Indexing (requires filesystem access)
-    "reindex_workspace": [Operation.FILESYSTEM_READ],
+    "get_repository_status": [Operation.GIT_READ],
+    "create_and_switch_branch": [Operation.GIT_WRITE],
+    "commit_and_push_changes": [Operation.GIT_WRITE, Operation.GIT_PUSH],
+    "create_improvement_pr": [
+        Operation.GIT_WRITE,
+        Operation.GIT_PUSH,
+        Operation.NETWORK_POST,
+    ],
+    "create_feature_pr": [
+        Operation.GIT_WRITE,
+        Operation.GIT_PUSH,
+        Operation.NETWORK_POST,
+    ],
+    "create_bugfix_pr": [
+        Operation.GIT_WRITE,
+        Operation.GIT_PUSH,
+        Operation.NETWORK_POST,
+    ],
+    # Indexing reads files and persists their contents in Penguin memory.
+    "reindex_workspace": [Operation.FILESYSTEM_READ, Operation.MEMORY_WRITE],
     # Image encoding
     "encode_image_to_base64": [Operation.FILESYSTEM_READ],
     # Linting
     "lint_python": [Operation.FILESYSTEM_READ, Operation.PROCESS_EXECUTE],
+    # Agent orchestration. Starting or resuming autonomous work is deliberately
+    # treated like process spawning; approving it does not approve the child's
+    # later tools, which remain subject to their own permission checks.
+    "spawn_sub_agent": [Operation.PROCESS_SPAWN],
+    "resume_sub_agent": [Operation.PROCESS_SPAWN],
+    "stop_sub_agent": [Operation.PROCESS_KILL],
+    "delegate": [Operation.PROCESS_SPAWN, Operation.NETWORK_POST],
+    "delegate_explore_task": [
+        Operation.PROCESS_SPAWN,
+        Operation.FILESYSTEM_READ,
+        Operation.NETWORK_POST,
+    ],
+    "send_message": [Operation.NETWORK_POST],
+    "sync_context": [Operation.MEMORY_WRITE],
+    # Inspection and lifecycle controls have no host side effect. MEMORY_READ is
+    # the existing read-only operation closest to Penguin runtime-state reads.
+    "get_agent_status": [Operation.MEMORY_READ],
+    "get_context_info": [Operation.MEMORY_READ],
+    "wait_for_agents": [Operation.MEMORY_READ],
+    "finish_response": [Operation.MEMORY_READ],
+    # The batch wrapper is inert; every child is authorized independently.
+    "ordered_tool_batch": [Operation.MEMORY_READ],
+    "finish_task": [Operation.MEMORY_WRITE],
+    "task_completed": [Operation.MEMORY_WRITE],
+}
+
+
+_OPERATION_POLICY_KEYS: dict[Operation, str] = {
+    Operation.PROCESS_EXECUTE: "shell",
+    Operation.PROCESS_SPAWN: "shell",
+    Operation.PROCESS_KILL: "shell",
+    Operation.FILESYSTEM_DELETE: "fileDelete",
+    Operation.FILESYSTEM_WRITE: "fileWrite",
+    Operation.FILESYSTEM_MKDIR: "fileWrite",
+    Operation.GIT_WRITE: "fileWrite",
+    Operation.MEMORY_WRITE: "fileWrite",
+    Operation.GIT_PUSH: "gitPush",
+    Operation.GIT_FORCE: "gitPush",
+    Operation.NETWORK_FETCH: "network",
+    Operation.NETWORK_POST: "network",
+    Operation.NETWORK_LISTEN: "network",
 }
 
 
@@ -108,6 +200,45 @@ def get_tool_operations(tool_name: str) -> list[Operation]:
         return [Operation.NETWORK_POST]
 
     return TOOL_OPERATION_MAP.get(tool_name, [])
+
+
+def get_tool_policy_keys(
+    tool_name: str,
+    tool_input: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+) -> set[str]:
+    """Return request-policy categories required by a tool.
+
+    Unknown or non-read-only operations fail closed through the ``default``
+    category. Pure read operations need no remote approval category because the
+    instance permission engine and request mode still enforce their boundaries.
+    """
+
+    operations = get_tool_operations(tool_name)
+    keys = {
+        policy_key
+        for operation in operations
+        if (policy_key := _OPERATION_POLICY_KEYS.get(operation)) is not None
+    }
+    if not operations or (
+        not keys
+        and not all(Operation.is_read_only(operation) for operation in operations)
+    ):
+        keys.add("default")
+    if tool_input is not None and _tool_accesses_secrets(
+        tool_name,
+        tool_input,
+        context,
+    ):
+        keys.add("secrets")
+    return keys
+
+
+def is_sensitive_resource(resource: str) -> bool:
+    """Return whether text references common credential paths or environment data."""
+
+    value = str(resource or "")
+    return bool(_SECRET_PATH_PATTERN.search(value) or _SECRET_ENV_PATTERN.search(value))
 
 
 def extract_resource_from_input(
@@ -130,9 +261,14 @@ def extract_resource_from_input(
             return str(tool_input[key])
 
     # Special cases
-    if tool_name in ("execute_command", "code_execution"):
+    if tool_name in ("execute_command", "code_execution", "process_start"):
         # For commands, the resource is the command itself
         return tool_input.get("command") or tool_input.get("code")
+
+    if tool_name == "process_write_stdin":
+        return (
+            tool_input.get("text") or tool_input.get("data") or tool_input.get("input")
+        )
 
     if tool_name in ("browser_navigate", "pydoll_browser_navigate", "browser_open_tab"):
         return tool_input.get("url")
@@ -263,6 +399,29 @@ def extract_resources_from_input(
         seen.add(text)
         deduped.append(text)
     return deduped
+
+
+def _tool_accesses_secrets(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    context: dict[str, Any] | None,
+) -> bool:
+    """Return whether a tool targets common credential paths or environment data."""
+
+    if tool_name == "process_start":
+        environment = tool_input.get("env")
+        if isinstance(environment, dict):
+            for name, value in environment.items():
+                if _SECRET_ENV_NAME_PATTERN.search(str(name)):
+                    return True
+                value_text = str(value or "")
+                if _SECRET_ENV_NAME_PATTERN.search(value_text) or is_sensitive_resource(
+                    value_text
+                ):
+                    return True
+
+    resources = extract_resources_from_input(tool_name, tool_input, context)
+    return any(is_sensitive_resource(resource) for resource in resources)
 
 
 def is_safe_tool(tool_name: str) -> bool:

--- a/penguin/system/execution_context.py
+++ b/penguin/system/execution_context.py
@@ -6,9 +6,9 @@ from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Iterator
 
-_CURRENT_EXECUTION_CONTEXT: ContextVar["ExecutionContext | None"] = ContextVar(
+_CURRENT_EXECUTION_CONTEXT: ContextVar[ExecutionContext | None] = ContextVar(
     "penguin_execution_context",
     default=None,
 )
@@ -18,15 +18,20 @@ _CURRENT_EXECUTION_CONTEXT: ContextVar["ExecutionContext | None"] = ContextVar(
 class ExecutionContext:
     """Request-scoped execution state used by tool execution paths."""
 
-    session_id: Optional[str] = None
-    conversation_id: Optional[str] = None
-    agent_id: Optional[str] = None
-    agent_mode: Optional[str] = None
-    directory: Optional[str] = None
-    project_root: Optional[str] = None
-    workspace_root: Optional[str] = None
-    request_id: Optional[str] = None
-    subagents_enabled: Optional[bool] = None
+    session_id: str | None = None
+    conversation_id: str | None = None
+    agent_id: str | None = None
+    agent_mode: str | None = None
+    directory: str | None = None
+    project_root: str | None = None
+    workspace_root: str | None = None
+    request_id: str | None = None
+    subagents_enabled: bool | None = None
+    permission_mode: str | None = None
+    approval_policy: dict[str, Any] | None = None
+    request_system_prompt: str | None = None
+    request_skills: tuple[str, ...] = ()
+    require_registered_agent: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dictionary representation for compatibility with existing APIs."""
@@ -40,10 +45,17 @@ class ExecutionContext:
             "workspace_root": self.workspace_root,
             "request_id": self.request_id,
             "subagents_enabled": self.subagents_enabled,
+            "permission_mode": self.permission_mode,
+            "approval_policy": dict(self.approval_policy)
+            if isinstance(self.approval_policy, dict)
+            else None,
+            "request_system_prompt": self.request_system_prompt,
+            "request_skills": list(self.request_skills),
+            "require_registered_agent": self.require_registered_agent,
         }
 
 
-def normalize_directory(directory: Optional[str]) -> Optional[str]:
+def normalize_directory(directory: str | None) -> str | None:
     """Return a resolved directory path when valid, otherwise None."""
     if not directory:
         return None
@@ -56,7 +68,7 @@ def normalize_directory(directory: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
-def get_current_execution_context() -> Optional[ExecutionContext]:
+def get_current_execution_context() -> ExecutionContext | None:
     """Get the active execution context, if any."""
     return _CURRENT_EXECUTION_CONTEXT.get()
 

--- a/penguin/tools/artifact_tools.py
+++ b/penguin/tools/artifact_tools.py
@@ -1,0 +1,89 @@
+"""Explicit projection of existing workspace files as outbound artifacts."""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from penguin.system.execution_context import get_current_execution_context
+from penguin.utils.path_utils import enforce_allowed_path
+
+__all__ = ["PublishArtifactTool"]
+
+
+class PublishArtifactTool:
+    """Validate one existing file and expose a typed artifact descriptor."""
+
+    def execute(self, path: str) -> dict[str, Any]:
+        if not isinstance(path, str) or not path.strip():
+            return {"error": "path is required"}
+        if len(path) > 4096:
+            return {"error": "artifact path is too long"}
+
+        try:
+            candidate = Path(path).expanduser()
+            context = get_current_execution_context()
+            base = (
+                Path(context.directory).expanduser()
+                if context and context.directory
+                else None
+            )
+            if not candidate.is_absolute() and base is not None:
+                candidate = base / candidate
+            if candidate.is_symlink():
+                return {"error": "artifact path must not be a symlink"}
+            roots = _request_roots(context) if context is not None else ()
+            has_request_root = context is not None and any(
+                isinstance(value, str) and bool(value.strip())
+                for value in (
+                    context.directory,
+                    context.project_root,
+                    context.workspace_root,
+                )
+            )
+            if has_request_root and not roots:
+                return {"error": "request workspace is unavailable"}
+            if roots:
+                artifact_path = candidate.resolve(strict=True)
+                if not any(
+                    artifact_path == root or root in artifact_path.parents
+                    for root in roots
+                ):
+                    return {"error": "artifact path is outside request workspace"}
+            else:
+                artifact_path = enforce_allowed_path(candidate, root_pref="auto")
+            if not artifact_path.is_file():
+                return {"error": "artifact path is not an existing file"}
+        except (OSError, RuntimeError, ValueError) as exc:
+            return {"error": f"artifact path is unavailable: {exc}"}
+
+        mime_type = mimetypes.guess_type(artifact_path.name)[0]
+        artifact_type = (
+            "image" if mime_type and mime_type.startswith("image/") else "file"
+        )
+        descriptor = {
+            "type": artifact_type,
+            "path": str(artifact_path),
+            "file_name": artifact_path.name,
+        }
+        if mime_type:
+            descriptor["mime_type"] = mime_type
+        return {
+            "result": f"Artifact ready for delivery: {artifact_path.name}",
+            "artifact": descriptor,
+        }
+
+
+def _request_roots(context: Any) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for value in (context.directory, context.project_root, context.workspace_root):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        try:
+            root = Path(value).expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if root.is_dir() and root not in roots:
+            roots.append(root)
+    return tuple(roots)

--- a/penguin/tools/async_dispatch.py
+++ b/penguin/tools/async_dispatch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from penguin.multi.policy import (
@@ -12,6 +13,7 @@ from penguin.multi.policy import (
     disabled_subagent_result,
     subagents_enabled,
 )
+from penguin.security.approval import ApprovalStatus, get_approval_manager
 from penguin.utils.profiling import profile_operation
 
 if TYPE_CHECKING:
@@ -105,6 +107,124 @@ class AsyncToolDispatcher:
         }
         return tool_map[tool_name]()
 
+    @staticmethod
+    def _approval_wait_settings(
+        context: dict[str, Any],
+    ) -> tuple[bool, float | None]:
+        """Read the opt-in resumable approval settings from a request context."""
+        policy = context.get("approval_policy")
+        if (
+            not isinstance(policy, dict)
+            or policy.get("wait_for_resolution") is not True
+        ):
+            return False, None
+
+        raw_timeout = policy.get("timeout_seconds")
+        if raw_timeout is None:
+            return True, None
+        if isinstance(raw_timeout, bool):
+            return True, 0.0
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            return True, 0.0
+        if not math.isfinite(timeout):
+            return True, 0.0
+        return True, max(timeout, 0.0)
+
+    @staticmethod
+    def _pending_approval_id(
+        permission_response: str | dict[str, Any],
+    ) -> str | None:
+        """Extract a pending approval ID from a permission response."""
+        payload: Any = permission_response
+        if isinstance(permission_response, str):
+            try:
+                payload = json.loads(permission_response)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("status") != "pending_approval":
+            return None
+        request_id = payload.get("approval_id")
+        return request_id if isinstance(request_id, str) and request_id else None
+
+    @staticmethod
+    def _approval_failure_response(
+        request_id: str,
+        status: ApprovalStatus | None,
+        tool_name: str,
+    ) -> str:
+        """Build a stable terminal response for a non-approved request."""
+        status_value = status.value if status is not None else "unavailable"
+        error = {
+            ApprovalStatus.DENIED: "approval_denied",
+            ApprovalStatus.EXPIRED: "approval_expired",
+        }.get(status, "approval_unavailable")
+        return json.dumps(
+            {
+                "error": error,
+                "status": status_value,
+                "approval_id": request_id,
+                "tool": tool_name,
+            }
+        )
+
+    async def _resolve_permission(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: dict[str, Any],
+    ) -> tuple[str | dict[str, Any] | None, str | None]:
+        """Check permission and optionally await an approval off-loop."""
+        manager = self._tool_manager
+        wait_for_resolution, timeout_seconds = self._approval_wait_settings(context)
+        if wait_for_resolution:
+            permission_response = await asyncio.to_thread(
+                manager._permission_response,
+                tool_name,
+                tool_input,
+                context,
+            )
+        else:
+            # Preserve the existing HTTP callback/event-loop behavior when the
+            # request has not opted into a blocking approval lifecycle.
+            permission_response = manager._permission_response(
+                tool_name,
+                tool_input,
+                context,
+            )
+        if permission_response is None:
+            return None, None
+
+        request_id = self._pending_approval_id(permission_response)
+        if not wait_for_resolution or request_id is None:
+            return permission_response, None
+
+        approval_manager = get_approval_manager()
+        try:
+            resolved = await asyncio.to_thread(
+                approval_manager.wait_for_resolution,
+                request_id,
+                timeout_seconds,
+            )
+        except asyncio.CancelledError:
+            # Cancelled channel/server work must not strand a worker thread or
+            # leave a stale approval capable of resuming later.
+            await asyncio.to_thread(approval_manager.deny, request_id)
+            raise
+        if resolved is not None and resolved.status == ApprovalStatus.APPROVED:
+            return None, request_id
+        return (
+            self._approval_failure_response(
+                request_id,
+                resolved.status if resolved is not None else None,
+                tool_name,
+            ),
+            None,
+        )
+
     async def execute(
         self,
         tool_name: str,
@@ -121,7 +241,8 @@ class AsyncToolDispatcher:
             effective_context
         ):
             return json.dumps(disabled_subagent_result(canonical_name))
-        if canonical_name not in ASYNC_TOOL_NAMES:
+        wait_for_resolution, _ = self._approval_wait_settings(effective_context)
+        if canonical_name not in ASYNC_TOOL_NAMES and not wait_for_resolution:
             return await asyncio.to_thread(
                 manager.execute_tool,
                 requested_name,
@@ -139,13 +260,47 @@ class AsyncToolDispatcher:
                 file_root,
             )
 
-            permission_response = manager._permission_response(
+            permission_response, approval_id = await self._resolve_permission(
                 canonical_name,
                 normalized_input,
                 effective_context,
             )
             if permission_response is not None:
                 return permission_response
+
+            if canonical_name not in ASYNC_TOOL_NAMES:
+                resume_context = effective_context
+                if approval_id is not None:
+                    resume_context = manager._with_approval_grant(
+                        effective_context,
+                        approval_id,
+                    )
+                return await asyncio.to_thread(
+                    manager.execute_tool,
+                    requested_name,
+                    normalized_input,
+                    resume_context,
+                )
+
+            if approval_id is not None:
+                resume_context = manager._with_approval_grant(
+                    effective_context,
+                    approval_id,
+                )
+                consumed = await asyncio.to_thread(
+                    manager._consume_approval_grant,
+                    canonical_name,
+                    normalized_input,
+                    resume_context,
+                )
+                if consumed is not True:
+                    return json.dumps(
+                        {
+                            "error": "approval_grant_invalid",
+                            "approval_id": approval_id,
+                            "tool": canonical_name,
+                        }
+                    )
 
             diagnostic_input = manager._redact_tool_input_for_diagnostics(
                 canonical_name,

--- a/penguin/tools/runtime.py
+++ b/penguin/tools/runtime.py
@@ -701,6 +701,8 @@ def infer_tool_effect(tool_call: ToolCall) -> ToolEffect:
     """Infer a conservative scheduler effect for a tool call."""
 
     name = tool_call.name
+    if name == "publish_artifact":
+        return "external_mutation"
     if name in _READ_ONLY_TOOL_NAMES:
         return "read"
     if name in _FILESYSTEM_MUTATION_TOOL_NAMES:
@@ -719,6 +721,9 @@ def infer_tool_resources(tool_call: ToolCall) -> tuple[ToolResource, ...]:
     name = tool_call.name
     if name in _READ_ONLY_TOOL_NAMES or name in _FILESYSTEM_MUTATION_TOOL_NAMES:
         resources.extend(_path_resources(tool_call.arguments))
+    if name == "publish_artifact":
+        resources.extend(_path_resources(tool_call.arguments))
+        resources.append("network:channel")
     if name in _PROCESS_MUTATION_TOOL_NAMES:
         resources.append("process:*")
         resources.extend(_command_git_resources(_argument_text(tool_call.arguments)))
@@ -1831,14 +1836,60 @@ def image_artifacts_from_action_result(
     return artifacts
 
 
-def legacy_action_result_from_tool_result(tool_result: ToolResult) -> dict[str, str]:
-    """Convert a normalized tool result back to Penguin's current result shape."""
+def _project_artifact(value: Any) -> Optional[dict[str, Any]]:
+    """Return one bounded, explicit artifact descriptor from tool output."""
 
-    return {
+    if not isinstance(value, dict):
+        return None
+    projected: dict[str, Any] = {}
+    for key in (
+        "type",
+        "path",
+        "file_path",
+        "image_path",
+        "file_name",
+        "mime_type",
+        "format",
+        "width",
+        "height",
+    ):
+        item = value.get(key)
+        if isinstance(item, str) and item.strip():
+            projected[key] = item.strip()[:4096]
+        elif (
+            key in {"width", "height"}
+            and isinstance(item, int)
+            and not isinstance(item, bool)
+            and item > 0
+        ):
+            projected[key] = item
+    if not any(key in projected for key in ("path", "file_path", "image_path")):
+        return None
+    return projected
+
+
+def legacy_action_result_from_tool_result(tool_result: ToolResult) -> dict[str, Any]:
+    """Convert a normalized tool result to the bounded public result shape."""
+
+    result: dict[str, Any] = {
         "action": tool_result.name,
         "result": tool_result.output,
         "status": tool_result.status,
     }
+    structured = tool_result.structured_output or {}
+    artifact = _project_artifact(structured.get("artifact"))
+    if artifact is not None:
+        result["artifact"] = artifact
+    raw_artifacts = structured.get("artifacts")
+    if isinstance(raw_artifacts, list):
+        artifacts = [
+            projected
+            for value in raw_artifacts[:20]
+            if (projected := _project_artifact(value)) is not None
+        ]
+        if artifacts:
+            result["artifacts"] = artifacts
+    return result
 
 
 __all__ = [

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import logging
 import math

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -66,12 +66,14 @@ from penguin.tools.schema_contract import (
     runtime_metadata_from_tool_schema,
 )
 from penguin.tools.image_tools import ReadImageTool
+from penguin.tools.artifact_tools import PublishArtifactTool
 from penguin.tools.async_dispatch import ASYNC_TOOL_NAMES, AsyncToolDispatcher
 
 # Lazy import for PyDoll to avoid breaking if pydoll-python is not installed
 _pydoll_tools_imported = False
 _pydoll_import_error = None
 ORDERED_TOOL_BATCH_NAME = "ordered_tool_batch"
+_APPROVAL_GRANT_CONTEXT_KEY = "_penguin_approval_grant_id"
 
 
 def _ensure_pydoll_imports():
@@ -318,6 +320,7 @@ class ToolManager:
             self._browser_harness_list_tabs_tool = None
             self._browser_harness_switch_tab_tool = None
             self._read_image_tool = None
+            self._publish_artifact_tool = None
 
             # PyDoll tools placeholders
             self._pydoll_browser_navigation_tool = None
@@ -360,6 +363,7 @@ class ToolManager:
                 "apply_patch": "self._execute_apply_patch",
                 "read_file": "penguin.tools.core.support.enhanced_read_file",
                 "read_image": "self.read_image_tool.execute",
+                "publish_artifact": "self.publish_artifact_tool.execute",
                 "list_files": "penguin.tools.core.support.list_files_filtered",
                 "find_file": "penguin.tools.core.support.find_files_enhanced",
                 "encode_image_to_base64": "penguin.tools.core.support.encode_image_to_base64",
@@ -1010,6 +1014,33 @@ class ToolManager:
                     "required": ["path"],
                 },
                 "x-penguin-permissions": read_only_permissions,
+            },
+            {
+                "name": "publish_artifact",
+                "description": (
+                    "Publish one existing project/workspace file as an explicit "
+                    "outbound artifact. Use only when the user asked to receive "
+                    "that file; ordinary file writes are never auto-published."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": (
+                                "Path to an existing file within the active "
+                                "project/workspace"
+                            ),
+                        }
+                    },
+                    "required": ["path"],
+                },
+                "x-penguin-permissions": {
+                    "mutates_state": False,
+                    "requires_approval": True,
+                    "parallel_safe": True,
+                    "risk": "medium",
+                },
             },
             {
                 "name": "add_summary_note",
@@ -2242,6 +2273,14 @@ class ToolManager:
         return self._read_image_tool
 
     @property
+    def publish_artifact_tool(self):
+        if self._publish_artifact_tool is None:
+            with profile_operation("ToolManager.lazy_load_publish_artifact_tool"):
+                logger.debug("Lazy-loading publish_artifact tool")
+                self._publish_artifact_tool = PublishArtifactTool()
+        return self._publish_artifact_tool
+
+    @property
     def process_runtime(self):
         """Lazy load the persistent process runtime."""
 
@@ -2341,9 +2380,173 @@ class ToolManager:
         if _check_tool_permission is None:
             return None, None
 
-        return _check_tool_permission(
-            tool_name, tool_input, self.permission_enforcer, context
+        effective_context = context if isinstance(context, dict) else {}
+        permission_mode = (
+            str(effective_context.get("permission_mode") or "").strip().lower()
         )
+        if permission_mode == "read_only":
+            from penguin.security.tool_permissions import is_safe_tool
+
+            if not is_safe_tool(tool_name):
+                return (
+                    _PermissionResult.DENY,
+                    "Request-scoped read-only mode blocks mutating tools",
+                )
+
+        if permission_mode == "workspace" and tool_name in {
+            "publish_artifact",
+            "read_image",
+        }:
+            raw_path = tool_input.get("path") or tool_input.get("file_path")
+            allowed_roots: list[Path] = []
+            for key in ("directory", "project_root", "workspace_root"):
+                raw_root = effective_context.get(key)
+                if not isinstance(raw_root, str) or not raw_root.strip():
+                    continue
+                try:
+                    resolved_root = Path(raw_root).expanduser().resolve()
+                except (OSError, RuntimeError):
+                    continue
+                if resolved_root not in allowed_roots:
+                    allowed_roots.append(resolved_root)
+
+            if isinstance(raw_path, str) and raw_path.strip() and allowed_roots:
+                try:
+                    resolved_path = Path(raw_path).expanduser().resolve()
+                except (OSError, RuntimeError):
+                    return (
+                        _PermissionResult.DENY,
+                        "File path is invalid for the request workspace",
+                    )
+                if not any(
+                    resolved_path == root or root in resolved_path.parents
+                    for root in allowed_roots
+                ):
+                    return (
+                        _PermissionResult.DENY,
+                        "File path is outside request workspace",
+                    )
+
+        result, reason = _check_tool_permission(
+            tool_name,
+            tool_input,
+            self.permission_enforcer,
+            effective_context,
+        )
+        if result == _PermissionResult.DENY:
+            return result, reason
+
+        approval_policy = effective_context.get("approval_policy")
+        if not isinstance(approval_policy, dict):
+            return result, reason
+
+        from penguin.security.permission_engine import Operation
+        from penguin.security.tool_permissions import get_tool_operations
+
+        operations = get_tool_operations(tool_name)
+        policy_keys: set[str] = set()
+        for operation in operations:
+            if operation in {Operation.PROCESS_EXECUTE, Operation.PROCESS_SPAWN}:
+                policy_keys.add("shell")
+            elif operation == Operation.FILESYSTEM_DELETE:
+                policy_keys.add("fileDelete")
+            elif operation in {
+                Operation.FILESYSTEM_WRITE,
+                Operation.FILESYSTEM_MKDIR,
+                Operation.GIT_WRITE,
+                Operation.MEMORY_WRITE,
+            }:
+                policy_keys.add("fileWrite")
+            elif operation == Operation.GIT_PUSH:
+                policy_keys.add("gitPush")
+            elif operation in {
+                Operation.NETWORK_FETCH,
+                Operation.NETWORK_POST,
+                Operation.NETWORK_LISTEN,
+            }:
+                policy_keys.add("network")
+        if not operations or (
+            not policy_keys
+            and not all(Operation.is_read_only(operation) for operation in operations)
+        ):
+            policy_keys.add("default")
+
+        decisions = {
+            str(approval_policy.get(key, approval_policy.get("default", "")))
+            for key in policy_keys
+        }
+        if "deny" in decisions:
+            return (
+                _PermissionResult.DENY,
+                "Request-scoped approval policy denies this operation",
+            )
+        if "ask" in decisions:
+            return (
+                _PermissionResult.ASK,
+                "Request-scoped approval policy requires approval",
+            )
+        return result, reason
+
+    @staticmethod
+    def _approval_target(
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: dict[str, Any],
+    ) -> tuple[str, str, Optional[str]]:
+        """Return the stable operation, resource, and session approval key."""
+        operation_value = context.get("operation", f"tool.{tool_name}")
+        resource_value = tool_input.get(
+            "path",
+            tool_input.get("file_path", tool_input.get("target", "")),
+        )
+        session_value = context.get("session_id")
+        return (
+            str(operation_value),
+            "" if resource_value is None else str(resource_value),
+            str(session_value) if session_value is not None else None,
+        )
+
+    @staticmethod
+    def _with_approval_grant(
+        context: dict[str, Any],
+        request_id: str,
+    ) -> dict[str, Any]:
+        """Copy a context and attach a private one-shot approval grant."""
+        resumed_context = dict(context)
+        resumed_context[_APPROVAL_GRANT_CONTEXT_KEY] = request_id
+        return resumed_context
+
+    def _consume_approval_grant(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: dict[str, Any],
+    ) -> Optional[bool]:
+        """Consume a resumed approval, or return ``None`` when absent."""
+        grant_id = context.get(_APPROVAL_GRANT_CONTEXT_KEY)
+        if grant_id is None:
+            return None
+        if not isinstance(grant_id, str) or not grant_id:
+            return False
+
+        try:
+            from penguin.security.approval import get_approval_manager
+
+            operation, resource, session_id = self._approval_target(
+                tool_name,
+                tool_input,
+                context,
+            )
+            return get_approval_manager().consume_approved_request(
+                grant_id,
+                tool_name=tool_name,
+                operation=operation,
+                resource=resource,
+                session_id=session_id,
+            )
+        except ImportError:
+            logger.error("Approval module unavailable while resuming %s", tool_name)
+            return False
 
     def _permission_response(
         self,
@@ -2361,6 +2564,20 @@ class ToolManager:
 
         if not self._permission_enabled:
             return None
+
+        approval_grant = self._consume_approval_grant(
+            tool_name,
+            tool_input,
+            context,
+        )
+        if approval_grant is False:
+            return json.dumps(
+                {
+                    "error": "approval_grant_invalid",
+                    "tool": tool_name,
+                    "message": "Approval was missing, mismatched, or already consumed.",
+                }
+            )
 
         result, reason = self.check_tool_permission(tool_name, tool_input, context)
         if result is None:
@@ -2389,6 +2606,28 @@ class ToolManager:
         if result != _PermissionResult.ASK:
             return None
 
+        approval_policy = context.get("approval_policy")
+        if (
+            isinstance(approval_policy, dict)
+            and approval_policy.get("default") == "deny"
+        ):
+            logger.warning(
+                "permission.approval_disabled tool=%s session=%s",
+                tool_name,
+                context.get("session_id"),
+            )
+            return json.dumps(
+                {
+                    "error": "permission_denied",
+                    "tool": tool_name,
+                    "reason": "Remote approval policy denies prompted operations",
+                }
+            )
+
+        if approval_grant is True:
+            logger.info("Resuming approved tool '%s' exactly once", tool_name)
+            return None
+
         logger.info(
             "permission.approval_required tool=%s agent=%s mode=%s "
             "session=%s reason=%s",
@@ -2398,12 +2637,11 @@ class ToolManager:
             context.get("session_id"),
             reason,
         )
-        operation = context.get("operation", f"tool.{tool_name}")
-        resource = tool_input.get(
-            "path",
-            tool_input.get("file_path", tool_input.get("target", "")),
+        operation, resource, session_id = self._approval_target(
+            tool_name,
+            tool_input,
+            context,
         )
-        session_id = context.get("session_id")
 
         try:
             from penguin.security.approval import get_approval_manager
@@ -2417,6 +2655,14 @@ class ToolManager:
                 logger.info("Tool '%s' pre-approved for %s", tool_name, resource)
                 return None
 
+            ttl_seconds = None
+            if isinstance(approval_policy, dict):
+                try:
+                    configured_ttl = float(approval_policy.get("timeout_seconds"))
+                except (TypeError, ValueError):
+                    configured_ttl = 0.0
+                if math.isfinite(configured_ttl) and configured_ttl > 0:
+                    ttl_seconds = min(3600.0, configured_ttl)
             approval_request = approval_manager.create_request(
                 tool_name=tool_name,
                 operation=operation,
@@ -2429,7 +2675,9 @@ class ToolManager:
                         tool_input,
                     ),
                     "agent_id": context.get("agent_id"),
+                    "request_id": context.get("request_id"),
                 },
+                ttl_seconds=ttl_seconds,
             )
             logger.info("Approval request created: %s", approval_request.id)
             return json.dumps(
@@ -2484,6 +2732,63 @@ class ToolManager:
                     ),
                 }
             )
+
+    def _permission_response_with_sync_wait(
+        self,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: dict[str, Any],
+    ) -> tuple[Optional[Union[str, dict[str, Any]]], dict[str, Any]]:
+        """Resolve an opted-in approval from a synchronous worker call.
+
+        The synchronous ToolManager API is used by legacy ActionXML handlers in
+        ``asyncio.to_thread``. Waiting is therefore safe there, but is skipped
+        when an event loop is running so this compatibility path can never
+        block the loop. AsyncToolDispatcher owns the native async lifecycle and
+        passes a consumed one-shot grant through this same check.
+        """
+        permission_response = self._permission_response(
+            tool_name,
+            tool_input,
+            context,
+        )
+        wait_for_resolution, timeout_seconds = (
+            AsyncToolDispatcher._approval_wait_settings(context)
+        )
+        if (
+            permission_response is None
+            or not wait_for_resolution
+            or self._is_in_async_context()
+        ):
+            return permission_response, context
+
+        request_id = AsyncToolDispatcher._pending_approval_id(permission_response)
+        if request_id is None:
+            return permission_response, context
+
+        from penguin.security.approval import ApprovalStatus, get_approval_manager
+
+        resolved = get_approval_manager().wait_for_resolution(
+            request_id,
+            timeout_seconds,
+        )
+        if resolved is None or resolved.status != ApprovalStatus.APPROVED:
+            return (
+                AsyncToolDispatcher._approval_failure_response(
+                    request_id,
+                    resolved.status if resolved is not None else None,
+                    tool_name,
+                ),
+                context,
+            )
+
+        resumed_context = self._with_approval_grant(context, request_id)
+        resumed_response = self._permission_response(
+            tool_name,
+            tool_input,
+            resumed_context,
+        )
+        return resumed_response, resumed_context
 
     async def ensure_memory_provider(self) -> Optional[MemoryProvider]:
         """Ensure memory provider is initialized. Used for lazy loading."""
@@ -2905,6 +3210,7 @@ class ToolManager:
             "apply_patch",
             "read_file",
             "read_image",
+            "publish_artifact",
             "list_files",
             "find_file",
             "enhanced_diff",
@@ -4315,6 +4621,18 @@ class ToolManager:
 
             if self._mcp_provider.is_mcp_tool(tool_name):
                 if self._permission_enabled:
+                    approval_grant = self._consume_approval_grant(
+                        tool_name,
+                        tool_input,
+                        effective_context,
+                    )
+                    if approval_grant is False:
+                        return {
+                            "error": (
+                                "Approval was missing, mismatched, or already "
+                                "consumed."
+                            )
+                        }
                     result, reason = self.check_tool_permission(
                         tool_name, tool_input, effective_context
                     )
@@ -4322,16 +4640,21 @@ class ToolManager:
                         _ensure_permission_imports()
                         if result == _PermissionResult.DENY:
                             return {"error": f"Permission denied: {reason}"}
-                        if result == _PermissionResult.ASK:
+                        if (
+                            result == _PermissionResult.ASK
+                            and approval_grant is not True
+                        ):
                             return {"error": f"Permission required: {reason}"}
                 return self._mcp_provider.execute_tool(tool_name, tool_input)
 
             tool_input = self._normalize_tool_input_paths(tool_input, file_root)
 
-            permission_response = self._permission_response(
-                tool_name,
-                tool_input,
-                effective_context,
+            permission_response, effective_context = (
+                self._permission_response_with_sync_wait(
+                    tool_name,
+                    tool_input,
+                    effective_context,
+                )
             )
             if permission_response is not None:
                 return permission_response
@@ -4359,6 +4682,9 @@ class ToolManager:
                     tool_input.get("path", ""),
                     tool_input.get("prompt"),
                     tool_input.get("max_dim"),
+                ),
+                "publish_artifact": lambda: self.publish_artifact_tool.execute(
+                    tool_input.get("path", "")
                 ),
                 "list_files": lambda: self._execute_file_operation(
                     "list_files", tool_input, file_root=file_root

--- a/penguin/tools/tool_manager.py
+++ b/penguin/tools/tool_manager.py
@@ -2442,36 +2442,9 @@ class ToolManager:
         if not isinstance(approval_policy, dict):
             return result, reason
 
-        from penguin.security.permission_engine import Operation
-        from penguin.security.tool_permissions import get_tool_operations
+        from penguin.security.tool_permissions import get_tool_policy_keys
 
-        operations = get_tool_operations(tool_name)
-        policy_keys: set[str] = set()
-        for operation in operations:
-            if operation in {Operation.PROCESS_EXECUTE, Operation.PROCESS_SPAWN}:
-                policy_keys.add("shell")
-            elif operation == Operation.FILESYSTEM_DELETE:
-                policy_keys.add("fileDelete")
-            elif operation in {
-                Operation.FILESYSTEM_WRITE,
-                Operation.FILESYSTEM_MKDIR,
-                Operation.GIT_WRITE,
-                Operation.MEMORY_WRITE,
-            }:
-                policy_keys.add("fileWrite")
-            elif operation == Operation.GIT_PUSH:
-                policy_keys.add("gitPush")
-            elif operation in {
-                Operation.NETWORK_FETCH,
-                Operation.NETWORK_POST,
-                Operation.NETWORK_LISTEN,
-            }:
-                policy_keys.add("network")
-        if not operations or (
-            not policy_keys
-            and not all(Operation.is_read_only(operation) for operation in operations)
-        ):
-            policy_keys.add("default")
+        policy_keys = get_tool_policy_keys(tool_name, tool_input, effective_context)
 
         decisions = {
             str(approval_policy.get(key, approval_policy.get("default", "")))
@@ -2490,17 +2463,49 @@ class ToolManager:
         return result, reason
 
     @staticmethod
+    def _approval_base_operation(
+        tool_name: str,
+        context: dict[str, Any],
+    ) -> str:
+        """Return the caller-compatible base operation for a tool approval."""
+        return str(context.get("operation", f"tool.{tool_name}"))
+
+    @classmethod
     def _approval_target(
+        cls,
         tool_name: str,
         tool_input: dict[str, Any],
         context: dict[str, Any],
     ) -> tuple[str, str, Optional[str]]:
         """Return the stable operation, resource, and session approval key."""
-        operation_value = context.get("operation", f"tool.{tool_name}")
-        resource_value = tool_input.get(
-            "path",
-            tool_input.get("file_path", tool_input.get("target", "")),
+        from penguin.security.tool_permissions import (
+            extract_resource_from_input,
+            get_tool_policy_keys,
         )
+
+        operation_value = cls._approval_base_operation(tool_name, context)
+        approval_policy = context.get("approval_policy")
+        if isinstance(approval_policy, dict):
+            policy_keys = get_tool_policy_keys(tool_name, tool_input, context)
+            ask_keys = sorted(
+                key
+                for key in policy_keys
+                if str(
+                    approval_policy.get(key, approval_policy.get("default", ""))
+                )
+                .strip()
+                .lower()
+                == "ask"
+            )
+            # An instance-level ASK with no request-policy ASK still needs a
+            # scoped identity so it cannot become a blanket base-operation grant.
+            operation_value = (
+                f"{operation_value}[ask={','.join(ask_keys) or 'instance'}]"
+            )
+
+        resource_value = extract_resource_from_input(tool_name, tool_input)
+        if tool_name.startswith("process_") and tool_input.get("process_id"):
+            resource_value = tool_input["process_id"]
         session_value = context.get("session_id")
         return (
             str(operation_value),
@@ -2609,10 +2614,19 @@ class ToolManager:
             return None
 
         approval_policy = context.get("approval_policy")
-        if (
-            isinstance(approval_policy, dict)
-            and approval_policy.get("default") == "deny"
-        ):
+        if isinstance(approval_policy, dict):
+            from penguin.security.tool_permissions import get_tool_policy_keys
+
+            policy_keys = get_tool_policy_keys(tool_name, tool_input, context) or {
+                "default"
+            }
+            policy_decisions = {
+                str(approval_policy.get(key, approval_policy.get("default", "")))
+                for key in policy_keys
+            }
+        else:
+            policy_decisions = set()
+        if "deny" in policy_decisions:
             logger.warning(
                 "permission.approval_disabled tool=%s session=%s",
                 tool_name,
@@ -2649,10 +2663,18 @@ class ToolManager:
             from penguin.security.approval import get_approval_manager
 
             approval_manager = get_approval_manager()
+            base_operation = self._approval_base_operation(tool_name, context)
             if approval_manager.check_pre_approved(
                 operation,
                 resource,
                 session_id,
+            ) or (
+                operation != base_operation
+                and approval_manager.check_pre_approved(
+                    base_operation,
+                    resource,
+                    session_id,
+                )
             ):
                 logger.info("Tool '%s' pre-approved for %s", tool_name, resource)
                 return None

--- a/penguin/utils/parser.py
+++ b/penguin/utils/parser.py
@@ -23,11 +23,15 @@ from penguin.multi.policy import (
     disabled_subagent_result,
     subagents_enabled,
 )
+from penguin.security.action_policy import (
+    authorize_direct_action,
+    deny_pending_approvals_for_current_request,
+    policy_timeout_seconds,
+)
 from penguin.tools import ToolManager
 from penguin.utils.process_manager import ProcessManager
 from penguin.system.conversation import MessageCategory
 from penguin.system.execution_context import get_current_execution_context
-from penguin.tools.image_tools import ReadImageTool
 from penguin.tools.browser_harness_tools import BrowserHarnessScreenshotTool
 from penguin.tools.browser_tools import BrowserScreenshotTool, browser_manager
 from penguin.constants import DEFAULT_LARGE_FILE_THRESHOLD_BYTES
@@ -139,6 +143,7 @@ class ActionType(Enum):
     BROWSER_INTERACT = "browser_interact"
     BROWSER_SCREENSHOT = "browser_screenshot"
     READ_IMAGE = "read_image"
+    PUBLISH_ARTIFACT = "publish_artifact"
     BROWSER_STATUS = "browser_status"
     BROWSER_CLEANUP = "browser_cleanup"
     BROWSER_OPEN_TAB = "browser_open_tab"
@@ -1641,6 +1646,13 @@ class ActionExecutor:
         ):
             return json.dumps(disabled_subagent_result(action.action_type.value))
 
+        permission_response = await authorize_direct_action(
+            action.action_type.value,
+            handler_params,
+        )
+        if permission_response is not None:
+            return permission_response
+
         # --------------------------------------------------
         # Emit *start* UI event
         # --------------------------------------------------
@@ -1731,6 +1743,7 @@ class ActionExecutor:
             ActionType.BROWSER_INTERACT: self._browser_interact,
             ActionType.BROWSER_SCREENSHOT: self._browser_screenshot,
             ActionType.READ_IMAGE: self._read_image,
+            ActionType.PUBLISH_ARTIFACT: self._publish_artifact,
             ActionType.BROWSER_STATUS: lambda params: self._browser_harness_tool(
                 "browser_status", params
             ),
@@ -1833,7 +1846,11 @@ class ActionExecutor:
                 )
                 # Offload synchronous tools to thread pool to avoid blocking the event loop.
                 # asyncio.to_thread preserves contextvars for per-request execution context.
-                result = await asyncio.to_thread(handler, handler_params)
+                try:
+                    result = await asyncio.to_thread(handler, handler_params)
+                except asyncio.CancelledError:
+                    await deny_pending_approvals_for_current_request()
+                    raise
 
                 if asyncio.iscoroutine(result):
                     result = await result
@@ -3566,6 +3583,13 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
                 request_context["agent_id"] = context.agent_id
             if context is not None and isinstance(context.directory, str):
                 request_context["directory"] = context.directory
+            if context is not None and isinstance(context.request_id, str):
+                request_context["request_id"] = context.request_id
+
+            timeout_seconds: Optional[float] = None
+            approval_policy = context.approval_policy if context is not None else None
+            if isinstance(approval_policy, dict):
+                timeout_seconds = policy_timeout_seconds(approval_policy)
 
             manager = get_question_manager()
             request = manager.create_request(
@@ -3573,7 +3597,10 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
                 questions=questions,
                 context=request_context,
             )
-            resolved = await manager.wait_for_resolution(request.id)
+            resolved = await manager.wait_for_resolution(
+                request.id,
+                timeout_seconds=timeout_seconds,
+            )
             if resolved is None:
                 return "Error: Question request was not resolved"
             if resolved.status == QuestionStatus.REJECTED:
@@ -3981,7 +4008,7 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
             return "Failed to initialize browser"
         return await browser_manager.navigate_to(params)
 
-    async def _read_image(self, params: str) -> str:
+    def _read_image(self, params: str) -> str:
         """Load a local image and add it to conversation as multimodal content."""
         try:
             payload = _parse_json_payload(params)
@@ -3997,7 +4024,18 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
             if not path:
                 return "Error reading image: path is required"
 
-            result = ReadImageTool().execute(str(path), prompt=prompt, max_dim=max_dim)
+            result = self.tool_manager.execute_tool(
+                "read_image",
+                {
+                    "path": str(path),
+                    "prompt": prompt,
+                    "max_dim": max_dim,
+                },
+            )
+            if isinstance(result, str):
+                return result
+            if not isinstance(result, dict):
+                return "Error reading image: unexpected tool result"
             if "filepath" in result and os.path.exists(result["filepath"]):
                 description = result.get("prompt") or "What can you see in this image?"
                 add_message_fn = None
@@ -4025,6 +4063,17 @@ When done exploring, provide your final summary WITHOUT any tool calls."""
             return result.get("error", "Failed to load image")
         except Exception as e:
             return f"Error reading image: {str(e)}"
+
+    def _publish_artifact(self, params: str) -> Any:
+        """Expose one explicitly requested workspace file for channel delivery."""
+
+        payload = _parse_json_payload(params)
+        path = payload.get("path") if isinstance(payload, dict) else params.strip()
+        if not isinstance(path, str) or not path.strip():
+            return {"error": "path is required"}
+        return self.tool_manager.execute_tool(
+            "publish_artifact", {"path": path.strip()}
+        )
 
     async def _browser_harness_tool(self, tool_name: str, params: str) -> str:
         """Execute a browser-harness tool from ActionXML using JSON payloads."""

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from typing import Optional, Dict, Any, List, AsyncGenerator, Callable, Awaitable
 
 from penguin import __version__
-from penguin.config import config, Config, _ensure_env_loaded
+from penguin.config import config, Config, _ensure_env_loaded, load_config
 from penguin.core import PenguinCore
 from penguin.core_runtime import startup as core_startup
 from penguin.run_mode import RunMode
@@ -166,6 +166,7 @@ def create_app() -> "FastAPI":
     # AuthConfig so a normal `penguin-web` restart retains dedicated service
     # credentials such as LINK_API_KEY.
     _ensure_env_loaded()
+    raw_config = load_config()
 
     try:
         from fastapi import FastAPI
@@ -174,6 +175,9 @@ def create_app() -> "FastAPI":
         from fastapi.middleware.cors import CORSMiddleware
         from .routes import router, get_capabilities
         from .integrations.github_webhook import router as github_webhook_router
+        from .integrations.telegram import build_telegram_router
+        from penguin.integrations.telegram import TelegramConfig
+        from penguin.integrations.telegram.manager import TelegramManager
         from .middleware.auth import AuthenticationMiddleware, AuthConfig
         from .sse_events import router as sse_router, set_core_instance
     except ImportError:
@@ -185,6 +189,9 @@ def create_app() -> "FastAPI":
     # Lifespan context manager for startup/shutdown hooks
     from contextlib import asynccontextmanager
 
+    telegram_config = TelegramConfig.from_mapping(raw_config)
+    telegram_manager: Optional[TelegramManager] = None
+
     @asynccontextmanager
     async def lifespan(app: "FastAPI"):
         # Startup
@@ -194,29 +201,44 @@ def create_app() -> "FastAPI":
             start_vcs_watcher(core)
         except Exception:
             logger.debug("Unable to start VCS watcher", exc_info=True)
-        yield
-        # Shutdown: close connection pools
-        logger.info("Penguin web application shutting down...")
         try:
-            await stop_vcs_watcher()
-        except Exception:
-            logger.debug("Unable to stop VCS watcher", exc_info=True)
-        try:
-            shutdown_agents = getattr(
-                getattr(core, "tool_manager", None),
-                "shutdown_background_agents",
-                None,
-            )
-            if callable(shutdown_agents):
-                await shutdown_agents()
-        except Exception:
-            logger.warning("Unable to stop background agents", exc_info=True)
-        try:
-            pool = ConnectionPoolManager.get_instance()
-            await pool.close_all()
-            logger.info("Connection pools closed successfully")
-        except Exception as e:
-            logger.warning(f"Error closing connection pools: {e}")
+            if telegram_manager is not None:
+                try:
+                    await telegram_manager.start()
+                except Exception:
+                    logger.error(
+                        "Telegram integration did not start: %s",
+                        telegram_manager.status().get("error") or "unknown error",
+                    )
+            yield
+        finally:
+            if telegram_manager is not None:
+                try:
+                    await telegram_manager.stop()
+                except Exception:
+                    logger.warning("Unable to stop Telegram", exc_info=True)
+            # Shutdown: close connection pools
+            logger.info("Penguin web application shutting down...")
+            try:
+                await stop_vcs_watcher()
+            except Exception:
+                logger.debug("Unable to stop VCS watcher", exc_info=True)
+            try:
+                shutdown_agents = getattr(
+                    getattr(core, "tool_manager", None),
+                    "shutdown_background_agents",
+                    None,
+                )
+                if callable(shutdown_agents):
+                    await shutdown_agents()
+            except Exception:
+                logger.warning("Unable to stop background agents", exc_info=True)
+            try:
+                pool = ConnectionPoolManager.get_instance()
+                await pool.close_all()
+                logger.info("Connection pools closed successfully")
+            except Exception as e:
+                logger.warning(f"Error closing connection pools: {e}")
 
     app = FastAPI(
         lifespan=lifespan,
@@ -265,6 +287,10 @@ def create_app() -> "FastAPI":
 
     # Add authentication middleware (applies after CORS)
     auth_config = AuthConfig()
+    if telegram_config.enabled and telegram_config.transport == "webhook":
+        # Telegram authenticates this one public ingress route with its own
+        # constant-time secret-token check.
+        auth_config.public_endpoints.add(telegram_config.webhook_path)
     app.add_middleware(AuthenticationMiddleware, config=auth_config)
 
     # Initialize core and attach to router
@@ -279,6 +305,8 @@ def create_app() -> "FastAPI":
         logger.info("Model configs loaded: unknown")
     router.core = core
     github_webhook_router.core = core
+    telegram_manager = TelegramManager(core, telegram_config)
+    app.state.telegram_manager = telegram_manager
 
     # Set core for SSE router
     set_core_instance(core)
@@ -287,6 +315,7 @@ def create_app() -> "FastAPI":
     app.include_router(router)
     app.include_router(sse_router)
     app.include_router(github_webhook_router)
+    app.include_router(build_telegram_router(telegram_config))
 
     # Optionally include MCP HTTP router when enabled
     try:

--- a/penguin/web/integrations/telegram.py
+++ b/penguin/web/integrations/telegram.py
@@ -21,7 +21,8 @@ __all__ = ["build_telegram_router"]
 class PairingCreateRequest(BaseModel):
     """Operator request for a short-lived pairing code."""
 
-    expected_user_id: Optional[str] = None
+    # Pydantic evaluates this annotation at runtime on supported Python 3.9.
+    expected_user_id: Optional[str] = None  # noqa: UP045
     ttl_seconds: int = Field(default=3600, ge=60, le=3600)
 
 

--- a/penguin/web/integrations/telegram.py
+++ b/penguin/web/integrations/telegram.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel, Field
@@ -21,7 +21,7 @@ __all__ = ["build_telegram_router"]
 class PairingCreateRequest(BaseModel):
     """Operator request for a short-lived pairing code."""
 
-    expected_user_id: str | None = None
+    expected_user_id: Optional[str] = None
     ttl_seconds: int = Field(default=3600, ge=60, le=3600)
 
 

--- a/penguin/web/integrations/telegram.py
+++ b/penguin/web/integrations/telegram.py
@@ -1,0 +1,162 @@
+"""Thin HTTP surfaces for Telegram webhooks and operator controls."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from typing import TYPE_CHECKING, Any, Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from pydantic import BaseModel, Field
+
+from penguin.integrations.telegram.manager import TelegramManager
+
+if TYPE_CHECKING:
+    from penguin.integrations.telegram.config import TelegramConfig
+
+__all__ = ["build_telegram_router"]
+
+
+class PairingCreateRequest(BaseModel):
+    """Operator request for a short-lived pairing code."""
+
+    expected_user_id: str | None = None
+    ttl_seconds: int = Field(default=3600, ge=60, le=3600)
+
+
+class DeadLetterActionRequest(BaseModel):
+    """Explicit retry or discard of one terminal record."""
+
+    kind: Literal["ingress", "delivery"]
+    record_id: str = Field(min_length=1, max_length=512)
+
+
+def build_telegram_router(config: TelegramConfig) -> APIRouter:
+    """Create routes using the configured webhook path."""
+
+    router = APIRouter()
+
+    @router.post(config.webhook_path, include_in_schema=False)
+    async def telegram_webhook(request: Request) -> dict[str, Any]:
+        manager = _manager(request)
+        if not config.enabled or config.transport != "webhook":
+            raise HTTPException(status_code=404, detail="Telegram webhook is disabled")
+        candidate = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+        expected = config.webhook_secret or ""
+        if not expected or not secrets.compare_digest(candidate, expected):
+            raise HTTPException(
+                status_code=401, detail="Invalid Telegram webhook secret"
+            )
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > config.webhook_body_limit_bytes:
+                    raise HTTPException(
+                        status_code=413, detail="Telegram webhook body is too large"
+                    )
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid Content-Length")
+        body = bytearray()
+        async for chunk in request.stream():
+            if len(body) + len(chunk) > config.webhook_body_limit_bytes:
+                raise HTTPException(
+                    status_code=413, detail="Telegram webhook body is too large"
+                )
+            body.extend(chunk)
+        try:
+            update = json.loads(bytes(body))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Invalid Telegram update"
+            ) from exc
+        if not isinstance(update, dict):
+            raise HTTPException(status_code=400, detail="Invalid Telegram update")
+        try:
+            admitted = await asyncio.wait_for(
+                manager.admit_webhook_update(update),
+                timeout=config.webhook_timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(
+                status_code=503, detail="Telegram update was not durably adopted"
+            ) from exc
+        return {"ok": True, "admitted": admitted}
+
+    @router.get("/api/v1/integrations/telegram/status")
+    async def telegram_status(request: Request) -> dict[str, Any]:
+        return _manager(request).status()
+
+    @router.post("/api/v1/integrations/telegram/pairings")
+    async def create_pairing(
+        payload: PairingCreateRequest,
+        request: Request,
+        response: Response,
+    ) -> dict[str, Any]:
+        manager = _manager(request)
+        if manager.config.dm_policy != "pairing":
+            raise HTTPException(status_code=409, detail="DM pairing policy is disabled")
+        expected_user_id = payload.expected_user_id
+        if expected_user_id is not None and (
+            not expected_user_id.isdigit() or int(expected_user_id) <= 0
+        ):
+            raise HTTPException(
+                status_code=422, detail="expected_user_id must be a positive numeric ID"
+            )
+        code = await manager.create_pairing(
+            expected_user_id=expected_user_id,
+            ttl_seconds=payload.ttl_seconds,
+        )
+        response.headers["Cache-Control"] = "no-store"
+        return {"code": code, "expires_in_seconds": payload.ttl_seconds}
+
+    @router.delete("/api/v1/integrations/telegram/pairings/{user_id}")
+    async def revoke_pairing(user_id: str, request: Request) -> dict[str, Any]:
+        if not user_id.isdigit() or int(user_id) <= 0:
+            raise HTTPException(status_code=422, detail="user_id must be numeric")
+        return {"revoked": await _manager(request).revoke_dm(user_id)}
+
+    @router.get("/api/v1/integrations/telegram/dead-letters")
+    async def list_dead_letters(
+        request: Request,
+        kind: Literal["ingress", "delivery"] = Query(...),
+        limit: int = Query(default=50, ge=1, le=100),
+    ) -> dict[str, Any]:
+        records = await _manager(request).list_dead_letters(kind=kind, limit=limit)
+        return {"kind": kind, "records": records}
+
+    @router.post("/api/v1/integrations/telegram/dead-letters/retry")
+    async def retry_dead_letter(
+        payload: DeadLetterActionRequest, request: Request
+    ) -> dict[str, Any]:
+        retried = await _manager(request).retry_dead_letter(
+            kind=payload.kind, record_id=payload.record_id
+        )
+        if not retried:
+            raise HTTPException(status_code=404, detail="Dead letter was not found")
+        return {"retried": True}
+
+    @router.post("/api/v1/integrations/telegram/dead-letters/discard")
+    async def discard_dead_letter(
+        payload: DeadLetterActionRequest, request: Request
+    ) -> dict[str, Any]:
+        discarded = await _manager(request).discard_dead_letter(
+            kind=payload.kind, record_id=payload.record_id
+        )
+        if not discarded:
+            raise HTTPException(
+                status_code=404,
+                detail="Dead letter was not found or remains referenced",
+            )
+        return {"discarded": True}
+
+    return router
+
+
+def _manager(request: Request) -> TelegramManager:
+    manager = getattr(request.app.state, "telegram_manager", None)
+    if not isinstance(manager, TelegramManager):
+        raise HTTPException(
+            status_code=503, detail="Telegram integration is not initialized"
+        )
+    return manager

--- a/penguin/web/routes.py
+++ b/penguin/web/routes.py
@@ -35,6 +35,7 @@ import websockets
 import httpx
 from PIL import Image, UnidentifiedImageError
 
+from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
 from penguin.config import WORKSPACE_PATH
 from penguin.core import PenguinCore
 from penguin.core_runtime import process_lifecycle
@@ -4339,66 +4340,37 @@ async def handle_chat_message(
                 reasoning_payload,
             )
 
-        # Process the message with all available options
-        with execution_context_scope(execution_context):
-            request_gate = _get_session_request_gate(core, request_session_id)
-            gate_locked_before = request_gate.locked()
-            gate_wait_started = time.perf_counter()
-            active_requests = getattr(core, "_opencode_active_requests", {})
-            active_request_count = (
-                active_requests.get(request_session_id, 0)
-                if isinstance(active_requests, dict) and request_session_id
-                else 0
-            )
-            _request_log_debug(
-                "chat.trace.before_process request=%s session=%s gate=%s gate_locked=%s active=%s cm=%s tracked=%s ctx=%s",
-                execution_context.request_id or "unknown",
-                request_session_id or "unknown",
-                hex(id(request_gate)),
-                gate_locked_before,
-                active_request_count,
-                hex(id(getattr(core, "conversation_manager", None)))
-                if getattr(core, "conversation_manager", None) is not None
-                else "none",
-                bool(request_tracked),
-                execution_context.as_dict(),
-            )
-            async with request_gate:
-                gate_wait_ms = (time.perf_counter() - gate_wait_started) * 1000
-                _request_log_debug(
-                    "chat.trace.gate_acquired request=%s session=%s gate=%s wait_ms=%.2f tracked=%s",
-                    execution_context.request_id or "unknown",
-                    request_session_id or "unknown",
-                    hex(id(request_gate)),
-                    gate_wait_ms,
-                    bool(request_tracked),
-                )
-                process_started = time.perf_counter()
-                process_result = await core.process(
-                    input_data=input_data,
-                    context=request.context,
-                    conversation_id=effective_session_id,
-                    agent_id=request.agent_id,
-                    max_iterations=request.max_iterations,
-                    context_files=context_files,
-                    streaming=effective_streaming,
-                    stream_callback=stream_cb,
-                    api_client_override=request_api_client,
-                    model_config_override=request_model_config,
-                )
-                process_ms = (time.perf_counter() - process_started) * 1000
-            _request_log_debug(
-                "chat.trace.after_process request=%s session=%s status=%s iterations=%s response_len=%s actions=%s usage=%s process_ms=%.2f preview=%r",
-                execution_context.request_id or "unknown",
-                request_session_id or "unknown",
-                process_result.get("status"),
-                process_result.get("iterations"),
-                len(process_result.get("assistant_response", "") or ""),
-                len(process_result.get("action_results", []) or []),
-                process_result.get("usage") or {},
-                process_ms,
-                _preview_text(process_result.get("assistant_response", "")),
-            )
+        # Use the shared transport-neutral authority and per-session gate.
+        process_started = time.perf_counter()
+        process_result = await execute_chat_turn(
+            core,
+            ChatProcessRequest(
+                input_data=input_data,
+                execution_context=execution_context,
+                session_id=request_session_id,
+                context=request.context,
+                agent_id=request.agent_id,
+                max_iterations=request.max_iterations,
+                context_files=context_files,
+                streaming=effective_streaming,
+                stream_callback=stream_cb,
+                api_client_override=request_api_client,
+                model_config_override=request_model_config,
+            ),
+        )
+        process_ms = (time.perf_counter() - process_started) * 1000
+        _request_log_debug(
+            "chat.trace.after_process request=%s session=%s status=%s iterations=%s response_len=%s actions=%s usage=%s process_ms=%.2f preview=%r",
+            execution_context.request_id or "unknown",
+            request_session_id or "unknown",
+            process_result.get("status"),
+            process_result.get("iterations"),
+            len(process_result.get("assistant_response", "") or ""),
+            len(process_result.get("action_results", []) or []),
+            process_result.get("usage") or {},
+            process_ms,
+            _preview_text(process_result.get("assistant_response", "")),
+        )
 
         # Build response
         if (
@@ -4912,11 +4884,13 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                         reasoning_payload,
                     )
                 try:
-                    with execution_context_scope(execution_context):
-                        process_task = asyncio.create_task(
-                            core.process(
+                    process_task = asyncio.create_task(
+                        execute_chat_turn(
+                            core,
+                            ChatProcessRequest(
                                 input_data=input_data,
-                                conversation_id=effective_session_id,
+                                execution_context=execution_context,
+                                session_id=effective_session_id,
                                 agent_id=agent_id,
                                 max_iterations=max_iterations,
                                 context_files=context_files,
@@ -4925,8 +4899,9 @@ async def stream_chat(websocket: WebSocket, core: PenguinCore = Depends(get_core
                                 stream_callback=per_request_stream_callback,
                                 api_client_override=request_api_client,
                                 model_config_override=request_model_config,
-                            )
+                            ),
                         )
+                    )
 
                     # Wait for the core process to finish
                     process_result = await process_task

--- a/penguin/web/services/link_inference.py
+++ b/penguin/web/services/link_inference.py
@@ -20,13 +20,14 @@ class LinkExecutionRequest(BaseModel):
     user_id: str
     # Omitted together for transient Link conversations that have no durable
     # Link session/agent-instance identity.
-    session_id: Optional[str] = None
-    agent_id: Optional[str] = None
+    # Pydantic evaluates these annotations at runtime on supported Python 3.9.
+    session_id: Optional[str] = None  # noqa: UP045
+    agent_id: Optional[str] = None  # noqa: UP045
     run_id: str
     requested_model_id: str
     # Optional for rolling compatibility with Link versions that predate the
     # explicit per-invocation spend bound.
-    max_output_tokens: Optional[PositiveInt] = None
+    max_output_tokens: Optional[PositiveInt] = None  # noqa: UP045
     execution_source: Literal["link_gateway"]
     provider_state_owner: Literal["link_managed"]
     settlement_mode: Literal["debit_link_credits"]

--- a/penguin/web/services/link_inference.py
+++ b/penguin/web/services/link_inference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import replace
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, PositiveInt
 
@@ -20,13 +20,13 @@ class LinkExecutionRequest(BaseModel):
     user_id: str
     # Omitted together for transient Link conversations that have no durable
     # Link session/agent-instance identity.
-    session_id: str | None = None
-    agent_id: str | None = None
+    session_id: Optional[str] = None
+    agent_id: Optional[str] = None
     run_id: str
     requested_model_id: str
     # Optional for rolling compatibility with Link versions that predate the
     # explicit per-invocation spend bound.
-    max_output_tokens: PositiveInt | None = None
+    max_output_tokens: Optional[PositiveInt] = None
     execution_source: Literal["link_gateway"]
     provider_state_owner: Literal["link_managed"]
     settlement_mode: Literal["debit_link_credits"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ llm_ollama = ["ollama>=0.1.7"]
 # Orchestration (Temporal for durable workflows)
 orchestration = ["temporalio>=1.5.0"]
 
+# Telegram bot transport (installed only when Telegram support is used)
+telegram = ["python-telegram-bot==22.6; python_version>='3.10'"]
+
 # PyDoll browser automation fallback (optional - no WebDriver required)
 pydoll = [
     "pydoll-python>=2.0.0; python_version>='3.10'",  # Requires Python 3.10+
@@ -183,6 +186,7 @@ all = [
     "bitsandbytes>=0.43.0; sys_platform != 'darwin'",
     "ollama>=0.1.7",
     "temporalio>=1.5.0",
+    "python-telegram-bot==22.6; python_version>='3.10'",
     "pydoll-python>=2.0.0; python_version>='3.10'",
     # browser-harness is not on PyPI; install it separately from source.
     "textual",

--- a/tests/channels/test_chat.py
+++ b/tests/channels/test_chat.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
+from penguin.channels.fake import FakeChannel
+from penguin.channels.schema import ChannelAddress, DeliveryRequest
+from penguin.system.execution_context import (
+    ExecutionContext,
+    get_current_execution_context,
+)
+
+
+class FakeCore:
+    def __init__(self) -> None:
+        self.active_by_session: dict[str, int] = {}
+        self.max_by_session: dict[str, int] = {}
+        self.all_active = 0
+        self.max_all_active = 0
+        self.release = asyncio.Event()
+        self.started = asyncio.Queue()
+        self.seen_contexts: list[ExecutionContext | None] = []
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        session_id = str(kwargs.get("conversation_id") or "")
+        self.active_by_session[session_id] = (
+            self.active_by_session.get(session_id, 0) + 1
+        )
+        self.max_by_session[session_id] = max(
+            self.max_by_session.get(session_id, 0),
+            self.active_by_session[session_id],
+        )
+        self.all_active += 1
+        self.max_all_active = max(self.max_all_active, self.all_active)
+        self.seen_contexts.append(get_current_execution_context())
+        await self.started.put(session_id)
+        await self.release.wait()
+        callback = kwargs.get("stream_callback")
+        if callback is not None:
+            await callback("hello", "assistant")
+        self.active_by_session[session_id] -= 1
+        self.all_active -= 1
+        return {"assistant_response": session_id, "action_results": []}
+
+
+def _request(session_id: str, callback: Any = None) -> ChatProcessRequest:
+    return ChatProcessRequest(
+        input_data={"text": "hi"},
+        session_id=session_id,
+        execution_context=ExecutionContext(
+            session_id=session_id,
+            conversation_id=session_id,
+            directory=f"/tmp/{session_id}",
+            request_id=f"request-{session_id}",
+        ),
+        stream_callback=callback,
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_session_turns_are_serialized_and_tracked() -> None:
+    core = FakeCore()
+    first = asyncio.create_task(execute_chat_turn(core, _request("one")))
+    assert await core.started.get() == "one"
+    second = asyncio.create_task(execute_chat_turn(core, _request("one")))
+    await asyncio.sleep(0)
+
+    assert core.max_by_session["one"] == 1
+    assert len(core._opencode_process_tasks["one"]) == 2
+
+    core.release.set()
+    await asyncio.gather(first, second)
+    assert core.max_by_session["one"] == 1
+    assert core._opencode_process_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_different_sessions_can_run_concurrently_with_isolated_context() -> None:
+    core = FakeCore()
+    first = asyncio.create_task(execute_chat_turn(core, _request("one")))
+    second = asyncio.create_task(execute_chat_turn(core, _request("two")))
+    assert {await core.started.get(), await core.started.get()} == {"one", "two"}
+
+    assert core.max_all_active == 2
+    assert {context.session_id for context in core.seen_contexts if context} == {
+        "one",
+        "two",
+    }
+
+    core.release.set()
+    await asyncio.gather(first, second)
+
+
+@pytest.mark.asyncio
+async def test_stream_callback_is_forwarded() -> None:
+    core = FakeCore()
+    chunks: list[tuple[str, str]] = []
+
+    async def callback(chunk: str, message_type: str) -> None:
+        chunks.append((chunk, message_type))
+
+    turn = asyncio.create_task(execute_chat_turn(core, _request("one", callback)))
+    await core.started.get()
+    core.release.set()
+    result = await turn
+
+    assert result["assistant_response"] == "one"
+    assert chunks == [("hello", "assistant")]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_is_untracked() -> None:
+    core = FakeCore()
+    first = asyncio.create_task(execute_chat_turn(core, _request("one")))
+    await core.started.get()
+    second = asyncio.create_task(execute_chat_turn(core, _request("one")))
+    await asyncio.sleep(0)
+    second.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await second
+    assert core._opencode_process_tasks["one"] == {first}
+
+    core.release.set()
+    await first
+    assert core._opencode_process_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_fake_channel_executes_streams_completes_and_delivers() -> None:
+    core = FakeCore()
+    channel = FakeChannel()
+    turn = asyncio.create_task(channel.execute(core, _request("one")))
+    await core.started.get()
+    core.release.set()
+
+    result = await turn
+    delivery = DeliveryRequest(
+        delivery_id="delivery-1",
+        address=ChannelAddress("fake", "account", "chat"),
+        kind="text",
+        payload={"text": "done"},
+    )
+    await channel.deliver(delivery)
+
+    assert result["assistant_response"] == "one"
+    assert [(update.text, update.final) for update in channel.streams] == [
+        ("hello", False),
+        ("one", True),
+    ]
+    assert channel.deliveries == [delivery]
+
+
+@pytest.mark.asyncio
+async def test_fake_channel_can_cancel_an_active_turn() -> None:
+    core = FakeCore()
+    channel = FakeChannel()
+    turn = asyncio.create_task(channel.execute(core, _request("one")))
+    await core.started.get()
+
+    assert channel.cancel_all() == 1
+    with pytest.raises(asyncio.CancelledError):
+        await turn
+    assert channel.cancel_all() == 0

--- a/tests/channels/test_schema.py
+++ b/tests/channels/test_schema.py
@@ -1,0 +1,10 @@
+from penguin.channels.schema import ChannelAddress
+
+
+def test_lane_key_distinguishes_topics_and_avoids_delimiter_collisions() -> None:
+    topic_one = ChannelAddress("telegram", "bot", "chat", "1")
+    topic_two = ChannelAddress("telegram", "bot", "chat", "2")
+    ambiguous = ChannelAddress("telegram", "bot\x1fchat", "1", "")
+
+    assert topic_one.lane_key != topic_two.lane_key
+    assert topic_one.lane_key != ambiguous.lane_key

--- a/tests/channels/test_store.py
+++ b/tests/channels/test_store.py
@@ -1,0 +1,1400 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from hypothesis import settings
+from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
+
+from penguin.channels.store import (
+    ChannelStore,
+    CompareAndSwapError,
+    IdempotencyConflictError,
+    LeaseLostError,
+    PayloadTooLargeError,
+    PollerLeaseConflictError,
+)
+
+PLATFORM = "telegram"
+ACCOUNT = "default"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ChannelStore:
+    return ChannelStore(tmp_path / "channels.db")
+
+
+def _admit(store: ChannelStore, event_id: str, lane: str, now: float) -> None:
+    assert store.admit_ingress(
+        event_id,
+        lane,
+        {"event": event_id},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=now,
+    )
+
+
+def _claim_and_start(
+    store: ChannelStore, event_id: str, owner: str, now: float
+) -> None:
+    claimed = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id=owner,
+        lease_seconds=10,
+        now=now,
+    )
+    assert claimed is not None
+    assert claimed.event_id == event_id
+    store.start_ingress(
+        event_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id=owner,
+        now=now,
+    )
+
+
+def test_database_uses_durable_pragmas_and_foreign_keys(
+    store: ChannelStore,
+) -> None:
+    with store._read() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30_000
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store.enqueue_delivery(
+            "delivery-1",
+            "key-1",
+            "lane-1",
+            {"text": "answer"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            source_event_id="missing-event",
+            now=1,
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_database_file_is_private(store: ChannelStore) -> None:
+    assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
+def test_database_and_sidecars_are_private_under_permissive_umask(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "public-parent"
+    parent.mkdir(mode=0o755)
+    parent.chmod(0o755)
+    script = """
+import os
+import stat
+import sys
+from pathlib import Path
+from penguin.channels.store import ChannelStore
+
+os.umask(0)
+path = Path(sys.argv[1])
+store = ChannelStore(path)
+with store._write() as connection:
+    connection.execute("CREATE TABLE mode_probe (id INTEGER)")
+    paths = (path, Path(str(path) + "-wal"), Path(str(path) + "-shm"))
+    assert all(item.exists() for item in paths)
+    assert all(stat.S_IMODE(item.stat().st_mode) == 0o600 for item in paths)
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", script, str(parent / "channels.db")],
+        check=True,
+        cwd=Path(__file__).parents[2],
+    )
+
+
+def test_payloads_and_error_messages_are_bounded(tmp_path: Path) -> None:
+    bounded = ChannelStore(
+        tmp_path / "bounded.db", max_payload_bytes=24, max_error_chars=8
+    )
+    with pytest.raises(PayloadTooLargeError):
+        bounded.admit_ingress(
+            "event",
+            "lane",
+            {"text": "x" * 30},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+        )
+
+    assert bounded.admit_ingress(
+        "event", "lane", {"ok": True}, platform=PLATFORM, account_id=ACCOUNT
+    )
+    claimed = bounded.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker",
+        lease_seconds=10,
+    )
+    assert claimed is not None
+    bounded.dead_letter_ingress(
+        "event",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker",
+        error_class="TransportError",
+        error_message="0123456789abcdef",
+    )
+    record = bounded.get_ingress("event", platform=PLATFORM, account_id=ACCOUNT)
+    assert record is not None
+    assert record.last_error_message == "01234567"
+
+
+def test_binding_replacement_supports_version_cas(store: ChannelStore) -> None:
+    first = store.upsert_binding(
+        "telegram/default/dm/7",
+        "session-1",
+        settings={
+            "prompt": "Be terse",
+            "skills": ["review"],
+            "activation": "mention",
+        },
+        expected_version=0,
+        now=1,
+    )
+    assert first.version == 1
+    assert first.settings["prompt"] == "Be terse"
+
+    second = store.upsert_binding(
+        first.address_key,
+        "session-2",
+        directory="/workspace",
+        expected_version=first.version,
+        now=2,
+    )
+    assert second.version == 2
+    assert second.session_id == "session-2"
+    assert second.directory == "/workspace"
+    assert second.settings == first.settings
+
+    with pytest.raises(CompareAndSwapError):
+        store.upsert_binding(
+            first.address_key,
+            "stale-session",
+            expected_version=first.version,
+            now=3,
+        )
+    assert store.get_binding(first.address_key) == second
+
+
+def test_supergroup_migration_moves_group_and_topics_atomically(
+    store: ChannelStore,
+) -> None:
+    separator = "\x1f"
+    old = separator.join((PLATFORM, ACCOUNT, "-100-old"))
+    new = separator.join((PLATFORM, ACCOUNT, "-100-new"))
+    topic = old + separator + "42"
+    store.upsert_binding(old, "group-session", settings={"prompt": "group"}, now=1)
+    store.upsert_binding(topic, "topic-session", settings={"skills": ["tdd"]}, now=1)
+    store.upsert_binding("unrelated", "dm-session", now=1)
+
+    versions = {
+        old: store.get_binding(old).version,
+        topic: store.get_binding(topic).version,
+    }
+    migrated = store.migrate_binding_prefix(old, new, expected_versions=versions, now=2)
+    assert [record.address_key for record in migrated] == [
+        new,
+        new + separator + "42",
+    ]
+    assert [record.session_id for record in migrated] == [
+        "group-session",
+        "topic-session",
+    ]
+    assert migrated[0].settings == {"prompt": "group"}
+    assert migrated[1].settings == {"skills": ["tdd"]}
+    assert store.get_binding(old) is None
+    assert store.get_binding(topic) is None
+    assert store.get_binding("unrelated") is not None
+
+    collision_old = separator.join((PLATFORM, ACCOUNT, "-100-collision-old"))
+    collision_new = separator.join((PLATFORM, ACCOUNT, "-100-collision-new"))
+    store.upsert_binding(collision_old, "source-session", now=3)
+    store.upsert_binding(collision_new, "destination-session", now=3)
+    with pytest.raises(CompareAndSwapError):
+        store.migrate_binding_prefix(collision_old, collision_new, now=4)
+    assert store.get_binding(collision_old).session_id == "source-session"
+    assert store.get_binding(collision_new).session_id == "destination-session"
+
+
+def test_group_migration_lineage_requires_a_current_allowed_source(
+    store: ChannelStore,
+) -> None:
+    separator = "\x1f"
+    first = separator.join((PLATFORM, ACCOUNT, "-100"))
+    second = separator.join((PLATFORM, ACCOUNT, "-200"))
+    third = separator.join((PLATFORM, ACCOUNT, "-300"))
+    store.migrate_binding_prefix(
+        first,
+        second,
+        group_authorization=(PLATFORM, ACCOUNT, "-100", "-200"),
+        now=1,
+    )
+    store.migrate_binding_prefix(
+        second,
+        third,
+        group_authorization=(PLATFORM, ACCOUNT, "-200", "-300"),
+        now=2,
+    )
+
+    assert store.is_group_authorized(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        chat_id="-300",
+        allowed_source_chat_ids=frozenset({"-100"}),
+    )
+    assert not store.is_group_authorized(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        chat_id="-300",
+        allowed_source_chat_ids=frozenset({"-999"}),
+    )
+
+
+def test_pairing_is_hashed_dm_only_single_use_and_revocable(
+    store: ChannelStore,
+) -> None:
+    code = "Penguin-123456"
+    pairing = store.create_pairing(
+        code,
+        account_id=ACCOUNT,
+        expected_user_id="7",
+        expires_at=100,
+        now=1,
+    )
+    assert pairing.code_hash != code
+    assert store.can_consume_pairing(
+        code,
+        account_id=ACCOUNT,
+        user_id="7",
+        chat_id="7",
+        now=2,
+    )
+    assert not store.can_consume_pairing(
+        code,
+        account_id=ACCOUNT,
+        user_id="8",
+        chat_id="8",
+        now=2,
+    )
+
+    with sqlite3.connect(store.path) as conn:
+        persisted = conn.execute(
+            """
+            SELECT code_hash, account_id, expected_user_id, state
+            FROM channel_pairings
+            """
+        ).fetchone()
+    assert persisted is not None
+    assert code not in "|".join(str(value) for value in persisted)
+
+    assert (
+        store.consume_pairing(
+            code,
+            account_id=ACCOUNT,
+            user_id="7",
+            chat_id="group-9",
+            now=2,
+        )
+        is None
+    )
+    assert (
+        store.consume_pairing(
+            code,
+            account_id=ACCOUNT,
+            user_id="8",
+            chat_id="8",
+            now=2,
+        )
+        is None
+    )
+
+    consumed = store.consume_pairing(
+        code, account_id=ACCOUNT, user_id="7", chat_id="7", now=2
+    )
+    assert consumed is not None
+    assert consumed.state == "consumed"
+    assert not store.can_consume_pairing(
+        code,
+        account_id=ACCOUNT,
+        user_id="7",
+        chat_id="7",
+        now=3,
+    )
+    assert store.is_dm_authorized(account_id=ACCOUNT, user_id="7")
+    assert (
+        store.consume_pairing(
+            code,
+            account_id=ACCOUNT,
+            user_id="7",
+            chat_id="7",
+            now=3,
+        )
+        is None
+    )
+
+    assert store.revoke_dm_authorization(account_id=ACCOUNT, user_id="7", now=4)
+    assert not store.is_dm_authorized(account_id=ACCOUNT, user_id="7")
+
+    store.create_pairing("revoke-me", account_id=ACCOUNT, expires_at=100, now=1)
+    assert store.revoke_pairing("revoke-me", account_id=ACCOUNT, now=2)
+    assert (
+        store.consume_pairing(
+            "revoke-me",
+            account_id=ACCOUNT,
+            user_id="9",
+            chat_id="9",
+            now=3,
+        )
+        is None
+    )
+
+
+def test_expired_pairing_cannot_authorize(store: ChannelStore) -> None:
+    store.create_pairing("expires", account_id=ACCOUNT, expires_at=10, now=1)
+    assert (
+        store.consume_pairing(
+            "expires",
+            account_id=ACCOUNT,
+            user_id="7",
+            chat_id="7",
+            now=10,
+        )
+        is None
+    )
+    assert not store.is_dm_authorized(account_id=ACCOUNT, user_id="7")
+
+
+def test_callback_claim_checks_full_recipient_scope_and_is_single_use(
+    store: ChannelStore,
+) -> None:
+    store.create_callback(
+        "callback-1",
+        account_id=ACCOUNT,
+        chat_id="chat-1",
+        topic_id="topic-1",
+        user_id="user-1",
+        request_id="request-1",
+        tool_call_id="tool-1",
+        payload={"choice": "approve"},
+        expires_at=100,
+        now=1,
+    )
+
+    wrong_scopes = [
+        {
+            "account_id": "other",
+            "chat_id": "chat-1",
+            "topic_id": "topic-1",
+            "user_id": "user-1",
+        },
+        {
+            "account_id": ACCOUNT,
+            "chat_id": "other",
+            "topic_id": "topic-1",
+            "user_id": "user-1",
+        },
+        {
+            "account_id": ACCOUNT,
+            "chat_id": "chat-1",
+            "topic_id": "other",
+            "user_id": "user-1",
+        },
+        {
+            "account_id": ACCOUNT,
+            "chat_id": "chat-1",
+            "topic_id": "topic-1",
+            "user_id": "other",
+        },
+    ]
+    for scope in wrong_scopes:
+        assert (
+            store.claim_callback("callback-1", owner_id="worker", now=2, **scope)
+            is None
+        )
+
+    claimed = store.claim_callback(
+        "callback-1",
+        account_id=ACCOUNT,
+        chat_id="chat-1",
+        topic_id="topic-1",
+        user_id="user-1",
+        owner_id="worker-1",
+        now=2,
+    )
+    assert claimed is not None
+    assert claimed.request_id == "request-1"
+    assert claimed.tool_call_id == "tool-1"
+    assert claimed.payload == {"choice": "approve"}
+    assert (
+        store.claim_callback(
+            "callback-1",
+            account_id=ACCOUNT,
+            chat_id="chat-1",
+            topic_id="topic-1",
+            user_id="user-1",
+            owner_id="worker-2",
+            now=2,
+        )
+        is None
+    )
+    with pytest.raises(LeaseLostError):
+        store.complete_callback("callback-1", owner_id="worker-2", now=3)
+    store.complete_callback("callback-1", owner_id="worker-1", now=3)
+
+
+def test_callback_claim_is_atomic_across_workers(store: ChannelStore) -> None:
+    store.create_callback(
+        "callback-race",
+        account_id=ACCOUNT,
+        chat_id="7",
+        topic_id=None,
+        user_id="7",
+        request_id="request",
+        payload={"answer": "yes"},
+        expires_at=100,
+        now=1,
+    )
+
+    def claim(owner: str) -> bool:
+        return (
+            store.claim_callback(
+                "callback-race",
+                account_id=ACCOUNT,
+                chat_id="7",
+                topic_id=None,
+                user_id="7",
+                owner_id=owner,
+                now=2,
+            )
+            is not None
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(claim, ["worker-1", "worker-2"]))
+    assert sorted(results) == [False, True]
+
+
+def test_callback_recovery_terminalizes_expired_and_dead_once(
+    store: ChannelStore,
+) -> None:
+    def create(callback_id: str, expires_at: float) -> None:
+        projection_id = f"projection-{callback_id}"
+        store.create_callback_with_delivery(
+            callback_id,
+            account_id=ACCOUNT,
+            chat_id="7",
+            topic_id=None,
+            user_id="7",
+            request_id=f"request-{callback_id}",
+            payload={
+                "kind": "approval",
+                "projection_delivery_id": projection_id,
+                "lane_key": "lane",
+                "platform": PLATFORM,
+                "session_id": "session",
+            },
+            expires_at=expires_at,
+            projection_delivery_id=projection_id,
+            lane_key="lane",
+            delivery_payload={"chat_id": "7", "text": "Approve?"},
+            platform=PLATFORM,
+            source_session_id="session",
+            now=1,
+        )
+
+    create("expired", 3)
+    create("dead", 100)
+    assert store.claim_callback(
+        "dead",
+        account_id=ACCOUNT,
+        chat_id="7",
+        topic_id=None,
+        user_id="7",
+        owner_id="worker",
+        lease_seconds=1,
+        now=2,
+    )
+
+    recovered = store.recover_expired_callbacks(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=4,
+    )
+    assert {record.callback_id: record.state for record in recovered} == {
+        "dead": "dead",
+        "expired": "expired",
+    }
+    assert (
+        store.recover_expired_callbacks(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=5,
+        )
+        == []
+    )
+    for callback_id in ("expired", "dead"):
+        projection = store.get_delivery(
+            f"projection-{callback_id}",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+        )
+        terminal = store.get_delivery(
+            f"telegram:callback-terminal:{callback_id}",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+        )
+        assert projection is not None
+        assert terminal is not None
+        assert terminal.sequence > projection.sequence
+        assert terminal.kind == "callback_terminal"
+        assert terminal.payload["label"] == "Expired"
+
+
+def test_ingress_deduplicates_and_rejects_conflicting_reuse(
+    store: ChannelStore,
+) -> None:
+    _admit(store, "event-1", "lane-1", 1)
+    assert not store.admit_ingress(
+        "event-1",
+        "lane-1",
+        {"event": "event-1"},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=2,
+    )
+    with pytest.raises(IdempotencyConflictError):
+        store.admit_ingress(
+            "event-1",
+            "lane-1",
+            {"event": "different"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=2,
+        )
+
+
+def test_ingress_claims_preserve_lane_order_without_blocking_other_lanes(
+    store: ChannelStore,
+) -> None:
+    _admit(store, "lane-a-1", "lane-a", 1)
+    _admit(store, "lane-a-2", "lane-a", 2)
+    _admit(store, "lane-b-1", "lane-b", 3)
+
+    first = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        lease_seconds=20,
+        now=4,
+    )
+    independent = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-2",
+        lease_seconds=20,
+        now=4,
+    )
+    assert first is not None and first.event_id == "lane-a-1"
+    assert independent is not None and independent.event_id == "lane-b-1"
+    assert (
+        store.claim_ingress(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker-3",
+            lease_seconds=20,
+            now=4,
+        )
+        is None
+    )
+
+    store.start_ingress(
+        first.event_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        now=5,
+    )
+    store.complete_ingress(
+        first.event_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        now=6,
+    )
+    second = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-3",
+        lease_seconds=20,
+        now=7,
+    )
+    assert second is not None and second.event_id == "lane-a-2"
+
+
+def test_ingress_claim_filters_reserve_interactive_capacity(
+    store: ChannelStore,
+) -> None:
+    suffix = "\x1finteractive"
+    _admit(store, "normal", "chat", 1)
+    _admit(store, "interactive", f"chat{suffix}", 2)
+
+    control = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="control-worker",
+        lease_seconds=10,
+        lane_suffix=suffix,
+        now=3,
+    )
+    normal = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="normal-worker",
+        lease_seconds=10,
+        exclude_lane_suffix=suffix,
+        now=3,
+    )
+
+    assert control is not None and control.event_id == "interactive"
+    assert normal is not None and normal.event_id == "normal"
+
+
+def test_ingress_claim_is_atomic_across_workers(store: ChannelStore) -> None:
+    _admit(store, "event", "lane", 1)
+
+    def claim(owner: str) -> str | None:
+        record = store.claim_ingress(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id=owner,
+            lease_seconds=10,
+            now=2,
+        )
+        return record.event_id if record is not None else None
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(claim, ["worker-1", "worker-2"]))
+    assert results.count("event") == 1
+    assert results.count(None) == 1
+
+
+def test_ingress_recovery_retries_unstarted_and_dead_letters_started(
+    store: ChannelStore,
+) -> None:
+    _admit(store, "unstarted", "lane-a", 1)
+    _admit(store, "started", "lane-b", 2)
+    first = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        lease_seconds=5,
+        now=3,
+    )
+    second = store.claim_ingress(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-2",
+        lease_seconds=5,
+        now=3,
+    )
+    assert first is not None and first.event_id == "unstarted"
+    assert second is not None and second.event_id == "started"
+    store.start_ingress(
+        "started",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-2",
+        now=4,
+    )
+
+    recovered = store.recover_expired_ingress(now=8)
+    assert recovered.retried == 1
+    assert recovered.dead == 1
+    safe = store.get_ingress("unstarted", platform=PLATFORM, account_id=ACCOUNT)
+    uncertain = store.get_ingress("started", platform=PLATFORM, account_id=ACCOUNT)
+    assert safe is not None and safe.state == "retry"
+    assert uncertain is not None and uncertain.state == "dead"
+    assert uncertain.last_error_class == "execution_uncertain"
+
+
+def test_ingress_dead_letter_operator_controls_are_bounded_and_terminal_only(
+    store: ChannelStore,
+) -> None:
+    for index, event_id in enumerate(("dead-1", "dead-2", "completed", "live")):
+        _admit(store, event_id, f"lane-{event_id}", index + 1)
+
+    for index, event_id in enumerate(("dead-1", "dead-2")):
+        claimed = store.claim_ingress(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id=f"worker-{index}",
+            lease_seconds=10,
+            now=5,
+        )
+        assert claimed is not None and claimed.event_id == event_id
+        store.dead_letter_ingress(
+            event_id,
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id=f"worker-{index}",
+            error_class="Rejected",
+            error_message="terminal",
+            now=6,
+        )
+
+    _claim_and_start(store, "completed", "worker-completed", 7)
+    store.complete_ingress(
+        "completed",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-completed",
+        now=8,
+    )
+
+    assert [
+        item.event_id
+        for item in store.list_dead_ingress(
+            platform=PLATFORM, account_id=ACCOUNT, limit=1
+        )
+    ] == ["dead-1"]
+    for invalid_limit in (0, 101, True):
+        with pytest.raises(ValueError):
+            store.list_dead_ingress(
+                platform=PLATFORM,
+                account_id=ACCOUNT,
+                limit=invalid_limit,
+            )
+
+    assert not store.discard_dead_ingress(
+        "completed", platform=PLATFORM, account_id=ACCOUNT
+    )
+    assert not store.discard_dead_ingress("live", platform=PLATFORM, account_id=ACCOUNT)
+    assert store.discard_dead_ingress("dead-1", platform=PLATFORM, account_id=ACCOUNT)
+    assert store.get_ingress("dead-1", platform=PLATFORM, account_id=ACCOUNT) is None
+    assert store.requeue_dead_ingress(
+        "dead-2", platform=PLATFORM, account_id=ACCOUNT, now=9
+    )
+    retried = store.get_ingress("dead-2", platform=PLATFORM, account_id=ACCOUNT)
+    assert retried is not None and retried.state == "retry"
+
+
+def test_delivery_enqueue_is_idempotent_and_lane_ordered(
+    store: ChannelStore,
+) -> None:
+    for delivery_id, lane in [
+        ("lane-a-1", "lane-a"),
+        ("lane-a-2", "lane-a"),
+        ("lane-b-1", "lane-b"),
+    ]:
+        assert store.enqueue_delivery(
+            delivery_id,
+            f"key-{delivery_id}",
+            lane,
+            {"text": delivery_id},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=1,
+        )
+    assert not store.enqueue_delivery(
+        "lane-a-1",
+        "key-lane-a-1",
+        "lane-a",
+        {"text": "lane-a-1"},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=2,
+    )
+    with pytest.raises(IdempotencyConflictError):
+        store.enqueue_delivery(
+            "lane-a-1",
+            "key-lane-a-1",
+            "lane-a",
+            {"text": "different"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=2,
+        )
+
+    first = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        lease_seconds=10,
+        now=3,
+    )
+    assert first is not None and first.delivery_id == "lane-a-1"
+    store.retry_delivery(
+        first.delivery_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-1",
+        retry_at=100,
+        error_class="RateLimit",
+        error_message="later",
+        now=4,
+    )
+
+    independent = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-2",
+        lease_seconds=10,
+        now=5,
+    )
+    assert independent is not None and independent.delivery_id == "lane-b-1"
+    store.complete_delivery(
+        independent.delivery_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-2",
+        external_message_id="telegram-42",
+        now=6,
+    )
+    assert (
+        store.claim_delivery(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker-3",
+            lease_seconds=10,
+            now=7,
+        )
+        is None
+    )
+
+    retried = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-3",
+        lease_seconds=10,
+        now=100,
+    )
+    assert retried is not None and retried.delivery_id == "lane-a-1"
+    store.complete_delivery(
+        retried.delivery_id,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-3",
+        now=101,
+    )
+    second = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-4",
+        lease_seconds=10,
+        now=102,
+    )
+    assert second is not None and second.delivery_id == "lane-a-2"
+
+
+def test_expired_delivery_claim_is_recovered_for_retry(store: ChannelStore) -> None:
+    store.enqueue_delivery(
+        "delivery",
+        "key",
+        "lane",
+        {"text": "hello"},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=1,
+    )
+    claimed = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker",
+        lease_seconds=5,
+        now=2,
+    )
+    assert claimed is not None
+    assert store.recover_expired_deliveries(now=7) == 1
+    record = store.get_delivery("delivery", platform=PLATFORM, account_id=ACCOUNT)
+    assert record is not None and record.state == "retry"
+
+
+def test_delivery_dead_letter_operator_controls_are_bounded_and_terminal_only(
+    store: ChannelStore,
+) -> None:
+    for delivery_id in ("dead-1", "dead-2", "delivered", "live"):
+        store.enqueue_delivery(
+            delivery_id,
+            f"key-{delivery_id}",
+            f"lane-{delivery_id}",
+            {"text": delivery_id},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=1,
+        )
+
+    for index, delivery_id in enumerate(("dead-1", "dead-2")):
+        claimed = store.claim_delivery(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id=f"worker-{index}",
+            lease_seconds=10,
+            now=2,
+        )
+        assert claimed is not None and claimed.delivery_id == delivery_id
+        store.dead_letter_delivery(
+            delivery_id,
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id=f"worker-{index}",
+            error_class="Forbidden",
+            error_message="terminal",
+            now=3,
+        )
+
+    delivered = store.claim_delivery(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-delivered",
+        lease_seconds=10,
+        now=4,
+    )
+    assert delivered is not None and delivered.delivery_id == "delivered"
+    store.complete_delivery(
+        "delivered",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker-delivered",
+        now=5,
+    )
+
+    assert [
+        item.delivery_id
+        for item in store.list_dead_deliveries(
+            platform=PLATFORM, account_id=ACCOUNT, limit=1
+        )
+    ] == ["dead-1"]
+    for invalid_limit in (0, 101, True):
+        with pytest.raises(ValueError):
+            store.list_dead_deliveries(
+                platform=PLATFORM,
+                account_id=ACCOUNT,
+                limit=invalid_limit,
+            )
+
+    assert not store.discard_dead_delivery(
+        "delivered", platform=PLATFORM, account_id=ACCOUNT
+    )
+    assert not store.discard_dead_delivery(
+        "live", platform=PLATFORM, account_id=ACCOUNT
+    )
+    assert store.discard_dead_delivery("dead-1", platform=PLATFORM, account_id=ACCOUNT)
+    assert store.get_delivery("dead-1", platform=PLATFORM, account_id=ACCOUNT) is None
+    assert store.requeue_dead_delivery(
+        "dead-2", platform=PLATFORM, account_id=ACCOUNT, now=6
+    )
+    retried = store.get_delivery("dead-2", platform=PLATFORM, account_id=ACCOUNT)
+    assert retried is not None and retried.state == "retry"
+
+
+def test_ingress_completion_and_delivery_enqueue_are_atomic(
+    store: ChannelStore,
+) -> None:
+    _admit(store, "event-success", "input-lane", 1)
+    _claim_and_start(store, "event-success", "worker", 2)
+    assert store.complete_ingress_and_enqueue_delivery(
+        "event-success",
+        ingress_owner_id="worker",
+        delivery_id="delivery-success",
+        idempotency_key="request-success:final",
+        lane_key="output-lane",
+        payload={"text": "done"},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        source_request_id="request-success",
+        now=3,
+    )
+    ingress = store.get_ingress("event-success", platform=PLATFORM, account_id=ACCOUNT)
+    delivery = store.get_delivery(
+        "delivery-success", platform=PLATFORM, account_id=ACCOUNT
+    )
+    assert ingress is not None and ingress.state == "completed"
+    assert delivery is not None and delivery.state == "pending"
+    assert delivery.source_event_id == "event-success"
+
+    _admit(store, "event-rollback", "input-lane-2", 4)
+    _claim_and_start(store, "event-rollback", "worker-2", 5)
+    store.enqueue_delivery(
+        "delivery-conflict",
+        "conflict-key",
+        "other-lane",
+        {"text": "existing"},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=5,
+    )
+    with pytest.raises(IdempotencyConflictError):
+        store.complete_ingress_and_enqueue_delivery(
+            "event-rollback",
+            ingress_owner_id="worker-2",
+            delivery_id="delivery-conflict",
+            idempotency_key="conflict-key",
+            lane_key="output-lane-2",
+            payload={"text": "new"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=6,
+        )
+    rolled_back = store.get_ingress(
+        "event-rollback", platform=PLATFORM, account_id=ACCOUNT
+    )
+    assert rolled_back is not None and rolled_back.state == "started"
+
+
+def test_atomic_completion_rolls_back_a_new_delivery_after_injected_failure(
+    store: ChannelStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _admit(store, "event-fault", "input-lane", 1)
+    _claim_and_start(store, "event-fault", "worker", 2)
+
+    def fail_after_enqueue(*_args: object, **_kwargs: object) -> None:
+        raise sqlite3.OperationalError("injected completion write failure")
+
+    monkeypatch.setattr(store, "_complete_ingress_conn", fail_after_enqueue)
+    with pytest.raises(sqlite3.OperationalError, match="injected"):
+        store.complete_ingress_and_enqueue_delivery(
+            "event-fault",
+            ingress_owner_id="worker",
+            delivery_id="delivery-fault",
+            idempotency_key="request-fault:final",
+            lane_key="output-lane",
+            payload={"text": "must roll back"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=3,
+        )
+
+    ingress = store.get_ingress("event-fault", platform=PLATFORM, account_id=ACCOUNT)
+    assert ingress is not None and ingress.state == "started"
+    assert (
+        store.get_delivery("delivery-fault", platform=PLATFORM, account_id=ACCOUNT)
+        is None
+    )
+
+
+def test_poller_lease_conflicts_and_token_rotation_resets_offset(
+    store: ChannelStore,
+) -> None:
+    fingerprint_a = store.fingerprint_token("token-a")
+    fingerprint_b = store.fingerprint_token("token-b")
+    lease = store.acquire_poller(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint_a,
+        owner_id="process-1",
+        lease_seconds=10,
+        now=1,
+    )
+    assert lease.update_offset is None
+    store.advance_poller_offset(
+        42,
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint_a,
+        owner_id="process-1",
+        now=2,
+    )
+
+    with pytest.raises(PollerLeaseConflictError):
+        store.acquire_poller(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint_a,
+            owner_id="process-2",
+            lease_seconds=10,
+            now=3,
+        )
+    with pytest.raises(PollerLeaseConflictError):
+        store.acquire_poller(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint_b,
+            owner_id="process-2",
+            lease_seconds=10,
+            now=3,
+        )
+
+    takeover = store.acquire_poller(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint_a,
+        owner_id="process-2",
+        lease_seconds=10,
+        now=11,
+    )
+    assert takeover.update_offset == 42
+    rotated = store.acquire_poller(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint_b,
+        owner_id="process-3",
+        lease_seconds=10,
+        now=22,
+    )
+    assert rotated.update_offset is None
+    with pytest.raises(PollerLeaseConflictError):
+        store.get_poller_offset(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint_a,
+        )
+
+
+def test_poller_admission_and_offset_advance_are_atomic(
+    store: ChannelStore,
+) -> None:
+    fingerprint = store.fingerprint_token("token")
+    store.acquire_poller(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint,
+        owner_id="process",
+        lease_seconds=100,
+        now=1,
+    )
+    assert store.admit_ingress_and_advance_poller(
+        "update-10",
+        "lane",
+        {"update_id": 10},
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        token_fingerprint=fingerprint,
+        owner_id="process",
+        new_offset=11,
+        now=2,
+    )
+    assert (
+        store.get_ingress("update-10", platform=PLATFORM, account_id=ACCOUNT)
+        is not None
+    )
+    assert (
+        store.get_poller_offset(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint,
+        )
+        == 11
+    )
+
+    with pytest.raises(IdempotencyConflictError):
+        store.admit_ingress_and_advance_poller(
+            "update-10",
+            "lane",
+            {"update_id": "different"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint,
+            owner_id="process",
+            new_offset=12,
+            now=3,
+        )
+    assert (
+        store.get_poller_offset(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            token_fingerprint=fingerprint,
+        )
+        == 11
+    )
+
+
+class IngressDurabilityStateMachine(RuleBasedStateMachine):
+    """Exercise crash/retry/CAS paths against one durable inbound event."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="penguin-channel-state-")
+        self.store = ChannelStore(Path(self.temp_dir.name) / "channels.db")
+        self.now = 1.0
+        self.model_state = "pending"
+        self.attempt_count = 0
+        self.ready_at = self.now
+        self.lease_expires_at: float | None = None
+        assert self.store.admit_ingress(
+            "event",
+            "lane",
+            {"event": "event"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=self.now,
+        )
+
+    def teardown(self) -> None:
+        self.temp_dir.cleanup()
+
+    @rule()
+    def duplicate_admission_never_creates_new_work(self) -> None:
+        assert not self.store.admit_ingress(
+            "event",
+            "lane",
+            {"event": "event"},
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=self.now,
+        )
+
+    @precondition(
+        lambda self: (
+            self.model_state in {"pending", "retry"} and self.now >= self.ready_at
+        )
+    )
+    @rule()
+    def claim(self) -> None:
+        record = self.store.claim_ingress(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker",
+            lease_seconds=5,
+            now=self.now,
+        )
+        assert record is not None
+        self.model_state = "claimed"
+        self.attempt_count += 1
+        self.lease_expires_at = self.now + 5
+
+    @precondition(lambda self: self.model_state == "claimed")
+    @rule()
+    def start(self) -> None:
+        self.store.start_ingress(
+            "event",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker",
+            now=self.now,
+        )
+        self.model_state = "started"
+
+    @precondition(lambda self: self.model_state in {"claimed", "started"})
+    @rule()
+    def retry_owned_work(self) -> None:
+        self.ready_at = self.now + 1
+        self.store.retry_ingress(
+            "event",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker",
+            retry_at=self.ready_at,
+            error_class="Transient",
+            error_message="retry",
+            now=self.now,
+        )
+        self.model_state = "retry"
+        self.lease_expires_at = None
+
+    @precondition(lambda self: self.model_state == "retry")
+    @rule()
+    def reach_retry_deadline(self) -> None:
+        self.now = self.ready_at
+
+    @precondition(lambda self: self.model_state == "started")
+    @rule()
+    def complete(self) -> None:
+        self.store.complete_ingress(
+            "event",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker",
+            now=self.now,
+        )
+        self.model_state = "completed"
+        self.lease_expires_at = None
+
+    @precondition(lambda self: self.model_state in {"claimed", "started"})
+    @rule()
+    def dead_letter(self) -> None:
+        self.store.dead_letter_ingress(
+            "event",
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            owner_id="worker",
+            error_class="Terminal",
+            error_message="dead",
+            now=self.now,
+        )
+        self.model_state = "dead"
+        self.lease_expires_at = None
+
+    @precondition(lambda self: self.model_state in {"claimed", "started"})
+    @rule()
+    def wrong_owner_cannot_transition(self) -> None:
+        with pytest.raises(LeaseLostError):
+            self.store.retry_ingress(
+                "event",
+                platform=PLATFORM,
+                account_id=ACCOUNT,
+                owner_id="intruder",
+                retry_at=self.now,
+                error_class="Transient",
+                error_message="must fail",
+                now=self.now,
+            )
+
+    @precondition(lambda self: self.model_state in {"claimed", "started"})
+    @rule()
+    def recover_after_worker_crash(self) -> None:
+        assert self.lease_expires_at is not None
+        self.now = self.lease_expires_at
+        counts = self.store.recover_expired_ingress(now=self.now)
+        if self.model_state == "claimed":
+            assert (counts.retried, counts.dead) == (1, 0)
+            self.model_state = "retry"
+            self.ready_at = self.now
+        else:
+            assert (counts.retried, counts.dead) == (0, 1)
+            self.model_state = "dead"
+        self.lease_expires_at = None
+
+    @precondition(lambda self: self.model_state == "dead")
+    @rule()
+    def operator_can_explicitly_retry_dead_work(self) -> None:
+        assert self.store.requeue_dead_ingress(
+            "event", platform=PLATFORM, account_id=ACCOUNT, now=self.now
+        )
+        self.model_state = "retry"
+        self.ready_at = self.now
+
+    @invariant()
+    def durable_record_matches_model(self) -> None:
+        record = self.store.get_ingress("event", platform=PLATFORM, account_id=ACCOUNT)
+        assert record is not None
+        assert record.state == self.model_state
+        assert record.attempt_count == self.attempt_count
+        expected_owner = (
+            "worker" if self.model_state in {"claimed", "started"} else None
+        )
+        assert record.claim_owner == expected_owner
+        if self.model_state in {"completed", "dead"}:
+            assert (
+                self.store.claim_ingress(
+                    platform=PLATFORM,
+                    account_id=ACCOUNT,
+                    owner_id="replay",
+                    lease_seconds=5,
+                    now=self.now,
+                )
+                is None
+            )
+
+
+TestIngressDurabilityStateMachine = IngressDurabilityStateMachine.TestCase
+TestIngressDurabilityStateMachine.settings = settings(
+    max_examples=20, stateful_step_count=20, deadline=None
+)

--- a/tests/integrations/telegram/test_app_lifespan.py
+++ b/tests/integrations/telegram/test_app_lifespan.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from penguin.integrations.telegram import manager as manager_module
+from penguin.web import app as web_app
+
+
+@pytest.mark.parametrize("fail_start", [False, True])
+def test_web_lifespan_starts_and_stops_telegram_manager(
+    monkeypatch: Any, fail_start: bool
+) -> None:
+    events: list[str] = []
+
+    class FakeManager:
+        def __init__(self, core: Any, config: Any) -> None:
+            self.core = core
+            self.config = config
+
+        async def start(self) -> None:
+            events.append("start")
+            if fail_start:
+                raise RuntimeError("Telegram unavailable")
+
+        async def stop(self) -> None:
+            events.append("stop")
+
+        def status(self) -> dict[str, str]:
+            return {"error": "Telegram unavailable"}
+
+    class FakePool:
+        async def close_all(self) -> None:
+            events.append("close_pool")
+
+    core = SimpleNamespace(
+        config=SimpleNamespace(model_configs={}),
+        tool_manager=None,
+    )
+
+    async def stop_vcs_watcher() -> None:
+        events.append("stop_vcs")
+
+    monkeypatch.setattr(manager_module, "TelegramManager", FakeManager)
+    monkeypatch.setattr(web_app, "get_or_create_core", lambda: core)
+    monkeypatch.setattr(web_app, "_rehydrate_provider_credentials", lambda _core: None)
+    monkeypatch.setattr(web_app, "start_vcs_watcher", lambda _core: None)
+    monkeypatch.setattr(web_app, "stop_vcs_watcher", stop_vcs_watcher)
+    monkeypatch.setattr(
+        web_app.ConnectionPoolManager,
+        "get_instance",
+        classmethod(lambda cls: FakePool()),
+    )
+
+    app = web_app.create_app()
+    with TestClient(app) as client:
+        assert client.get("/api/v1/health").status_code == 200
+        assert events == ["start"]
+
+    assert events == ["start", "stop", "stop_vcs", "close_pool"]

--- a/tests/integrations/telegram/test_approval_ui.py
+++ b/tests/integrations/telegram/test_approval_ui.py
@@ -1,0 +1,41 @@
+"""Focused tests for Telegram approval presentation helpers."""
+
+from penguin.integrations.telegram._approval_ui import terminal_edit_payload
+from penguin.integrations.telegram.formatting import (
+    TELEGRAM_TEXT_LIMIT,
+    utf16_length,
+)
+
+
+def test_terminal_edit_keeps_exact_boundary_prompt_and_marker() -> None:
+    marker = "\n\n<b>Approved</b>"
+    original = "a" * (TELEGRAM_TEXT_LIMIT - utf16_length(marker))
+
+    payload, fallback = terminal_edit_payload(
+        {"text": original},
+        label="Approved",
+        chat_id="42",
+        message_id="7",
+    )
+
+    assert payload["text"] == f"{original}{marker}"
+    assert utf16_length(payload["text"]) == TELEGRAM_TEXT_LIMIT
+    assert fallback.endswith("\n\nApproved")
+
+
+def test_terminal_edit_truncates_emoji_prompt_but_keeps_expired_marker() -> None:
+    original = "🐧" * 3_000
+    marker = "\n\n<b>Expired</b>"
+
+    payload, fallback = terminal_edit_payload(
+        {"text": original},
+        label="Expired",
+        chat_id="42",
+        message_id="7",
+    )
+
+    expected_penguins = (TELEGRAM_TEXT_LIMIT - utf16_length(marker)) // 2
+    assert payload["text"] == f"{'🐧' * expected_penguins}{marker}"
+    assert fallback.endswith("\n\nExpired")
+    assert utf16_length(payload["text"]) <= TELEGRAM_TEXT_LIMIT
+    assert utf16_length(fallback) <= TELEGRAM_TEXT_LIMIT

--- a/tests/integrations/telegram/test_commands.py
+++ b/tests/integrations/telegram/test_commands.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from penguin.channels.schema import ChannelAddress, InboundEnvelope
+from penguin.integrations.telegram._commands import handle_command
+from penguin.integrations.telegram.config import TelegramConfig
+
+
+@pytest.mark.asyncio
+async def test_permissions_command_is_read_only_and_reports_effective_policy() -> None:
+    config = TelegramConfig.from_mapping(
+        {
+            "security": {"mode": "read_only"},
+            "channels": {
+                "telegram": {
+                    "permissions": {
+                        "mode": "full_access",
+                        "approvals": {
+                            "shell": "ask",
+                            "fileWrite": "deny",
+                            "default": "allow",
+                        },
+                        "timeout_seconds": 60,
+                    }
+                }
+            },
+        },
+        {},
+    )
+    manager = SimpleNamespace(store=object(), config=config)
+    envelope = InboundEnvelope(
+        event_id="telegram:test:1",
+        source_sequence=1,
+        address=ChannelAddress(
+            platform="telegram",
+            account_id="test",
+            chat_id="42",
+        ),
+        sender_id="42",
+        text="/permissions",
+    )
+    binding = SimpleNamespace(session_id="session-1")
+
+    response = await handle_command(
+        manager,
+        "permissions",
+        "ignored",
+        envelope,
+        binding,
+    )
+
+    assert response is not None
+    assert "Mode cap: read_only" in response
+    assert "Telegram category decisions:" in response
+    assert "- shell: ask" in response
+    assert "- fileWrite: deny" in response
+    assert "- default: allow" in response
+    assert "Approval timeout: 60 seconds" in response
+    assert "instance or agent policy can still ASK" in response
+    assert "workspace DENY still blocks" in response
+
+
+@pytest.mark.asyncio
+async def test_help_advertises_permissions_command() -> None:
+    manager = SimpleNamespace(store=object(), config=TelegramConfig())
+    envelope = InboundEnvelope(
+        event_id="telegram:test:2",
+        source_sequence=2,
+        address=ChannelAddress(
+            platform="telegram",
+            account_id="test",
+            chat_id="42",
+        ),
+        sender_id="42",
+    )
+
+    response = await handle_command(
+        manager,
+        "help",
+        "",
+        envelope,
+        SimpleNamespace(session_id="session-1"),
+    )
+
+    assert response is not None
+    assert "/permissions" in response

--- a/tests/integrations/telegram/test_config.py
+++ b/tests/integrations/telegram/test_config.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from penguin.integrations.telegram.config import TelegramConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(**telegram: object) -> dict[str, object]:
+    return {"channels": {"telegram": telegram}}
+
+
+def test_defaults_are_disabled_and_fail_closed() -> None:
+    config = TelegramConfig.from_mapping(
+        {"enabled": True, "allow_from": [123]},
+        {},
+    )
+
+    assert config.enabled is False
+    assert config.token is None
+    assert config.expected_username == "Penguin_agent_bot"
+    assert config.transport == "polling"
+    assert config.allows_dm(123) is False
+    assert config.allows_group(-100123) is False
+    assert config.allows_group_sender(123) is False
+    assert config.activation == "mention"
+    assert config.permission_mode == "workspace"
+    assert config.approval_policy["shell"] == "ask"
+    assert config.approval_policy["default"] == "ask"
+    assert config.approval_policy["allowLists"] == {}
+
+
+def test_direct_config_construction_rebases_binding_activation() -> None:
+    config = TelegramConfig(activation="always")
+
+    assert config.binding_for(-100).activation == "always"
+
+
+def test_token_comes_only_from_fixed_environment_variable_and_is_redacted() -> None:
+    disabled = TelegramConfig.from_mapping(
+        {}, {"TELEGRAM_BOT_TOKEN": "unused-test-token"}
+    )
+    config = TelegramConfig.from_mapping(
+        _config(enabled=True), {"TELEGRAM_BOT_TOKEN": "test-token"}
+    )
+
+    assert disabled.token is None
+    assert config.token == "test-token"
+    assert "test-token" not in repr(config)
+
+    with pytest.raises(ValueError, match="must not be stored"):
+        TelegramConfig.from_mapping(_config(token="inline"), {})
+    with pytest.raises(ValueError, match="TELEGRAM_BOT_TOKEN"):
+        TelegramConfig.from_mapping(_config(token_env="SOME_OTHER_ENV"), {})
+
+
+def test_enabled_bot_requires_token() -> None:
+    with pytest.raises(ValueError, match="TELEGRAM_BOT_TOKEN"):
+        TelegramConfig.from_mapping(_config(enabled=True), {})
+
+
+def test_numeric_allowlists_are_normalized_and_default_deny() -> None:
+    config = TelegramConfig.from_mapping(
+        _config(
+            allow_from=[123, "456"],
+            group_allow_from=[-100789],
+            group_sender_allow_from=[789],
+        ),
+        {},
+    )
+
+    assert config.allow_from == frozenset({123, 456})
+    assert config.allowed_group_ids == frozenset({-100789})
+    assert config.allowed_group_sender_ids == frozenset({789})
+    assert config.allows_dm(123) is True
+    assert config.allows_dm(999) is False
+    assert config.allows_group(-100789) is True
+    assert config.allows_group(-100999) is False
+    assert config.allows_group_sender(789) is True
+
+    with pytest.raises(ValueError, match="numeric"):
+        TelegramConfig.from_mapping(_config(allow_from=["username"]), {})
+
+
+def test_open_access_requires_explicit_acknowledgement() -> None:
+    with pytest.raises(ValueError, match="open_access_acknowledged"):
+        TelegramConfig.from_mapping(_config(dm_policy="open"), {})
+
+    config = TelegramConfig.from_mapping(
+        _config(dm_policy="open", open_access_acknowledged=True), {}
+    )
+    assert config.allows_dm(999) is True
+
+
+def test_webhook_mode_requires_secret_and_validates_transport() -> None:
+    env = {"TELEGRAM_BOT_TOKEN": "test-token"}
+    with pytest.raises(ValueError, match="TELEGRAM_WEBHOOK_SECRET"):
+        TelegramConfig.from_mapping(_config(enabled=True, transport="webhook"), env)
+
+    config = TelegramConfig.from_mapping(
+        _config(enabled=True, transport="webhook"),
+        {**env, "TELEGRAM_WEBHOOK_SECRET": "test-secret"},
+    )
+    assert config.transport == "webhook"
+    assert config.webhook_secret == "test-secret"
+    assert "test-secret" not in repr(config)
+
+    with pytest.raises(ValueError, match="transport"):
+        TelegramConfig.from_mapping(_config(transport="both"), {})
+
+    with pytest.raises(ValueError, match=r"webhook\.path"):
+        TelegramConfig.from_mapping(
+            _config(webhook={"path": "/api/v1/integrations/telegram/"}),
+            {},
+        )
+
+
+def test_remote_permissions_are_prompted_and_capped_by_instance() -> None:
+    config = TelegramConfig.from_mapping(
+        {
+            "security": {"mode": "read_only"},
+            "channels": {"telegram": {"permissions": {"mode": "full_access"}}},
+        },
+        {},
+    )
+
+    assert config.permission_mode == "read_only"
+    assert config.approval_policy["shell"] == "ask"
+    assert config.approval_policy["wait_for_resolution"] is True
+    assert config.approval_policy["timeout_seconds"] == 300.0
+
+
+@pytest.mark.parametrize(
+    ("telegram", "message"),
+    [
+        ({"streaming": {"edit_interval_ms": 10}}, "edit_interval_ms"),
+        ({"media": {"max_download_mb": 500}}, "max_download_mb"),
+        ({"runtime": {"ingress_workers": 0}}, "ingress_workers"),
+        ({"delivery": {"retry_attempts": 100}}, "retry_attempts"),
+        (
+            {
+                "delivery": {
+                    "retry_base_seconds": 20,
+                    "retry_max_seconds": 10,
+                }
+            },
+            "retry_max_seconds",
+        ),
+    ],
+)
+def test_runtime_and_delivery_values_are_bounded(
+    telegram: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        TelegramConfig.from_mapping(_config(**telegram), {})
+
+
+def test_remote_bot_rejects_yolo_and_disabled_security() -> None:
+    env = {"TELEGRAM_BOT_TOKEN": "test-token", "PENGUIN_YOLO": "true"}
+    with pytest.raises(ValueError, match="PENGUIN_YOLO"):
+        TelegramConfig.from_mapping(_config(enabled=True), env)
+
+    with pytest.raises(ValueError, match="security enforcement"):
+        TelegramConfig.from_mapping(
+            {
+                "security": {"enabled": False},
+                "channels": {"telegram": {"enabled": True}},
+            },
+            {"TELEGRAM_BOT_TOKEN": "test-token"},
+        )
+
+    with pytest.raises(ValueError, match="cannot opt in"):
+        TelegramConfig.from_mapping(_config(permissions={"allow_yolo": True}), {})
+
+
+def test_group_and_topic_bindings_inherit_deterministically(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    config = TelegramConfig.from_mapping(
+        _config(
+            activation="mention",
+            groups={
+                "-100123": {
+                    "enabled": True,
+                    "require_mention": False,
+                    "history_limit": 50,
+                    "prompt": "Keep group answers concise.",
+                    "directory": str(project),
+                    "agent_id": "research_agent",
+                    "mode": "plan",
+                    "skills": ["ponytail", "browser", "ponytail"],
+                    "topics": {
+                        "42": {
+                            "activation": "mention",
+                            "history_limit": 5,
+                            "prompt": None,
+                            "directory": None,
+                            "agent_id": None,
+                            "mode": "build",
+                            "skills": [],
+                        }
+                    },
+                },
+                "-100456": {
+                    "enabled": False,
+                    "topics": {"7": {"enabled": True}},
+                },
+            },
+        ),
+        {},
+    )
+
+    group = config.binding_for("-100123")
+    assert group.activation == "always"
+    assert group.history_limit == 50
+    assert group.prompt == "Keep group answers concise."
+    assert group.directory == str(project.resolve())
+    assert group.agent_id == "research_agent"
+    assert group.mode == "plan"
+    assert group.skills == ("ponytail", "browser")
+
+    inherited_topic = config.binding_for(-100123, 99)
+    assert inherited_topic == group
+
+    topic = config.binding_for(-100123, "42")
+    assert topic.enabled is True
+    assert topic.activation == "mention"
+    assert topic.history_limit == 5
+    assert topic.prompt is None
+    assert topic.directory is None
+    assert topic.agent_id is None
+    assert topic.mode == "build"
+    assert topic.skills == ()
+
+    assert config.binding_for(-100456, 7).enabled is False
+    assert config.binding_for(-100999).activation == "mention"
+
+
+@pytest.mark.parametrize(
+    ("groups", "message"),
+    [
+        ({"group-name": {}}, "numeric Telegram"),
+        ({"-1001": {"topics": {"topic-name": {}}}}, "numeric Telegram"),
+        ({"-1001": {"history_limit": 201}}, "history_limit"),
+        ({"-1001": {"require_mention": "yes"}}, "boolean"),
+        ({"-1001": {"unexpected": True}}, "unknown fields"),
+        ({"-1001": {"agent_id": "Upper Case"}}, "agent_id"),
+        ({"-1001": {"skills": ["Not-A-Skill"]}}, "kebab-case"),
+        (
+            {"-1001": {"activation": "always", "require_mention": True}},
+            "conflicts",
+        ),
+    ],
+)
+def test_group_binding_config_rejects_ambiguous_values(
+    groups: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        TelegramConfig.from_mapping(_config(groups=groups), {})
+
+
+def test_group_binding_rejects_invalid_directory(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(ValueError, match="existing directory"):
+        TelegramConfig.from_mapping(
+            _config(groups={"-1001": {"directory": str(missing)}}),
+            {},
+        )
+
+    with pytest.raises(ValueError, match="absolute existing directory"):
+        TelegramConfig.from_mapping(
+            _config(groups={"-1001": {"directory": "relative/project"}}),
+            {},
+        )

--- a/tests/integrations/telegram/test_config.py
+++ b/tests/integrations/telegram/test_config.py
@@ -134,6 +134,119 @@ def test_remote_permissions_are_prompted_and_capped_by_instance() -> None:
     assert config.approval_policy["timeout_seconds"] == 300.0
 
 
+def test_granular_remote_permissions_preserve_instance_ceiling() -> None:
+    config = TelegramConfig.from_mapping(
+        {
+            "security": {"mode": "workspace"},
+            "channels": {
+                "telegram": {
+                    "permissions": {
+                        "mode": "full_access",
+                        "approvals": {
+                            "shell": "ask",
+                            "fileWrite": "allow",
+                            "fileDelete": "deny",
+                            "gitPush": "deny",
+                            "network": "allow",
+                            "secrets": "deny",
+                            "default": "deny",
+                        },
+                        "timeout_seconds": 90,
+                    }
+                }
+            },
+        },
+        {},
+    )
+
+    assert config.permission_mode == "workspace"
+    assert config.approval_policy == {
+        "shell": "ask",
+        "fileWrite": "allow",
+        "fileDelete": "deny",
+        "gitPush": "deny",
+        "network": "allow",
+        "secrets": "deny",
+        "default": "deny",
+        "allowLists": {},
+        "timeout_seconds": 90.0,
+        "wait_for_resolution": True,
+    }
+
+
+def test_granular_remote_permissions_fall_back_to_secure_default() -> None:
+    config = TelegramConfig.from_mapping(
+        _config(permissions={"approvals": {"network": "allow"}}),
+        {},
+    )
+
+    assert config.approval_policy["network"] == "allow"
+    assert config.approval_policy["shell"] == "ask"
+    assert config.approval_policy["default"] == "ask"
+    assert config.approval_policy["wait_for_resolution"] is True
+
+
+def test_legacy_scalar_deny_remains_supported() -> None:
+    config = TelegramConfig.from_mapping(
+        _config(permissions={"approvals": "deny"}),
+        {},
+    )
+
+    assert config.approvals == "deny"
+    assert config.approval_policy["shell"] == "deny"
+    assert config.approval_policy["default"] == "deny"
+    assert "wait_for_resolution" not in config.approval_policy
+
+
+@pytest.mark.parametrize(
+    ("approvals", "message"),
+    [
+        ({"shell": "prompt"}, r"approvals\.shell"),
+        ({"futureCategory": "ask"}, "unknown categories"),
+        ("allow", "permissions.approvals"),
+    ],
+)
+def test_remote_permissions_reject_ambiguous_decisions(
+    approvals: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        TelegramConfig.from_mapping(
+            _config(permissions={"approvals": approvals}),
+            {},
+        )
+
+
+def test_permissions_summary_is_effective_and_credential_free() -> None:
+    config = TelegramConfig.from_mapping(
+        _config(
+            permissions={
+                "mode": "read_only",
+                "approvals": {"shell": "deny", "default": "allow"},
+                "timeout_seconds": 45,
+            }
+        ),
+        {},
+    )
+
+    assert config.permissions_summary == (
+        "Telegram permission policy\n"
+        "Mode cap: read_only (cannot exceed Penguin security.mode)\n"
+        "Approval timeout: 45 seconds\n"
+        "Telegram category decisions:\n"
+        "- shell: deny\n"
+        "- fileWrite: allow\n"
+        "- fileDelete: allow\n"
+        "- gitPush: allow\n"
+        "- network: allow\n"
+        "- secrets: allow\n"
+        "- default: allow\n"
+        "allow means Telegram adds no prompt; Penguin instance or agent policy "
+        "can still ASK, and any instance, agent, or workspace DENY still blocks. "
+        "YOLO is unavailable."
+    )
+
+
 @pytest.mark.parametrize(
     ("telegram", "message"),
     [

--- a/tests/integrations/telegram/test_formatting.py
+++ b/tests/integrations/telegram/test_formatting.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from hypothesis import given, strategies as st
+
+from penguin.integrations.telegram.formatting import (
+    StreamingCoalescer,
+    formatted_chunks,
+    html_chunks,
+    plain_chunks,
+    plain_text,
+    render_html,
+    split_text,
+    utf16_length,
+)
+
+
+def test_utf16_split_respects_telegram_limit_without_losing_text() -> None:
+    text = ("word 😀\n" * 700) + "done"
+    chunks = split_text(text)
+
+    assert "".join(chunks) == text
+    assert len(chunks) > 1
+    assert all(utf16_length(chunk) <= 4000 for chunk in chunks)
+    assert utf16_length("😀") == 2
+
+
+def test_render_html_escapes_input_and_formats_safe_markdown() -> None:
+    text = (
+        "# Heading\n**bold** and *italic* with <script>alert(1)</script> "
+        "and [docs](https://example.com?a=1&b=2) and `x < y`"
+    )
+
+    rendered = render_html(text)
+
+    assert rendered.startswith("<b>Heading</b>")
+    assert "<b>bold</b>" in rendered
+    assert "<i>italic</i>" in rendered
+    assert "&lt;script&gt;" in rendered
+    assert "<script>" not in rendered
+    assert '<a href="https://example.com?a=1&amp;b=2">docs</a>' in rendered
+    assert "<code>x &lt; y</code>" in rendered
+
+
+def test_html_chunks_account_for_escape_expansion() -> None:
+    chunks = html_chunks("<" * 5000)
+
+    assert "".join(chunks) == "&lt;" * 5000
+    assert all(utf16_length(chunk) <= 4000 for chunk in chunks)
+
+
+def test_html_and_plain_fallback_chunks_stay_aligned() -> None:
+    markdown = ("<unsafe> **bold** and `code`\n" * 1000) + "done"
+
+    chunks = formatted_chunks(markdown)
+
+    assert [html for html, _plain in chunks] == html_chunks(markdown)
+    assert all(utf16_length(html) <= 4000 for html, _plain in chunks)
+    assert all(utf16_length(plain) <= 4000 for _html, plain in chunks)
+    assert len(chunks) > 1
+
+
+def test_plain_fallback_removes_supported_markdown_and_splits() -> None:
+    markdown = "# **Title**\nUse `code` and [docs](https://example.com)." * 200
+
+    fallback = plain_text(markdown)
+    chunks = plain_chunks(markdown, limit=200)
+
+    assert "**" not in fallback
+    assert "`" not in fallback
+    assert "[docs]" not in fallback
+    assert "".join(chunks) == fallback
+    assert all(utf16_length(chunk) <= 200 for chunk in chunks)
+
+
+def test_streaming_coalescer_throttles_cumulative_previews() -> None:
+    coalescer = StreamingCoalescer(interval_seconds=0.75)
+
+    coalescer.push("hel")
+    assert coalescer.take(1.0) == "hel"
+    coalescer.push("lo")
+    assert coalescer.take(1.5) is None
+    assert coalescer.take(1.75) == "hello"
+    assert coalescer.take(2.0) is None
+    coalescer.push("!")
+    assert coalescer.take(2.1, force=True) == "hello!"
+
+
+@given(
+    st.text(
+        alphabet=st.characters(blacklist_categories=("Cs",)),
+        max_size=500,
+    )
+)
+def test_arbitrary_unicode_chunks_never_exceed_telegram_limit(text: str) -> None:
+    chunks = formatted_chunks(text, limit=64)
+
+    assert all(utf16_length(html) <= 64 for html, _plain in chunks)
+    assert all(utf16_length(plain) <= 64 for _html, plain in chunks)
+    assert "".join(split_text(text, limit=64)) == text

--- a/tests/integrations/telegram/test_history.py
+++ b/tests/integrations/telegram/test_history.py
@@ -1,0 +1,14 @@
+from penguin.integrations.telegram._history import GroupHistory
+
+
+def test_group_history_bounds_lanes_messages_and_configured_slice() -> None:
+    history = GroupHistory(max_lanes=2, max_messages=3)
+    for value in ("one", "two", "three", "four"):
+        history.append("lane-1", value)
+    history.append("lane-2", "two")
+    assert history.recent("lane-1", 2) == ["three", "four"]
+
+    history.append("lane-3", "three")
+    assert len(history) == 2
+    assert history.recent("lane-2", 10) == []
+    assert history.recent("lane-1", 10) == ["two", "three", "four"]

--- a/tests/integrations/telegram/test_manager.py
+++ b/tests/integrations/telegram/test_manager.py
@@ -1022,7 +1022,7 @@ async def test_slow_delivery_renews_lease_until_send_completes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 0.12)
+    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 1.0)
     bot = SlowDeliveryBot()
     store = ChannelStore(tmp_path / "channel.db")
     manager = TelegramManager(
@@ -1041,7 +1041,7 @@ async def test_slow_delivery_renews_lease_until_send_completes(
     try:
         assert await manager.admit_webhook_update(_update(23, "slow send"))
         await asyncio.wait_for(bot.send_started.wait(), timeout=1.0)
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(1.4)
 
         assert store.recover_expired_deliveries() == 0
         assert (

--- a/tests/integrations/telegram/test_manager.py
+++ b/tests/integrations/telegram/test_manager.py
@@ -23,7 +23,11 @@ from penguin.integrations.telegram.binding_policy import TelegramBindingPolicy
 from penguin.integrations.telegram.config import TelegramConfig
 from penguin.integrations.telegram.manager import TelegramManager
 from penguin.integrations.telegram.updates import normalize_update
-from penguin.security.approval import ApprovalStatus, get_approval_manager
+from penguin.security.approval import (
+    ApprovalScope,
+    ApprovalStatus,
+    get_approval_manager,
+)
 from penguin.security.question import get_question_manager
 from penguin.system.execution_context import get_current_execution_context
 from penguin.tools.artifact_tools import PublishArtifactTool
@@ -105,11 +109,23 @@ class FakeBot:
         return SimpleNamespace(message_id=kwargs["message_id"])
 
 
-def _callback_data(markup: Any) -> str:
+def _callback_data(markup: Any, *, text: str | None = None) -> str:
     keyboard = getattr(markup, "inline_keyboard", None)
     if keyboard is not None:
-        return str(keyboard[0][0].callback_data)
-    return str(markup[0][0]["data"])
+        buttons = [button for row in keyboard for button in row]
+        selected = next(
+            (button for button in buttons if text is None or button.text == text),
+            None,
+        )
+        assert selected is not None
+        return str(selected.callback_data)
+    buttons = [button for row in markup for button in row]
+    selected = next(
+        (button for button in buttons if text is None or button["text"] == text),
+        None,
+    )
+    assert selected is not None
+    return str(selected["data"])
 
 
 class PollingBot(FakeBot):
@@ -512,6 +528,62 @@ class ApprovalCore(FakeCore):
         }
 
 
+class CascadingApprovalCore(FakeCore):
+    """Attempt a second protected operation unless Telegram aborts the turn."""
+
+    def __init__(self, *, ttl_seconds: float = 2) -> None:
+        super().__init__()
+        self.ttl_seconds = ttl_seconds
+        self.first_request_id: str | None = None
+        self.first_request_created = asyncio.Event()
+        self.second_request_created = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.aborted_sessions: list[str] = []
+
+    async def abort_session(self, session_id: str) -> bool:
+        self.aborted_sessions.append(session_id)
+        tasks = getattr(self, "_opencode_process_tasks", {}).get(session_id, set())
+        for task in tuple(tasks):
+            task.cancel()
+        return bool(tasks)
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        context = get_current_execution_context()
+        try:
+            request = get_approval_manager().create_request(
+                tool_name="execute_command",
+                operation="tool.execute_command",
+                resource="first",
+                reason="test cascade",
+                session_id=str(context.session_id),
+                context={"request_id": context.request_id},
+                ttl_seconds=self.ttl_seconds,
+            )
+            self.first_request_id = request.id
+            self.first_request_created.set()
+            await asyncio.to_thread(
+                get_approval_manager().wait_for_resolution,
+                request.id,
+                self.ttl_seconds,
+            )
+            await asyncio.sleep(0)
+            get_approval_manager().create_request(
+                tool_name="execute_command",
+                operation="tool.execute_command",
+                resource="second",
+                reason="test cascade",
+                session_id=str(context.session_id),
+                context={"request_id": context.request_id},
+                ttl_seconds=self.ttl_seconds,
+            )
+            self.second_request_created.set()
+            return {"assistant_response": "continued", "status": "ok"}
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
 class SharedSessionProjectionCore(FakeCore):
     """Create request-scoped approvals from two serialized shared-session turns."""
 
@@ -655,6 +727,7 @@ async def test_webhook_dm_round_trip_is_durable_and_reuses_binding(
     manager = TelegramManager(core, _config(), bot=bot, store=store)
     await manager.start()
     try:
+        assert ("permissions", "Show Telegram tool permissions") in bot.commands
         assert await manager.admit_webhook_update(_update(1, "hello")) is True
         await _wait_for(lambda: len(core.calls) == 1 and bool(bot.edits))
 
@@ -1058,7 +1131,9 @@ async def test_delivery_worker_survives_completion_lease_loss(tmp_path: Path) ->
 async def test_ingress_lease_loss_cancels_live_turn(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
-    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 0.06)
+    # Leave enough startup headroom for SQLite/thread-pool scheduling on loaded CI
+    # hosts, while still forcing ownership loss well inside the test deadline.
+    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 0.3)
     bot = FakeBot()
     core = BlockingCore()
     store = IngressLeaseLossStore(tmp_path / "channel.db")
@@ -1277,7 +1352,12 @@ async def test_media_downloads_are_bounded_and_temporary_files_are_cleaned(
             "[End untrusted Telegram document]\n\n"
             "read this document"
         )
-        assert document_file.paths
+        await _wait_for(
+            lambda: (
+                bool(document_file.paths)
+                and all(not path.exists() for path in document_file.paths)
+            )
+        )
         assert all(not path.exists() for path in document_file.paths)
     finally:
         await manager.stop()
@@ -2168,11 +2248,13 @@ async def test_group_approval_hides_details_and_rejects_wrong_sender(
         await manager.admit_webhook_update(callback_update(72, 42))
         await _wait_for(lambda: core.side_effect_count == 1)
         await _wait_for(
-            lambda: any(item.get("text") == "<b>Approved</b>" for item in bot.edits)
+            lambda: any("<b>Approved</b>" in item.get("text", "") for item in bot.edits)
         )
         terminal = next(
-            item for item in bot.edits if item.get("text") == "<b>Approved</b>"
+            item for item in bot.edits if "<b>Approved</b>" in item.get("text", "")
         )
+        assert "Sensitive operation details are hidden" in terminal["text"]
+        assert "notes.txt" not in terminal["text"]
         assert terminal["reply_markup"] is None
         assert bot.callback_answers[0]["text"] == "This action is unavailable."
         assert bot.callback_answers[-1]["text"] == "Recorded."
@@ -2264,12 +2346,12 @@ async def test_question_text_reply_bypasses_busy_session_lane(tmp_path: Path) ->
             lambda: any("answer:Beta" in item.get("text", "") for item in bot.messages)
         )
         await _wait_for(
-            lambda: any(item.get("text") == "<b>Answered</b>" for item in bot.edits)
+            lambda: any("<b>Answered</b>" in item.get("text", "") for item in bot.edits)
         )
         assert (
-            next(item for item in bot.edits if item.get("text") == "<b>Answered</b>")[
-                "reply_markup"
-            ]
+            next(
+                item for item in bot.edits if "<b>Answered</b>" in item.get("text", "")
+            )["reply_markup"]
             is None
         )
 
@@ -2316,7 +2398,7 @@ async def test_multi_question_requires_one_answer_per_line(tmp_path: Path) -> No
         await _wait_for(lambda: core.answered.is_set())
         assert core.answers == [["alpha"], ["beta"]]
         await _wait_for(
-            lambda: any(item.get("text") == "<b>Answered</b>" for item in bot.edits)
+            lambda: any("<b>Answered</b>" in item.get("text", "") for item in bot.edits)
         )
     finally:
         await manager.stop()
@@ -2348,15 +2430,131 @@ async def test_external_approval_resolution_terminalizes_prompt(
         assert get_approval_manager().deny(core.request_id) is not None
 
         await _wait_for(
-            lambda: any(item.get("text") == "<b>Denied</b>" for item in bot.edits)
+            lambda: any(
+                "Tool approval required" in item.get("text", "")
+                and "<b>Denied</b>" in item.get("text", "")
+                for item in bot.edits
+            )
         )
         terminal = next(
-            item for item in bot.edits if item.get("text") == "<b>Denied</b>"
+            item for item in bot.edits if "<b>Denied</b>" in item.get("text", "")
         )
+        assert "Tool: write" in terminal["text"]
+        assert "Resource: notes.txt" in terminal["text"]
         assert terminal["reply_markup"] is None
         await _wait_for(
             lambda: any(item.get("text") == "denied" for item in bot.messages)
         )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_denied_approval_stops_turn_before_next_protected_operation(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = CascadingApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(91, "run commands"))
+        await asyncio.wait_for(core.first_request_created.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item.get("text", "")
+                for item in bot.messages
+            )
+        )
+        prompt = next(
+            item
+            for item in bot.messages
+            if "Tool approval required" in item.get("text", "")
+        )
+        await manager.admit_webhook_update(
+            {
+                "update_id": 92,
+                "callback_query": {
+                    "id": "callback-deny",
+                    "from": {"id": 42},
+                    "data": _callback_data(prompt["reply_markup"], text="Deny"),
+                    "message": {
+                        "message_id": 52,
+                        "chat": {"id": 42, "type": "private"},
+                        "from": {"id": 867, "username": "Penguin_agent_bot"},
+                    },
+                },
+            }
+        )
+
+        await asyncio.wait_for(core.cancelled.wait(), timeout=1.0)
+        await asyncio.sleep(0.05)
+        assert core.aborted_sessions == ["session-1"]
+        assert not core.second_request_created.is_set()
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_expired_approval_stops_turn_before_next_protected_operation(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = CascadingApprovalCore(ttl_seconds=0.05)
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(93, "run commands"))
+        await asyncio.wait_for(core.first_request_created.wait(), timeout=1.0)
+        await asyncio.wait_for(core.cancelled.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item.get("text", "")
+                and "<b>Expired</b>" in item.get("text", "")
+                for item in bot.edits
+            )
+        )
+
+        assert core.aborted_sessions == ["session-1"]
+        assert not core.second_request_created.is_set()
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_non_telegram_approval_resolution_does_not_abort_session(
+    tmp_path: Path,
+) -> None:
+    core = CascadingApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=FakeBot(),
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        request = get_approval_manager().create_request(
+            tool_name="execute_command",
+            operation="tool.execute_command",
+            resource="outside Telegram",
+            reason="test shared singleton",
+            session_id="web-session",
+        )
+        assert get_approval_manager().deny(request.id) is not None
+        await asyncio.sleep(0.05)
+
+        assert core.aborted_sessions == []
     finally:
         await manager.stop()
 
@@ -2414,7 +2612,7 @@ async def test_restart_terminalizes_orphaned_prompt_before_ttl(
         await _wait_for(lambda: bool(bot.messages) and bool(bot.edits))
         assert bot.messages[0]["text"] == "Tool approval required"
         assert bot.edits[0]["message_id"] == 1
-        assert bot.edits[0]["text"] == "<b>Expired</b>"
+        assert bot.edits[0]["text"] == "Tool approval required\n\n<b>Expired</b>"
         assert bot.edits[0]["reply_markup"] is None
         with store._read() as conn:
             state = conn.execute(
@@ -2466,7 +2664,7 @@ async def test_approval_callback_resumes_once_and_duplicate_is_inert(
         await manager.admit_webhook_update(callback_update)
         await _wait_for(lambda: core.side_effect_count == 1)
         await _wait_for(
-            lambda: any(item.get("text") == "<b>Approved</b>" for item in bot.edits)
+            lambda: any("<b>Approved</b>" in item.get("text", "") for item in bot.edits)
         )
 
         duplicate = dict(callback_update)
@@ -2478,7 +2676,61 @@ async def test_approval_callback_resumes_once_and_duplicate_is_inert(
 
         assert core.side_effect_count == 1
         assert len(core.calls) == 1
-        assert sum(item.get("text") == "<b>Approved</b>" for item in bot.edits) == 1
+        assert sum("<b>Approved</b>" in item.get("text", "") for item in bot.edits) == 1
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_callback_can_approve_similar_operations_for_session(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = ApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(13, "write it"))
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item["text"] for item in bot.messages
+            )
+        )
+        prompt = next(
+            item for item in bot.messages if "Tool approval required" in item["text"]
+        )
+        callback_data = _callback_data(
+            prompt["reply_markup"], text="Approve for session"
+        )
+        await manager.admit_webhook_update(
+            {
+                "update_id": 14,
+                "callback_query": {
+                    "id": "callback-session",
+                    "from": {"id": 42},
+                    "data": callback_data,
+                    "message": {
+                        "message_id": 51,
+                        "chat": {"id": 42, "type": "private"},
+                        "from": {"id": 867, "username": "Penguin_agent_bot"},
+                    },
+                },
+            }
+        )
+        await _wait_for(lambda: core.side_effect_count == 1)
+
+        assert core.request_id is not None
+        request = get_approval_manager().get_request(core.request_id)
+        assert request is not None
+        assert request.resolution_scope == ApprovalScope.SESSION
+        assert get_approval_manager().check_pre_approved(
+            "filesystem.write", "another.txt", "session-1"
+        )
     finally:
         await manager.stop()
 

--- a/tests/integrations/telegram/test_manager.py
+++ b/tests/integrations/telegram/test_manager.py
@@ -1,0 +1,2612 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import time
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from PIL import Image
+
+from penguin.channels.store import (
+    ChannelStore,
+    LeaseLostError,
+    PollerLeaseConflictError,
+)
+from penguin.integrations.telegram import manager as manager_module
+from penguin.integrations.telegram._artifacts import artifact_paths
+from penguin.integrations.telegram.binding_policy import TelegramBindingPolicy
+from penguin.integrations.telegram.config import TelegramConfig
+from penguin.integrations.telegram.manager import TelegramManager
+from penguin.integrations.telegram.updates import normalize_update
+from penguin.security.approval import ApprovalStatus, get_approval_manager
+from penguin.security.question import get_question_manager
+from penguin.system.execution_context import get_current_execution_context
+from penguin.tools.artifact_tools import PublishArtifactTool
+from penguin.tools.runtime import (
+    legacy_action_result_from_tool_result,
+    tool_result_from_action_result,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_interactive_managers():
+    get_approval_manager().reset()
+    get_question_manager().reset()
+    yield
+    get_approval_manager().reset()
+    get_question_manager().reset()
+
+
+class FakeBot:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+        self.edits: list[dict[str, Any]] = []
+        self.documents: list[dict[str, Any]] = []
+        self.photos: list[dict[str, Any]] = []
+        self.markup_edits: list[dict[str, Any]] = []
+        self.callback_answers: list[dict[str, Any]] = []
+        self.actions: list[dict[str, Any]] = []
+        self.commands: list[Any] = []
+        self.webhook: dict[str, Any] | None = None
+        self.initialized = False
+        self.closed = False
+        self._next_message_id = 1
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def shutdown(self) -> None:
+        self.closed = True
+
+    async def get_me(self) -> Any:
+        return SimpleNamespace(id=867, username="Penguin_agent_bot")
+
+    async def set_my_commands(self, commands: list[Any]) -> None:
+        self.commands = commands
+
+    async def set_webhook(self, **kwargs: Any) -> None:
+        self.webhook = kwargs
+
+    async def send_message(self, **kwargs: Any) -> Any:
+        self.messages.append(dict(kwargs))
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        return SimpleNamespace(message_id=message_id)
+
+    async def edit_message_text(self, **kwargs: Any) -> Any:
+        self.edits.append(dict(kwargs))
+        return SimpleNamespace(message_id=kwargs["message_id"])
+
+    async def send_chat_action(self, **kwargs: Any) -> None:
+        self.actions.append(dict(kwargs))
+
+    async def send_document(self, *, document: Any, **kwargs: Any) -> Any:
+        self.documents.append({**kwargs, "name": Path(document.name).name})
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        return SimpleNamespace(message_id=message_id)
+
+    async def send_photo(self, *, photo: Any, **kwargs: Any) -> Any:
+        self.photos.append({**kwargs, "name": Path(photo.name).name})
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        return SimpleNamespace(message_id=message_id)
+
+    async def answer_callback_query(self, **kwargs: Any) -> None:
+        self.callback_answers.append(dict(kwargs))
+
+    async def edit_message_reply_markup(self, **kwargs: Any) -> Any:
+        self.markup_edits.append(dict(kwargs))
+        return SimpleNamespace(message_id=kwargs["message_id"])
+
+
+class PollingBot(FakeBot):
+    """Fake Bot API boundary that inspects state before the next long poll."""
+
+    def __init__(self, store: ChannelStore, update: dict[str, Any]) -> None:
+        super().__init__()
+        self.store = store
+        self.update = update
+        self.offsets: list[int | None] = []
+        self.persisted_before_next_poll = False
+        self.observed = asyncio.Event()
+
+    async def delete_webhook(self, **kwargs: Any) -> None:
+        del kwargs
+
+    async def get_updates(self, *, offset: int | None, **kwargs: Any) -> list[Any]:
+        del kwargs
+        self.offsets.append(offset)
+        if len(self.offsets) == 1:
+            return [self.update]
+
+        account_id = "867"
+        fingerprint = self.store.fingerprint_token("test-only-token")
+        ingress = self.store.get_ingress(
+            f"telegram:{account_id}:{self.update['update_id']}",
+            platform="telegram",
+            account_id=account_id,
+        )
+        persisted_offset = self.store.get_poller_offset(
+            platform="telegram",
+            account_id=account_id,
+            token_fingerprint=fingerprint,
+        )
+        self.persisted_before_next_poll = (
+            ingress is not None
+            and persisted_offset == self.update["update_id"] + 1
+            and offset == persisted_offset
+        )
+        self.observed.set()
+        await asyncio.Event().wait()
+        return []
+
+
+class TransportLeaseBot(FakeBot):
+    """Track transport mutations while keeping polling alive."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.deleted_webhooks = 0
+        self.polling_started = asyncio.Event()
+
+    async def delete_webhook(self, **kwargs: Any) -> None:
+        del kwargs
+        self.deleted_webhooks += 1
+
+    async def get_updates(self, **kwargs: Any) -> list[Any]:
+        del kwargs
+        self.polling_started.set()
+        await asyncio.Event().wait()
+        return []
+
+
+class MigrationBatchPollingBot(FakeBot):
+    def __init__(self, updates: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.updates = updates
+        self.poll_count = 0
+        self.batch_persisted = asyncio.Event()
+
+    async def delete_webhook(self, **kwargs: Any) -> None:
+        del kwargs
+
+    async def get_updates(self, **kwargs: Any) -> list[Any]:
+        del kwargs
+        self.poll_count += 1
+        if self.poll_count == 1:
+            return self.updates
+        self.batch_persisted.set()
+        await asyncio.Event().wait()
+        return []
+
+
+class NetworkError(Exception):
+    """Transport-shaped transient failure recognized by retry classification."""
+
+
+class BadRequest(Exception):
+    """Transport-shaped fatal formatting/edit failure."""
+
+
+class Conflict(Exception):
+    """Transport-shaped competing getUpdates failure."""
+
+
+class InvalidToken(Exception):
+    """Transport-shaped integration-fatal credential failure."""
+
+
+class ConflictPollingBot(FakeBot):
+    async def delete_webhook(self, **kwargs: Any) -> None:
+        del kwargs
+
+    async def get_updates(self, **kwargs: Any) -> list[Any]:
+        del kwargs
+        raise Conflict("another getUpdates consumer")
+
+
+class InvalidTokenDeliveryBot(FakeBot):
+    async def send_message(self, **kwargs: Any) -> Any:
+        del kwargs
+        raise InvalidToken("invalid test-only-token")
+
+
+class FlakyDeliveryBot(FakeBot):
+    """Fail the first final send, then behave like Telegram recovered."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_attempts = 0
+
+    async def send_message(self, **kwargs: Any) -> Any:
+        self.send_attempts += 1
+        if self.send_attempts == 1:
+            raise NetworkError("temporary Telegram outage")
+        return await super().send_message(**kwargs)
+
+
+class StalledDeliveryBot(FakeBot):
+    """Let the manager's request deadline cancel the first delivery attempt."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_attempts = 0
+        self.first_attempt_cancelled = asyncio.Event()
+
+    async def send_message(self, **kwargs: Any) -> Any:
+        self.send_attempts += 1
+        if self.send_attempts == 1:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.first_attempt_cancelled.set()
+                raise
+        return await super().send_message(**kwargs)
+
+
+class SlowDeliveryBot(FakeBot):
+    """Hold a send open while the durable delivery lease is renewed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_started = asyncio.Event()
+        self.release_send = asyncio.Event()
+
+    async def send_message(self, **kwargs: Any) -> Any:
+        self.send_started.set()
+        await self.release_send.wait()
+        return await super().send_message(**kwargs)
+
+
+class CompleteLeaseLossStore(ChannelStore):
+    def __init__(self, path: Path) -> None:
+        super().__init__(path)
+        self.fail_next_completion = True
+
+    def complete_delivery(self, *args: Any, **kwargs: Any) -> None:
+        if self.fail_next_completion:
+            self.fail_next_completion = False
+            raise LeaseLostError("simulated stale delivery owner")
+        super().complete_delivery(*args, **kwargs)
+
+
+class IngressLeaseLossStore(ChannelStore):
+    def renew_ingress_lease(self, *args: Any, **kwargs: Any) -> bool:
+        return False
+
+
+class ArtifactEnqueueFailureStore(ChannelStore):
+    def enqueue_delivery(self, *args: Any, **kwargs: Any) -> bool:
+        if kwargs.get("kind") in {"photo", "document"}:
+            raise RuntimeError("simulated artifact projection failure")
+        return super().enqueue_delivery(*args, **kwargs)
+
+
+class EditFailBot(FakeBot):
+    async def edit_message_text(self, **kwargs: Any) -> Any:
+        del kwargs
+        raise BadRequest("preview is no longer editable")
+
+
+class FailingPollingBot(FakeBot):
+    async def delete_webhook(self, **kwargs: Any) -> None:
+        del kwargs
+        raise RuntimeError("polling setup failed")
+
+
+class DownloadableFile:
+    """Fake Telegram file that records every temporary download target."""
+
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.paths: list[Path] = []
+
+    async def download_to_drive(self, *, custom_path: str) -> None:
+        path = Path(custom_path)
+        self.paths.append(path)
+        path.write_bytes(self.content)
+
+
+class MediaBot(FakeBot):
+    """Fake Bot API media boundary with deterministic file payloads."""
+
+    def __init__(self, files: dict[str, DownloadableFile]) -> None:
+        super().__init__()
+        self.files = files
+
+    async def get_file(self, file_id: str) -> DownloadableFile:
+        return self.files[file_id]
+
+
+class FakeCore:
+    def __init__(self) -> None:
+        self.session_number = 0
+        self.calls: list[dict[str, Any]] = []
+        self.contexts: list[Any] = []
+        self.model_config = SimpleNamespace(model="fake-model")
+
+    def create_conversation(self) -> str:
+        self.session_number += 1
+        return f"session-{self.session_number}"
+
+    async def abort_session(self, session_id: str) -> bool:
+        return bool(session_id)
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        self.contexts.append(get_current_execution_context())
+        callback = kwargs.get("stream_callback")
+        if callback is not None:
+            await callback("streamed ", "assistant")
+        return {
+            "assistant_response": f"reply:{kwargs['input_data']['text']}",
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+class MediaCore(FakeCore):
+    """Observe that downloaded image paths exist only during Penguin execution."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.image_path: Path | None = None
+        self.image_existed_during_turn = False
+        self.document_input_text: str | None = None
+        self.context_files: list[str] = []
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        image_paths = kwargs["input_data"].get("image_paths") or []
+        if image_paths:
+            self.image_path = Path(image_paths[0])
+            self.image_existed_during_turn = self.image_path.is_file()
+        self.context_files = list(kwargs.get("context_files") or [])
+        self.document_input_text = str(kwargs["input_data"].get("text") or "")
+        return await super().process(**kwargs)
+
+
+class ArtifactCore(FakeCore):
+    def __init__(self, paths: list[Path]) -> None:
+        super().__init__()
+        self.paths = paths
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {
+            "assistant_response": "artifacts ready",
+            "action_results": [
+                {"artifact": {"path": str(path)}} for path in self.paths
+            ],
+            "status": "ok",
+        }
+
+
+class RuntimeArtifactCore(FakeCore):
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self.path = path
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        produced = PublishArtifactTool().execute(str(self.path))
+        tool_result = tool_result_from_action_result(
+            produced,
+            call_id="publish-report",
+            structured_output=produced,
+        )
+        return {
+            "assistant_response": "report ready",
+            "action_results": [legacy_action_result_from_tool_result(tool_result)],
+            "status": "ok",
+        }
+
+
+class QuestionCore(FakeCore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.answered = asyncio.Event()
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        context = get_current_execution_context()
+        request = get_question_manager().create_request(
+            session_id=str(context.session_id),
+            questions=[
+                {
+                    "header": "Choice",
+                    "question": "Which option?",
+                    "options": [
+                        {"label": "Alpha", "description": "First"},
+                        {"label": "Beta", "description": "Second"},
+                    ],
+                }
+            ],
+        )
+        resolved = await get_question_manager().wait_for_resolution(
+            request.id, timeout_seconds=2
+        )
+        assert resolved is not None
+        self.answered.set()
+        return {
+            "assistant_response": f"answer:{resolved.answers[0][0]}",
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+class MultiQuestionCore(FakeCore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.answered = asyncio.Event()
+        self.answers: list[list[str]] | None = None
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        context = get_current_execution_context()
+        request = get_question_manager().create_request(
+            session_id=str(context.session_id),
+            questions=[
+                {"header": "First", "question": "First answer?", "options": []},
+                {"header": "Second", "question": "Second answer?", "options": []},
+            ],
+        )
+        resolved = await get_question_manager().wait_for_resolution(
+            request.id, timeout_seconds=3
+        )
+        assert resolved is not None
+        self.answers = resolved.answers
+        self.answered.set()
+        return {
+            "assistant_response": "multi answered",
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+class ApprovalCore(FakeCore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.side_effect_count = 0
+        self.request_id: str | None = None
+        self.request_created = asyncio.Event()
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        context = get_current_execution_context()
+        request = get_approval_manager().create_request(
+            tool_name="write",
+            operation="filesystem.write",
+            resource="notes.txt",
+            reason="test approval",
+            session_id=str(context.session_id),
+            context={"tool_call_id": "call-1"},
+            ttl_seconds=2,
+        )
+        self.request_id = request.id
+        self.request_created.set()
+        resolved = await asyncio.to_thread(
+            get_approval_manager().wait_for_resolution, request.id, 2
+        )
+        if resolved is not None and resolved.status == ApprovalStatus.APPROVED:
+            self.side_effect_count += 1
+            response = "approved"
+        else:
+            response = "denied"
+        return {
+            "assistant_response": response,
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+class SharedSessionProjectionCore(FakeCore):
+    """Create request-scoped approvals from two serialized shared-session turns."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_started = asyncio.Event()
+        self.release_first = asyncio.Event()
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        text = str(kwargs["input_data"]["text"])
+        execution = get_current_execution_context()
+        if text == "first":
+            self.first_started.set()
+            await self.release_first.wait()
+        get_approval_manager().create_request(
+            tool_name="write",
+            operation="filesystem.write",
+            resource=f"{text}.txt",
+            reason=f"approve {text}",
+            session_id=str(execution.session_id),
+            context={"request_id": execution.request_id},
+            ttl_seconds=2,
+        )
+        return {
+            "assistant_response": f"queued:{text}",
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+class BlockingCore(FakeCore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+    async def abort_session(self, session_id: str) -> bool:
+        tasks = getattr(self, "_opencode_process_tasks", {}).get(session_id, set())
+        for task in tuple(tasks):
+            task.cancel()
+        return bool(tasks)
+
+
+class MigrationOrderingCore(FakeCore):
+    """Hold the pre-migration turn while later group updates are admitted."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_started = asyncio.Event()
+        self.release_first = asyncio.Event()
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        text = str(kwargs["input_data"]["text"])
+        if text == "before migration":
+            self.first_started.set()
+            await self.release_first.wait()
+        return {
+            "assistant_response": f"reply:{text}",
+            "action_results": [],
+            "status": "ok",
+        }
+
+
+def _config(**overrides: Any) -> TelegramConfig:
+    values: dict[str, Any] = {
+        "enabled": True,
+        "token": "test-only-token",
+        "expected_username": "Penguin_agent_bot",
+        "transport": "webhook",
+        "webhook_public_url": "https://example.test",
+        "webhook_secret": "secret",
+        "dm_policy": "allowlist",
+        "allow_from": frozenset({42}),
+        "streaming_mode": "progress",
+        "ingress_workers": 2,
+        "delivery_workers": 2,
+    }
+    values.update(overrides)
+    return TelegramConfig(**values)
+
+
+def _update(update_id: int, text: str, *, user_id: int = 42) -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": update_id,
+            "chat": {"id": user_id, "type": "private"},
+            "from": {"id": user_id, "username": f"user{user_id}"},
+            "text": text,
+        },
+    }
+
+
+async def _wait_for(predicate: Any, timeout: float = 3.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition did not become true")
+        await asyncio.sleep(0.01)
+
+
+def test_missing_runtime_explains_python_and_install_extra(monkeypatch: Any) -> None:
+    manager = TelegramManager(FakeCore(), _config())
+    monkeypatch.setitem(sys.modules, "telegram", None)
+
+    with pytest.raises(RuntimeError, match=r"Python 3\.10\+.*penguin-ai\[telegram\]"):
+        manager._create_bot("test-only-token")
+
+
+def test_artifact_discovery_requires_an_explicit_projection() -> None:
+    assert artifact_paths(
+        {
+            "action_results": [
+                {"path": "/private/direct.txt"},
+                {"result": {"path": "/private/result.txt"}},
+                {"output": {"file_path": "/private/output.txt"}},
+                {"artifact": {"path": "/safe/report.txt"}},
+            ]
+        }
+    ) == ["/safe/report.txt"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_dm_round_trip_is_durable_and_reuses_binding(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(core, _config(), bot=bot, store=store)
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(1, "hello")) is True
+        await _wait_for(lambda: len(core.calls) == 1 and bool(bot.edits))
+
+        assert await manager.admit_webhook_update(_update(1, "hello")) is False
+        assert await manager.admit_webhook_update(_update(2, "again")) is True
+        await _wait_for(lambda: len(core.calls) == 2)
+
+        assert {call["conversation_id"] for call in core.calls} == {"session-1"}
+        assert core.contexts[0].permission_mode == "workspace"
+        assert core.contexts[0].approval_policy["wait_for_resolution"] is True
+        assert (
+            store.get_ingress(
+                "telegram:867:1", platform="telegram", account_id="867"
+            ).state
+            == "completed"
+        )
+        assert manager.status()["username"] == "@Penguin_agent_bot"
+        assert "token" not in repr(manager.status()).lower()
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_polling_persists_update_before_requesting_the_next_offset(
+    tmp_path: Path,
+) -> None:
+    """The next poll may begin only after ingress and its watermark are durable."""
+    store = ChannelStore(tmp_path / "channel.db")
+    bot = PollingBot(store, _update(20, "persist me"))
+    manager = TelegramManager(
+        FakeCore(),
+        _config(transport="polling", streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        await asyncio.wait_for(bot.observed.wait(), timeout=1.0)
+
+        assert bot.offsets[:2] == [None, 21]
+        assert bot.persisted_before_next_poll is True
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.parametrize(
+    ("owner_transport", "contender_transport"),
+    [("webhook", "polling"), ("polling", "webhook")],
+)
+@pytest.mark.asyncio
+async def test_polling_and_webhook_share_transport_ownership(
+    tmp_path: Path,
+    owner_transport: str,
+    contender_transport: str,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    owner_bot = TransportLeaseBot()
+    owner = TelegramManager(
+        FakeCore(),
+        _config(transport=owner_transport, streaming_mode="off"),
+        bot=owner_bot,
+        store=store,
+    )
+    contender_bot = TransportLeaseBot()
+    contender = TelegramManager(
+        FakeCore(),
+        _config(transport=contender_transport, streaming_mode="off"),
+        bot=contender_bot,
+        store=store,
+    )
+
+    await owner.start()
+    try:
+        if owner_transport == "polling":
+            await asyncio.wait_for(owner_bot.polling_started.wait(), timeout=1.0)
+        with pytest.raises(PollerLeaseConflictError):
+            await contender.start()
+
+        assert contender_bot.deleted_webhooks == 0
+        assert contender_bot.webhook is None
+    finally:
+        await owner.stop()
+
+    replacement_bot = TransportLeaseBot()
+    replacement = TelegramManager(
+        FakeCore(),
+        _config(transport=contender_transport, streaming_mode="off"),
+        bot=replacement_bot,
+        store=store,
+    )
+    await replacement.start()
+    try:
+        if contender_transport == "polling":
+            assert replacement_bot.deleted_webhooks == 1
+        else:
+            assert replacement_bot.webhook is not None
+    finally:
+        await replacement.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_failure_rolls_back_bot_and_poller_ownership(
+    tmp_path: Path,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    bot = FailingPollingBot()
+    config = _config(transport="polling")
+    manager = TelegramManager(FakeCore(), config, bot=bot, store=store)
+
+    with pytest.raises(RuntimeError, match="polling setup failed"):
+        await manager.start()
+
+    assert bot.closed is True
+    assert manager.status()["running"] is False
+    assert "polling setup failed" in str(manager.status()["error"])
+    replacement = store.acquire_poller(
+        platform="telegram",
+        account_id="867",
+        token_fingerprint=store.fingerprint_token("test-only-token"),
+        owner_id="replacement",
+        lease_seconds=10,
+    )
+    assert replacement.owner_id == "replacement"
+
+
+@pytest.mark.asyncio
+async def test_fatal_polling_exit_updates_running_status(tmp_path: Path) -> None:
+    manager = TelegramManager(
+        FakeCore(),
+        _config(transport="polling", streaming_mode="off"),
+        bot=ConflictPollingBot(),
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await _wait_for(lambda: manager.status()["running"] is False)
+        assert "Conflict" in str(manager.status()["error"])
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_delivery_stops_integration_and_sets_safe_status(
+    tmp_path: Path,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        FakeCore(),
+        _config(streaming_mode="off", delivery_workers=1),
+        bot=InvalidTokenDeliveryBot(),
+        store=store,
+    )
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(26, "credential"))
+        await _wait_for(lambda: manager.status()["running"] is False)
+        delivery = store.get_delivery(
+            "telegram:867:26:final",
+            platform="telegram",
+            account_id="867",
+        )
+        assert delivery is not None and delivery.state == "dead"
+        error = str(manager.status()["error"])
+        assert "InvalidToken" in error
+        assert "test-only-token" not in error
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_transient_delivery_failure_is_durable_and_eventually_retried(
+    tmp_path: Path,
+) -> None:
+    """A transient Bot API failure remains recoverable in the delivery outbox."""
+    bot = FlakyDeliveryBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        FakeCore(),
+        _config(
+            streaming_mode="off",
+            delivery_workers=1,
+            retry_base_seconds=0.2,
+            retry_max_seconds=0.2,
+        ),
+        bot=bot,
+        store=store,
+    )
+    delivery_id = "telegram:867:21:final"
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(21, "retry me")) is True
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        delivery_id,
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "retry"
+            )
+        )
+        retry_record = store.get_delivery(
+            delivery_id,
+            platform="telegram",
+            account_id="867",
+        )
+        assert retry_record is not None
+        assert retry_record.last_error_class == "NetworkError"
+
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        delivery_id,
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "delivered"
+            )
+        )
+        delivered = store.get_delivery(
+            delivery_id,
+            platform="telegram",
+            account_id="867",
+        )
+
+        assert delivered is not None
+        assert delivered.attempt_count == 2
+        assert bot.send_attempts == 2
+        assert [message["text"] for message in bot.messages] == ["reply:retry me"]
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_stalled_delivery_is_timed_out_and_retried(tmp_path: Path) -> None:
+    bot = StalledDeliveryBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        FakeCore(),
+        _config(
+            streaming_mode="off",
+            delivery_workers=1,
+            request_timeout_seconds=0.05,
+            retry_base_seconds=0.05,
+            retry_max_seconds=0.05,
+        ),
+        bot=bot,
+        store=store,
+    )
+    delivery_id = "telegram:867:22:final"
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(22, "timeout")) is True
+        await asyncio.wait_for(bot.first_attempt_cancelled.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        delivery_id,
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "delivered"
+            )
+        )
+        delivered = store.get_delivery(
+            delivery_id,
+            platform="telegram",
+            account_id="867",
+        )
+
+        assert delivered is not None and delivered.attempt_count == 2
+        assert bot.send_attempts == 2
+        assert [message["text"] for message in bot.messages] == ["reply:timeout"]
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_slow_delivery_renews_lease_until_send_completes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 0.12)
+    bot = SlowDeliveryBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        FakeCore(),
+        _config(
+            streaming_mode="off",
+            delivery_workers=1,
+            request_timeout_seconds=2,
+        ),
+        bot=bot,
+        store=store,
+    )
+    delivery_id = "telegram:867:23:final"
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(23, "slow send"))
+        await asyncio.wait_for(bot.send_started.wait(), timeout=1.0)
+        await asyncio.sleep(0.2)
+
+        assert store.recover_expired_deliveries() == 0
+        assert (
+            store.claim_delivery(
+                platform="telegram",
+                account_id="867",
+                owner_id="contender",
+                lease_seconds=1,
+            )
+            is None
+        )
+        bot.release_send.set()
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        delivery_id,
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "delivered"
+            )
+        )
+        delivered = store.get_delivery(
+            delivery_id,
+            platform="telegram",
+            account_id="867",
+        )
+        assert delivered is not None and delivered.attempt_count == 1
+    finally:
+        bot.release_send.set()
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_delivery_worker_survives_completion_lease_loss(tmp_path: Path) -> None:
+    bot = FakeBot()
+    store = CompleteLeaseLossStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        FakeCore(),
+        _config(
+            allow_from=frozenset({42, 43}),
+            streaming_mode="off",
+            delivery_workers=1,
+        ),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(24, "first"))
+        await _wait_for(
+            lambda: any(item.get("text") == "reply:first" for item in bot.messages)
+        )
+        assert await manager.admit_webhook_update(_update(25, "second", user_id=43))
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        "telegram:867:25:final",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "delivered"
+            )
+        )
+        second = store.get_delivery(
+            "telegram:867:25:final",
+            platform="telegram",
+            account_id="867",
+        )
+        assert second is not None and second.state == "delivered"
+        assert any(
+            task.get_name() == "telegram-out-0" and not task.done()
+            for task in manager._tasks
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_ingress_lease_loss_cancels_live_turn(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(manager_module, "_LEASE_SECONDS", 0.06)
+    bot = FakeBot()
+    core = BlockingCore()
+    store = IngressLeaseLossStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(90, "keep working"))
+        await asyncio.wait_for(core.started.wait(), timeout=1.0)
+        await asyncio.wait_for(core.cancelled.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_ingress(
+                        "telegram:867:90", platform="telegram", account_id="867"
+                    )
+                )
+                is not None
+                and record.state == "dead"
+            )
+        )
+
+        assert bot.messages == []
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_final_edit_failure_falls_back_to_plain_new_message() -> None:
+    bot = EditFailBot()
+    manager = TelegramManager(FakeCore(), _config(), bot=bot)
+
+    message_id = await manager._send_text_payload(
+        {
+            "text": "**final answer**",
+            "edit_message_id": "99",
+            "reply_to_message_id": "7",
+        },
+        "42",
+        "10",
+    )
+
+    assert message_id == "1"
+    assert bot.messages == [
+        {
+            "chat_id": "42",
+            "text": "final answer",
+            "message_thread_id": 10,
+            "reply_to_message_id": 7,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lease_expiring_after_start_is_recovered_without_another_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    store.enqueue_delivery(
+        "stale-delivery",
+        "stale-delivery",
+        "telegram\x1f867\x1f42\x1f",
+        {"chat_id": "42", "topic_id": "", "text": "recovered"},
+        platform="telegram",
+        account_id="867",
+    )
+    claimed = store.claim_delivery(
+        platform="telegram",
+        account_id="867",
+        owner_id="crashed-process",
+        lease_seconds=0.3,
+        now=time.time(),
+    )
+    assert claimed is not None
+    monkeypatch.setattr(manager_module, "_RECOVERY_INTERVAL_SECONDS", 0.01)
+    bot = FakeBot()
+    manager = TelegramManager(FakeCore(), _config(), bot=bot, store=store)
+
+    await manager.start()
+    try:
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_delivery(
+                        "stale-delivery",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "delivered"
+            )
+        )
+        delivered = store.get_delivery(
+            "stale-delivery",
+            platform="telegram",
+            account_id="867",
+        )
+
+        assert delivered is not None and delivered.state == "delivered"
+        assert bot.messages[0]["text"] == "recovered"
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_media_downloads_are_bounded_and_temporary_files_are_cleaned(
+    tmp_path: Path,
+) -> None:
+    """Media exists for the turn only; downloaded oversize bodies never execute."""
+    image_buffer = BytesIO()
+    Image.new("RGB", (1, 1), color="blue").save(image_buffer, format="PNG")
+    valid_file = DownloadableFile(image_buffer.getvalue())
+    oversized_file = DownloadableFile(b"x" * 2048)
+    document_file = DownloadableFile(b"untrusted document")
+    bot = MediaBot(
+        {
+            "valid-photo": valid_file,
+            "oversized-photo": oversized_file,
+            "text-document": document_file,
+        }
+    )
+    core = MediaCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(
+            streaming_mode="off",
+            max_download_bytes=1024,
+            retry_attempts=1,
+        ),
+        bot=bot,
+        store=store,
+    )
+    valid_update = _update(40, "inspect this photo")
+    valid_update["message"]["photo"] = [
+        {
+            "file_id": "valid-photo",
+            "file_size": len(valid_file.content),
+        }
+    ]
+    oversized_update = _update(41, "reject this photo")
+    oversized_update["message"]["photo"] = [
+        {
+            "file_id": "oversized-photo",
+            "file_size": 10,
+        }
+    ]
+    document_update = _update(43, "read this document")
+    document_update["message"]["document"] = {
+        "file_id": "text-document",
+        "file_name": "notes.txt",
+        "mime_type": "text/plain",
+        "file_size": len(document_file.content),
+    }
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(valid_update) is True
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_ingress(
+                        "telegram:867:40",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "completed"
+            )
+        )
+
+        assert core.image_existed_during_turn is True
+        assert core.image_path is not None
+        assert core.image_path.is_file() is False
+        assert valid_file.paths and all(not path.exists() for path in valid_file.paths)
+
+        assert await manager.admit_webhook_update(oversized_update) is True
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_ingress(
+                        "telegram:867:41",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "completed"
+            )
+        )
+        await _wait_for(
+            lambda: any(
+                "size limit" in message.get("text", "") for message in bot.messages
+            )
+        )
+
+        assert len(core.calls) == 1
+        assert oversized_file.paths
+        assert all(not path.exists() for path in oversized_file.paths)
+
+        assert await manager.admit_webhook_update(document_update) is True
+        await _wait_for(lambda: len(core.calls) == 2)
+
+        assert core.context_files == []
+        assert core.document_input_text == (
+            "[Begin untrusted Telegram document 'notes.txt']\n"
+            "untrusted document\n"
+            "[End untrusted Telegram document]\n\n"
+            "read this document"
+        )
+        assert document_file.paths
+        assert all(not path.exists() for path in document_file.paths)
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_artifacts_are_durable_and_confined_to_bound_project(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    allowed = project / "report.txt"
+    allowed.write_text("report", encoding="utf-8")
+    outside = tmp_path / "private.txt"
+    outside.write_text("private", encoding="utf-8")
+    bot = FakeBot()
+    core = ArtifactCore([allowed, outside])
+    store = ChannelStore(tmp_path / "channel.db")
+    store.upsert_binding(
+        "telegram\x1f867\x1f42\x1f",
+        "session-artifacts",
+        directory=str(project),
+        agent_mode="build",
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(42, "make artifacts"))
+        await _wait_for(lambda: bool(bot.documents))
+        await _wait_for(
+            lambda: any(
+                "skipped 1 unsafe" in message.get("text", "")
+                for message in bot.messages
+            )
+        )
+
+        assert bot.documents == [{"chat_id": "42", "name": "report.txt"}]
+        assert all(item["name"] != "private.txt" for item in bot.documents)
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_explicit_runtime_artifact_reaches_telegram_delivery(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "report.txt"
+    artifact.write_text("report", encoding="utf-8")
+    bot = FakeBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    store.upsert_binding(
+        "telegram\x1f867\x1f42\x1f",
+        "session-runtime-artifact",
+        directory=str(project),
+        agent_mode="build",
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        RuntimeArtifactCore(artifact),
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(46, "send the report"))
+        await _wait_for(lambda: bool(bot.documents))
+
+        assert bot.documents == [{"chat_id": "42", "name": "report.txt"}]
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_artifact_projection_failure_is_visible_in_final_message(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "report.txt"
+    artifact.write_text("report", encoding="utf-8")
+    bot = FakeBot()
+    store = ArtifactEnqueueFailureStore(tmp_path / "channel.db")
+    store.upsert_binding(
+        "telegram\x1f867\x1f42\x1f",
+        "session-artifact-failure",
+        directory=str(project),
+        agent_mode="build",
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        ArtifactCore([artifact]),
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(45, "make artifact"))
+        await _wait_for(
+            lambda: any(
+                "could not queue one or more generated artifacts"
+                in message.get("text", "")
+                for message in bot.messages
+            )
+        )
+
+        ingress = store.get_ingress(
+            "telegram:867:45", platform="telegram", account_id="867"
+        )
+        assert ingress is not None and ingress.state == "completed"
+        assert bot.documents == []
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_artifact_symlink_swap_after_enqueue_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    artifact = project / "report.txt"
+    artifact.write_text("safe report", encoding="utf-8")
+    outside = tmp_path / "private.txt"
+    outside.write_text("private", encoding="utf-8")
+    bot = FakeBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(FakeCore(), _config(), bot=bot, store=store)
+    manager.account_id = "867"
+    envelope = normalize_update(_update(43, "make artifact"), account_id="867")
+    assert envelope is not None
+    store.admit_ingress(
+        envelope.event_id,
+        envelope.address.lane_key,
+        {"event": envelope.event_id},
+        platform="telegram",
+        account_id="867",
+    )
+    ingress = store.get_ingress(
+        envelope.event_id,
+        platform="telegram",
+        account_id="867",
+    )
+    assert ingress is not None
+    await manager._enqueue_artifacts(
+        envelope,
+        "session-artifact-swap",
+        ingress,
+        {"action_results": [{"artifact": {"path": str(artifact)}}]},
+        allowed_root=project,
+    )
+    delivery = store.get_delivery(
+        f"{envelope.event_id}:artifact:0",
+        platform="telegram",
+        account_id="867",
+    )
+    assert delivery is not None
+    assert delivery.payload["allowed_root"] == str(project.resolve())
+
+    artifact.unlink()
+    artifact.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="unsafe or unavailable"):
+        await manager._send_delivery(delivery)
+    assert bot.documents == []
+
+
+@pytest.mark.asyncio
+async def test_missing_bound_project_is_rejected_without_workspace_fallback(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "removed-project"
+    project.mkdir()
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    store.upsert_binding(
+        "telegram\x1f867\x1f42\x1f",
+        "session-missing-project",
+        directory=str(project),
+        agent_mode="build",
+        expected_version=0,
+    )
+    project.rmdir()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(44, "do work"))
+        await _wait_for(
+            lambda: any(
+                "Bound project unavailable" in message.get("text", "")
+                for message in bot.messages
+            )
+        )
+
+        assert core.calls == []
+        record = store.get_ingress(
+            "telegram:867:44", platform="telegram", account_id="867"
+        )
+        assert record is not None and record.state == "completed"
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_sender_never_reaches_penguin(tmp_path: Path) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(),
+        bot=bot,
+        store=store,
+    )
+    await manager.start()
+    try:
+        with sqlite3.connect(store.path) as conn:
+            before = conn.execute(
+                """SELECT
+                    (SELECT COUNT(*) FROM channel_ingress),
+                    (SELECT COUNT(*) FROM channel_deliveries)
+                """
+            ).fetchone()
+
+        assert (
+            await manager.admit_webhook_update(_update(3, "hello", user_id=99)) is False
+        )
+        await asyncio.sleep(0.05)
+
+        with sqlite3.connect(store.path) as conn:
+            after = conn.execute(
+                """SELECT
+                    (SELECT COUNT(*) FROM channel_ingress),
+                    (SELECT COUNT(*) FROM channel_deliveries)
+                """
+            ).fetchone()
+
+        assert core.calls == []
+        assert bot.messages == []
+        assert before == after == (0, 0)
+        assert (
+            store.get_ingress("telegram:867:3", platform="telegram", account_id="867")
+            is None
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_pairing_grants_one_expected_dm_without_broadening_access(
+    tmp_path: Path,
+) -> None:
+    """A manager-issued code is expected-user, single-use, and DM-only."""
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(dm_policy="pairing", streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+    await manager.start()
+    try:
+        code = await manager.create_pairing(expected_user_id="42", ttl_seconds=60)
+
+        assert (
+            await manager.admit_webhook_update(_update(30, f"/pair {code}", user_id=99))
+            is False
+        )
+        assert not store.is_dm_authorized(account_id="867", user_id="99")
+
+        assert await manager.admit_webhook_update(_update(31, f"/pair {code}"))
+        await _wait_for(lambda: store.is_dm_authorized(account_id="867", user_id="42"))
+        assert await manager.admit_webhook_update(_update(32, "paired hello"))
+        await _wait_for(lambda: len(core.calls) == 1)
+
+        assert (
+            await manager.admit_webhook_update(_update(33, f"/pair {code}", user_id=99))
+            is False
+        )
+        assert (
+            await manager.admit_webhook_update(
+                {
+                    "update_id": 34,
+                    "message": {
+                        "message_id": 34,
+                        "chat": {"id": -100, "type": "supergroup"},
+                        "from": {"id": 42},
+                        "text": "paired grant must not authorize this group",
+                    },
+                }
+            )
+            is False
+        )
+
+        assert len(core.calls) == 1
+        assert not store.is_dm_authorized(account_id="867", user_id="99")
+        assert all(
+            store.get_ingress(
+                f"telegram:867:{update_id}",
+                platform="telegram",
+                account_id="867",
+            )
+            is None
+            for update_id in (30, 33, 34)
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_new_command_rebinds_without_running_a_model_turn(tmp_path: Path) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(core, _config(streaming_mode="off"), bot=bot, store=store)
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(4, "/status"))
+        await _wait_for(lambda: bool(bot.messages))
+        address_key = "telegram\x1f867\x1f42\x1f"
+        assert store.get_binding(address_key).session_id == "session-1"
+
+        await manager.admit_webhook_update(_update(5, "/new"))
+        await _wait_for(
+            lambda: store.get_binding(address_key).session_id == "session-2"
+        )
+
+        assert core.calls == []
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_uses_reserved_control_worker_and_preserves_normal_capacity(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = BlockingCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=store,
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(50, "keep working"))
+        await asyncio.wait_for(core.started.wait(), timeout=1.0)
+        await manager.admit_webhook_update(_update(51, "/stop"))
+
+        await asyncio.wait_for(core.cancelled.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: any(
+                "Stopped the active Penguin turn" in message.get("text", "")
+                for message in bot.messages
+            )
+        )
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_ingress(
+                        "telegram:867:50",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "dead"
+            )
+        )
+
+        assert any(
+            task.get_name() == "telegram-in-0" and not task.done()
+            for task in manager._tasks
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_group_topics_receive_distinct_sessions(tmp_path: Path) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    config = _config(
+        group_policy="allowlist",
+        allowed_group_ids=frozenset({-100}),
+        allowed_group_sender_ids=frozenset({42}),
+        activation="always",
+        streaming_mode="off",
+    )
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(core, config, bot=bot, store=store)
+    await manager.start()
+    try:
+        for update_id, topic_id in ((6, 10), (7, 11)):
+            await manager.admit_webhook_update(
+                {
+                    "update_id": update_id,
+                    "message": {
+                        "message_id": update_id,
+                        "message_thread_id": topic_id,
+                        "chat": {"id": -100, "type": "supergroup"},
+                        "from": {"id": 42},
+                        "text": "hello",
+                    },
+                }
+            )
+        await _wait_for(lambda: len(core.calls) == 2)
+
+        assert len({call["conversation_id"] for call in core.calls}) == 2
+        assert store.get_binding("telegram\x1f867\x1f-100\x1f10") is not None
+        assert store.get_binding("telegram\x1f867\x1f-100\x1f11") is not None
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_webhook_migration_preserves_binding_order_and_destination(
+    tmp_path: Path,
+) -> None:
+    core = MigrationOrderingCore()
+    bot = FakeBot()
+    store = ChannelStore(tmp_path / "channel.db")
+    old_lane = "telegram\x1f867\x1f-100\x1f"
+    new_lane = "telegram\x1f867\x1f-200\x1f"
+    store.upsert_binding(
+        old_lane,
+        "session-existing",
+        directory=str(tmp_path),
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        core,
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            activation="always",
+            streaming_mode="off",
+        ),
+        bot=bot,
+        store=store,
+    )
+    before = {
+        "update_id": 99,
+        "message": {
+            "message_id": 99,
+            "chat": {"id": -100, "type": "group"},
+            "from": {"id": 42},
+            "text": "before migration",
+        },
+    }
+    migration = {
+        "update_id": 100,
+        "message": {
+            "message_id": 100,
+            "chat": {"id": -100, "type": "group"},
+            "migrate_to_chat_id": -200,
+        },
+    }
+    following = {
+        "update_id": 101,
+        "message": {
+            "message_id": 101,
+            "chat": {"id": -200, "type": "supergroup"},
+            "from": {"id": 42},
+            "text": "after migration",
+        },
+    }
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(before)
+        await asyncio.wait_for(core.first_started.wait(), timeout=1.0)
+        assert await manager.admit_webhook_update(migration)
+        assert await manager.admit_webhook_update(following)
+
+        records = [
+            store.get_ingress(
+                f"telegram:867:{update_id}",
+                platform="telegram",
+                account_id="867",
+            )
+            for update_id in (99, 100, 101)
+        ]
+        assert all(record is not None for record in records)
+        assert {record.lane_key for record in records if record is not None} == {
+            old_lane
+        }
+        assert (
+            store.claim_ingress(
+                platform="telegram",
+                account_id="867",
+                owner_id="race-check",
+                lease_seconds=1,
+            )
+            is None
+        )
+        assert len(core.calls) == 1
+
+        core.release_first.set()
+        await _wait_for(lambda: len(core.calls) == 2 and len(bot.messages) == 2)
+
+        assert [call["input_data"]["text"] for call in core.calls] == [
+            "before migration",
+            "after migration",
+        ]
+        assert [call["conversation_id"] for call in core.calls] == [
+            "session-existing",
+            "session-existing",
+        ]
+        assert [message["chat_id"] for message in bot.messages] == ["-200", "-200"]
+        assert [message["text"] for message in bot.messages] == [
+            "reply:before migration",
+            "reply:after migration",
+        ]
+        assert store.get_binding(old_lane) is None
+        assert store.get_binding(new_lane).session_id == "session-existing"
+    finally:
+        core.release_first.set()
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_polling_migration_batch_admits_following_new_group_update(
+    tmp_path: Path,
+) -> None:
+    updates = [
+        {
+            "update_id": 110,
+            "message": {
+                "message_id": 110,
+                "chat": {"id": -100, "type": "group"},
+                "migrate_to_chat_id": -200,
+            },
+        },
+        {
+            "update_id": 111,
+            "message": {
+                "message_id": 111,
+                "chat": {"id": -200, "type": "supergroup"},
+                "from": {"id": 42},
+                "text": "continue",
+            },
+        },
+    ]
+    core = FakeCore()
+    bot = MigrationBatchPollingBot(updates)
+    manager = TelegramManager(
+        core,
+        _config(
+            transport="polling",
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            activation="always",
+            streaming_mode="off",
+        ),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+
+    await manager.start()
+    try:
+        await asyncio.wait_for(bot.batch_persisted.wait(), timeout=1.0)
+        await _wait_for(lambda: len(core.calls) == 1)
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.parametrize(
+    ("migration_field", "event_chat_id", "event_chat_type"),
+    [
+        ("migrate_to_chat_id", -100, "group"),
+        ("migrate_from_chat_id", -100200, "supergroup"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_supergroup_migration_moves_base_and_topic_bindings(
+    tmp_path: Path,
+    migration_field: str,
+    event_chat_id: int,
+    event_chat_type: str,
+) -> None:
+    old_prefix = "telegram\x1f867\x1f-100"
+    new_prefix = "telegram\x1f867\x1f-100200"
+    old_base_key = old_prefix + "\x1f"
+    old_topic_key = old_prefix + "\x1f42"
+    store = ChannelStore(tmp_path / "channel.db")
+    base_before = store.upsert_binding(
+        old_base_key,
+        "session-group",
+        directory=str(tmp_path),
+        agent_id="group-agent",
+        agent_mode="build",
+        settings={
+            "activation": "mention",
+            "prompt": "Base group prompt",
+            "skills": ["review"],
+        },
+        expected_version=0,
+    )
+    topic_before = store.upsert_binding(
+        old_topic_key,
+        "session-topic-42",
+        directory=str(tmp_path),
+        agent_id="topic-agent",
+        agent_mode="plan",
+        settings={
+            "activation": "always",
+            "prompt": "Topic prompt",
+            "skills": ["tdd"],
+        },
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        FakeCore(),
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            streaming_mode="off",
+        ),
+        bot=FakeBot(),
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(
+            {
+                "update_id": 63,
+                "message": {
+                    "message_id": 63,
+                    "chat": {"id": event_chat_id, "type": event_chat_type},
+                    migration_field: -100200
+                    if migration_field == "migrate_to_chat_id"
+                    else -100,
+                },
+            }
+        )
+        await _wait_for(
+            lambda: (
+                (
+                    record := store.get_ingress(
+                        "telegram:867:63",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "completed"
+            )
+        )
+
+        assert store.get_binding(old_base_key) is None
+        assert store.get_binding(old_topic_key) is None
+        base_after = store.get_binding(new_prefix + "\x1f")
+        topic_after = store.get_binding(new_prefix + "\x1f42")
+        assert base_after is not None
+        assert topic_after is not None
+        assert (
+            base_after.session_id,
+            base_after.directory,
+            base_after.agent_id,
+            base_after.agent_mode,
+            base_after.settings,
+            base_after.version,
+        ) == (
+            base_before.session_id,
+            base_before.directory,
+            base_before.agent_id,
+            base_before.agent_mode,
+            base_before.settings,
+            base_before.version + 1,
+        )
+        assert (
+            topic_after.session_id,
+            topic_after.directory,
+            topic_after.agent_id,
+            topic_after.agent_mode,
+            topic_after.settings,
+            topic_after.version,
+        ) == (
+            topic_before.session_id,
+            topic_before.directory,
+            topic_before.agent_id,
+            topic_before.agent_mode,
+            topic_before.settings,
+            topic_before.version + 1,
+        )
+        assert store.is_group_authorized(
+            platform="telegram",
+            account_id="867",
+            chat_id="-100200",
+            allowed_source_chat_ids=frozenset({"-100"}),
+        )
+        assert not store.is_group_authorized(
+            platform="telegram",
+            account_id="867",
+            chat_id="-100200",
+            allowed_source_chat_ids=frozenset({"-999"}),
+        )
+        assert manager.core.calls == []
+
+        assert not await manager.admit_webhook_update(
+            {
+                "update_id": 64,
+                "message": {
+                    "message_id": 64,
+                    "chat": {"id": -100200, "type": "supergroup"},
+                    "from": {"id": 999},
+                    "text": "@Penguin_agent_bot unauthorized",
+                },
+            }
+        )
+        assert await manager.admit_webhook_update(
+            {
+                "update_id": 65,
+                "message": {
+                    "message_id": 65,
+                    "chat": {"id": -100200, "type": "supergroup"},
+                    "from": {"id": 42},
+                    "text": "@Penguin_agent_bot continue",
+                },
+            }
+        )
+        await _wait_for(lambda: len(manager.core.calls) == 1)
+        assert manager.core.calls[0]["conversation_id"] == "session-group"
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_group_mention_gate_observes_context_without_running_ambient_turns(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    manager = TelegramManager(
+        core,
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            activation="mention",
+            streaming_mode="off",
+        ),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+
+    def group_update(update_id: int, text: str) -> dict[str, Any]:
+        return {
+            "update_id": update_id,
+            "message": {
+                "message_id": update_id,
+                "chat": {"id": -100, "type": "supergroup"},
+                "from": {"id": 42, "username": "member"},
+                "text": text,
+            },
+        }
+
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(group_update(60, "ambient context"))
+        await manager.admit_webhook_update(group_update(61, "/status@Other_bot"))
+        await _wait_for(
+            lambda: all(
+                (
+                    record := manager.store.get_ingress(
+                        f"telegram:867:{update_id}",
+                        platform="telegram",
+                        account_id="867",
+                    )
+                )
+                is not None
+                and record.state == "completed"
+                for update_id in (60, 61)
+            )
+        )
+        assert core.calls == []
+
+        await manager.admit_webhook_update(
+            group_update(62, "@Penguin_agent_bot answer now")
+        )
+        await _wait_for(lambda: len(core.calls) == 1)
+
+        assert core.calls[0]["input_data"]["text"] == (
+            "[Untrusted recent Telegram group context]\n"
+            "member: ambient context\n"
+            "[End untrusted Telegram group context]\n\n"
+            "answer now"
+        )
+        assert core.calls[0]["context"]["observed_group_context"] == [
+            "member: ambient context"
+        ]
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_group_approval_hides_details_and_rejects_wrong_sender(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = ApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42, 99}),
+            activation="always",
+            streaming_mode="off",
+            ingress_workers=1,
+        ),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    original = {
+        "update_id": 70,
+        "message": {
+            "message_id": 70,
+            "message_thread_id": 10,
+            "chat": {"id": -100, "type": "supergroup"},
+            "from": {"id": 42},
+            "text": "write it",
+        },
+    }
+
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(original)
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item["text"] for item in bot.messages
+            )
+        )
+        prompt = next(
+            item for item in bot.messages if "Tool approval required" in item["text"]
+        )
+        assert "notes.txt" not in prompt["text"]
+        assert "test approval" not in prompt["text"]
+        callback_data = prompt["reply_markup"].inline_keyboard[0][0].callback_data
+
+        def callback_update(update_id: int, sender_id: int) -> dict[str, Any]:
+            return {
+                "update_id": update_id,
+                "callback_query": {
+                    "id": f"callback-{update_id}",
+                    "from": {"id": sender_id},
+                    "data": callback_data,
+                    "message": {
+                        "message_id": 71,
+                        "message_thread_id": 10,
+                        "chat": {"id": -100, "type": "supergroup"},
+                        "from": {"id": 867},
+                    },
+                },
+            }
+
+        await manager.admit_webhook_update(callback_update(71, 99))
+        await asyncio.sleep(0.05)
+        assert core.side_effect_count == 0
+        assert bot.edits == []
+
+        await manager.admit_webhook_update(callback_update(72, 42))
+        await _wait_for(lambda: core.side_effect_count == 1)
+        await _wait_for(
+            lambda: any(item.get("text") == "<b>Approved</b>" for item in bot.edits)
+        )
+        terminal = next(
+            item for item in bot.edits if item.get("text") == "<b>Approved</b>"
+        )
+        assert terminal["reply_markup"] is None
+        assert bot.callback_answers[0]["text"] == "This action is unavailable."
+        assert bot.callback_answers[-1]["text"] == "Recorded."
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_shared_session_projections_use_exact_execution_request(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = SharedSessionProjectionCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    for user_id in (42, 43):
+        store.upsert_binding(
+            f"telegram\x1f867\x1f{user_id}\x1f",
+            "shared-session",
+            directory=str(tmp_path),
+            agent_mode="build",
+            expected_version=0,
+        )
+    manager = TelegramManager(
+        core,
+        _config(
+            allow_from=frozenset({42, 43}),
+            streaming_mode="off",
+            ingress_workers=2,
+            delivery_workers=2,
+        ),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(80, "first"))
+        await asyncio.wait_for(core.first_started.wait(), timeout=1.0)
+        assert await manager.admit_webhook_update(_update(81, "second", user_id=43))
+        await _wait_for(lambda: len(manager._request_targets) == 2)
+        core.release_first.set()
+        await _wait_for(
+            lambda: (
+                sum(
+                    "Tool approval required" in message.get("text", "")
+                    for message in bot.messages
+                )
+                == 2
+            )
+        )
+
+        first_prompt = next(
+            message
+            for message in bot.messages
+            if "first.txt" in message.get("text", "")
+        )
+        second_prompt = next(
+            message
+            for message in bot.messages
+            if "second.txt" in message.get("text", "")
+        )
+        assert first_prompt["chat_id"] == "42"
+        assert second_prompt["chat_id"] == "43"
+        await _wait_for(lambda: not manager._request_targets)
+        assert manager._session_targets == {}
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_question_text_reply_bypasses_busy_session_lane(tmp_path: Path) -> None:
+    bot = FakeBot()
+    core = QuestionCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(8, "ask me"))
+        await _wait_for(
+            lambda: any("needs your input" in item["text"] for item in bot.messages)
+        )
+        await manager.admit_webhook_update(_update(9, "Beta"))
+        await _wait_for(lambda: core.answered.is_set())
+        await _wait_for(
+            lambda: any("answer:Beta" in item.get("text", "") for item in bot.messages)
+        )
+        await _wait_for(
+            lambda: any(item.get("text") == "<b>Answered</b>" for item in bot.edits)
+        )
+        assert (
+            next(item for item in bot.edits if item.get("text") == "<b>Answered</b>")[
+                "reply_markup"
+            ]
+            is None
+        )
+
+        assert len(core.calls) == 1
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_multi_question_requires_one_answer_per_line(tmp_path: Path) -> None:
+    bot = FakeBot()
+    core = MultiQuestionCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(86, "ask twice"))
+        await _wait_for(
+            lambda: any(
+                "First answer?" in item.get("text", "")
+                and "Second answer?" in item.get("text", "")
+                for item in bot.messages
+            )
+        )
+        prompt = next(
+            item for item in bot.messages if "First answer?" in item.get("text", "")
+        )
+        assert "reply_markup" not in prompt
+
+        await manager.admit_webhook_update(_update(87, "only one"))
+        await _wait_for(
+            lambda: any(
+                "one non-empty answer per question" in item.get("text", "")
+                for item in bot.messages
+            )
+        )
+        assert not core.answered.is_set()
+
+        await manager.admit_webhook_update(_update(88, "alpha\nbeta"))
+        await _wait_for(lambda: core.answered.is_set())
+        assert core.answers == [["alpha"], ["beta"]]
+        await _wait_for(
+            lambda: any(item.get("text") == "<b>Answered</b>" for item in bot.edits)
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_external_approval_resolution_terminalizes_prompt(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = ApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=1),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(90, "write it"))
+        await asyncio.wait_for(core.request_created.wait(), timeout=1.0)
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item.get("text", "")
+                for item in bot.messages
+            )
+        )
+        assert core.request_id is not None
+        assert get_approval_manager().deny(core.request_id) is not None
+
+        await _wait_for(
+            lambda: any(item.get("text") == "<b>Denied</b>" for item in bot.edits)
+        )
+        terminal = next(
+            item for item in bot.edits if item.get("text") == "<b>Denied</b>"
+        )
+        assert terminal["reply_markup"] is None
+        await _wait_for(
+            lambda: any(item.get("text") == "denied" for item in bot.messages)
+        )
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_restart_terminalizes_orphaned_prompt_before_ttl(
+    tmp_path: Path,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    now = time.time()
+    store.create_callback_with_delivery(
+        "orphan",
+        account_id="867",
+        chat_id="42",
+        topic_id=None,
+        user_id="42",
+        request_id="lost-request",
+        payload={
+            "kind": "approval",
+            "projection_delivery_id": "projection-orphan",
+            "lane_key": "telegram\x1f867\x1f42\x1f",
+            "platform": "telegram",
+            "session_id": "lost-session",
+        },
+        expires_at=now + 60,
+        projection_delivery_id="projection-orphan",
+        lane_key="telegram\x1f867\x1f42\x1f",
+        delivery_payload={
+            "chat_id": "42",
+            "topic_id": "",
+            "text": "Tool approval required",
+            "buttons": [
+                [
+                    {
+                        "text": "Approve once",
+                        "data": "penguin:orphan:approve",
+                    }
+                ]
+            ],
+        },
+        platform="telegram",
+        source_session_id="lost-session",
+        now=now,
+    )
+    bot = FakeBot()
+    manager = TelegramManager(
+        FakeCore(),
+        _config(streaming_mode="off", delivery_workers=1),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        await _wait_for(lambda: bool(bot.messages) and bool(bot.edits))
+        assert bot.messages[0]["text"] == "Tool approval required"
+        assert bot.edits[0]["message_id"] == 1
+        assert bot.edits[0]["text"] == "<b>Expired</b>"
+        assert bot.edits[0]["reply_markup"] is None
+        with store._read() as conn:
+            state = conn.execute(
+                "SELECT state FROM channel_callbacks WHERE callback_id = 'orphan'"
+            ).fetchone()[0]
+        assert state == "expired"
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_approval_callback_resumes_once_and_duplicate_is_inert(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = ApprovalCore()
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off", ingress_workers=2),
+        bot=bot,
+        store=ChannelStore(tmp_path / "channel.db"),
+    )
+    await manager.start()
+    try:
+        await manager.admit_webhook_update(_update(10, "write it"))
+        await _wait_for(
+            lambda: any(
+                "Tool approval required" in item["text"] for item in bot.messages
+            )
+        )
+        prompt = next(
+            item for item in bot.messages if "Tool approval required" in item["text"]
+        )
+        markup = prompt["reply_markup"]
+        callback_data = markup.inline_keyboard[0][0].callback_data
+        callback_message = {
+            "message_id": 50,
+            "chat": {"id": 42, "type": "private"},
+            "from": {"id": 867, "username": "Penguin_agent_bot"},
+        }
+        callback_update = {
+            "update_id": 11,
+            "callback_query": {
+                "id": "callback-1",
+                "from": {"id": 42},
+                "data": callback_data,
+                "message": callback_message,
+            },
+        }
+        await manager.admit_webhook_update(callback_update)
+        await _wait_for(lambda: core.side_effect_count == 1)
+        await _wait_for(
+            lambda: any(item.get("text") == "<b>Approved</b>" for item in bot.edits)
+        )
+
+        duplicate = dict(callback_update)
+        duplicate["update_id"] = 12
+        duplicate["callback_query"] = dict(callback_update["callback_query"])
+        duplicate["callback_query"]["id"] = "callback-2"
+        await manager.admit_webhook_update(duplicate)
+        await asyncio.sleep(0.1)
+
+        assert core.side_effect_count == 1
+        assert len(core.calls) == 1
+        assert sum(item.get("text") == "<b>Approved</b>" for item in bot.edits) == 1
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_group_topic_policy_seeds_and_scopes_execution(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "configured-project"
+    project.mkdir()
+    policy = TelegramBindingPolicy.from_mapping(
+        {
+            "-100": {
+                "activation": "mention",
+                "history_limit": 1,
+                "prompt": "Answer for the release team.",
+                "directory": str(project),
+                "agent_id": "configured-agent",
+                "mode": "plan",
+                "skills": ["ponytail"],
+            }
+        }
+    )
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            activation="mention",
+            binding_policy=policy,
+            streaming_mode="off",
+        ),
+        bot=FakeBot(),
+        store=store,
+    )
+
+    def group_update(update_id: int, text: str) -> dict[str, Any]:
+        return {
+            "update_id": update_id,
+            "message": {
+                "message_id": update_id,
+                "chat": {"id": -100, "type": "supergroup"},
+                "from": {"id": 42, "username": "member"},
+                "text": text,
+            },
+        }
+
+    await manager.start()
+    try:
+        for update_id, text in ((101, "old context"), (102, "recent context")):
+            assert await manager.admit_webhook_update(group_update(update_id, text))
+            await _wait_for(
+                lambda update_id=update_id: (
+                    (
+                        record := store.get_ingress(
+                            f"telegram:867:{update_id}",
+                            platform="telegram",
+                            account_id="867",
+                        )
+                    )
+                    is not None
+                    and record.state == "completed"
+                )
+            )
+
+        assert await manager.admit_webhook_update(
+            group_update(103, "@Penguin_agent_bot ship it")
+        )
+        await _wait_for(lambda: len(core.calls) == 1)
+
+        binding = store.get_binding("telegram\x1f867\x1f-100\x1f")
+        assert binding is not None
+        assert binding.directory == str(project.resolve())
+        assert binding.agent_id == "configured-agent"
+        assert binding.agent_mode == "plan"
+        assert binding.settings == {
+            "activation": "mention",
+            "history_limit": 1,
+            "prompt": "Answer for the release team.",
+            "skills": ["ponytail"],
+        }
+        assert "old context" not in core.calls[0]["input_data"]["text"]
+        assert "member: recent context" in core.calls[0]["input_data"]["text"]
+        execution = core.contexts[0]
+        assert execution.directory == str(project.resolve())
+        assert execution.agent_mode == "plan"
+        assert execution.request_system_prompt == "Answer for the release team."
+        assert execution.request_skills == ("ponytail",)
+        assert execution.require_registered_agent is True
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_disabled_group_binding_is_rejected_before_durable_admission(
+    tmp_path: Path,
+) -> None:
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(
+            group_policy="allowlist",
+            allowed_group_ids=frozenset({-100}),
+            allowed_group_sender_ids=frozenset({42}),
+            binding_policy=TelegramBindingPolicy.from_mapping(
+                {"-100": {"enabled": False}}
+            ),
+            streaming_mode="off",
+        ),
+        bot=FakeBot(),
+        store=store,
+    )
+    await manager.start()
+    try:
+        admitted = await manager.admit_webhook_update(
+            {
+                "update_id": 104,
+                "message": {
+                    "message_id": 104,
+                    "chat": {"id": -100, "type": "supergroup"},
+                    "from": {"id": 42},
+                    "text": "@Penguin_agent_bot should not run",
+                },
+            }
+        )
+        assert admitted is False
+        assert core.calls == []
+        assert (
+            store.get_ingress("telegram:867:104", platform="telegram", account_id="867")
+            is None
+        )
+    finally:
+        await manager.stop()

--- a/tests/integrations/telegram/test_manager.py
+++ b/tests/integrations/telegram/test_manager.py
@@ -105,6 +105,13 @@ class FakeBot:
         return SimpleNamespace(message_id=kwargs["message_id"])
 
 
+def _callback_data(markup: Any) -> str:
+    keyboard = getattr(markup, "inline_keyboard", None)
+    if keyboard is not None:
+        return str(keyboard[0][0].callback_data)
+    return str(markup[0][0]["data"])
+
+
 class PollingBot(FakeBot):
     """Fake Bot API boundary that inspects state before the next long poll."""
 
@@ -2135,7 +2142,7 @@ async def test_group_approval_hides_details_and_rejects_wrong_sender(
         )
         assert "notes.txt" not in prompt["text"]
         assert "test approval" not in prompt["text"]
-        callback_data = prompt["reply_markup"].inline_keyboard[0][0].callback_data
+        callback_data = _callback_data(prompt["reply_markup"])
 
         def callback_update(update_id: int, sender_id: int) -> dict[str, Any]:
             return {
@@ -2441,8 +2448,7 @@ async def test_approval_callback_resumes_once_and_duplicate_is_inert(
         prompt = next(
             item for item in bot.messages if "Tool approval required" in item["text"]
         )
-        markup = prompt["reply_markup"]
-        callback_data = markup.inline_keyboard[0][0].callback_data
+        callback_data = _callback_data(prompt["reply_markup"])
         callback_message = {
             "message_id": 50,
             "chat": {"id": 42, "type": "private"},

--- a/tests/integrations/telegram/test_transport.py
+++ b/tests/integrations/telegram/test_transport.py
@@ -1,0 +1,35 @@
+from datetime import timedelta
+
+from penguin.integrations.telegram.transport import classify_failure, retry_delay
+
+
+class RetryAfter(Exception):
+    def __init__(self) -> None:
+        super().__init__("slow down")
+        self.retry_after = timedelta(seconds=12)
+
+
+class NetworkError(Exception):
+    pass
+
+
+class BadRequest(Exception):
+    pass
+
+
+class Conflict(Exception):
+    pass
+
+
+def test_classifies_retry_after_network_fatal_and_polling_conflict() -> None:
+    assert classify_failure(RetryAfter()).retry_after == 12
+    assert classify_failure(NetworkError()).retryable is True
+    assert classify_failure(TimeoutError()).retryable is True
+    assert classify_failure(BadRequest()).retryable is False
+    assert classify_failure(Conflict()).polling_conflict is True
+
+
+def test_retry_delay_is_bounded_and_honors_retry_after() -> None:
+    assert retry_delay(3, base_seconds=2, max_seconds=30, random_value=lambda: 0) == 4
+    assert retry_delay(10, base_seconds=2, max_seconds=30, random_value=lambda: 1) == 30
+    assert retry_delay(1, base_seconds=2, max_seconds=30, retry_after=12) == 12

--- a/tests/integrations/telegram/test_updates.py
+++ b/tests/integrations/telegram/test_updates.py
@@ -1,0 +1,111 @@
+from penguin.integrations.telegram.updates import (
+    envelope_from_dict,
+    envelope_to_dict,
+    is_addressed_to_bot,
+    normalize_update,
+    parse_command,
+    strip_bot_mention,
+)
+
+
+def _message_update(**message_overrides):
+    message = {
+        "message_id": 5,
+        "chat": {"id": -1001, "type": "supergroup", "title": "Penguins"},
+        "from": {"id": 42, "username": "max"},
+        "message_thread_id": 7,
+        "text": "@Penguin_agent_bot hello",
+    }
+    message.update(message_overrides)
+    return {"update_id": 99, "message": message}
+
+
+def test_normalize_group_topic_and_round_trip() -> None:
+    envelope = normalize_update(_message_update(), account_id="867")
+
+    assert envelope is not None
+    assert envelope.event_id == "telegram:867:99"
+    assert envelope.address.chat_id == "-1001"
+    assert envelope.address.topic_id == "7"
+    assert envelope.sender_id == "42"
+    assert envelope.metadata["chat_type"] == "supergroup"
+    assert envelope_from_dict(envelope_to_dict(envelope)) == envelope
+
+
+def test_photo_and_document_are_metadata_only() -> None:
+    envelope = normalize_update(
+        _message_update(
+            text=None,
+            caption="files",
+            photo=[
+                {"file_id": "small", "file_size": 10},
+                {"file_id": "large", "file_size": 20},
+            ],
+            document={
+                "file_id": "doc",
+                "file_name": "notes.txt",
+                "mime_type": "text/plain",
+                "file_size": 30,
+            },
+        ),
+        account_id="867",
+    )
+
+    assert envelope is not None
+    assert [(item.kind, item.file_id) for item in envelope.attachments] == [
+        ("photo", "large"),
+        ("document", "doc"),
+    ]
+    assert "bytes" not in repr(envelope)
+
+
+def test_callback_uses_callback_sender_and_message_scope() -> None:
+    update = {
+        "update_id": 100,
+        "callback_query": {
+            "id": "callback",
+            "from": {"id": 55},
+            "data": "penguin:abc:approve",
+            "message": _message_update()["message"],
+        },
+    }
+    envelope = normalize_update(update, account_id="867")
+
+    assert envelope is not None
+    assert envelope.sender_id == "55"
+    assert envelope.metadata["callback_data"] == "penguin:abc:approve"
+
+
+def test_empty_service_message_is_not_normalized() -> None:
+    assert (
+        normalize_update(
+            _message_update(text=None, new_chat_members=[{"id": 99}]),
+            account_id="867",
+        )
+        is None
+    )
+
+
+def test_senderless_group_migration_is_normalized() -> None:
+    envelope = normalize_update(
+        _message_update(text=None, **{"from": None}, migrate_from_chat_id=-1000),
+        account_id="867",
+    )
+
+    assert envelope is not None
+    assert envelope.sender_id == ""
+    assert envelope.metadata["migrate_from_chat_id"] == "-1000"
+
+
+def test_command_targeting_and_mention_stripping() -> None:
+    assert parse_command("/status@Penguin_agent_bot now") == (
+        "status",
+        "now",
+        "Penguin_agent_bot",
+    )
+    assert is_addressed_to_bot("/status@Penguin_agent_bot", "Penguin_agent_bot")
+    assert not is_addressed_to_bot("/status@Other_bot", "Penguin_agent_bot")
+    assert (
+        strip_bot_mention("please @penguin_AGENT_bot help", "Penguin_agent_bot")
+        == "please  help"
+    )

--- a/tests/integrations/telegram/test_webhook.py
+++ b/tests/integrations/telegram/test_webhook.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+from types import MethodType
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from penguin.integrations.telegram.config import TelegramConfig
+from penguin.integrations.telegram.manager import TelegramManager
+from penguin.web.integrations.telegram import build_telegram_router
+
+
+def _app(
+    *, body_limit: int = 1024, timeout: float = 1.0
+) -> tuple[TestClient, TelegramManager, list[dict[str, Any]]]:
+    config = TelegramConfig(
+        enabled=True,
+        token="test-only-token",
+        expected_username="Penguin_agent_bot",
+        transport="webhook",
+        webhook_public_url="https://example.test",
+        webhook_secret="webhook-secret",
+        webhook_body_limit_bytes=body_limit,
+        webhook_timeout_seconds=timeout,
+    )
+    manager = TelegramManager(object(), config)
+    adopted: list[dict[str, Any]] = []
+
+    async def admit(self: TelegramManager, update: Any) -> bool:
+        del self
+        adopted.append(update)
+        return True
+
+    manager.admit_webhook_update = MethodType(admit, manager)
+    app = FastAPI()
+    app.state.telegram_manager = manager
+    app.include_router(build_telegram_router(config))
+    return TestClient(app), manager, adopted
+
+
+def test_webhook_requires_secret_and_acknowledges_after_adoption() -> None:
+    client, _manager, adopted = _app()
+    update = {"update_id": 1, "message": {}}
+
+    assert (
+        client.post("/api/v1/integrations/telegram/webhook", json=update).status_code
+        == 401
+    )
+    response = client.post(
+        "/api/v1/integrations/telegram/webhook",
+        json=update,
+        headers={"X-Telegram-Bot-Api-Secret-Token": "webhook-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "admitted": True}
+    assert adopted == [update]
+
+
+def test_webhook_rejects_oversized_body_before_adoption() -> None:
+    client, _manager, adopted = _app(body_limit=32)
+    response = client.post(
+        "/api/v1/integrations/telegram/webhook",
+        content=b"{" + b'"padding":"' + b"x" * 40 + b'"}',
+        headers={
+            "Content-Type": "application/json",
+            "X-Telegram-Bot-Api-Secret-Token": "webhook-secret",
+        },
+    )
+
+    assert response.status_code == 413
+    assert adopted == []
+
+
+def test_webhook_bounds_streamed_body_without_content_length() -> None:
+    client, _manager, adopted = _app(body_limit=32)
+
+    def chunks() -> Any:
+        yield b'{"padding":"'
+        yield b"x" * 40
+        yield b'"}'
+
+    response = client.post(
+        "/api/v1/integrations/telegram/webhook",
+        content=chunks(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Telegram-Bot-Api-Secret-Token": "webhook-secret",
+        },
+    )
+
+    assert response.status_code == 413
+    assert adopted == []
+
+
+def test_webhook_does_not_acknowledge_an_adoption_timeout() -> None:
+    client, manager, adopted = _app(timeout=0.01)
+
+    async def slow(self: TelegramManager, update: Any) -> bool:
+        del self
+        adopted.append(update)
+        await asyncio.sleep(1)
+        return True
+
+    manager.admit_webhook_update = MethodType(slow, manager)
+    response = client.post(
+        "/api/v1/integrations/telegram/webhook",
+        json={"update_id": 2},
+        headers={"X-Telegram-Bot-Api-Secret-Token": "webhook-secret"},
+    )
+
+    assert response.status_code == 503

--- a/tests/llm/test_link_provider.py
+++ b/tests/llm/test_link_provider.py
@@ -454,7 +454,7 @@ async def test_stream_http_error_reads_link_error_body_before_reporting() -> Non
     provider = _provider(handler)
     with pytest.raises(
         LLMProviderError,
-        match="The selected model rejected this request.",
+        match=r"The selected model rejected this request\.",
     ) as raised:
         await provider.get_response(
             [{"role": "user", "content": "hi"}],

--- a/tests/test_action_executor_policy.py
+++ b/tests/test_action_executor_policy.py
@@ -16,7 +16,7 @@ from penguin.security.action_policy import (
     TOOL_MANAGED_ACTION_NAMES,
     authorize_direct_action,
 )
-from penguin.security.approval import get_approval_manager
+from penguin.security.approval import ApprovalScope, get_approval_manager
 from penguin.system.execution_context import ExecutionContext, execution_context_scope
 from penguin.tools.tool_manager import ToolManager
 from penguin.utils.parser import (
@@ -54,6 +54,9 @@ def test_every_actionxml_action_has_an_explicit_policy_classification() -> None:
     assert DIRECT_ACTION_POLICY_KEYS[ActionType.PROCESS_EXIT.value] == "fileWrite"
     assert DIRECT_ACTION_POLICY_KEYS[ActionType.FINISH_TASK.value] == "fileWrite"
     assert DIRECT_ACTION_POLICY_KEYS[ActionType.TASK_COMPLETED.value] == "fileWrite"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.SPAWN_SUB_AGENT.value] == "shell"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.RESUME_SUB_AGENT.value] == "shell"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.STOP_SUB_AGENT.value] == "shell"
     assert ActionType.READ_IMAGE.value in tool_managed
     assert ActionType.PUBLISH_ARTIFACT.value in tool_managed
 
@@ -132,6 +135,7 @@ async def test_read_only_actionxml_cannot_start_process() -> None:
         ExecutionContext(
             session_id="telegram-read-only",
             permission_mode="read_only",
+            approval_policy={"shell": "allow", "default": "allow"},
         )
     ):
         raw_result = await executor.execute_action(
@@ -221,8 +225,42 @@ async def test_deny_policy_actionxml_cannot_start_process() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prompt_policy_resumes_actionxml_process_once() -> None:
-    """An approved direct action resumes the original handler exactly once."""
+async def test_secret_policy_caps_allowed_actionxml_shell() -> None:
+    """Allowing shell must not implicitly allow access to environment secrets."""
+
+    class _ProcessManager:
+        async def start_process(self, name: str, command: str) -> str:
+            raise AssertionError(f"unexpected process start: {name}={command}")
+
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = _ProcessManager()
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-secret-deny",
+            permission_mode="workspace",
+            approval_policy={
+                "shell": "allow",
+                "secrets": "deny",
+                "default": "allow",
+            },
+        )
+    ):
+        raw_result = await executor.execute_action(
+            CodeActAction(ActionType.PROCESS_START, "inspect: printenv API_TOKEN")
+        )
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["action"] == "process_start"
+
+
+@pytest.mark.asyncio
+async def test_granular_prompt_resumes_actionxml_process_once() -> None:
+    """An explicit category ASK overrides only a DENY fallback."""
     approval_manager = get_approval_manager()
     approval_manager.reset()
 
@@ -250,7 +288,7 @@ async def test_prompt_policy_resumes_actionxml_process_once() -> None:
             permission_mode="workspace",
             approval_policy={
                 "shell": "ask",
-                "default": "ask",
+                "default": "deny",
                 "wait_for_resolution": True,
                 "timeout_seconds": 1.0,
             },
@@ -309,6 +347,49 @@ async def test_non_waiting_prompt_returns_pending_without_process_start() -> Non
     pending = approval_manager.get_pending(session_id=session_id)
     assert [request.id for request in pending] == [result["approval_id"]]
     approval_manager.deny(result["approval_id"])
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_actionxml_session_approval_does_not_bypass_new_ask_category() -> None:
+    """A direct-action shell grant must not silently include secret access."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    session_id = "action-category-escalation"
+    context = ExecutionContext(
+        session_id=session_id,
+        permission_mode="workspace",
+        approval_policy={
+            "default": "deny",
+            "shell": "ask",
+            "secrets": "ask",
+        },
+    )
+
+    with execution_context_scope(context):
+        first_result = json.loads(
+            await authorize_direct_action("process_start", "server: pwd")
+        )
+    first_request = approval_manager.get_request(first_result["approval_id"])
+    assert first_request is not None
+    assert (
+        approval_manager.approve(
+            first_request.id,
+            scope=ApprovalScope.SESSION,
+        )
+        is not None
+    )
+
+    with execution_context_scope(context):
+        assert await authorize_direct_action("process_start", "server: whoami") is None
+        escalated_result = json.loads(
+            await authorize_direct_action("process_start", "inspect: cat .env")
+        )
+
+    escalated_request = approval_manager.get_request(escalated_result["approval_id"])
+    assert escalated_request is not None
+    assert escalated_request.operation != first_request.operation
+    approval_manager.deny(escalated_request.id)
     approval_manager.reset()
 
 

--- a/tests/test_action_executor_policy.py
+++ b/tests/test_action_executor_policy.py
@@ -1,0 +1,505 @@
+"""Request-scoped permission contracts for model-emitted ActionXML."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+from PIL import Image
+
+from penguin.security.action_policy import (
+    DIRECT_ACTION_POLICY_KEYS,
+    SAFE_ACTION_NAMES,
+    TOOL_MANAGED_ACTION_NAMES,
+    authorize_direct_action,
+)
+from penguin.security.approval import get_approval_manager
+from penguin.system.execution_context import ExecutionContext, execution_context_scope
+from penguin.tools.tool_manager import ToolManager
+from penguin.utils.parser import (
+    ActionExecutor,
+    ActionType,
+    CodeActAction,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+async def _wait_for_pending_approval(session_id: str) -> str:
+    manager = get_approval_manager()
+    for _ in range(200):
+        pending = manager.get_pending(session_id=session_id)
+        if pending:
+            return pending[0].id
+        await asyncio.sleep(0.005)
+    raise AssertionError("Approval request was never created")
+
+
+def test_every_actionxml_action_has_an_explicit_policy_classification() -> None:
+    """New ActionTypes must be consciously classified before they can ship."""
+    direct = set(DIRECT_ACTION_POLICY_KEYS)
+    safe = set(SAFE_ACTION_NAMES)
+    tool_managed = set(TOOL_MANAGED_ACTION_NAMES)
+
+    assert direct.isdisjoint(safe)
+    assert direct.isdisjoint(tool_managed)
+    assert safe.isdisjoint(tool_managed)
+    assert direct | safe | tool_managed == {item.value for item in ActionType}
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.PROCESS_LIST.value] == "shell"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.PROCESS_ENTER.value] == "shell"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.PROCESS_EXIT.value] == "fileWrite"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.FINISH_TASK.value] == "fileWrite"
+    assert DIRECT_ACTION_POLICY_KEYS[ActionType.TASK_COMPLETED.value] == "fileWrite"
+    assert ActionType.READ_IMAGE.value in tool_managed
+    assert ActionType.PUBLISH_ARTIFACT.value in tool_managed
+
+
+@pytest.mark.asyncio
+async def test_actionxml_publish_artifact_preserves_explicit_descriptor() -> None:
+    class _ToolManager:
+        def execute_tool(self, name: str, payload: dict[str, str]) -> dict[str, object]:
+            assert name == "publish_artifact"
+            assert payload == {"path": "reports/result.pdf"}
+            return {
+                "result": "Artifact ready for delivery: result.pdf",
+                "artifact": {
+                    "type": "file",
+                    "path": "/workspace/reports/result.pdf",
+                },
+            }
+
+    executor = ActionExecutor(
+        tool_manager=_ToolManager(),
+        task_manager=SimpleNamespace(),
+    )
+
+    result = await executor.execute_action(
+        CodeActAction(
+            ActionType.PUBLISH_ARTIFACT,
+            '{"path":"reports/result.pdf"}',
+        )
+    )
+
+    assert result["artifact"] == {
+        "type": "file",
+        "path": "/workspace/reports/result.pdf",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unclassified_future_action_uses_default_deny_policy() -> None:
+    """A future manual ActionXML handler must fail closed until classified."""
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-future-action",
+            permission_mode="workspace",
+            approval_policy={"default": "deny"},
+        )
+    ):
+        raw_result = await authorize_direct_action("future_mutation", "payload")
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["action"] == "future_mutation"
+
+
+@pytest.mark.asyncio
+async def test_read_only_actionxml_cannot_start_process() -> None:
+    """Direct ActionXML mutations must honor the request permission ceiling."""
+
+    class _ProcessManager:
+        def __init__(self) -> None:
+            self.start_calls = 0
+
+        async def start_process(self, name: str, command: str) -> str:
+            del name, command
+            self.start_calls += 1
+            return "started"
+
+    process_manager = _ProcessManager()
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = process_manager
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-read-only",
+            permission_mode="read_only",
+        )
+    ):
+        raw_result = await executor.execute_action(
+            CodeActAction(ActionType.PROCESS_START, "server: python -m http.server")
+        )
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["action"] == "process_start"
+    assert process_manager.start_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action_type", "params"),
+    [
+        (ActionType.PROCESS_LIST, ""),
+        (ActionType.PROCESS_ENTER, "server"),
+        (ActionType.FINISH_TASK, "done"),
+        (ActionType.TASK_COMPLETED, "done"),
+    ],
+)
+async def test_read_only_blocks_sensitive_legacy_actionxml_handlers(
+    action_type: ActionType,
+    params: str,
+) -> None:
+    """Remote reads and completion transitions cannot bypass read-only mode."""
+
+    class _ProcessManager:
+        async def list_processes(self) -> dict[str, str]:
+            raise AssertionError("process list must not run")
+
+        async def enter_process(self, _name: str) -> object:
+            raise AssertionError("process enter must not run")
+
+    class _TaskTools:
+        def finish_task(self, _summary: str) -> str:
+            raise AssertionError("finish task must not run")
+
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(task_tools=_TaskTools()),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = _ProcessManager()
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-read-only-sensitive-action",
+            permission_mode="read_only",
+        )
+    ):
+        raw_result = await executor.execute_action(CodeActAction(action_type, params))
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["action"] == action_type.value
+
+
+@pytest.mark.asyncio
+async def test_deny_policy_actionxml_cannot_start_process() -> None:
+    """A remote deny decision must not create or start a process."""
+
+    class _ProcessManager:
+        async def start_process(self, name: str, command: str) -> str:
+            raise AssertionError(f"unexpected process start: {name}={command}")
+
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = _ProcessManager()
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-deny",
+            permission_mode="workspace",
+            approval_policy={"shell": "deny", "default": "deny"},
+        )
+    ):
+        raw_result = await executor.execute_action(
+            CodeActAction(ActionType.PROCESS_START, "server: python -m http.server")
+        )
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["action"] == "process_start"
+
+
+@pytest.mark.asyncio
+async def test_prompt_policy_resumes_actionxml_process_once() -> None:
+    """An approved direct action resumes the original handler exactly once."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+
+    class _ProcessManager:
+        def __init__(self) -> None:
+            self.start_calls = 0
+
+        async def start_process(self, name: str, command: str) -> str:
+            assert name == "server"
+            assert command == "python -m http.server"
+            self.start_calls += 1
+            return "started"
+
+    process_manager = _ProcessManager()
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = process_manager
+    session_id = "telegram-prompt"
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            permission_mode="workspace",
+            approval_policy={
+                "shell": "ask",
+                "default": "ask",
+                "wait_for_resolution": True,
+                "timeout_seconds": 1.0,
+            },
+        )
+    ):
+        execution = asyncio.create_task(
+            executor.execute_action(
+                CodeActAction(
+                    ActionType.PROCESS_START,
+                    "server: python -m http.server",
+                )
+            )
+        )
+        request_id = await _wait_for_pending_approval(session_id)
+        assert execution.done() is False
+        assert approval_manager.approve(request_id) is not None
+        assert approval_manager.approve(request_id) is None
+        result = await asyncio.wait_for(execution, timeout=1.0)
+
+    assert result == "started"
+    assert process_manager.start_calls == 1
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_non_waiting_prompt_returns_pending_without_process_start() -> None:
+    """Non-channel callers keep the callback-style pending response contract."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+
+    class _ProcessManager:
+        async def start_process(self, name: str, command: str) -> str:
+            raise AssertionError(f"unexpected process start: {name}={command}")
+
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = _ProcessManager()
+    session_id = "http-style-prompt"
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            permission_mode="workspace",
+            approval_policy={"shell": "ask", "default": "ask"},
+        )
+    ):
+        raw_result = await executor.execute_action(
+            CodeActAction(ActionType.PROCESS_START, "server: python app.py")
+        )
+
+    result = json.loads(raw_result)
+    assert result["status"] == "pending_approval"
+    assert result["action"] == "process_start"
+    pending = approval_manager.get_pending(session_id=session_id)
+    assert [request.id for request in pending] == [result["approval_id"]]
+    approval_manager.deny(result["approval_id"])
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_denied_prompt_never_resumes_actionxml_process() -> None:
+    """A resolved denial must terminate the suspended direct action."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+
+    class _ProcessManager:
+        async def start_process(self, name: str, command: str) -> str:
+            raise AssertionError(f"unexpected process start: {name}={command}")
+
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    executor.process_manager = _ProcessManager()
+    session_id = "telegram-prompt-denied"
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            permission_mode="workspace",
+            approval_policy={
+                "shell": "ask",
+                "default": "ask",
+                "wait_for_resolution": True,
+                "timeout_seconds": 1.0,
+            },
+        )
+    ):
+        execution = asyncio.create_task(
+            executor.execute_action(
+                CodeActAction(ActionType.PROCESS_START, "server: python app.py")
+            )
+        )
+        request_id = await _wait_for_pending_approval(session_id)
+        assert approval_manager.deny(request_id) is not None
+        result = json.loads(await asyncio.wait_for(execution, timeout=1.0))
+
+    assert result["error"] == "approval_denied"
+    assert approval_manager.approve(request_id) is None
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_prompt_policy_resumes_tool_backed_actionxml_write_once(
+    tmp_path: Path,
+) -> None:
+    """Synchronous ToolManager ActionXML handlers resume after approval."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    executor = ActionExecutor(
+        tool_manager=manager,
+        task_manager=SimpleNamespace(),
+    )
+    target = tmp_path / "approved.txt"
+    session_id = "telegram-tool-backed-prompt"
+    payload = json.dumps({"path": str(target), "content": "approved once"})
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            directory=str(tmp_path),
+            permission_mode="workspace",
+            approval_policy={
+                "fileWrite": "ask",
+                "default": "ask",
+                "wait_for_resolution": True,
+                "timeout_seconds": 1.0,
+            },
+        )
+    ):
+        execution = asyncio.create_task(
+            executor.execute_action(CodeActAction(ActionType.WRITE_FILE, payload))
+        )
+        request_id = await _wait_for_pending_approval(session_id)
+        assert execution.done() is False
+        assert target.exists() is False
+        assert approval_manager.approve(request_id) is not None
+        assert approval_manager.approve(request_id) is None
+        await asyncio.wait_for(execution, timeout=1.0)
+
+    assert target.read_text(encoding="utf-8") == "approved once"
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_tool_backed_actionxml_denies_late_write(
+    tmp_path: Path,
+) -> None:
+    """Cancelling the outer action closes its worker-thread approval."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    executor = ActionExecutor(
+        tool_manager=manager,
+        task_manager=SimpleNamespace(),
+    )
+    target = tmp_path / "cancelled.txt"
+    session_id = "telegram-tool-backed-cancel"
+    request_id = "telegram-turn-cancel"
+    payload = json.dumps({"path": str(target), "content": "must not exist"})
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            request_id=request_id,
+            directory=str(tmp_path),
+            permission_mode="workspace",
+            approval_policy={
+                "fileWrite": "ask",
+                "default": "ask",
+                "wait_for_resolution": True,
+                "timeout_seconds": 1.0,
+            },
+        )
+    ):
+        execution = asyncio.create_task(
+            executor.execute_action(CodeActAction(ActionType.WRITE_FILE, payload))
+        )
+        approval_id = await _wait_for_pending_approval(session_id)
+        pending = approval_manager.get_request(approval_id)
+        assert pending is not None
+        assert pending.context["request_id"] == request_id
+        execution.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await execution
+
+    assert approval_manager.approve(approval_id) is None
+    await asyncio.sleep(0.01)
+    assert target.exists() is False
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_actionxml_read_image_cannot_escape_request_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote workspace mode must not expose arbitrary host image paths."""
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    outside_image = outside / "private.png"
+    Image.new("RGB", (1, 1), color="red").save(outside_image)
+    monkeypatch.setenv("PENGUIN_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PENGUIN_CWD", str(tmp_path))
+
+    class _Conversation:
+        def add_message(self, **_kwargs: object) -> None:
+            raise AssertionError("denied image must not enter conversation context")
+
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    executor = ActionExecutor(
+        tool_manager=manager,
+        task_manager=SimpleNamespace(),
+        conversation_system=_Conversation(),
+    )
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-read-image-escape",
+            request_id="telegram-image-turn",
+            directory=str(workspace),
+            project_root=str(workspace),
+            workspace_root=str(workspace),
+            permission_mode="workspace",
+            approval_policy={"default": "deny"},
+        )
+    ):
+        raw_result = await executor.execute_action(
+            CodeActAction(
+                ActionType.READ_IMAGE,
+                json.dumps({"path": str(outside_image)}),
+            )
+        )
+
+    result = json.loads(raw_result)
+    assert result["error"] == "permission_denied"
+    assert result["tool"] == "read_image"
+    assert "outside request workspace" in result["reason"]

--- a/tests/test_action_executor_question.py
+++ b/tests/test_action_executor_question.py
@@ -65,6 +65,69 @@ async def test_wait_for_resolution_returns_answered_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_question_shutdown_rejects_and_wakes_pending_waiters() -> None:
+    """Shutdown must resolve suspended question actions without orphaned tasks."""
+    manager = get_question_manager()
+    manager.reset()
+    request = manager.create_request(
+        session_id="session_question_shutdown",
+        questions=[{"question": "Continue?", "header": "Continue"}],
+    )
+    waiter = asyncio.create_task(manager.wait_for_resolution(request.id))
+    await asyncio.sleep(0)
+
+    assert manager.shutdown() == 1
+    resolved = await asyncio.wait_for(waiter, timeout=1.0)
+
+    assert resolved is not None
+    assert resolved.status.value == "rejected"
+    assert manager.list_pending() == []
+    manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_question_waiter_rejects_stale_request() -> None:
+    """Cancelling an action must not leave an answerable orphan request."""
+    manager = get_question_manager()
+    manager.reset()
+    request = manager.create_request(
+        session_id="session_question_cancel",
+        questions=[{"question": "Continue?", "header": "Continue"}],
+    )
+    waiter = asyncio.create_task(manager.wait_for_resolution(request.id))
+    await asyncio.sleep(0)
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    resolved = manager.get_request(request.id)
+    assert resolved is not None
+    assert resolved.status.value == "rejected"
+    manager.reset()
+
+
+def test_question_callback_can_be_unregistered() -> None:
+    """Adapters can detach lifecycle callbacks during clean shutdown."""
+    manager = get_question_manager()
+    manager.reset()
+    observed: list[str] = []
+
+    def _on_created(request: object) -> None:
+        observed.append(str(request))
+
+    manager.on_request_created(_on_created)
+    manager.remove_callback(_on_created)
+    manager.create_request(
+        session_id="session_question_callback",
+        questions=[{"question": "Continue?", "header": "Continue"}],
+    )
+
+    assert observed == []
+    manager.reset()
+
+
+@pytest.mark.asyncio
 async def test_question_action_blocks_until_reply_and_returns_summary() -> None:
     manager = get_question_manager()
     manager.reset()
@@ -137,3 +200,118 @@ async def test_question_action_returns_error_when_rejected() -> None:
         await resolver
 
     assert result == "Error: The user rejected this question request"
+
+
+@pytest.mark.asyncio
+async def test_question_action_uses_request_scoped_timeout() -> None:
+    manager = get_question_manager()
+    manager.reset()
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    payload = json.dumps(
+        {
+            "questions": [
+                {
+                    "question": "Continue?",
+                    "header": "Continue",
+                    "options": [{"label": "Yes", "description": "Continue"}],
+                }
+            ]
+        }
+    )
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="session_question_timeout",
+            approval_policy={"timeout_seconds": 0.01},
+        )
+    ):
+        result = await asyncio.wait_for(executor._question(payload), timeout=1.0)
+
+    assert result == "Error: Question request was not resolved"
+    assert manager.list_pending(session_id="session_question_timeout") == []
+    manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_question_policy_without_timeout_waits_for_reply() -> None:
+    """An unrelated approval policy must not become a zero-second timeout."""
+    manager = get_question_manager()
+    manager.reset()
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    payload = json.dumps(
+        {
+            "questions": [
+                {
+                    "question": "Continue?",
+                    "header": "Continue",
+                    "options": [{"label": "Yes", "description": "Continue"}],
+                }
+            ]
+        }
+    )
+    session_id = "session_question_without_timeout"
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id=session_id,
+            approval_policy={"default": "ask"},
+        )
+    ):
+        resolver = asyncio.create_task(
+            _resolve_pending_question(session_id, answers=[["Yes"]])
+        )
+        result = await asyncio.wait_for(executor._question(payload), timeout=3.0)
+        await resolver
+
+    assert '"Continue?"="Yes"' in result
+    manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_question_request_carries_execution_request_id() -> None:
+    """Channel projections can correlate a question to its exact turn."""
+    manager = get_question_manager()
+    manager.reset()
+    executor = ActionExecutor(
+        tool_manager=SimpleNamespace(),
+        task_manager=SimpleNamespace(),
+    )
+    payload = json.dumps(
+        {
+            "questions": [
+                {
+                    "question": "Continue?",
+                    "header": "Continue",
+                    "options": [{"label": "Yes", "description": "Continue"}],
+                }
+            ]
+        }
+    )
+    session_id = "session_question_request_id"
+    request_id = "telegram-turn-question"
+
+    with execution_context_scope(
+        ExecutionContext(session_id=session_id, request_id=request_id)
+    ):
+        execution = asyncio.create_task(executor._question(payload))
+        request = None
+        for _ in range(200):
+            pending = manager.list_pending(session_id=session_id)
+            if pending:
+                request = pending[0]
+                break
+            await asyncio.sleep(0.005)
+        assert request is not None
+        try:
+            assert request.context["request_id"] == request_id
+        finally:
+            manager.reject(request.id)
+            await asyncio.wait_for(execution, timeout=1.0)
+
+    manager.reset()

--- a/tests/test_approval_wait.py
+++ b/tests/test_approval_wait.py
@@ -1,0 +1,68 @@
+"""Focused tests for resumable approval state."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from penguin.security.approval import ApprovalStatus, get_approval_manager
+
+
+@pytest.mark.asyncio
+async def test_approved_request_can_be_consumed_exactly_once() -> None:
+    """An approval wakes its waiter but grants only one matching execution."""
+    manager = get_approval_manager()
+    manager.reset()
+    request = manager.create_request(
+        tool_name="write_file",
+        operation="tool.write_file",
+        resource="notes.txt",
+        reason="approval required",
+        session_id="session_once",
+    )
+
+    waiter = asyncio.create_task(
+        asyncio.to_thread(manager.wait_for_resolution, request.id, 1.0)
+    )
+    await asyncio.sleep(0)
+    assert manager.approve(request.id) is not None
+    resolved = await waiter
+
+    assert resolved is not None
+    assert resolved.status == ApprovalStatus.APPROVED
+    claim = {
+        "tool_name": "write_file",
+        "operation": "tool.write_file",
+        "resource": "notes.txt",
+        "session_id": "session_once",
+    }
+    assert manager.consume_approved_request(request.id, **claim) is True
+    assert manager.consume_approved_request(request.id, **claim) is False
+    assert manager.approve(request.id) is None
+    manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_wait_timeout_expires_request_and_blocks_late_approval() -> None:
+    """A timed-out wait closes the request instead of leaving stale work."""
+    manager = get_approval_manager()
+    manager.reset()
+    request = manager.create_request(
+        tool_name="execute_command",
+        operation="tool.execute_command",
+        resource="echo safe",
+        reason="approval required",
+        session_id="session_timeout",
+    )
+
+    resolved = await asyncio.to_thread(
+        manager.wait_for_resolution,
+        request.id,
+        0.01,
+    )
+
+    assert resolved is not None
+    assert resolved.status == ApprovalStatus.EXPIRED
+    assert manager.approve(request.id) is None
+    manager.reset()

--- a/tests/test_engine_execution_scope.py
+++ b/tests/test_engine_execution_scope.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from penguin.engine import Engine, EngineSettings
+from penguin.skills.manager import SkillManager
+from penguin.skills.models import Skill
 from penguin.system.execution_context import ExecutionContext, execution_context_scope
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _conversation_manager(session_id: str) -> Any:
@@ -38,7 +43,7 @@ def test_plain_preloaded_manager_is_stable_for_the_entire_engine_run() -> None:
     request_manager = _conversation_manager("session_requested_by_tui")
     engine = Engine(
         EngineSettings(),
-        cast(Any, base_manager),
+        cast("Any", base_manager),
         MagicMock(),
         MagicMock(),
         MagicMock(),
@@ -68,7 +73,7 @@ async def test_unknown_requested_agent_normalizes_to_default() -> None:
 
     engine = Engine(
         EngineSettings(),
-        cast(Any, _conversation_manager("session_requested_by_tui")),
+        cast("Any", _conversation_manager("session_requested_by_tui")),
         MagicMock(),
         MagicMock(),
         MagicMock(),
@@ -83,3 +88,111 @@ async def test_unknown_requested_agent_normalizes_to_default() -> None:
     assert resolved_agent == "default"
     assert lite_result is None
     assert engine.list_agents() == ["default"]
+
+
+@pytest.mark.asyncio
+async def test_trusted_request_agent_missing_from_registry_fails_closed() -> None:
+    engine = Engine(
+        EngineSettings(),
+        cast("Any", _conversation_manager("telegram-session")),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-session",
+            agent_id="configured-agent",
+            require_registered_agent=True,
+        )
+    ):
+        with pytest.raises(ValueError, match="unavailable: configured-agent"):
+            await engine._resolve_agent(
+                agent_id="configured-agent",
+                agent_role=None,
+                prompt="Use the configured Telegram agent.",
+            )
+
+
+def test_request_prompt_and_skills_are_ephemeral_system_messages(
+    tmp_path: Path,
+) -> None:
+    skill_root = tmp_path / "skills" / "focused-work"
+    skill_root.mkdir(parents=True)
+    skill_file = skill_root / "SKILL.md"
+    skill_file.write_text("unused", encoding="utf-8")
+    skill = Skill(
+        name="focused-work",
+        description="Stay focused.",
+        path=skill_root,
+        skill_file=skill_file,
+        body="Use the smallest complete solution.",
+        source="test",
+    )
+    skill_manager = SkillManager.__new__(SkillManager)
+    skill_manager._skills = {skill.name: skill}
+    skill_manager._diagnostics = []
+    skill_manager._activated_by_session = {}
+
+    conversation_manager = _conversation_manager("telegram-session")
+    conversation_manager.skill_manager = skill_manager
+    engine = Engine(
+        EngineSettings(),
+        cast("Any", conversation_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+    messages = [{"role": "user", "content": "hello"}]
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-session",
+            agent_id="default",
+            agent_mode="plan",
+            request_system_prompt="Answer for the operations team.",
+            request_skills=("focused-work",),
+        )
+    ):
+        scoped = engine._apply_agent_mode_notice(messages)
+        repeated = engine._apply_agent_mode_notice(scoped)
+
+    assert scoped is not messages
+    assert [message["role"] for message in scoped] == [
+        "user",
+        "system",
+        "system",
+        "system",
+    ]
+    assert "[PENGUIN_AGENT_MODE_PLAN]" in scoped[1]["content"]
+    assert "[PENGUIN_TRUSTED_REQUEST_PROMPT]" in scoped[2]["content"]
+    assert "Answer for the operations team." in scoped[2]["content"]
+    assert "[PENGUIN_REQUEST_SKILL:focused-work]" in scoped[3]["content"]
+    assert "Use the smallest complete solution." in scoped[3]["content"]
+    assert repeated == scoped
+    assert conversation_manager.conversation.session.messages == []
+    assert skill_manager.active_names("telegram-session") == []
+    assert engine._apply_agent_mode_notice(messages) is messages
+
+
+def test_request_skill_missing_from_trusted_catalog_fails_closed() -> None:
+    conversation_manager = _conversation_manager("telegram-session")
+    conversation_manager.skill_manager = SimpleNamespace(get=lambda _name: None)
+    engine = Engine(
+        EngineSettings(),
+        cast("Any", conversation_manager),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+    )
+
+    with execution_context_scope(
+        ExecutionContext(
+            session_id="telegram-session",
+            agent_id="default",
+            request_skills=("missing-skill",),
+        )
+    ):
+        with pytest.raises(ValueError, match="unavailable: missing-skill"):
+            engine._apply_agent_mode_notice([{"role": "user", "content": "hello"}])

--- a/tests/test_permission_engine.py
+++ b/tests/test_permission_engine.py
@@ -438,6 +438,119 @@ class TestToolPermissionMapping:
         assert is_safe_tool("read_file") is True
         assert is_safe_tool("list_files") is True
         assert is_safe_tool("grep_search") is True
+        assert is_safe_tool("list_skills") is True
+
+    def test_every_native_model_tool_has_an_explicit_classification(self):
+        from penguin.security.tool_permissions import get_tool_operations
+        from penguin.tools.tool_manager import ToolManager
+
+        manager = ToolManager(
+            {},
+            lambda *_args, **_kwargs: None,
+            fast_startup=True,
+        )
+        native_names = {str(schema["name"]) for schema in manager.tools}
+
+        assert {
+            tool_name
+            for tool_name in native_names
+            if not get_tool_operations(tool_name)
+        } == set()
+
+    def test_agent_orchestration_is_conservatively_classified(self):
+        from penguin.security.tool_permissions import (
+            get_tool_operations,
+            get_tool_policy_keys,
+        )
+
+        assert get_tool_operations("spawn_sub_agent") == [Operation.PROCESS_SPAWN]
+        assert get_tool_policy_keys("spawn_sub_agent") == {"shell"}
+        assert get_tool_policy_keys("stop_sub_agent") == {"shell"}
+        assert get_tool_policy_keys("list_skills") == set()
+
+    def test_secret_resources_add_a_separate_fail_closed_category(self):
+        from penguin.security.tool_permissions import get_tool_policy_keys
+
+        assert get_tool_policy_keys("read_file", {"path": ".env.local"}) == {"secrets"}
+        assert get_tool_policy_keys(
+            "write_file",
+            {"path": "certs/private.pem", "content": "test"},
+        ) == {"fileWrite", "secrets"}
+        assert get_tool_policy_keys(
+            "execute_command",
+            {"command": "printenv TELEGRAM_BOT_TOKEN"},
+        ) == {"shell", "secrets"}
+        assert get_tool_policy_keys("read_file", {"path": "docs/config.md"}) == set()
+
+    @pytest.mark.parametrize(
+        ("tool_input", "expected_keys"),
+        [
+            (
+                {
+                    "command": "python server.py",
+                    "env": {"TELEGRAM_BOT_TOKEN": "opaque-value"},
+                },
+                {"shell", "secrets"},
+            ),
+            (
+                {
+                    "command": "python server.py",
+                    "env": {"RUNTIME_ALIAS": "$OPENAI_API_KEY"},
+                },
+                {"shell", "secrets"},
+            ),
+            (
+                {
+                    "command": "python server.py",
+                    "env": {"PYTHONUNBUFFERED": "1"},
+                },
+                {"shell"},
+            ),
+        ],
+    )
+    def test_process_start_classifies_sensitive_environment_overrides(
+        self,
+        tool_input,
+        expected_keys,
+    ):
+        from penguin.security.tool_permissions import get_tool_policy_keys
+
+        assert get_tool_policy_keys("process_start", tool_input) == expected_keys
+
+    def test_process_start_does_not_expose_environment_values_as_resources(self):
+        from penguin.security.tool_permissions import extract_resources_from_input
+
+        assert extract_resources_from_input(
+            "process_start",
+            {
+                "command": "python server.py",
+                "env": {"TELEGRAM_BOT_TOKEN": "opaque-value"},
+            },
+        ) == ["python server.py"]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "echo $TELEGRAM_BOT_TOKEN\n",
+            "printenv TELEGRAM_BOT_TOKEN\n",
+            "python -c 'import os; print(os.environ[\"OPENAI_API_KEY\"])'\n",
+        ],
+    )
+    def test_process_write_stdin_classifies_secret_access(self, text):
+        from penguin.security.tool_permissions import get_tool_policy_keys
+
+        assert get_tool_policy_keys(
+            "process_write_stdin",
+            {"process_id": "process-1", "text": text},
+        ) == {"shell", "secrets"}
+
+    def test_process_write_stdin_non_secret_text_stays_shell_only(self):
+        from penguin.security.tool_permissions import get_tool_policy_keys
+
+        assert get_tool_policy_keys(
+            "process_write_stdin",
+            {"process_id": "process-1", "text": "echo ready\n"},
+        ) == {"shell"}
 
     def test_write_tools_are_not_safe(self):
         from penguin.security.tool_permissions import is_safe_tool
@@ -450,6 +563,9 @@ class TestToolPermissionMapping:
         assert is_safe_tool("patch_file") is False
         assert is_safe_tool("patch_files") is False
         assert is_safe_tool("apply_diff") is False
+        assert is_safe_tool("browser_interact") is False
+        assert is_safe_tool("pydoll_browser_interact") is False
+        assert is_safe_tool("reindex_workspace") is False
 
     def test_extract_resource(self):
         from penguin.security.tool_permissions import extract_resource_from_input

--- a/tests/test_tool_call_runtime_phase0.py
+++ b/tests/test_tool_call_runtime_phase0.py
@@ -88,6 +88,51 @@ async def test_engine_executes_only_first_actionxml_action_per_iteration() -> No
 
 
 @pytest.mark.asyncio
+async def test_engine_projects_explicit_actionxml_artifact() -> None:
+    engine = Engine.__new__(Engine)
+    emitted: list[dict[str, Any]] = []
+
+    async def _emit_tool_event(_cm: Any, action_result: dict[str, Any]) -> None:
+        emitted.append(action_result)
+
+    engine._emit_tool_event = _emit_tool_event  # type: ignore[method-assign]
+    cm = SimpleNamespace(add_action_result=lambda **_kwargs: None)
+
+    class _ActionExecutor:
+        async def execute_action(self, _action: CodeActAction) -> dict[str, Any]:
+            return {
+                "action": "read_image",
+                "result": "loaded",
+                "status": "completed",
+                "artifact": {
+                    "type": "image",
+                    "image_path": "/workspace/image.png",
+                    "mime_type": "image/png",
+                },
+            }
+
+    action_results = await Engine._execute_codeact_actions(
+        engine,
+        cm,
+        _ActionExecutor(),
+        '<read_image>{"path":"image.png"}</read_image>',
+    )
+
+    expected = {
+        "action": "read_image",
+        "result": "loaded",
+        "status": "completed",
+        "artifact": {
+            "type": "image",
+            "image_path": "/workspace/image.png",
+            "mime_type": "image/png",
+        },
+    }
+    assert {key: action_results[0][key] for key in expected} == expected
+    assert emitted == [expected]
+
+
+@pytest.mark.asyncio
 async def test_responses_tool_call_execution_preserves_provider_identity() -> None:
     persisted: list[dict[str, Any]] = []
     started: list[dict[str, Any]] = []

--- a/tests/test_tool_runtime_ir.py
+++ b/tests/test_tool_runtime_ir.py
@@ -104,6 +104,56 @@ def test_tool_result_adapter_round_trips_current_action_result_shape() -> None:
     assert legacy_action_result_from_tool_result(result) == action_result
 
 
+def test_legacy_action_result_projects_only_explicit_bounded_artifacts() -> None:
+    result = ToolResult(
+        call_id="call_image",
+        name="read_image",
+        status="completed",
+        output="loaded",
+        artifact_path="/internal/truncated-output.txt",
+        structured_output={
+            "path": "/generic/path-must-not-project",
+            "artifact": {
+                "type": "image",
+                "image_path": "/workspace/image.png",
+                "mime_type": "image/png",
+                "secret": "must-not-project",
+            },
+        },
+    )
+
+    assert legacy_action_result_from_tool_result(result) == {
+        "action": "read_image",
+        "result": "loaded",
+        "status": "completed",
+        "artifact": {
+            "type": "image",
+            "image_path": "/workspace/image.png",
+            "mime_type": "image/png",
+        },
+    }
+
+
+def test_publish_artifact_is_an_approval_gated_external_effect() -> None:
+    scheduled = tool_call_with_schedule_metadata(
+        ToolCall(
+            id="publish-1",
+            name="publish_artifact",
+            arguments={"path": "report.pdf"},
+            source="action_xml",
+        ),
+        {
+            "mutates_state": False,
+            "requires_approval": True,
+            "parallel_safe": True,
+        },
+    )
+
+    assert scheduled.effect == "external_mutation"
+    assert scheduled.requires_approval is True
+    assert scheduled.resources == ("fs:report.pdf", "network:channel")
+
+
 def test_scheduler_policy_can_select_first_or_all_calls() -> None:
     calls = tool_calls_from_actionxml(
         """

--- a/tests/tools/test_artifact_tools.py
+++ b/tests/tools/test_artifact_tools.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from penguin.security.permission_engine import Operation
+from penguin.security.tool_permissions import get_tool_operations
+from penguin.system.execution_context import (
+    ExecutionContext,
+    execution_context_scope,
+)
+from penguin.tools.artifact_tools import PublishArtifactTool
+from penguin.tools.tool_manager import ToolManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_publish_artifact_is_explicit_and_request_root_scoped(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    report = project / "report.txt"
+    report.write_text("report", encoding="utf-8")
+    outside = tmp_path / "private.txt"
+    outside.write_text("private", encoding="utf-8")
+    context = ExecutionContext(
+        directory=str(project),
+        project_root=str(project),
+        workspace_root=str(project),
+    )
+
+    with execution_context_scope(context):
+        published = PublishArtifactTool().execute("report.txt")
+        rejected = PublishArtifactTool().execute(str(outside))
+
+    assert published == {
+        "result": "Artifact ready for delivery: report.txt",
+        "artifact": {
+            "type": "file",
+            "path": str(report),
+            "file_name": "report.txt",
+            "mime_type": "text/plain",
+        },
+    }
+    assert rejected == {"error": "artifact path is outside request workspace"}
+
+
+def test_publish_artifact_rejects_symlinks(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / "target.txt"
+    target.write_text("target", encoding="utf-8")
+    link = project / "link.txt"
+    link.symlink_to(target)
+
+    with execution_context_scope(ExecutionContext(directory=str(project))):
+        result = PublishArtifactTool().execute(str(link))
+
+    assert result == {"error": "artifact path must not be a symlink"}
+
+
+def test_tool_manager_registers_and_dispatches_publish_artifact(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    report = project / "report.txt"
+    report.write_text("report", encoding="utf-8")
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = False
+    schema = manager.get_available_tool_schemas()["publish_artifact"]
+
+    with execution_context_scope(ExecutionContext(directory=str(project))):
+        result = manager.execute_tool(
+            "publish_artifact",
+            {"path": "report.txt"},
+        )
+
+    assert schema["x-penguin-permissions"]["requires_approval"] is True
+    assert get_tool_operations("publish_artifact") == [
+        Operation.FILESYSTEM_READ,
+        Operation.NETWORK_POST,
+    ]
+    assert result["artifact"]["path"] == str(report)

--- a/tests/tools/test_async_tool_dispatch.py
+++ b/tests/tools/test_async_tool_dispatch.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 
-from penguin.security.approval import get_approval_manager
+from penguin.security.approval import ApprovalScope, get_approval_manager
 from penguin.security.permission_engine import PermissionResult
 from penguin.system.execution_context import ExecutionContext, execution_context_scope
 from penguin.tools.tool_manager import ToolManager
@@ -485,6 +485,175 @@ def test_request_approval_policy_governs_shell_tools(
     )
 
     assert result == expected
+
+
+def test_default_deny_policy_allows_explicit_shell_prompt() -> None:
+    """A deny fallback must not disable a category explicitly set to ask."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+
+    raw_result = manager._permission_response(
+        "execute_command",
+        {"command": "pwd"},
+        {
+            "session_id": "session_explicit_shell_prompt",
+            "approval_policy": {"default": "deny", "shell": "ask"},
+        },
+    )
+
+    assert isinstance(raw_result, str)
+    result = json.loads(raw_result)
+    assert result["status"] == "pending_approval"
+    assert result["resource"] == "pwd"
+    pending = approval_manager.get_pending(session_id="session_explicit_shell_prompt")
+    assert [request.resource for request in pending] == ["pwd"]
+    approval_manager.reset()
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "expected_resource"),
+    [
+        ("execute_command", {"command": "pwd"}, "pwd"),
+        ("code_execution", {"code": "print('hi')"}, "print('hi')"),
+        ("process_start", {"command": "python app.py"}, "python app.py"),
+        ("process_stop", {"process_id": "process-123"}, "process-123"),
+    ],
+)
+def test_approval_target_exposes_executed_resource(
+    tool_name: str,
+    tool_input: dict[str, str],
+    expected_resource: str,
+) -> None:
+    """Execution approval cards must identify what will actually run."""
+    _operation, resource, _session_id = ToolManager._approval_target(
+        tool_name,
+        tool_input,
+        {},
+    )
+
+    assert resource == expected_resource
+
+
+def test_session_approval_does_not_bypass_new_ask_category() -> None:
+    """A shell grant must not silently include later secret access."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    session_id = "session_category_escalation"
+    context = {
+        "session_id": session_id,
+        "approval_policy": {
+            "default": "deny",
+            "shell": "ask",
+            "secrets": "ask",
+        },
+    }
+
+    first_result = json.loads(
+        manager._permission_response(
+            "execute_command",
+            {"command": "pwd"},
+            context,
+        )
+    )
+    first_request = approval_manager.get_request(first_result["approval_id"])
+    assert first_request is not None
+    assert first_request.resource == "pwd"
+    assert (
+        approval_manager.approve(
+            first_request.id,
+            scope=ApprovalScope.SESSION,
+        )
+        is not None
+    )
+
+    assert (
+        manager._permission_response(
+            "execute_command",
+            {"command": "whoami"},
+            context,
+        )
+        is None
+    )
+    escalated_result = json.loads(
+        manager._permission_response(
+            "execute_command",
+            {"command": "cat .env"},
+            context,
+        )
+    )
+    escalated_request = approval_manager.get_request(escalated_result["approval_id"])
+    assert escalated_request is not None
+    assert escalated_request.resource == "cat .env"
+    assert escalated_request.operation != first_request.operation
+    approval_manager.deny(escalated_request.id)
+    approval_manager.reset()
+
+
+def test_explicit_base_operation_preapproval_covers_fingerprinted_prompt() -> None:
+    """Existing callers may intentionally preapprove a whole tool operation."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    approval_manager.pre_approve(
+        "tool.execute_command",
+        session_id="session_explicit_base_preapproval",
+    )
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+
+    result = manager._permission_response(
+        "execute_command",
+        {"command": "pwd"},
+        {
+            "session_id": "session_explicit_base_preapproval",
+            "approval_policy": {"default": "deny", "shell": "ask"},
+        },
+    )
+
+    assert result is None
+    approval_manager.reset()
+
+
+def test_remote_allow_cannot_override_instance_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote allow removes only its own prompt, never an instance-level ASK."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "instance approval required"),
+    )
+
+    raw_result = manager._permission_response(
+        "execute_command",
+        {"command": "pwd"},
+        {
+            "session_id": "session_instance_ask",
+            "approval_policy": {"default": "deny", "shell": "allow"},
+        },
+    )
+
+    assert isinstance(raw_result, str)
+    result = json.loads(raw_result)
+    assert result["status"] == "pending_approval"
+    assert approval_manager.get_pending(session_id="session_instance_ask")
+    approval_manager.reset()
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_async_tool_dispatch.py
+++ b/tests/tools/test_async_tool_dispatch.py
@@ -16,6 +16,17 @@ from penguin.tools.tool_manager import ToolManager
 from penguin.utils.parser import ActionExecutor, ActionType, CodeActAction
 
 
+async def _wait_for_pending_approval(session_id: str) -> str:
+    """Return the first approval ID created for a test session."""
+    manager = get_approval_manager()
+    for _ in range(200):
+        pending = manager.get_pending(session_id=session_id)
+        if pending:
+            return pending[0].id
+        await asyncio.sleep(0.005)
+    raise AssertionError("Approval request was never created")
+
+
 @pytest.mark.asyncio
 async def test_foreground_subagent_executes_on_the_callers_event_loop() -> None:
     """Foreground native dispatch must not create or block a second event loop."""
@@ -399,6 +410,330 @@ async def test_preapproved_async_tool_stays_on_callers_event_loop(
 
     assert json.loads(raw_result)["status"] == "ok"
     assert observed_loop is caller_loop
+
+
+@pytest.mark.asyncio
+async def test_default_async_approval_still_returns_pending_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing HTTP-style contexts must not start waiting implicitly."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    calls = 0
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+
+    async def _memory_search(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"status": "executed"}
+
+    monkeypatch.setattr(manager, "perform_memory_search", _memory_search)
+    raw_result = await manager.execute_tool_async(
+        "memory_search",
+        {"query": "penguin"},
+        {"session_id": "session_default_pending"},
+    )
+
+    result = json.loads(raw_result)
+    assert result["status"] == "pending_approval"
+    assert calls == 0
+    approval_manager.reset()
+
+
+def test_request_scoped_read_only_mode_blocks_mutating_tools() -> None:
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+
+    result, reason = manager.check_tool_permission(
+        "write_file",
+        {"path": "notes.txt", "content": "mutate"},
+        {"permission_mode": "read_only"},
+    )
+
+    assert result == PermissionResult.DENY
+    assert "read-only" in reason
+
+
+@pytest.mark.parametrize(
+    ("decision", "expected"),
+    [("ask", PermissionResult.ASK), ("deny", PermissionResult.DENY)],
+)
+def test_request_approval_policy_governs_shell_tools(
+    decision: str,
+    expected: PermissionResult,
+) -> None:
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+
+    result, _reason = manager.check_tool_permission(
+        "execute_command",
+        {"command": "pwd"},
+        {"approval_policy": {"default": decision, "shell": decision}},
+    )
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_remote_deny_policy_never_creates_approval_or_executes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+
+    async def _unexpected_execution(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("deny policy executed the tool")
+
+    monkeypatch.setattr(manager, "perform_memory_search", _unexpected_execution)
+    result = json.loads(
+        await manager.execute_tool_async(
+            "memory_search",
+            {"query": "penguin"},
+            {
+                "session_id": "session_remote_deny",
+                "approval_policy": {"default": "deny"},
+            },
+        )
+    )
+
+    assert result["error"] == "permission_denied"
+    assert approval_manager.get_pending(session_id="session_remote_deny") == []
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_async_tool_resumes_once_after_opt_in_approval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An opted-in async call continues once after the matching approval."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    calls = 0
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+    monkeypatch.setattr(manager, "add_message_to_search", lambda _message: None)
+
+    async def _memory_search(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        nonlocal calls
+        calls += 1
+        return {"status": "executed"}
+
+    monkeypatch.setattr(manager, "perform_memory_search", _memory_search)
+    session_id = "session_async_resume"
+    execution = asyncio.create_task(
+        manager.execute_tool_async(
+            "memory_search",
+            {"query": "penguin"},
+            {
+                "session_id": session_id,
+                "approval_policy": {
+                    "wait_for_resolution": True,
+                    "timeout_seconds": 1.0,
+                },
+            },
+        )
+    )
+
+    request_id = await _wait_for_pending_approval(session_id)
+    await asyncio.sleep(0)
+    assert execution.done() is False
+    assert approval_manager.approve(request_id) is not None
+    assert approval_manager.approve(request_id) is None
+    result = await asyncio.wait_for(execution, timeout=1.0)
+
+    assert result == {"status": "executed"}
+    assert calls == 1
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resolution", ["deny", "expire"])
+async def test_denied_or_expired_approval_never_executes_async_tool(
+    monkeypatch: pytest.MonkeyPatch,
+    resolution: str,
+) -> None:
+    """Terminal non-approval outcomes must never mutate through the tool."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+
+    async def _unexpected_execution(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("denied or expired tool executed")
+
+    monkeypatch.setattr(manager, "perform_memory_search", _unexpected_execution)
+    session_id = f"session_async_{resolution}"
+    timeout_seconds = 1.0 if resolution == "deny" else 0.01
+    execution = asyncio.create_task(
+        manager.execute_tool_async(
+            "memory_search",
+            {"query": "penguin"},
+            {
+                "session_id": session_id,
+                "approval_policy": {
+                    "wait_for_resolution": True,
+                    "timeout_seconds": timeout_seconds,
+                },
+            },
+        )
+    )
+
+    request_id = await _wait_for_pending_approval(session_id)
+    if resolution == "deny":
+        assert approval_manager.deny(request_id) is not None
+    result = json.loads(await asyncio.wait_for(execution, timeout=1.0))
+
+    expected_error = "approval_denied" if resolution == "deny" else "approval_expired"
+    assert result["error"] == expected_error
+    assert approval_manager.approve(request_id) is None
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_sync_tool_resumes_once_without_blocking_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A synchronous tool waits and runs in worker threads, exactly once."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    calls = 0
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+    monkeypatch.setattr(manager, "add_message_to_search", lambda _message: None)
+
+    def _grep_search(*_args: Any, **_kwargs: Any) -> str:
+        nonlocal calls
+        calls += 1
+        return "executed"
+
+    monkeypatch.setattr(manager, "perform_grep_search", _grep_search)
+    session_id = "session_sync_resume"
+    execution = asyncio.create_task(
+        manager.execute_tool_async(
+            "grep_search",
+            {"pattern": "penguin"},
+            {
+                "session_id": session_id,
+                "approval_policy": {
+                    "wait_for_resolution": True,
+                    "timeout_seconds": 1.0,
+                },
+            },
+        )
+    )
+
+    request_id = await _wait_for_pending_approval(session_id)
+    heartbeat_ran = False
+
+    async def _heartbeat() -> None:
+        nonlocal heartbeat_ran
+        await asyncio.sleep(0)
+        heartbeat_ran = True
+
+    await _heartbeat()
+    assert heartbeat_ran is True
+    assert approval_manager.approve(request_id) is not None
+    result = await asyncio.wait_for(execution, timeout=1.0)
+
+    assert result == "executed"
+    assert calls == 1
+    approval_manager.reset()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_approval_wait_denies_request_and_never_executes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling channel work must wake its approval worker and close state."""
+    approval_manager = get_approval_manager()
+    approval_manager.reset()
+    manager = ToolManager(
+        {"diagnostics": {"enabled": False}},
+        lambda _error, _context: None,
+    )
+    manager._permission_enabled = True
+    monkeypatch.setattr(
+        manager,
+        "check_tool_permission",
+        lambda *_args, **_kwargs: (PermissionResult.ASK, "approval required"),
+    )
+
+    async def _unexpected_execution(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("cancelled tool executed")
+
+    monkeypatch.setattr(manager, "perform_memory_search", _unexpected_execution)
+    session_id = "session_async_cancel"
+    execution = asyncio.create_task(
+        manager.execute_tool_async(
+            "memory_search",
+            {"query": "penguin"},
+            {
+                "session_id": session_id,
+                "approval_policy": {
+                    "wait_for_resolution": True,
+                    "timeout_seconds": 10.0,
+                },
+            },
+        )
+    )
+
+    request_id = await _wait_for_pending_approval(session_id)
+    execution.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution
+
+    resolved = approval_manager.get_request(request_id)
+    assert resolved is not None
+    assert resolved.status.value == "denied"
+    assert approval_manager.get_pending(session_id=session_id) == []
+    approval_manager.reset()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a transport-neutral chat execution seam and durable channel contracts without putting Telegram logic in `PenguinCore`
- add optional `python-telegram-bot==22.6` support for DMs, allowlisted groups, forum topics, commands, bounded media, streaming previews, and explicit outbound artifacts
- add request-scoped remote permission caps, granular allow/ask/deny categories, resumable one-shot/session approvals, `/permissions`, and direct question replies/buttons
- preserve approval prompts through terminal states and stop Telegram turns after a denied or expired approval instead of accumulating serial waits
- add SQLite-backed bindings, ingress/outbox leases, deduplication, lane ordering, retries, dead letters, polling ownership, supergroup migration, and authenticated webhooks
- add default-deny config, setup/operator documentation, package checks, and Python 3.9–3.12 Telegram contract CI

See `context/tasks/penguin-telegram.md` and `docs/docs/usage/telegram.md`.

## Security

- Telegram is disabled and deny-by-default; authorization uses numeric Telegram IDs
- bot and webhook credentials are environment-only and redacted from status/errors
- remote permissions cannot exceed Penguin's instance policy; YOLO mode is rejected
- unauthorized updates are dropped before durable admission
- outbound files require the explicit, approval-gated `publish_artifact` tool and are revalidated at send time

The supplied bot token is not committed or fixtured. A local polling smoke test used environment configuration, and the credential will be rotated before production use.

## Verification

- focused channel/Telegram/runtime gate: **233 passed**
- repository suite: **2,494 passed, 3 skipped**; the five reported failures plus one explicitly deselected test reproduce on clean `HEAD` under the same environment
- Ruff check/format for the new channel and Telegram surface: passed
- changed Python syntax and critical undefined-name checks: passed apart from a pre-existing `FastAPI` forward-annotation lint finding
- fresh wheel and sdist build: passed
- Twine archive checks and fresh-wheel imports: passed
- generic credential scans across source, wheel, and sdist: zero matches
- live Telegram smoke: user-confirmed for polling, DM startup, pairing, and the approval flow

## Stack and scope

This draft targets `fix/multi-agent-runtime` (PR #82), which is the branch the worktree was created from, so the Telegram diff remains isolated. Phases 6–8—voice/TTS, broader media/reactions, proactive scheduling, and final Hermes parity hardening—remain explicitly deferred.
