### PR TITLE
feat(telegram): add session controls

### DIFF
--- a/context/tasks/penguin-telegram.md
+++ b/context/tasks/penguin-telegram.md
@@ -3,7 +3,7 @@
 ## Status
 
 - Created: 2026-08-11
-- State: active — Phases 0–5 baseline implemented; Phases 6–8 planned
+- State: active — Phases 0–5 and Telegram controls implemented; Phases 6–8 planned
 - Owner: Penguin runtime and integrations
 - Target: basic personal bot through Hermes-level Telegram parity
 - Primary implementation language: Python
@@ -661,7 +661,9 @@ recoverable/manual-retry outcome.
 | Final text chunking/fallback | yes | yes | yes |
 | Editable streaming answer | no | yes | yes |
 | Tool/progress status | no | yes | yes |
-| `/stop`, `/status`, `/model` | partial | yes | yes |
+| `/stop` and `/status` | yes | yes | yes |
+| Session model/reasoning/fast controls | no | yes | yes |
+| Recent session picker and safe rebinding | no | yes | yes |
 | Inbound photos | no | yes | yes |
 | Bounded text documents | no | yes | yes |
 | Groups and mention gating | no | yes | yes |
@@ -859,6 +861,40 @@ Acceptance criteria:
 - One blocked lane does not stall unrelated chats.
 - Polling and webhook paths pass the same normalized ingress contract tests.
 
+### Completed Follow-Up — Session And Runtime Controls
+
+Objective: expose the useful TUI-style controls without mutating Penguin's
+process-wide configuration or allowing arbitrary YAML edits from Telegram.
+
+Work:
+
+- [x] Add a session-scoped `/model` picker plus exact
+  `/model <provider-id>/<model-id>` selection and reset.
+- [x] Add `/reasoning` picker/direct/reset behavior using only variants supported
+  by the active model.
+- [x] Add OpenAI-only `/fast on|off|reset` for priority, default, or inherited
+  service tier.
+- [x] Add `/sessions` with a bounded, chat/topic-lane-owned history and safe
+  direct rebinding by session ID.
+- [x] Add curated `/settings` controls for model, reasoning, fast mode,
+  plan/build mode, sessions, permissions, and streaming.
+- [x] Store streaming per Telegram binding; keep model, reasoning, and fast mode
+  with their Penguin session across rebinding.
+- [x] Apply setting changes only to future turns while in-flight turns retain
+  their initial runtime snapshot.
+- [x] Scope durable control callbacks to bot account, sender, chat, and topic;
+  keep them restart-resumable until TTL.
+- [x] Reject busy sessions, stale controls, cross-lane session IDs, and
+  concurrent binding changes without partial mutation.
+
+Acceptance criteria:
+
+- Telegram controls never mutate global model configuration or persist provider
+  credentials.
+- A chat/topic can list and rebind only sessions previously owned by its binding.
+- Restart-safe pickers remain usable until expiry; stale or busy controls fail
+  closed.
+
 ### Phase 6 — Voice, Files, Reactions, And Media Parity
 
 Objective: reach Hermes-level conversational media support.
@@ -928,7 +964,8 @@ Work:
 - [ ] Test polling, webhook, proxy, and local Bot API configurations.
 - [ ] Add notification modes, edited status, pins, and recovery notices.
 - [ ] Complete command menu validation, help text, and access tiers.
-- [ ] Add model picker, topic skill binding, and per-channel prompt behavior.
+- [x] Add the model picker.
+- [ ] Add topic skill binding and per-channel prompt behavior.
 - [ ] Add setup, status, probe, doctor, pairing, and dead-letter CLI flows.
 - [ ] Add actionable diagnostics for token, permissions, privacy mode, webhook,
   network, polling conflicts, and delivery backlog.

--- a/docs/docs/usage/telegram.md
+++ b/docs/docs/usage/telegram.md
@@ -10,6 +10,10 @@ DMs, allowlisted groups and forum topics, stable Penguin sessions, streaming,
 basic media, questions and approvals, polling or authenticated webhooks, and
 restart-safe SQLite ingress and delivery.
 
+It also provides curated controls for session model, reasoning, fast mode,
+recent-session rebinding, plan/build mode, permissions, and per-binding
+streaming.
+
 Voice transcription, TTS, audio/video and broad media support, reactions,
 scheduled delivery, and general proactive/background sends are later phases.
 
@@ -275,14 +279,33 @@ The bot registers this command menu:
 | `/stop` | Abort the active Penguin turn for the bound session. |
 | `/whoami` | Show numeric user, chat, and topic IDs. |
 | `/session` | Show the bound Penguin session ID. |
-| `/mode plan`, `/mode build` | Show or change the binding's agent mode. |
-| `/model` | Show the active model. |
+| `/mode` | Pick `plan` or `build`; `/mode plan` and `/mode build` change it directly. |
+| `/model` | Pick a connected model; `/model <provider-id>/<model-id>` selects one directly and `/model reset` inherits Penguin's default. |
+| `/reasoning` | Pick an effort supported by the active model; `/reasoning <effort>` sets it directly and `/reasoning reset` inherits the model default. |
+| `/fast` | Pick OpenAI fast mode; `/fast on`, `/fast off`, or `/fast reset` selects priority, default, or inherited service tier. |
+| `/sessions` | Pick a recent session owned by this chat/topic lane; `/sessions <session-id>` rebinds directly when that ID is in the lane's history. |
+| `/settings` | Open curated controls for model, reasoning, fast mode, plan/build mode, session, permissions, and streaming. |
 | `/goal ...` | Use Penguin's session-goal command for the bound session. |
 | `/project` | Show the bound project directory. |
 | `/permissions` | Show Telegram's capped permission policy and timeout. |
 
 Additional policy commands are `/pair CODE`, `/activation mention|always`, and
 `/topic`. A command explicitly addressed to another bot is ignored.
+
+Model, reasoning, and fast-mode choices are stored on the Penguin session and
+return with that session when it is rebound. Plan/build mode and streaming are
+stored on the Telegram chat/topic binding and remain in place while switching
+sessions. Changes affect future turns; an in-flight turn keeps the runtime
+snapshot with which it started.
+
+`/sessions` is not a global session browser. It exposes at most 20 sessions
+previously bound to the same Telegram chat/topic lane, and direct rebinding is
+limited to that history. Busy sessions, concurrent binding changes, and stale
+buttons fail without changing state.
+
+The settings surface is deliberately curated: it cannot read or edit arbitrary
+YAML. Its inline controls are durable across a Penguin restart until their TTL,
+but remain scoped to the originating bot account, sender, chat, and topic.
 
 ## Streaming and media
 
@@ -292,6 +315,9 @@ conservative 4,000 UTF-16 code units. The streaming modes are:
 - `off`: typing indicator followed by the final response.
 - `progress`: one `Penguin is working…` message, replaced by the final response.
 - `edit`: throttled, coalesced assistant previews followed by the final response.
+
+The configured mode is the default. The Streaming control under `/settings`
+can override it independently for each Telegram chat or forum-topic binding.
 
 Reasoning is hidden by default. Enable `include_reasoning` only when everyone
 with access to the destination is allowed to see model reasoning.

--- a/penguin/channels/_store_callbacks.py
+++ b/penguin/channels/_store_callbacks.py
@@ -245,6 +245,42 @@ class CallbackStoreMixin:
             assert row is not None
             return callback_record_from_row(row)
 
+    def renew_callback_lease(
+        self,
+        callback_id: str,
+        *,
+        platform: str,
+        account_id: str,
+        owner_id: str,
+        lease_seconds: float,
+        now: float | None = None,
+    ) -> bool:
+        """Extend an owned callback lease before it expires."""
+
+        del platform
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        timestamp = self._now(now)
+        with self._write() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE channel_callbacks
+                SET lease_expires_at = ?, updated_at = ?
+                WHERE callback_id = ? AND account_id = ?
+                  AND state = 'claimed' AND claim_owner = ?
+                  AND lease_expires_at > ?
+                """,
+                (
+                    timestamp + lease_seconds,
+                    timestamp,
+                    callback_id,
+                    account_id,
+                    owner_id,
+                    timestamp,
+                ),
+            )
+            return cursor.rowcount == 1
+
     def complete_callback(
         self,
         callback_id: str,
@@ -416,6 +452,12 @@ class CallbackStoreMixin:
                 (account_id,),
             ).fetchall()
             for row in rows:
+                callback = callback_record_from_row(row)
+                if (
+                    row["state"] == "pending"
+                    and callback.payload.get("kind") == "control"
+                ):
+                    continue
                 terminal_state = "expired" if row["state"] == "pending" else "dead"
                 cursor = conn.execute(
                     """UPDATE channel_callbacks

--- a/penguin/channels/chat.py
+++ b/penguin/channels/chat.py
@@ -5,16 +5,27 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Mapping, Sequence
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
 
 from penguin.core_runtime import process_lifecycle
 from penguin.system.execution_context import ExecutionContext, execution_context_scope
 
-__all__ = ["ChatProcessRequest", "ChatStreamCallback", "execute_chat_turn"]
+__all__ = [
+    "ChatProcessRequest",
+    "ChatRuntimeResolutionError",
+    "ChatRuntimeResolver",
+    "ChatStreamCallback",
+    "execute_chat_turn",
+]
 
 logger = logging.getLogger(__name__)
 
 ChatStreamCallback = Callable[[str, str], Awaitable[None]]
+ChatRuntimeResolver = Callable[[], Awaitable[Optional[tuple[Any, Any]]]]
+
+
+class ChatRuntimeResolutionError(RuntimeError):
+    """A request-scoped runtime could not be resolved."""
 
 
 @dataclass(frozen=True)
@@ -37,6 +48,7 @@ class ChatProcessRequest:
     stream_callback: ChatStreamCallback | None = None
     api_client_override: Any = None
     model_config_override: Any = None
+    runtime_resolver: ChatRuntimeResolver | None = None
 
 
 def _track_request(core: Any, session_id: str | None) -> asyncio.Task[Any] | None:
@@ -88,6 +100,15 @@ async def execute_chat_turn(
     try:
         with execution_context_scope(request.execution_context):
             async with gate:
+                model_config_override = request.model_config_override
+                api_client_override = request.api_client_override
+                if request.runtime_resolver is not None:
+                    try:
+                        runtime = await request.runtime_resolver()
+                    except (RuntimeError, ValueError) as exc:
+                        raise ChatRuntimeResolutionError(str(exc)) from exc
+                    if runtime is not None:
+                        model_config_override, api_client_override = runtime
                 result = await core.process(
                     input_data=request.input_data,
                     context=dict(request.context)
@@ -99,8 +120,8 @@ async def execute_chat_turn(
                     context_files=list(request.context_files),
                     streaming=request.streaming,
                     stream_callback=request.stream_callback,
-                    api_client_override=request.api_client_override,
-                    model_config_override=request.model_config_override,
+                    api_client_override=api_client_override,
+                    model_config_override=model_config_override,
                 )
         if not isinstance(result, dict):
             raise TypeError("PenguinCore.process() must return a dictionary")

--- a/penguin/channels/fake.py
+++ b/penguin/channels/fake.py
@@ -41,6 +41,7 @@ class FakeChannel:
             stream_callback=capture,
             api_client_override=request.api_client_override,
             model_config_override=request.model_config_override,
+            runtime_resolver=request.runtime_resolver,
         )
         task = asyncio.current_task()
         if task is not None:

--- a/penguin/integrations/telegram/_attachments.py
+++ b/penguin/integrations/telegram/_attachments.py
@@ -1,0 +1,35 @@
+"""Inbound Telegram attachment validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PIL import Image, UnidentifiedImageError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TEXT_DOCUMENT_MIMES = frozenset(
+    {
+        "application/json",
+        "application/xml",
+        "application/x-yaml",
+        "text/csv",
+        "text/markdown",
+        "text/plain",
+        "text/yaml",
+    }
+)
+
+
+def validate_image(path: Path) -> None:
+    """Reject malformed or unsupported Telegram photos."""
+
+    try:
+        with Image.open(path) as image:
+            image.verify()
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ValueError("Telegram photo is not a valid supported image") from exc
+
+
+__all__ = ["TEXT_DOCUMENT_MIMES", "validate_image"]

--- a/penguin/integrations/telegram/_callback_resolution.py
+++ b/penguin/integrations/telegram/_callback_resolution.py
@@ -1,0 +1,130 @@
+"""Lease-safe resolution of Telegram inline callbacks."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from penguin.integrations.telegram._controls import resolve_control_callback
+from penguin.integrations.telegram._leases import run_with_lease_heartbeat
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import InboundEnvelope
+    from penguin.channels.store_models import CallbackRecord
+
+__all__ = ["resolve_callback"]
+
+_PLATFORM = "telegram"
+_CALLBACK_LEASE_SECONDS = 30.0
+
+
+async def _resolve_claimed_callback(
+    manager: Any,
+    envelope: InboundEnvelope,
+    callback: CallbackRecord,
+    action: str,
+) -> tuple[bool, str, str | None]:
+    """Apply one claimed callback while its durable lease is live."""
+
+    kind = callback.payload.get("kind")
+    resolved = False
+    label = "Expired"
+    callback_answer: str | None = None
+    if kind == "approval":
+        from penguin.security.approval import ApprovalScope, get_approval_manager
+
+        approval_manager = get_approval_manager()
+        if action == "approve":
+            resolved = (
+                approval_manager.approve(callback.request_id, scope=ApprovalScope.ONCE)
+                is not None
+            )
+            if resolved:
+                label = "Approved"
+        elif action == "approve_session":
+            resolved = (
+                approval_manager.approve(
+                    callback.request_id, scope=ApprovalScope.SESSION
+                )
+                is not None
+            )
+            if resolved:
+                label = "Approved for session"
+        elif action == "deny":
+            resolved = approval_manager.deny(callback.request_id) is not None
+            if resolved:
+                label = "Denied"
+    elif kind == "question" and action.startswith("q"):
+        try:
+            index = int(action[1:])
+        except ValueError:
+            index = -1
+        questions = callback.payload.get("questions") or []
+        options = questions[0].get("options") if questions else []
+        if 0 <= index < len(options):
+            option = options[index]
+            answer = str(option.get("label") or option.get("description") or "")
+            resolved = await manager._reply_to_question(callback.request_id, answer)
+            if resolved:
+                label = "Answered"
+                manager._pending_questions.pop(
+                    (envelope.address.lane_key, envelope.sender_id), None
+                )
+    elif kind == "control":
+        resolution = await resolve_control_callback(
+            manager, envelope, callback.payload, action
+        )
+        resolved = resolution.resolved
+        label = resolution.label
+        callback_answer = resolution.answer
+    return resolved, label, callback_answer
+
+
+async def resolve_callback(
+    manager: Any,
+    envelope: InboundEnvelope,
+    callback_data: str,
+    worker_id: str,
+) -> None:
+    """Claim, renew, and terminalize one addressed Telegram callback."""
+
+    parts = callback_data.split(":", 2)
+    if len(parts) != 3:
+        return
+    _prefix, callback_id, action = parts
+    callback = await asyncio.to_thread(
+        manager.store.claim_callback,
+        callback_id,
+        account_id=manager.account_id,
+        chat_id=envelope.address.chat_id,
+        topic_id=envelope.address.topic_id or None,
+        user_id=envelope.sender_id,
+        owner_id=worker_id,
+        lease_seconds=_CALLBACK_LEASE_SECONDS,
+        platform=_PLATFORM,
+    )
+    if callback is None:
+        await manager._answer_callback(envelope, "This action is unavailable.")
+        return
+    resolved, label, callback_answer = await run_with_lease_heartbeat(
+        _resolve_claimed_callback(manager, envelope, callback, action),
+        manager.store.renew_callback_lease,
+        callback_id,
+        platform=_PLATFORM,
+        account_id=manager.account_id,
+        owner_id=worker_id,
+        lease_seconds=_CALLBACK_LEASE_SECONDS,
+    )
+    await asyncio.to_thread(
+        manager.store.complete_callback_with_terminal,
+        callback_id,
+        owner_id=worker_id,
+        label=label,
+        platform=_PLATFORM,
+    )
+    manager._work_available.set()
+    await manager._answer_callback(
+        envelope,
+        callback_answer
+        or ("Recorded." if resolved else "This request is no longer pending."),
+    )

--- a/penguin/integrations/telegram/_commands.py
+++ b/penguin/integrations/telegram/_commands.py
@@ -3,12 +3,54 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from penguin.config import WORKSPACE_PATH
+from penguin.integrations.telegram._controls import (
+    CONTROL_COMMANDS,
+    handle_control_command,
+)
 
 if TYPE_CHECKING:
     from penguin.channels.schema import InboundEnvelope
+
+BOT_COMMANDS = [
+    ("start", "Start or resume Penguin"),
+    ("help", "Show Telegram commands"),
+    ("new", "Start a fresh Penguin session"),
+    ("status", "Show bot and session status"),
+    ("stop", "Stop the active Penguin turn"),
+    ("whoami", "Show your numeric Telegram identity"),
+    ("session", "Show the bound Penguin session"),
+    ("sessions", "Switch Penguin sessions"),
+    ("mode", "Show or set plan/build mode"),
+    ("model", "Show or set the session model"),
+    ("reasoning", "Show or set reasoning effort"),
+    ("fast", "Show or set OpenAI fast mode"),
+    ("settings", "Show session controls"),
+    ("permissions", "Show Telegram tool permissions"),
+    ("goal", "Show or update the session goal"),
+    ("project", "Show the bound project directory"),
+    ("activation", "Set group mention activation"),
+    ("topic", "Show the current topic binding"),
+    ("pair", "Authorize this private chat"),
+]
+
+
+def bot_commands() -> list[tuple[str, str]]:
+    """Return the curated Telegram command catalog."""
+
+    return list(BOT_COMMANDS)
+
+
+async def set_bot_commands(manager: Any) -> None:
+    """Register the curated command catalog when supported by the bot client."""
+
+    setter = getattr(manager.bot, "set_my_commands", None)
+    if callable(setter):
+        with suppress(Exception):
+            await manager._api_call(setter(bot_commands()))
 
 
 async def handle_command(
@@ -22,11 +64,16 @@ async def handle_command(
 
     store = manager.store
     assert store is not None
+    if command in CONTROL_COMMANDS:
+        return await handle_control_command(
+            manager, command, arguments, envelope, binding
+        )
     if command in {"start", "help"}:
         return (
             "Penguin is ready. Send a message or use /new, /status, /stop, "
-            "/session, /mode, /model, /goal, /project, /permissions, "
-            "/activation, /topic, /pair, or /whoami."
+            "/session, /sessions, /mode, /model, /reasoning, /fast, "
+            "/settings, /goal, /project, /permissions, /activation, "
+            "/topic, /pair, or /whoami."
         )
     if command == "whoami":
         return (
@@ -48,23 +95,6 @@ async def handle_command(
         abort = getattr(manager.core, "abort_session", None)
         stopped = bool(await abort(binding.session_id)) if callable(abort) else False
         return "Stopped the active Penguin turn." if stopped else "No active turn."
-    if command == "mode":
-        normalized = arguments.strip().lower()
-        if not normalized:
-            return f"Mode: {getattr(binding, 'agent_mode', None) or 'build'}"
-        if normalized not in {"plan", "build"}:
-            return "Usage: /mode plan|build"
-        updated = await asyncio.to_thread(
-            store.upsert_binding,
-            envelope.address.lane_key,
-            binding.session_id,
-            directory=getattr(binding, "directory", None),
-            agent_id=getattr(binding, "agent_id", None),
-            agent_mode=normalized,
-            settings=getattr(binding, "settings", {}),
-            expected_version=binding.version,
-        )
-        return f"Mode set to {updated.agent_mode}."
     if command == "activation":
         if envelope.metadata.get("chat_type") == "private":
             return "/activation is only available in groups and topics."
@@ -89,10 +119,6 @@ async def handle_command(
             f"Topic binding: {envelope.address.topic_id or 'none'}\n"
             f"Session: {binding.session_id}"
         )
-    if command == "model":
-        model_config = getattr(manager.core, "model_config", None)
-        model = getattr(model_config, "model", None) or "not configured"
-        return f"Active Penguin model: {model}"
     if command == "project":
         directory = getattr(binding, "directory", None) or WORKSPACE_PATH
         return f"Project directory: {directory}"
@@ -122,4 +148,4 @@ async def handle_command(
     return "Unknown command. Use /help for supported commands."
 
 
-__all__ = ["handle_command"]
+__all__ = ["BOT_COMMANDS", "bot_commands", "handle_command", "set_bot_commands"]

--- a/penguin/integrations/telegram/_controls.py
+++ b/penguin/integrations/telegram/_controls.py
@@ -1,0 +1,928 @@
+"""Curated, session-scoped Telegram runtime controls."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from penguin.channels.store import CompareAndSwapError
+from penguin.core_runtime import process_lifecycle
+from penguin.integrations.telegram._session_runtime import (
+    SessionRuntimePreferences,
+    load_session_runtime_preferences,
+    service_tier_for_fast_mode,
+    update_session_runtime_preferences,
+)
+from penguin.integrations.telegram._sessions import (
+    SessionAccessError,
+    SessionBusyError,
+    list_recent_sessions,
+    rebind_session,
+    with_recent_session,
+)
+
+if TYPE_CHECKING:
+    from penguin.channels.schema import InboundEnvelope
+
+__all__ = [
+    "CONTROL_COMMANDS",
+    "ControlResolution",
+    "binding_streaming_mode",
+    "handle_control_command",
+    "resolve_control_callback",
+]
+
+logger = logging.getLogger(__name__)
+
+CONTROL_COMMANDS = frozenset(
+    {"fast", "mode", "model", "reasoning", "sessions", "settings"}
+)
+_STREAMING_KEY = "streaming_mode"
+_STREAMING_MODES = ("off", "edit", "progress")
+_MAX_CHOICES = 40
+_MAX_CHOICE_VALUE_CHARS = 512
+_MODEL_PAGE_SIZE = 25
+_SESSION_CONTROLS = frozenset({"fast", "model", "reasoning"})
+
+
+class SessionControlStaleError(RuntimeError):
+    """Raised when a picker targets superseded session preferences."""
+
+
+@dataclass(frozen=True)
+class ModelChoice:
+    """One connected provider model safe to expose in Telegram."""
+
+    provider_id: str
+    model_id: str
+    name: str
+    reasoning_variants: tuple[str, ...]
+
+    @property
+    def selector(self) -> str:
+        return f"{self.provider_id}/{self.model_id}"
+
+
+@dataclass(frozen=True)
+class PickerChoice:
+    """One bounded callback choice."""
+
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class ControlResolution:
+    """Result of consuming a durable control callback."""
+
+    resolved: bool
+    label: str
+    answer: str
+
+
+def _build_provider_payload(core: Any) -> Mapping[str, Any]:
+    from penguin.web.services.opencode_provider import build_provider_list_payload
+
+    payload = build_provider_list_payload(core)
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _model_choices(payload: Mapping[str, Any]) -> tuple[ModelChoice, ...]:
+    """Extract active models from connected provider entries."""
+
+    connected_raw = payload.get("connected")
+    connected = (
+        {str(item) for item in connected_raw if isinstance(item, str) and item.strip()}
+        if isinstance(connected_raw, (list, tuple, set, frozenset))
+        else set()
+    )
+    choices: list[ModelChoice] = []
+    providers = payload.get("all")
+    if not isinstance(providers, list):
+        return ()
+    for provider in providers:
+        if not isinstance(provider, Mapping):
+            continue
+        provider_id = str(provider.get("id") or "").strip()
+        if not provider_id or (
+            not bool(provider.get("connected")) and provider_id not in connected
+        ):
+            continue
+        models = provider.get("models")
+        if not isinstance(models, Mapping):
+            continue
+        for raw_model_id, raw_model in models.items():
+            if not isinstance(raw_model_id, str) or not raw_model_id.strip():
+                continue
+            model = raw_model if isinstance(raw_model, Mapping) else {}
+            if str(model.get("status") or "active").lower() != "active":
+                continue
+            variants = model.get("variants")
+            variant_names = (
+                tuple(str(item) for item in variants if str(item).strip())
+                if isinstance(variants, Mapping)
+                else ()
+            )
+            choices.append(
+                ModelChoice(
+                    provider_id=provider_id,
+                    model_id=raw_model_id.strip(),
+                    name=str(model.get("name") or raw_model_id).strip(),
+                    reasoning_variants=variant_names,
+                )
+            )
+    return tuple(choices)
+
+
+def _resolve_model(selector: str, choices: Sequence[ModelChoice]) -> ModelChoice | None:
+    normalized = selector.strip()
+    qualified = [choice for choice in choices if choice.selector == normalized]
+    if len(qualified) == 1:
+        return qualified[0]
+    unqualified = [choice for choice in choices if choice.model_id == normalized]
+    return unqualified[0] if len(unqualified) == 1 else None
+
+
+def _global_model(core: Any) -> tuple[str | None, str | None]:
+    getter = getattr(core, "get_current_model", None)
+    current = getter() if callable(getter) else None
+    if isinstance(current, Mapping):
+        provider = str(current.get("provider") or "").strip() or None
+        model = str(current.get("model") or "").strip() or None
+    else:
+        config = getattr(core, "model_config", None)
+        provider = str(getattr(config, "provider", "") or "").strip() or None
+        model = str(getattr(config, "model", "") or "").strip() or None
+    provider = provider.lower() if provider else None
+    if provider and model and model.lower().startswith(f"{provider}/"):
+        model = model[len(provider) + 1 :]
+    return provider, model
+
+
+def _effective_model(
+    core: Any, preferences: SessionRuntimePreferences | None
+) -> tuple[str | None, str | None]:
+    if preferences and preferences.provider_id and preferences.model_id:
+        return preferences.provider_id, preferences.model_id
+    return _global_model(core)
+
+
+def binding_streaming_mode(manager: Any, binding: Any) -> str:
+    settings = getattr(binding, "settings", {})
+    value = settings.get(_STREAMING_KEY) if isinstance(settings, Mapping) else None
+    return value if value in _STREAMING_MODES else manager.config.streaming_mode
+
+
+async def _preferences(manager: Any, session_id: str) -> SessionRuntimePreferences:
+    loaded = await asyncio.to_thread(
+        load_session_runtime_preferences, manager.core, session_id
+    )
+    return loaded or SessionRuntimePreferences()
+
+
+async def _catalog(manager: Any) -> tuple[ModelChoice, ...]:
+    payload = await asyncio.to_thread(_build_provider_payload, manager.core)
+    return _model_choices(payload)
+
+
+def _preferences_revision(preferences: SessionRuntimePreferences) -> str:
+    values = (
+        preferences.provider_id or "",
+        preferences.model_id or "",
+        preferences.reasoning_variant or "",
+        preferences.service_tier or "",
+    )
+    digest = hashlib.sha256("\x1f".join(values).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+async def _session_revision(manager: Any, session_id: str) -> str:
+    preferences = await _preferences(manager, session_id)
+    return _preferences_revision(preferences)
+
+
+async def _assert_session_revision(
+    manager: Any,
+    session_id: str,
+    expected_revision: str | None,
+) -> None:
+    if expected_revision is None:
+        return
+    if await _session_revision(manager, session_id) != expected_revision:
+        raise SessionControlStaleError(
+            "Session settings changed. Reopen the control and try again."
+        )
+
+
+async def _assert_callback_binding(
+    manager: Any,
+    address_key: str | None,
+    session_id: str,
+    expected_version: int | None,
+) -> None:
+    if address_key is None:
+        return
+    current = await asyncio.to_thread(manager.store.get_binding, address_key)
+    if (
+        current is None
+        or current.session_id != session_id
+        or current.version != expected_version
+    ):
+        raise SessionControlStaleError(
+            "Settings changed. Reopen the control and try again."
+        )
+
+
+async def _thread_write(operation: Any, /, *args: Any, **kwargs: Any) -> Any:
+    """Finish an in-flight SQLite/session write before propagating cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError as cancellation:
+        try:
+            await task
+        except Exception:
+            logger.exception("Telegram control write failed during cancellation")
+        raise cancellation
+
+
+async def _set_model_preferences(
+    manager: Any,
+    session_id: str,
+    choice: ModelChoice | None,
+    *,
+    expected_revision: str | None = None,
+    expected_address_key: str | None = None,
+    expected_binding_version: int | None = None,
+) -> None:
+    """Validate a fresh request runtime, then persist under the session gate."""
+
+    gate = process_lifecycle.get_session_request_gate(manager.core, session_id)
+    if gate.locked():
+        raise SessionBusyError("The current session is busy. Use /stop or retry later.")
+    await gate.acquire()
+    try:
+        await _assert_callback_binding(
+            manager,
+            expected_address_key,
+            session_id,
+            expected_binding_version,
+        )
+        await _assert_session_revision(manager, session_id, expected_revision)
+        if choice is not None:
+            resolver = getattr(manager.core, "resolve_request_runtime", None)
+            if not callable(resolver):
+                raise ValueError("Penguin cannot validate model changes right now.")
+            resolved = resolver(choice.selector)
+            if inspect.isawaitable(resolved):
+                resolved = await resolved
+            if not isinstance(resolved, tuple) or len(resolved) != 2:
+                raise ValueError(
+                    "Penguin could not build a request runtime for that model."
+                )
+            model_config, api_client = resolved
+            if model_config is getattr(
+                manager.core, "model_config", None
+            ) or api_client is getattr(manager.core, "api_client", None):
+                raise ValueError("Penguin returned a shared runtime for that model.")
+        updated = await _thread_write(
+            update_session_runtime_preferences,
+            manager.core,
+            session_id,
+            provider_id=choice.provider_id if choice is not None else None,
+            model_id=choice.model_id if choice is not None else None,
+            reasoning_variant=None,
+            service_tier=None,
+        )
+        if updated is None:
+            raise ValueError("The Penguin session is no longer available.")
+    finally:
+        gate.release()
+
+
+async def _set_model(
+    manager: Any,
+    binding: Any,
+    value: str,
+    *,
+    expected_revision: str | None = None,
+    expected_address_key: str | None = None,
+    expected_binding_version: int | None = None,
+) -> str:
+    if value.strip().lower() in {"inherit", "reset"}:
+        await _set_model_preferences(
+            manager,
+            binding.session_id,
+            None,
+            expected_revision=expected_revision,
+            expected_address_key=expected_address_key,
+            expected_binding_version=expected_binding_version,
+        )
+        return "Session model reset to the Penguin default."
+    choice = _resolve_model(value, await _catalog(manager))
+    if choice is None:
+        raise ValueError(
+            "Unknown or ambiguous model. Use /model to choose a connected "
+            "provider model, or provide an exact provider/model ID."
+        )
+    await _set_model_preferences(
+        manager,
+        binding.session_id,
+        choice,
+        expected_revision=expected_revision,
+        expected_address_key=expected_address_key,
+        expected_binding_version=expected_binding_version,
+    )
+    return f"Session model set to {choice.selector}. Reasoning and fast mode reset."
+
+
+async def _set_reasoning(
+    manager: Any,
+    binding: Any,
+    value: str,
+    *,
+    expected_revision: str | None = None,
+    expected_address_key: str | None = None,
+    expected_binding_version: int | None = None,
+) -> str:
+    normalized = value.strip().lower()
+    gate = process_lifecycle.get_session_request_gate(manager.core, binding.session_id)
+    if gate.locked():
+        raise SessionBusyError("The current session is busy. Use /stop or retry later.")
+    await gate.acquire()
+    try:
+        await _assert_callback_binding(
+            manager,
+            expected_address_key,
+            binding.session_id,
+            expected_binding_version,
+        )
+        await _assert_session_revision(manager, binding.session_id, expected_revision)
+        if normalized in {"inherit", "reset"}:
+            reasoning_variant = None
+        else:
+            preferences = await _preferences(manager, binding.session_id)
+            provider_id, model_id = _effective_model(manager.core, preferences)
+            model = _resolve_model(
+                f"{provider_id}/{model_id}" if provider_id and model_id else "",
+                await _catalog(manager),
+            )
+            if model is None or normalized not in model.reasoning_variants:
+                supported = ", ".join(model.reasoning_variants) if model else "none"
+                raise ValueError(
+                    f"Unsupported reasoning effort. Available: {supported}."
+                )
+            reasoning_variant = normalized
+        updated = await _thread_write(
+            update_session_runtime_preferences,
+            manager.core,
+            binding.session_id,
+            reasoning_variant=reasoning_variant,
+        )
+        if updated is None:
+            raise ValueError("The Penguin session is no longer available.")
+    finally:
+        gate.release()
+    if reasoning_variant is None:
+        return "Session reasoning reset to the model default."
+    return f"Session reasoning set to {normalized}."
+
+
+async def _set_fast(
+    manager: Any,
+    binding: Any,
+    value: str,
+    *,
+    expected_revision: str | None = None,
+    expected_address_key: str | None = None,
+    expected_binding_version: int | None = None,
+) -> str:
+    normalized = value.strip().lower()
+    values = {"on": True, "off": False, "inherit": None, "reset": None}
+    if normalized not in values:
+        raise ValueError("Usage: /fast on|off|reset")
+    gate = process_lifecycle.get_session_request_gate(manager.core, binding.session_id)
+    if gate.locked():
+        raise SessionBusyError("The current session is busy. Use /stop or retry later.")
+    await gate.acquire()
+    try:
+        await _assert_callback_binding(
+            manager,
+            expected_address_key,
+            binding.session_id,
+            expected_binding_version,
+        )
+        await _assert_session_revision(manager, binding.session_id, expected_revision)
+        preferences = await _preferences(manager, binding.session_id)
+        provider_id, _model_id = _effective_model(manager.core, preferences)
+        if values[normalized] is not None and provider_id != "openai":
+            raise ValueError("Fast mode is available only for OpenAI models.")
+        tier = service_tier_for_fast_mode(values[normalized])
+        updated = await _thread_write(
+            update_session_runtime_preferences,
+            manager.core,
+            binding.session_id,
+            service_tier=tier,
+        )
+        if updated is None:
+            raise ValueError("The Penguin session is no longer available.")
+    finally:
+        gate.release()
+    state = "inherited" if values[normalized] is None else normalized
+    return f"Session fast mode set to {state}."
+
+
+async def _set_mode(
+    manager: Any,
+    envelope: InboundEnvelope,
+    binding: Any,
+    value: str,
+) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"plan", "build"}:
+        raise ValueError("Usage: /mode plan|build")
+    gate = process_lifecycle.get_session_request_gate(manager.core, binding.session_id)
+    if gate.locked():
+        raise SessionBusyError("The current session is busy. Use /stop or retry later.")
+    await gate.acquire()
+    try:
+        updated = await _thread_write(
+            manager.store.upsert_binding,
+            envelope.address.lane_key,
+            binding.session_id,
+            directory=getattr(binding, "directory", None),
+            agent_id=getattr(binding, "agent_id", None),
+            agent_mode=normalized,
+            settings=getattr(binding, "settings", {}),
+            expected_version=binding.version,
+        )
+    finally:
+        gate.release()
+    return f"Mode set to {updated.agent_mode}."
+
+
+async def _set_streaming(
+    manager: Any, envelope: InboundEnvelope, binding: Any, value: str
+) -> str:
+    normalized = value.strip().lower()
+    if normalized not in _STREAMING_MODES:
+        raise ValueError("Streaming must be off, edit, or progress.")
+    gate = process_lifecycle.get_session_request_gate(manager.core, binding.session_id)
+    if gate.locked():
+        raise SessionBusyError("The current session is busy. Use /stop or retry later.")
+    settings = dict(getattr(binding, "settings", {}) or {})
+    settings[_STREAMING_KEY] = normalized
+    await gate.acquire()
+    try:
+        await _thread_write(
+            manager.store.upsert_binding,
+            envelope.address.lane_key,
+            binding.session_id,
+            directory=getattr(binding, "directory", None),
+            agent_id=getattr(binding, "agent_id", None),
+            agent_mode=getattr(binding, "agent_mode", None),
+            settings=settings,
+            expected_version=binding.version,
+        )
+    finally:
+        gate.release()
+    return f"Telegram streaming set to {normalized}."
+
+
+async def _rebind(manager: Any, binding: Any, session_id: str) -> str:
+    updated = await rebind_session(
+        manager.core, manager.store, binding, session_id.strip()
+    )
+    return f"Telegram is now bound to Penguin session {updated.session_id}."
+
+
+def _choice(label: str, value: str) -> PickerChoice:
+    return PickerChoice(label=label[:40], value=value[:_MAX_CHOICE_VALUE_CHARS])
+
+
+async def _settings_text(manager: Any, binding: Any) -> str:
+    preferences = await _preferences(manager, binding.session_id)
+    provider_id, model_id = _effective_model(manager.core, preferences)
+    model = f"{provider_id}/{model_id}" if provider_id and model_id else "unavailable"
+    fast = {
+        "priority": "on",
+        "default": "off",
+    }.get(preferences.service_tier, "inherit")
+    return (
+        "Penguin Telegram settings\n"
+        f"Session: {binding.session_id}\n"
+        f"Model: {model}"
+        f"{' (session)' if preferences.qualified_model_id else ' (default)'}\n"
+        f"Reasoning: {preferences.reasoning_variant or 'inherit'}\n"
+        f"Fast mode: {fast}\n"
+        f"Mode: {getattr(binding, 'agent_mode', None) or 'build'}\n"
+        f"Streaming: {binding_streaming_mode(manager, binding)}\n"
+        f"Permissions: {manager.config.permission_mode} cap; use /permissions"
+    )
+
+
+async def _picker(
+    manager: Any,
+    envelope: InboundEnvelope,
+    binding: Any,
+    control: str,
+    *,
+    page: int = 0,
+) -> tuple[str, tuple[PickerChoice, ...]]:
+    if control == "settings":
+        return await _settings_text(manager, binding), tuple(
+            _choice(label, f"open:{value}")
+            for label, value in (
+                ("Model", "model"),
+                ("Reasoning", "reasoning"),
+                ("Fast mode", "fast"),
+                ("Plan / build", "mode"),
+                ("Sessions", "sessions"),
+                ("Streaming", "streaming"),
+                ("Permissions", "permissions"),
+            )
+        )
+    if control == "model":
+        models = await _catalog(manager)
+        page_count = max(1, (len(models) + _MODEL_PAGE_SIZE - 1) // _MODEL_PAGE_SIZE)
+        if page < 0 or page >= page_count:
+            raise ValueError("Model catalog changed. Reopen /model.")
+        start = page * _MODEL_PAGE_SIZE
+        choices = [_choice("Use Penguin default", "reset")]
+        choices.extend(
+            _choice(f"{model.name} · {model.provider_id}", model.selector)
+            for model in models[start : start + _MODEL_PAGE_SIZE]
+        )
+        if page:
+            choices.append(_choice("Previous", f"page:{page - 1}"))
+        if page + 1 < page_count:
+            choices.append(_choice("Next", f"page:{page + 1}"))
+        return (
+            f"Choose a session model (page {page + 1}/{page_count}):",
+            tuple(choices),
+        )
+    if control == "reasoning":
+        preferences = await _preferences(manager, binding.session_id)
+        provider_id, model_id = _effective_model(manager.core, preferences)
+        models = await _catalog(manager)
+        model = _resolve_model(
+            f"{provider_id}/{model_id}" if provider_id and model_id else "", models
+        )
+        variants = model.reasoning_variants if model else ()
+        choices = [_choice("Use model default", "reset")]
+        choices.extend(_choice(value, value) for value in variants)
+        return "Choose session reasoning effort:", tuple(choices)
+    if control == "fast":
+        return "Choose OpenAI fast mode:", (
+            _choice("On (priority)", "on"),
+            _choice("Off (default tier)", "off"),
+            _choice("Inherit", "reset"),
+        )
+    if control == "mode":
+        return "Choose plan or build mode:", (
+            _choice("Plan", "plan"),
+            _choice("Build", "build"),
+        )
+    if control == "streaming":
+        return "Choose Telegram streaming:", tuple(
+            _choice(value.title(), value) for value in _STREAMING_MODES
+        )
+    if control == "sessions":
+        sessions = await asyncio.to_thread(list_recent_sessions, manager.core, binding)
+        choices = tuple(
+            _choice(
+                ("✓ " if session.current else "")
+                + (session.title or session.session_id),
+                session.session_id,
+            )
+            for session in sessions[:_MAX_CHOICES]
+        )
+        return "Choose a recent Telegram-owned session:", choices
+    if control == "permissions":
+        return manager.config.permissions_summary, (
+            _choice("Back to settings", "open:settings"),
+        )
+    raise ValueError("Unknown Telegram control")
+
+
+async def _open_picker(
+    manager: Any,
+    envelope: InboundEnvelope,
+    binding: Any,
+    control: str,
+    *,
+    page: int = 0,
+    expected_revision: str | None = None,
+) -> None:
+    session_revision: str | None = None
+    if control in _SESSION_CONTROLS:
+        gate = process_lifecycle.get_session_request_gate(
+            manager.core, binding.session_id
+        )
+        if gate.locked():
+            raise SessionBusyError(
+                "The current session is busy. Use /stop or retry later."
+            )
+        await gate.acquire()
+        try:
+            await _assert_session_revision(
+                manager, binding.session_id, expected_revision
+            )
+            text, choices = await _picker(
+                manager, envelope, binding, control, page=page
+            )
+            session_revision = await _session_revision(manager, binding.session_id)
+        finally:
+            gate.release()
+    else:
+        text, choices = await _picker(manager, envelope, binding, control, page=page)
+    if not choices:
+        text += "\n\nNo choices are currently available."
+    choices = choices[:_MAX_CHOICES]
+    callback_id = uuid.uuid4().hex
+    buttons = [
+        [
+            {
+                "text": choice.label,
+                "data": f"penguin:{callback_id}:c{index}",
+            }
+        ]
+        for index, choice in enumerate(choices)
+    ]
+    payload: dict[str, Any] = {
+        "kind": "control",
+        "control": control,
+        "session_id": binding.session_id,
+        "binding_version": binding.version,
+        "choices": [choice.value for choice in choices],
+    }
+    if session_revision is not None:
+        payload["session_revision"] = session_revision
+    await manager._create_projection(
+        envelope.address,
+        f"control:{callback_id}",
+        text,
+        buttons,
+        session_id=binding.session_id,
+        user_id=envelope.sender_id,
+        callback_id=callback_id,
+        request_id=f"control:{callback_id}",
+        callback_payload=payload,
+    )
+
+
+async def _safe_control(operation: Any) -> str | None:
+    try:
+        return await operation
+    except SessionBusyError as exc:
+        return str(exc) or "The session is busy. Use /stop or retry later."
+    except SessionAccessError:
+        return "That session is not available to this Telegram binding."
+    except CompareAndSwapError:
+        return "Settings changed concurrently. Reopen the control and try again."
+    except SessionControlStaleError as exc:
+        return str(exc)
+    except ValueError as exc:
+        return str(exc) or "That setting is not available."
+    except RuntimeError:
+        return "Penguin could not persist that setting. Try again."
+
+
+async def _seed_recent_binding(
+    manager: Any, envelope: InboundEnvelope, binding: Any
+) -> Any:
+    settings = dict(getattr(binding, "settings", {}) or {})
+    seeded = with_recent_session(settings, binding.session_id)
+    if seeded == settings:
+        return binding
+    try:
+        return await asyncio.to_thread(
+            manager.store.upsert_binding,
+            envelope.address.lane_key,
+            binding.session_id,
+            directory=getattr(binding, "directory", None),
+            agent_id=getattr(binding, "agent_id", None),
+            agent_mode=getattr(binding, "agent_mode", None),
+            settings=seeded,
+            expected_version=binding.version,
+        )
+    except CompareAndSwapError:
+        current = await asyncio.to_thread(
+            manager.store.get_binding, envelope.address.lane_key
+        )
+        current_settings = getattr(current, "settings", {}) if current else {}
+        if (
+            current
+            and with_recent_session(current_settings, current.session_id)
+            == current_settings
+        ):
+            return current
+        raise
+
+
+async def handle_control_command(
+    manager: Any,
+    command: str,
+    arguments: str,
+    envelope: InboundEnvelope,
+    binding: Any,
+) -> str | None:
+    """Handle one curated control command without global runtime mutation."""
+
+    if command in {"sessions", "settings"}:
+        try:
+            binding = await _seed_recent_binding(manager, envelope, binding)
+        except CompareAndSwapError:
+            return "Settings changed concurrently. Try again."
+    value = arguments.strip()
+    if command == "settings" and value:
+        section, _, setting = value.partition(" ")
+        if section == "streaming" and setting:
+            return await _safe_control(
+                _set_streaming(manager, envelope, binding, setting)
+            )
+        if section == "mode" and setting:
+            return await _safe_control(_set_mode(manager, envelope, binding, setting))
+        return "Usage: /settings or /settings streaming off|edit|progress"
+    if value:
+        if command == "model":
+            return await _safe_control(
+                _set_model(
+                    manager,
+                    binding,
+                    value,
+                    expected_address_key=envelope.address.lane_key,
+                    expected_binding_version=binding.version,
+                )
+            )
+        if command == "reasoning":
+            return await _safe_control(
+                _set_reasoning(
+                    manager,
+                    binding,
+                    value,
+                    expected_address_key=envelope.address.lane_key,
+                    expected_binding_version=binding.version,
+                )
+            )
+        if command == "fast":
+            return await _safe_control(
+                _set_fast(
+                    manager,
+                    binding,
+                    value,
+                    expected_address_key=envelope.address.lane_key,
+                    expected_binding_version=binding.version,
+                )
+            )
+        if command == "mode":
+            return await _safe_control(_set_mode(manager, envelope, binding, value))
+        if command == "sessions":
+            return await _safe_control(_rebind(manager, binding, value))
+    return await _safe_control(_open_picker(manager, envelope, binding, command))
+
+
+async def _apply_choice(
+    manager: Any,
+    envelope: InboundEnvelope,
+    binding: Any,
+    control: str,
+    value: str,
+    *,
+    expected_revision: str | None = None,
+    expected_address_key: str | None = None,
+    expected_binding_version: int | None = None,
+) -> str:
+    if value.startswith("open:"):
+        target = value.removeprefix("open:")
+        await _open_picker(manager, envelope, binding, target)
+        return f"Opened {target}"
+    if control == "model" and value.startswith("page:"):
+        try:
+            page = int(value.removeprefix("page:"))
+        except ValueError as exc:
+            raise ValueError("Invalid model page.") from exc
+        await _open_picker(
+            manager,
+            envelope,
+            binding,
+            control,
+            page=page,
+            expected_revision=expected_revision,
+        )
+        return f"Opened model page {page + 1}"
+    if control == "model":
+        return await _set_model(
+            manager,
+            binding,
+            value,
+            expected_revision=expected_revision,
+            expected_address_key=expected_address_key,
+            expected_binding_version=expected_binding_version,
+        )
+    if control == "reasoning":
+        return await _set_reasoning(
+            manager,
+            binding,
+            value,
+            expected_revision=expected_revision,
+            expected_address_key=expected_address_key,
+            expected_binding_version=expected_binding_version,
+        )
+    if control == "fast":
+        return await _set_fast(
+            manager,
+            binding,
+            value,
+            expected_revision=expected_revision,
+            expected_address_key=expected_address_key,
+            expected_binding_version=expected_binding_version,
+        )
+    if control == "mode":
+        return await _set_mode(manager, envelope, binding, value)
+    if control == "streaming":
+        return await _set_streaming(manager, envelope, binding, value)
+    if control == "sessions":
+        return await _rebind(manager, binding, value)
+    raise ValueError("That control is no longer available.")
+
+
+async def resolve_control_callback(
+    manager: Any,
+    envelope: InboundEnvelope,
+    payload: Mapping[str, Any],
+    action: str,
+) -> ControlResolution:
+    """Validate and consume one claimed control callback."""
+
+    current = await asyncio.to_thread(
+        manager.store.get_binding, envelope.address.lane_key
+    )
+    expected_session = str(payload.get("session_id") or "")
+    expected_version = payload.get("binding_version")
+    if (
+        current is None
+        or current.session_id != expected_session
+        or current.version != expected_version
+    ):
+        return ControlResolution(
+            False,
+            "Stale",
+            "Settings changed. Reopen the control and try again.",
+        )
+    if not action.startswith("c"):
+        return ControlResolution(False, "Unavailable", "Invalid control choice.")
+    try:
+        index = int(action[1:])
+    except ValueError:
+        index = -1
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not (0 <= index < len(choices)):
+        return ControlResolution(False, "Unavailable", "Invalid control choice.")
+    value = choices[index]
+    control = payload.get("control")
+    if not isinstance(value, str) or not isinstance(control, str):
+        return ControlResolution(False, "Unavailable", "Invalid control choice.")
+    expected_revision = payload.get("session_revision")
+    if control in _SESSION_CONTROLS and not isinstance(expected_revision, str):
+        return ControlResolution(
+            False,
+            "Stale",
+            "Session settings changed. Reopen the control and try again.",
+        )
+    try:
+        message = await _apply_choice(
+            manager,
+            envelope,
+            current,
+            control,
+            value,
+            expected_revision=expected_revision,
+            expected_address_key=envelope.address.lane_key,
+            expected_binding_version=current.version,
+        )
+    except SessionBusyError as exc:
+        return ControlResolution(False, "Busy", str(exc) or "Session is busy.")
+    except SessionAccessError:
+        return ControlResolution(False, "Unavailable", "Session is unavailable.")
+    except CompareAndSwapError:
+        return ControlResolution(
+            False, "Stale", "Settings changed. Reopen the control and try again."
+        )
+    except SessionControlStaleError as exc:
+        return ControlResolution(False, "Stale", str(exc))
+    except ValueError as exc:
+        return ControlResolution(False, "Unavailable", str(exc))
+    except RuntimeError:
+        return ControlResolution(
+            False,
+            "Unavailable",
+            "Penguin could not persist that setting. Try again.",
+        )
+    return ControlResolution(True, message[:80], "Updated.")

--- a/penguin/integrations/telegram/_preview.py
+++ b/penguin/integrations/telegram/_preview.py
@@ -20,9 +20,16 @@ logger = logging.getLogger(__name__)
 class Preview:
     """Per-turn typing/progress task; stream callbacks only mutate memory."""
 
-    def __init__(self, manager: Any, envelope: InboundEnvelope) -> None:
+    def __init__(
+        self,
+        manager: Any,
+        envelope: InboundEnvelope,
+        *,
+        mode: str | None = None,
+    ) -> None:
         self.manager = manager
         self.envelope = envelope
+        self.mode = mode or manager.config.streaming_mode
         self.coalescer = StreamingCoalescer(
             interval_seconds=manager.config.edit_interval_ms / 1000
         )
@@ -33,9 +40,9 @@ class Preview:
 
     async def start(self) -> None:
         self._tasks.append(asyncio.create_task(self._typing_loop()))
-        if self.manager.config.streaming_mode == "progress":
+        if self.mode == "progress":
             await self._send_or_edit("Penguin is working…")
-        if self.manager.config.streaming_mode in {"edit", "progress"}:
+        if self.mode in {"edit", "progress"}:
             self._tasks.append(asyncio.create_task(self._preview_loop()))
 
     async def push(self, chunk: str, message_type: str = "assistant") -> None:
@@ -81,7 +88,6 @@ class Preview:
                 continue
 
     async def _preview_loop(self) -> None:
-        mode = self.manager.config.streaming_mode
         while not self._closed.is_set():
             try:
                 await asyncio.wait_for(
@@ -91,7 +97,7 @@ class Preview:
             except asyncio.TimeoutError:
                 pass
             self._event.clear()
-            if mode != "edit":
+            if self.mode != "edit":
                 continue
             preview = self.coalescer.take(time.monotonic())
             if preview:

--- a/penguin/integrations/telegram/_session_runtime.py
+++ b/penguin/integrations/telegram/_session_runtime.py
@@ -1,0 +1,496 @@
+"""Session-scoped model preferences for Telegram requests."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from penguin.core_runtime.opencode_bridge import (
+    SESSION_MODEL_ID_KEY,
+    SESSION_PROVIDER_ID_KEY,
+    SESSION_VARIANT_KEY,
+)
+from penguin.core_runtime.session_lookup import iter_session_managers
+from penguin.llm.model_config import normalize_openai_service_tier
+from penguin.llm.runtime import apply_reasoning_variant_override
+from penguin.system.state import Session
+
+SESSION_SERVICE_TIER_KEY = "_penguin_service_tier_v1"
+
+
+class _UnchangedValue:
+    """Sentinel type for omitted preference updates."""
+
+    __slots__ = ()
+
+
+UNCHANGED: Final = _UnchangedValue()
+
+
+@dataclass(frozen=True)
+class SessionRuntimePreferences:
+    """Credential-free model preferences persisted on one Penguin session."""
+
+    provider_id: str | None = None
+    model_id: str | None = None
+    reasoning_variant: str | None = None
+    service_tier: str | None = None
+
+    def __post_init__(self) -> None:
+        provider_id = _normalize_optional_string(self.provider_id, lowercase=True)
+        model_id = _normalize_optional_string(self.model_id)
+        if provider_id and model_id:
+            prefix, separator, remainder = model_id.partition("/")
+            if separator and prefix.lower() == provider_id and remainder.strip():
+                model_id = remainder.strip()
+        if bool(provider_id) != bool(model_id):
+            raise ValueError("provider_id and model_id must be set or cleared together")
+
+        reasoning_variant = _normalize_optional_string(
+            self.reasoning_variant,
+            lowercase=True,
+        )
+        service_tier = _normalize_service_tier(self.service_tier)
+        object.__setattr__(self, "provider_id", provider_id)
+        object.__setattr__(self, "model_id", model_id)
+        object.__setattr__(self, "reasoning_variant", reasoning_variant)
+        object.__setattr__(self, "service_tier", service_tier)
+
+    @property
+    def qualified_model_id(self) -> str | None:
+        """Return the provider-qualified model selector for core resolution."""
+
+        if self.provider_id is None or self.model_id is None:
+            return None
+        return f"{self.provider_id}/{self.model_id}"
+
+    @property
+    def has_overrides(self) -> bool:
+        """Return whether this session changes any request runtime setting."""
+
+        return any(
+            value is not None
+            for value in (
+                self.provider_id,
+                self.model_id,
+                self.reasoning_variant,
+                self.service_tier,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _FileSnapshot:
+    """Exact pre-save state for one session persistence artifact."""
+
+    path: Path
+    content: bytes | None
+    mode: int | None
+
+
+def load_session_runtime_preferences(
+    core: Any,
+    session_id: str,
+) -> SessionRuntimePreferences | None:
+    """Load runtime preferences for an existing session."""
+
+    session, _manager = _find_session_without_activation(core, session_id)
+    if session is None:
+        return None
+    metadata = getattr(session, "metadata", None)
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return SessionRuntimePreferences(
+        provider_id=metadata.get(SESSION_PROVIDER_ID_KEY),
+        model_id=metadata.get(SESSION_MODEL_ID_KEY),
+        reasoning_variant=metadata.get(SESSION_VARIANT_KEY),
+        service_tier=metadata.get(SESSION_SERVICE_TIER_KEY),
+    )
+
+
+def update_session_runtime_preferences(
+    core: Any,
+    session_id: str,
+    *,
+    provider_id: str | _UnchangedValue | None = UNCHANGED,
+    model_id: str | _UnchangedValue | None = UNCHANGED,
+    reasoning_variant: str | _UnchangedValue | None = UNCHANGED,
+    service_tier: str | _UnchangedValue | None = UNCHANGED,
+) -> SessionRuntimePreferences | None:
+    """Update selected preferences, preserving fields left ``UNCHANGED``."""
+
+    session, manager = _find_session_without_activation(core, session_id)
+    if session is None or manager is None:
+        return None
+    original_metadata = getattr(session, "metadata", UNCHANGED)
+    metadata = (
+        deepcopy(original_metadata) if isinstance(original_metadata, dict) else {}
+    )
+
+    current = SessionRuntimePreferences(
+        provider_id=metadata.get(SESSION_PROVIDER_ID_KEY),
+        model_id=metadata.get(SESSION_MODEL_ID_KEY),
+        reasoning_variant=metadata.get(SESSION_VARIANT_KEY),
+        service_tier=metadata.get(SESSION_SERVICE_TIER_KEY),
+    )
+    updated = SessionRuntimePreferences(
+        provider_id=_updated_value(current.provider_id, provider_id),
+        model_id=_updated_value(current.model_id, model_id),
+        reasoning_variant=_updated_value(
+            current.reasoning_variant,
+            reasoning_variant,
+        ),
+        service_tier=_updated_value(current.service_tier, service_tier),
+    )
+    if updated == current:
+        return updated
+
+    original_last_active = getattr(session, "last_active", UNCHANGED)
+    original_current_session = getattr(manager, "current_session", UNCHANGED)
+    original_cache_entry = _cached_entry(manager, session_id)
+    original_index_entry = _session_index_entry(manager, session_id)
+    original_files = _snapshot_session_files(manager, session_id)
+    session.metadata = metadata
+    _store_optional(metadata, SESSION_PROVIDER_ID_KEY, updated.provider_id)
+    _store_optional(metadata, SESSION_MODEL_ID_KEY, updated.model_id)
+    _store_optional(metadata, SESSION_VARIANT_KEY, updated.reasoning_variant)
+    _store_optional(metadata, SESSION_SERVICE_TIER_KEY, updated.service_tier)
+    try:
+        manager.mark_session_modified(session.id)
+        if manager.save_session(session) is False:
+            raise RuntimeError(
+                f"Unable to persist runtime preferences for {session.id}"
+            )
+    except Exception:
+        _restore_attribute(session, "metadata", original_metadata)
+        _restore_attribute(session, "last_active", original_last_active)
+        _restore_cached_entry(manager, session_id, original_cache_entry)
+        _restore_session_index_entry(manager, session_id, original_index_entry)
+        try:
+            _restore_session_files(original_files)
+        except Exception as rollback_error:
+            raise RuntimeError(
+                f"Unable to roll back runtime preferences for {session.id}"
+            ) from rollback_error
+        raise
+    finally:
+        _restore_attribute(manager, "current_session", original_current_session)
+    if original_cache_entry is UNCHANGED:
+        _restore_cached_entry(manager, session_id, original_cache_entry)
+    return updated
+
+
+async def resolve_session_request_runtime(
+    core: Any,
+    session_id: str,
+) -> tuple[Any, Any] | None:
+    """Build fresh request-owned model overrides for one existing session."""
+
+    preferences = load_session_runtime_preferences(core, session_id)
+    if preferences is None or not preferences.has_overrides:
+        return None
+
+    resolver = getattr(core, "resolve_request_runtime", None)
+    if not callable(resolver):
+        raise RuntimeError("Penguin core cannot resolve a request runtime")
+    model_config, api_client = await resolver(preferences.qualified_model_id)
+    if model_config is getattr(core, "model_config", None):
+        raise RuntimeError("Request runtime resolver returned the global model config")
+    if api_client is getattr(core, "api_client", None):
+        raise RuntimeError("Request runtime resolver returned the global API client")
+
+    if preferences.reasoning_variant is not None:
+        supported_efforts: Any = None
+        capabilities_getter = getattr(api_client, "get_provider_capabilities", None)
+        if callable(capabilities_getter):
+            capabilities = capabilities_getter()
+            supported_efforts = getattr(capabilities, "reasoning_efforts", None)
+        apply_reasoning_variant_override(
+            model_config,
+            preferences.reasoning_variant,
+            supported_efforts=supported_efforts,
+        )
+    if preferences.service_tier is not None:
+        provider_id = str(getattr(model_config, "provider", "") or "").lower()
+        if provider_id != "openai":
+            raise ValueError("Fast mode is available only for OpenAI models")
+        model_config.service_tier = _normalize_service_tier(preferences.service_tier)
+    return model_config, api_client
+
+
+def service_tier_for_fast_mode(enabled: bool | None) -> str | None:
+    """Map Telegram's fast-mode switch to an explicit request service tier."""
+
+    if enabled is None:
+        return None
+    return "priority" if enabled else "default"
+
+
+def read_session_file_without_activation(
+    manager: Any,
+    session_id: str,
+) -> Session | None:
+    """Read and validate one exact primary session without manager activation."""
+
+    if not _is_exact_session_id(session_id):
+        return None
+    path = _session_file_path(manager, session_id)
+    if path is None:
+        return None
+    return _read_session_file(path, session_id)
+
+
+def _updated_value(
+    current: str | None,
+    update: str | _UnchangedValue | None,
+) -> str | None:
+    if update is UNCHANGED:
+        return current
+    return update
+
+
+def _store_optional(metadata: dict[str, Any], key: str, value: str | None) -> None:
+    if value is None:
+        metadata.pop(key, None)
+    else:
+        metadata[key] = value
+
+
+def _normalize_optional_string(
+    value: Any,
+    *,
+    lowercase: bool = False,
+) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized.lower() if lowercase else normalized
+
+
+def _normalize_service_tier(value: Any) -> str | None:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return None
+    normalized = normalize_openai_service_tier(value)
+    if normalized is None:
+        raise ValueError(f"Unsupported OpenAI service tier: {value!r}")
+    return normalized
+
+
+def _find_session_without_activation(
+    core: Any,
+    session_id: Any,
+) -> tuple[Any | None, Any | None]:
+    """Find an exact session without calling the activating manager loader."""
+
+    if not _is_exact_session_id(session_id):
+        return None, None
+    conversation_manager = getattr(core, "conversation_manager", core)
+    for manager in iter_session_managers(conversation_manager):
+        cached = getattr(manager, "sessions", {})
+        if isinstance(cached, dict) and session_id in cached:
+            entry = cached[session_id]
+            session = entry[0] if isinstance(entry, tuple) and entry else entry
+            if getattr(session, "id", None) == session_id:
+                return session, manager
+            return None, None
+
+        current_session = getattr(manager, "current_session", None)
+        if getattr(current_session, "id", None) == session_id:
+            return current_session, manager
+
+        path = _session_file_path(manager, session_id)
+        if path is None:
+            continue
+        session = _read_session_file(path, session_id)
+        if session is not None:
+            return session, manager
+        return None, None
+    return None, None
+
+
+def _session_file_path(manager: Any, session_id: str) -> Path | None:
+    """Resolve an exact primary session path contained by its manager root."""
+
+    path = _session_artifact_path(manager, session_id)
+    if path is None or not path.is_file():
+        return None
+    return path
+
+
+def _session_artifact_path(
+    manager: Any,
+    session_id: str,
+    *,
+    suffix: str = "",
+) -> Path | None:
+    """Resolve one path-confined persistence artifact, whether present or absent."""
+
+    base_path = getattr(manager, "base_path", None)
+    if base_path is None or getattr(manager, "format", "json") != "json":
+        return None
+    try:
+        root = Path(base_path).resolve()
+        candidate = root / f"{session_id}.json{suffix}"
+        if candidate.is_symlink():
+            return None
+        resolved_parent = candidate.parent.resolve()
+    except (OSError, TypeError):
+        return None
+    if resolved_parent != root:
+        return None
+    return candidate
+
+
+def _read_session_file(path: Path, session_id: str) -> Session | None:
+    """Read one primary session file without touching manager runtime state."""
+
+    try:
+        session = Session.from_json(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError):
+        return None
+    if session.id != session_id or not session.validate():
+        return None
+    return session
+
+
+def _is_exact_session_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and value == value.strip()
+        and len(value) <= 512
+    )
+
+
+def _cached_entry(manager: Any, session_id: str) -> Any:
+    cached = getattr(manager, "sessions", None)
+    if not isinstance(cached, dict):
+        return UNCHANGED
+    return cached.get(session_id, UNCHANGED)
+
+
+def _restore_cached_entry(manager: Any, session_id: str, entry: Any) -> None:
+    cached = getattr(manager, "sessions", None)
+    if not isinstance(cached, dict):
+        return
+    if entry is UNCHANGED:
+        cached.pop(session_id, None)
+    else:
+        cached[session_id] = entry
+
+
+def _session_index_entry(manager: Any, session_id: str) -> Any:
+    index = getattr(manager, "session_index", None)
+    if not isinstance(index, dict) or session_id not in index:
+        return UNCHANGED
+    return deepcopy(index[session_id])
+
+
+def _restore_session_index_entry(
+    manager: Any,
+    session_id: str,
+    entry: Any,
+) -> None:
+    index = getattr(manager, "session_index", None)
+    if not isinstance(index, dict):
+        return
+    if entry is UNCHANGED:
+        index.pop(session_id, None)
+    else:
+        index[session_id] = entry
+
+
+def _restore_attribute(owner: Any, name: str, value: Any) -> None:
+    if value is UNCHANGED:
+        if hasattr(owner, name):
+            delattr(owner, name)
+    else:
+        setattr(owner, name, value)
+
+
+def _snapshot_session_files(
+    manager: Any,
+    session_id: str,
+) -> tuple[_FileSnapshot, ...]:
+    """Snapshot primary and backup files before a potentially partial save."""
+
+    primary = _session_artifact_path(manager, session_id)
+    backup = _session_artifact_path(manager, session_id, suffix=".bak")
+    if primary is None or backup is None:
+        return ()
+    return (_snapshot_file(primary), _snapshot_file(backup))
+
+
+def _snapshot_file(path: Path) -> _FileSnapshot:
+    if not path.exists():
+        return _FileSnapshot(path=path, content=None, mode=None)
+    if not path.is_file():
+        raise RuntimeError(f"Session persistence path is not a file: {path}")
+    try:
+        return _FileSnapshot(
+            path=path,
+            content=path.read_bytes(),
+            mode=path.stat().st_mode & 0o777,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"Unable to snapshot session persistence: {path}") from exc
+
+
+def _restore_session_files(snapshots: tuple[_FileSnapshot, ...]) -> None:
+    for snapshot in snapshots:
+        _restore_file(snapshot)
+
+
+def _restore_file(snapshot: _FileSnapshot) -> None:
+    path = snapshot.path
+    if snapshot.content is None:
+        if path.exists() or path.is_symlink():
+            if not path.is_file() and not path.is_symlink():
+                raise RuntimeError(f"Cannot remove non-file session artifact: {path}")
+            path.unlink()
+            _sync_directory(path.parent)
+        return
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.telegram-rollback-",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(snapshot.content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if snapshot.mode is not None:
+            temporary_path.chmod(snapshot.mode)
+        os.replace(temporary_path, path)
+        _sync_directory(path.parent)
+    finally:
+        if temporary_path.exists():
+            temporary_path.unlink()
+
+
+def _sync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "SESSION_SERVICE_TIER_KEY",
+    "UNCHANGED",
+    "SessionRuntimePreferences",
+    "load_session_runtime_preferences",
+    "read_session_file_without_activation",
+    "resolve_session_request_runtime",
+    "service_tier_for_fast_mode",
+    "update_session_runtime_preferences",
+]

--- a/penguin/integrations/telegram/_sessions.py
+++ b/penguin/integrations/telegram/_sessions.py
@@ -1,0 +1,317 @@
+"""Lane-owned Telegram session history and safe rebinding."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Mapping
+
+from penguin.core_runtime import process_lifecycle, session_lookup
+from penguin.integrations.telegram._session_runtime import (
+    read_session_file_without_activation,
+)
+from penguin.system.execution_context import normalize_directory
+
+if TYPE_CHECKING:
+    from penguin.channels.store import ChannelStore
+    from penguin.channels.store_models import BindingRecord
+
+RECENT_SESSIONS_KEY = "_telegram_recent_sessions_v1"
+MAX_RECENT_SESSIONS = 20
+_MAX_SESSION_ID_CHARS = 512
+
+
+class SessionAccessError(RuntimeError):
+    """Raised when a session is not available to this Telegram lane."""
+
+
+class SessionBusyError(RuntimeError):
+    """Raised when rebinding would race an active session turn."""
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    """Display-safe metadata for one session owned by a Telegram lane."""
+
+    session_id: str
+    title: str
+    last_active: str | None
+    current: bool
+
+
+def create_bound_session(core: Any, agent_id: str | None) -> str:
+    """Create a session through the binding's explicit agent scope."""
+
+    normalized_agent = agent_id.strip() if isinstance(agent_id, str) else ""
+    agent_creator = getattr(core, "create_agent_conversation", None)
+    if normalized_agent:
+        if not callable(agent_creator):
+            raise SessionAccessError(
+                f"Cannot create a session for agent {normalized_agent!r}."
+            )
+        session_id = agent_creator(normalized_agent)
+    elif callable(agent_creator):
+        session_id = agent_creator("default")
+    else:
+        creator = getattr(core, "create_conversation", None)
+        if not callable(creator):
+            raise SessionAccessError("Cannot create a session for the default agent.")
+        session_id = creator()
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise SessionAccessError("Penguin did not return a valid session ID.")
+    return session_id.strip()
+
+
+def _normalized_session_id(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > _MAX_SESSION_ID_CHARS:
+        return None
+    return normalized
+
+
+def _recent_session_ids(settings: Mapping[str, Any] | None) -> tuple[str, ...]:
+    raw = settings.get(RECENT_SESSIONS_KEY, []) if isinstance(settings, Mapping) else []
+    if not isinstance(raw, (list, tuple)):
+        return ()
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in raw:
+        session_id = _normalized_session_id(value)
+        if session_id is None or session_id in seen:
+            continue
+        seen.add(session_id)
+        result.append(session_id)
+        if len(result) == MAX_RECENT_SESSIONS:
+            break
+    return tuple(result)
+
+
+def with_recent_session(
+    settings: Mapping[str, Any] | None,
+    session_id: str,
+) -> dict[str, Any]:
+    """Return settings with ``session_id`` first in bounded recent history."""
+
+    normalized = _normalized_session_id(session_id)
+    if normalized is None:
+        raise ValueError("session_id must be a non-empty string")
+
+    updated = dict(settings) if isinstance(settings, Mapping) else {}
+    existing = _recent_session_ids(settings)
+    updated[RECENT_SESSIONS_KEY] = [
+        normalized,
+        *(item for item in existing if item != normalized),
+    ][:MAX_RECENT_SESSIONS]
+    return updated
+
+
+def with_session_transition(
+    settings: Mapping[str, Any] | None,
+    *,
+    current_session_id: str,
+    target_session_id: str,
+) -> dict[str, Any]:
+    """Record both sides of a transition with its target newest."""
+
+    with_current = with_recent_session(settings, current_session_id)
+    return with_recent_session(with_current, target_session_id)
+
+
+def _find_session(core: Any, session_id: str) -> Any | None:
+    if _normalized_session_id(session_id) != session_id:
+        return None
+    conversation_manager = getattr(core, "conversation_manager", core)
+    for manager in session_lookup.iter_session_managers(conversation_manager):
+        cached = getattr(manager, "sessions", {})
+        if isinstance(cached, dict) and session_id in cached:
+            entry = cached[session_id]
+            session = entry[0] if isinstance(entry, tuple) and entry else entry
+            return session if getattr(session, "id", None) == session_id else None
+
+        current_session = getattr(manager, "current_session", None)
+        if getattr(current_session, "id", None) == session_id:
+            return current_session
+
+        index = getattr(manager, "session_index", {})
+        if not isinstance(index, dict) or session_id not in index:
+            continue
+        metadata = index[session_id]
+        if not isinstance(metadata, Mapping):
+            return None
+        indexed_id = metadata.get("id")
+        if indexed_id is not None and indexed_id != session_id:
+            return None
+        session = read_session_file_without_activation(manager, session_id)
+        if session is None:
+            return None
+        return session
+    return None
+
+
+def _metadata(session: Any) -> Mapping[str, Any]:
+    value = getattr(session, "metadata", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _matches_binding(session: Any, binding: BindingRecord) -> bool:
+    metadata = _metadata(session)
+    raw_directory = metadata.get("directory")
+    if isinstance(raw_directory, str) and raw_directory.strip():
+        binding_directory = normalize_directory(binding.directory)
+        session_directory = normalize_directory(raw_directory)
+        if (
+            binding_directory is None
+            or session_directory is None
+            or session_directory != binding_directory
+        ):
+            return False
+
+    expected_agent = (binding.agent_id or "default").strip()
+    for key in ("agent_id", "agentID"):
+        raw_agent = metadata.get(key)
+        if (
+            isinstance(raw_agent, str)
+            and raw_agent.strip()
+            and raw_agent.strip() != expected_agent
+        ):
+            return False
+    return True
+
+
+def _session_title(session: Any, session_id: str) -> str:
+    title = _metadata(session).get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    messages = getattr(session, "messages", [])
+    if isinstance(messages, (list, tuple)):
+        for message in messages:
+            if getattr(message, "role", None) != "user":
+                continue
+            content = getattr(message, "content", None)
+            if isinstance(content, str) and content.strip():
+                return content.split("\n", 1)[0].strip()[:64]
+    return f"Session {session_id[-8:]}"
+
+
+def _last_active(session: Any) -> str | None:
+    value = getattr(session, "last_active", None)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    value = _metadata(session).get("last_active")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def list_recent_sessions(
+    core: Any,
+    binding: BindingRecord,
+) -> tuple[SessionSummary, ...]:
+    """Hydrate only the session IDs recorded for this binding's lane."""
+
+    summaries: list[SessionSummary] = []
+    for session_id in _recent_session_ids(binding.settings):
+        session = _find_session(core, session_id)
+        if session is None or not _matches_binding(session, binding):
+            continue
+        summaries.append(
+            SessionSummary(
+                session_id=session_id,
+                title=_session_title(session, session_id),
+                last_active=_last_active(session),
+                current=session_id == binding.session_id,
+            )
+        )
+    return tuple(summaries)
+
+
+def _owned_target(
+    core: Any,
+    binding: BindingRecord,
+    target_session_id: str,
+) -> tuple[str, Any]:
+    normalized = _normalized_session_id(target_session_id)
+    if normalized is None or normalized not in _recent_session_ids(binding.settings):
+        raise SessionAccessError("Session is not available to this Telegram chat.")
+
+    session = _find_session(core, normalized)
+    if session is None or not _matches_binding(session, binding):
+        raise SessionAccessError("Session is not available to this Telegram chat.")
+    return normalized, session
+
+
+async def rebind_session(
+    core: Any,
+    store: ChannelStore,
+    binding: BindingRecord,
+    target_session_id: str,
+) -> BindingRecord:
+    """CAS-rebind one lane after validating ownership, metadata, and idleness."""
+
+    target_id, _session = _owned_target(core, binding, target_session_id)
+    session_ids = sorted({binding.session_id, target_id})
+    gates = [
+        (session_id, process_lifecycle.get_session_request_gate(core, session_id))
+        for session_id in session_ids
+    ]
+    for session_id, gate in gates:
+        if gate.locked():
+            raise SessionBusyError(f"Session {session_id} is busy.")
+
+    acquired: list[asyncio.Lock] = []
+    try:
+        for session_id, gate in gates:
+            if gate.locked():
+                raise SessionBusyError(f"Session {session_id} is busy.")
+            await gate.acquire()
+            acquired.append(gate)
+
+        settings = with_session_transition(
+            binding.settings,
+            current_session_id=binding.session_id,
+            target_session_id=target_id,
+        )
+        cas_task = asyncio.create_task(
+            asyncio.to_thread(
+                store.upsert_binding,
+                binding.address_key,
+                target_id,
+                directory=binding.directory,
+                agent_id=binding.agent_id,
+                agent_mode=binding.agent_mode,
+                settings=settings,
+                expected_version=binding.version,
+            )
+        )
+        cancellation: asyncio.CancelledError | None = None
+        while not cas_task.done():
+            try:
+                await asyncio.shield(cas_task)
+            except asyncio.CancelledError as exc:
+                cancellation = exc
+        if cancellation is not None:
+            if not cas_task.cancelled():
+                _ = cas_task.exception()
+            raise cancellation
+        return cas_task.result()
+    finally:
+        for gate in reversed(acquired):
+            gate.release()
+
+
+__all__ = [
+    "MAX_RECENT_SESSIONS",
+    "RECENT_SESSIONS_KEY",
+    "SessionAccessError",
+    "SessionBusyError",
+    "SessionSummary",
+    "create_bound_session",
+    "list_recent_sessions",
+    "rebind_session",
+    "with_recent_session",
+    "with_session_transition",
+]

--- a/penguin/integrations/telegram/manager.py
+++ b/penguin/integrations/telegram/manager.py
@@ -13,9 +13,11 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Mapping
 
-from PIL import Image, UnidentifiedImageError
-
-from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
+from penguin.channels.chat import (
+    ChatProcessRequest,
+    ChatRuntimeResolutionError,
+    execute_chat_turn,
+)
 from penguin.channels.store import (
     ChannelStore,
     CompareAndSwapError,
@@ -25,7 +27,7 @@ from penguin.channels.store import (
     PollerLeaseConflictError,
 )
 from penguin.config import WORKSPACE_PATH
-from penguin.integrations.telegram import _migration
+from penguin.integrations.telegram import _attachments, _migration
 from penguin.integrations.telegram._approval_ui import (
     approval_buttons,
     send_terminal_edit,
@@ -38,7 +40,11 @@ from penguin.integrations.telegram._authorization import (
     group_event_is_authorized,
     migration_chat_ids,
 )
-from penguin.integrations.telegram._commands import handle_command
+from penguin.integrations.telegram._callback_resolution import (
+    resolve_callback as resolve_interactive_callback,
+)
+from penguin.integrations.telegram._commands import handle_command, set_bot_commands
+from penguin.integrations.telegram._controls import binding_streaming_mode
 from penguin.integrations.telegram._helpers import (
     delivery_payload as _delivery_payload,
     inline_markup as _inline_markup,
@@ -49,6 +55,15 @@ from penguin.integrations.telegram._helpers import (
 from penguin.integrations.telegram._history import GroupHistory
 from penguin.integrations.telegram._leases import run_with_lease_heartbeat
 from penguin.integrations.telegram._preview import Preview
+from penguin.integrations.telegram._session_runtime import (
+    resolve_session_request_runtime,
+)
+from penguin.integrations.telegram._sessions import (
+    SessionAccessError,
+    create_bound_session,
+    with_recent_session,
+    with_session_transition,
+)
 from penguin.integrations.telegram.formatting import formatted_chunks
 from penguin.integrations.telegram.transport import classify_failure, retry_delay
 from penguin.integrations.telegram.updates import (
@@ -77,17 +92,6 @@ _RECOVERY_INTERVAL_SECONDS = 30.0
 _INTERACTIVE_PREFIX = "penguin:"
 _INTERACTIVE_LANE_SUFFIX = "\x1finteractive"
 _TOKEN_PATTERN = re.compile(r"\b\d{6,12}:[A-Za-z0-9_-]{30,}\b")
-_TEXT_DOCUMENT_MIMES = frozenset(
-    {
-        "application/json",
-        "application/xml",
-        "application/x-yaml",
-        "text/csv",
-        "text/markdown",
-        "text/plain",
-        "text/yaml",
-    }
-)
 
 
 class TelegramManager:
@@ -186,7 +190,7 @@ class TelegramManager:
         if recovered_callbacks:
             self._work_available.set()
         self._register_interactive_callbacks()
-        await self._set_commands()
+        await set_bot_commands(self)
 
         if self.config.transport == "polling":
             deleter = getattr(self.bot, "delete_webhook", None)
@@ -755,7 +759,24 @@ class TelegramManager:
                 await self._complete_without_delivery(record, worker_id)
                 return
 
-            binding = await self._binding_for(envelope.address)
+            try:
+                binding = await self._binding_for(envelope.address)
+            except SessionAccessError as exc:
+                await asyncio.to_thread(
+                    self.store.start_ingress,
+                    record.event_id,
+                    platform=_PLATFORM,
+                    account_id=self.account_id,
+                    owner_id=worker_id,
+                )
+                started = True
+                await self._complete_with_text(
+                    record,
+                    worker_id,
+                    envelope,
+                    f"Penguin session unavailable: {self._safe_error(exc)}",
+                )
+                return
             if command is not None:
                 await asyncio.to_thread(
                     self.store.start_ingress,
@@ -765,9 +786,12 @@ class TelegramManager:
                     owner_id=worker_id,
                 )
                 started = True
-                response = await handle_command(
-                    self, command, arguments, envelope, binding
-                )
+                try:
+                    response = await handle_command(
+                        self, command, arguments, envelope, binding
+                    )
+                except SessionAccessError as exc:
+                    response = f"Penguin session unavailable: {self._safe_error(exc)}"
                 if response is None:
                     await self._complete_without_delivery(record, worker_id)
                 else:
@@ -982,30 +1006,6 @@ class TelegramManager:
             ) from exc
         return Bot(token=token)
 
-    async def _set_commands(self) -> None:
-        setter = getattr(self.bot, "set_my_commands", None)
-        if not callable(setter):
-            return
-        commands = [
-            ("start", "Start or resume Penguin"),
-            ("help", "Show Telegram commands"),
-            ("new", "Start a fresh Penguin session"),
-            ("status", "Show bot and session status"),
-            ("stop", "Stop the active Penguin turn"),
-            ("whoami", "Show your numeric Telegram identity"),
-            ("session", "Show the bound Penguin session"),
-            ("mode", "Show or set plan/build mode"),
-            ("model", "Show the active Penguin model"),
-            ("permissions", "Show Telegram tool permissions"),
-            ("goal", "Show or update the session goal"),
-            ("project", "Show the bound project directory"),
-            ("activation", "Set group mention activation"),
-            ("topic", "Show the current topic binding"),
-            ("pair", "Authorize this private chat"),
-        ]
-        with suppress(Exception):
-            await self._api_call(setter(commands))
-
     async def _api_call(self, operation: Any, *, timeout: float | None = None) -> Any:
         """Run one Bot API operation within its configured wall-clock budget."""
 
@@ -1163,7 +1163,11 @@ class TelegramManager:
             if binding is not None:
                 return binding
             policy = self._configured_group_binding(address)
-            session_id = await asyncio.to_thread(self.core.create_conversation)
+            agent_id = policy.agent_id if policy is not None else None
+            session_id = await asyncio.to_thread(
+                create_bound_session, self.core, agent_id
+            )
+            base_settings = policy.durable_settings() if policy is not None else None
             try:
                 return await asyncio.to_thread(
                     self.store.upsert_binding,
@@ -1174,11 +1178,9 @@ class TelegramManager:
                         if policy is not None and policy.directory is not None
                         else normalize_directory(WORKSPACE_PATH)
                     ),
-                    agent_id=policy.agent_id if policy is not None else None,
+                    agent_id=agent_id,
                     agent_mode=policy.mode if policy is not None else "build",
-                    settings=(
-                        policy.durable_settings() if policy is not None else None
-                    ),
+                    settings=with_recent_session(base_settings, session_id),
                     expected_version=0,
                 )
             except CompareAndSwapError:
@@ -1193,7 +1195,22 @@ class TelegramManager:
         assert self.store is not None
         async with self._session_create_lock:
             policy = self._configured_group_binding(address)
-            session_id = await asyncio.to_thread(self.core.create_conversation)
+            agent_id = (
+                policy.agent_id
+                if policy is not None and policy.agent_id
+                else getattr(binding, "agent_id", None)
+            )
+            session_id = await asyncio.to_thread(
+                create_bound_session, self.core, agent_id
+            )
+            base_settings = (
+                {
+                    **dict(getattr(binding, "settings", {}) or {}),
+                    **policy.durable_settings(),
+                }
+                if policy is not None
+                else getattr(binding, "settings", {})
+            )
             return await asyncio.to_thread(
                 self.store.upsert_binding,
                 address.lane_key,
@@ -1203,20 +1220,16 @@ class TelegramManager:
                     if policy is not None
                     else getattr(binding, "directory", None)
                 ),
-                agent_id=(
-                    policy.agent_id
-                    if policy is not None
-                    else getattr(binding, "agent_id", None)
-                ),
+                agent_id=agent_id,
                 agent_mode=(
                     policy.mode
                     if policy is not None
                     else getattr(binding, "agent_mode", None)
                 ),
-                settings=(
-                    policy.durable_settings()
-                    if policy is not None
-                    else getattr(binding, "settings", {})
+                settings=with_session_transition(
+                    base_settings,
+                    current_session_id=binding.session_id,
+                    target_session_id=session_id,
                 ),
                 expected_version=getattr(binding, "version", None),
             )
@@ -1324,26 +1337,39 @@ class TelegramManager:
             request_skills=skills,
             require_registered_agent=bool(agent_id),
         )
+        streaming_mode = binding_streaming_mode(self, binding)
         target = (envelope.address, envelope.sender_id)
         self._request_targets[request_id] = target
         self._session_targets[binding.session_id] = target
-        preview = Preview(self, envelope)
+        preview = Preview(self, envelope, mode=streaming_mode)
         try:
             await preview.start()
-            result = await execute_chat_turn(
-                self.core,
-                ChatProcessRequest(
-                    input_data=input_data,
-                    execution_context=execution_context,
-                    session_id=binding.session_id,
-                    context=context,
-                    agent_id=agent_id,
-                    streaming=self.config.streaming_mode != "off",
-                    stream_callback=preview.push
-                    if self.config.streaming_mode != "off"
-                    else None,
-                ),
-            )
+            try:
+                result = await execute_chat_turn(
+                    self.core,
+                    ChatProcessRequest(
+                        input_data=input_data,
+                        execution_context=execution_context,
+                        session_id=binding.session_id,
+                        context=context,
+                        agent_id=agent_id,
+                        streaming=streaming_mode != "off",
+                        stream_callback=(
+                            preview.push if streaming_mode != "off" else None
+                        ),
+                        runtime_resolver=lambda: resolve_session_request_runtime(
+                            self.core, binding.session_id
+                        ),
+                    ),
+                )
+            except ChatRuntimeResolutionError as exc:
+                return {
+                    "status": "error",
+                    "error": {
+                        "message": "Session model settings are invalid: "
+                        f"{self._safe_error(exc)}"
+                    },
+                }, await preview.finish()
             return result, await preview.finish()
         finally:
             await preview.close()
@@ -1379,11 +1405,13 @@ class TelegramManager:
                     "Downloaded Telegram attachment exceeds the size limit"
                 )
             if attachment.kind == "photo":
-                await asyncio.to_thread(_validate_image, target)
+                await asyncio.to_thread(_attachments.validate_image, target)
                 image_paths.append(str(target))
                 continue
             mime = (attachment.mime_type or "").lower()
-            if not (mime.startswith("text/") or mime in _TEXT_DOCUMENT_MIMES):
+            if not (
+                mime.startswith("text/") or mime in _attachments.TEXT_DOCUMENT_MIMES
+            ):
                 raise ValueError(
                     f"Unsupported Telegram document type: {mime or 'unknown'}"
                 )
@@ -1893,76 +1921,7 @@ class TelegramManager:
         self, envelope: InboundEnvelope, callback_data: str, worker_id: str
     ) -> None:
         assert self.store is not None
-        parts = callback_data.split(":", 2)
-        if len(parts) != 3:
-            return
-        _prefix, callback_id, action = parts
-        callback = await asyncio.to_thread(
-            self.store.claim_callback,
-            callback_id,
-            account_id=self.account_id,
-            chat_id=envelope.address.chat_id,
-            topic_id=envelope.address.topic_id or None,
-            user_id=envelope.sender_id,
-            owner_id=worker_id,
-            platform=_PLATFORM,
-        )
-        if callback is None:
-            await self._answer_callback(envelope, "This action is unavailable.")
-            return
-        kind = callback.payload.get("kind")
-        resolved = False
-        label = "Expired"
-        if kind == "approval":
-            from penguin.security.approval import ApprovalScope, get_approval_manager
-
-            manager = get_approval_manager()
-            if action == "approve":
-                resolved = (
-                    manager.approve(callback.request_id, scope=ApprovalScope.ONCE)
-                    is not None
-                )
-                if resolved:
-                    label = "Approved"
-            elif action == "approve_session":
-                resolved = (
-                    manager.approve(callback.request_id, scope=ApprovalScope.SESSION)
-                    is not None
-                )
-                if resolved:
-                    label = "Approved for session"
-            elif action == "deny":
-                resolved = manager.deny(callback.request_id) is not None
-                if resolved:
-                    label = "Denied"
-        elif kind == "question" and action.startswith("q"):
-            try:
-                index = int(action[1:])
-            except ValueError:
-                index = -1
-            questions = callback.payload.get("questions") or []
-            options = questions[0].get("options") if questions else []
-            if 0 <= index < len(options):
-                option = options[index]
-                answer = str(option.get("label") or option.get("description") or "")
-                resolved = await self._reply_to_question(callback.request_id, answer)
-                if resolved:
-                    label = "Answered"
-                    self._pending_questions.pop(
-                        (envelope.address.lane_key, envelope.sender_id), None
-                    )
-        await asyncio.to_thread(
-            self.store.complete_callback_with_terminal,
-            callback_id,
-            owner_id=worker_id,
-            label=label,
-            platform=_PLATFORM,
-        )
-        self._work_available.set()
-        await self._answer_callback(
-            envelope,
-            "Recorded." if resolved else "This request is no longer pending.",
-        )
+        await resolve_interactive_callback(self, envelope, callback_data, worker_id)
 
     async def _reply_to_question(self, request_id: str, text: str) -> bool | None:
         from penguin.security.question import get_question_manager
@@ -1988,11 +1947,3 @@ class TelegramManager:
                 await self._api_call(
                     answer(callback_query_id=callback_id, text=text[:200])
                 )
-
-
-def _validate_image(path: Path) -> None:
-    try:
-        with Image.open(path) as image:
-            image.verify()
-    except (OSError, UnidentifiedImageError) as exc:
-        raise ValueError("Telegram photo is not a valid supported image") from exc

--- a/tests/channels/test_chat.py
+++ b/tests/channels/test_chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -8,6 +9,7 @@ import pytest
 from penguin.channels.chat import ChatProcessRequest, execute_chat_turn
 from penguin.channels.fake import FakeChannel
 from penguin.channels.schema import ChannelAddress, DeliveryRequest
+from penguin.core_runtime import process_lifecycle
 from penguin.system.execution_context import (
     ExecutionContext,
     get_current_execution_context,
@@ -23,6 +25,7 @@ class FakeCore:
         self.release = asyncio.Event()
         self.started = asyncio.Queue()
         self.seen_contexts: list[ExecutionContext | None] = []
+        self.seen_process_kwargs: list[dict[str, Any]] = []
 
     async def process(self, **kwargs: Any) -> dict[str, Any]:
         session_id = str(kwargs.get("conversation_id") or "")
@@ -36,6 +39,7 @@ class FakeCore:
         self.all_active += 1
         self.max_all_active = max(self.max_all_active, self.all_active)
         self.seen_contexts.append(get_current_execution_context())
+        self.seen_process_kwargs.append(kwargs)
         await self.started.put(session_id)
         await self.release.wait()
         callback = kwargs.get("stream_callback")
@@ -127,6 +131,74 @@ async def test_cancelled_waiter_is_untracked() -> None:
     core.release.set()
     await first
     assert core._opencode_process_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_runtime_resolver_runs_inside_session_gate() -> None:
+    core = FakeCore()
+    gate = process_lifecycle.get_session_request_gate(core, "one")
+    resolved = asyncio.Event()
+
+    async def resolve_runtime() -> tuple[object, object]:
+        assert gate.locked()
+        resolved.set()
+        return object(), object()
+
+    request = replace(_request("one"), runtime_resolver=resolve_runtime)
+    async with gate:
+        turn = asyncio.create_task(execute_chat_turn(core, request))
+        await asyncio.sleep(0)
+        assert not resolved.is_set()
+
+    await resolved.wait()
+    await core.started.get()
+    core.release.set()
+    await turn
+
+
+@pytest.mark.asyncio
+async def test_runtime_resolver_is_serialized_against_session_writer() -> None:
+    core = FakeCore()
+    gate = process_lifecycle.get_session_request_gate(core, "one")
+    resolver_started = asyncio.Event()
+    release_resolver = asyncio.Event()
+    writer_started = asyncio.Event()
+    writer_finished = asyncio.Event()
+    model_config = object()
+    api_client = object()
+    updated_model_config = object()
+    runtime = {"model_config": model_config, "api_client": api_client}
+
+    async def resolve_runtime() -> tuple[object, object]:
+        resolver_started.set()
+        await release_resolver.wait()
+        return runtime["model_config"], runtime["api_client"]
+
+    async def write_session_preferences() -> None:
+        writer_started.set()
+        async with gate:
+            runtime["model_config"] = updated_model_config
+            writer_finished.set()
+
+    request = replace(_request("one"), runtime_resolver=resolve_runtime)
+    turn = asyncio.create_task(execute_chat_turn(core, request))
+    await resolver_started.wait()
+    writer = asyncio.create_task(write_session_preferences())
+    await writer_started.wait()
+    await asyncio.sleep(0)
+    assert not writer_finished.is_set()
+
+    release_resolver.set()
+    await core.started.get()
+    assert not writer_finished.is_set()
+    assert core.seen_process_kwargs[-1]["model_config_override"] is model_config
+    assert core.seen_process_kwargs[-1]["api_client_override"] is api_client
+
+    core.release.set()
+    await turn
+    await writer
+    assert writer_finished.is_set()
+    assert runtime["model_config"] is updated_model_config
 
 
 @pytest.mark.asyncio

--- a/tests/channels/test_store.py
+++ b/tests/channels/test_store.py
@@ -492,6 +492,78 @@ def test_callback_claim_is_atomic_across_workers(store: ChannelStore) -> None:
     assert sorted(results) == [False, True]
 
 
+def test_callback_lease_renewal_uses_owner_and_account_cas(
+    store: ChannelStore,
+) -> None:
+    store.create_callback(
+        "callback-renew",
+        account_id=ACCOUNT,
+        chat_id="7",
+        topic_id=None,
+        user_id="7",
+        request_id="request",
+        payload={"answer": "yes"},
+        expires_at=100,
+        now=1,
+    )
+    assert store.claim_callback(
+        "callback-renew",
+        account_id=ACCOUNT,
+        chat_id="7",
+        topic_id=None,
+        user_id="7",
+        owner_id="worker",
+        lease_seconds=2,
+        now=2,
+    )
+    assert store.renew_callback_lease(
+        "callback-renew",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker",
+        lease_seconds=2,
+        now=3,
+    )
+    assert not store.renew_callback_lease(
+        "callback-renew",
+        platform=PLATFORM,
+        account_id="other",
+        owner_id="worker",
+        lease_seconds=2,
+        now=3,
+    )
+    assert not store.renew_callback_lease(
+        "callback-renew",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="other",
+        lease_seconds=2,
+        now=3,
+    )
+    assert (
+        store.recover_expired_callbacks(
+            platform=PLATFORM,
+            account_id=ACCOUNT,
+            now=4.5,
+        )
+        == []
+    )
+    recovered = store.recover_expired_callbacks(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=5,
+    )
+    assert [record.state for record in recovered] == ["dead"]
+    assert not store.renew_callback_lease(
+        "callback-renew",
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        owner_id="worker",
+        lease_seconds=2,
+        now=5,
+    )
+
+
 def test_callback_recovery_terminalizes_expired_and_dead_once(
     store: ChannelStore,
 ) -> None:
@@ -566,6 +638,55 @@ def test_callback_recovery_terminalizes_expired_and_dead_once(
         assert terminal.sequence > projection.sequence
         assert terminal.kind == "callback_terminal"
         assert terminal.payload["label"] == "Expired"
+
+
+def test_orphan_recovery_preserves_pending_control_callbacks(
+    store: ChannelStore,
+) -> None:
+    for callback_id, kind in (("approval", "approval"), ("control", "control")):
+        store.create_callback(
+            callback_id,
+            account_id=ACCOUNT,
+            chat_id="7",
+            topic_id=None,
+            user_id="7",
+            request_id=f"request-{callback_id}",
+            payload={"kind": kind},
+            expires_at=100,
+            now=1,
+        )
+
+    recovered = store.recover_orphaned_callbacks(
+        platform=PLATFORM,
+        account_id=ACCOUNT,
+        now=2,
+    )
+
+    assert [record.callback_id for record in recovered] == ["approval"]
+    assert (
+        store.claim_callback(
+            "approval",
+            account_id=ACCOUNT,
+            chat_id="7",
+            topic_id=None,
+            user_id="7",
+            owner_id="worker",
+            now=3,
+        )
+        is None
+    )
+    assert (
+        store.claim_callback(
+            "control",
+            account_id=ACCOUNT,
+            chat_id="7",
+            topic_id=None,
+            user_id="7",
+            owner_id="worker",
+            now=3,
+        )
+        is not None
+    )
 
 
 def test_ingress_deduplicates_and_rejects_conflicting_reuse(

--- a/tests/integrations/telegram/test_controls.py
+++ b/tests/integrations/telegram/test_controls.py
@@ -1,0 +1,1074 @@
+"""Telegram session control and picker regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from penguin.channels.schema import ChannelAddress, InboundEnvelope
+from penguin.channels.store import ChannelStore
+from penguin.core_runtime import process_lifecycle
+from penguin.integrations.telegram import _controls
+from penguin.integrations.telegram._controls import (
+    handle_control_command,
+    resolve_control_callback,
+)
+from penguin.integrations.telegram._session_runtime import (
+    SessionRuntimePreferences,
+    load_session_runtime_preferences,
+    update_session_runtime_preferences,
+)
+from penguin.integrations.telegram._sessions import RECENT_SESSIONS_KEY
+from penguin.integrations.telegram.binding_policy import TelegramBindingPolicy
+from penguin.integrations.telegram.config import TelegramConfig
+from penguin.integrations.telegram.manager import TelegramManager
+
+
+class SessionManager:
+    def __init__(self, *session_ids: str) -> None:
+        self.sessions = {
+            session_id: (
+                SimpleNamespace(
+                    id=session_id,
+                    metadata={},
+                    messages=[],
+                    last_active="2026-08-11T12:00:00",
+                ),
+                False,
+            )
+            for session_id in session_ids
+        }
+        self.session_index: dict[str, Any] = {}
+
+    def mark_session_modified(self, session_id: str) -> None:
+        del session_id
+
+    def save_session(self, session: Any) -> bool:
+        del session
+        return True
+
+
+class ControlCore:
+    def __init__(self, *session_ids: str) -> None:
+        self.session_manager = SessionManager(*session_ids)
+        self.conversation_manager = SimpleNamespace(
+            session_manager=self.session_manager,
+            agent_session_managers={},
+        )
+        self.model_config = SimpleNamespace(
+            provider="openai",
+            model="gpt-5.6-sol",
+            reasoning_enabled=False,
+            reasoning_effort=None,
+            reasoning_max_tokens=None,
+            reasoning_exclude=False,
+            service_tier=None,
+        )
+        self.api_client = SimpleNamespace(name="global")
+        self.resolved: list[str | None] = []
+        self.calls: list[dict[str, Any]] = []
+        self.fail_resolution: str | None = None
+
+    def get_current_model(self) -> dict[str, str]:
+        return {"provider": "openai", "model": "gpt-5.6-sol"}
+
+    async def resolve_request_runtime(self, model_id: str | None = None) -> Any:
+        self.resolved.append(model_id)
+        if self.fail_resolution:
+            raise ValueError(self.fail_resolution)
+        model_config = deepcopy(self.model_config)
+        if model_id:
+            provider, _, model = model_id.partition("/")
+            model_config.provider = provider
+            model_config.model = model
+        model_config.supported_reasoning_levels = [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        ]
+        return model_config, SimpleNamespace(model_config=model_config)
+
+    async def process(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "ok", "assistant_response": "done"}
+
+
+class ProjectionManager(SimpleNamespace):
+    def __init__(self, core: ControlCore, store: ChannelStore) -> None:
+        super().__init__(
+            core=core,
+            store=store,
+            config=SimpleNamespace(
+                streaming_mode="edit",
+                permission_mode="workspace",
+                permissions_summary="Mode cap: workspace",
+            ),
+        )
+        self.projections: list[dict[str, Any]] = []
+
+    async def _create_projection(
+        self,
+        address: ChannelAddress,
+        key: str,
+        text: str,
+        buttons: list[list[dict[str, str]]],
+        **kwargs: Any,
+    ) -> None:
+        self.projections.append(
+            {
+                "address": address,
+                "key": key,
+                "text": text,
+                "buttons": buttons,
+                **kwargs,
+            }
+        )
+
+
+def catalog() -> dict[str, Any]:
+    return {
+        "connected": ["anthropic", "openai"],
+        "all": [
+            {
+                "id": "openai",
+                "connected": True,
+                "models": {
+                    "gpt-5.6-sol": {
+                        "name": "GPT 5.6 Sol",
+                        "status": "active",
+                        "variants": {
+                            "low": {},
+                            "medium": {},
+                            "high": {},
+                        },
+                    }
+                },
+            },
+            {
+                "id": "anthropic",
+                "connected": True,
+                "models": {
+                    "claude-sonnet-4-6": {
+                        "name": "Claude Sonnet 4.6",
+                        "status": "active",
+                        "variants": {"low": {}, "high": {}},
+                    }
+                },
+            },
+            {
+                "id": "unconnected",
+                "connected": False,
+                "models": {"hidden": {"name": "Secret"}},
+            },
+        ],
+    }
+
+
+def model_catalog(count: int) -> dict[str, Any]:
+    return {
+        "connected": ["openai"],
+        "all": [
+            {
+                "id": "openai",
+                "connected": True,
+                "models": {
+                    f"model-{index:02d}": {
+                        "name": f"Model {index:02d}",
+                        "status": "active",
+                        "variants": {"low": {}, "medium": {}},
+                    }
+                    for index in range(count)
+                },
+            }
+        ],
+    }
+
+
+def envelope() -> InboundEnvelope:
+    return InboundEnvelope(
+        event_id="telegram:bot:1",
+        source_sequence=1,
+        address=ChannelAddress("telegram", "bot", "42"),
+        sender_id="42",
+    )
+
+
+def binding(store: ChannelStore, *, settings: dict[str, Any] | None = None) -> Any:
+    return store.upsert_binding(
+        envelope().address.lane_key,
+        "session-one",
+        directory="/tmp/project",
+        agent_mode="build",
+        settings=settings or {},
+        expected_version=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_model_accepts_unique_unqualified_exact_and_validates_first(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+
+    response = await handle_control_command(
+        manager, "model", "gpt-5.6-sol", envelope(), current
+    )
+
+    assert response == (
+        "Session model set to openai/gpt-5.6-sol. Reasoning and fast mode reset."
+    )
+    assert core.resolved == ["openai/gpt-5.6-sol"]
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences(provider_id="openai", model_id="gpt-5.6-sol")
+    )
+    assert core.model_config.model == "gpt-5.6-sol"
+    assert core.api_client.name == "global"
+
+
+@pytest.mark.asyncio
+async def test_connected_catalog_model_is_not_persisted_when_resolver_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    core.fail_resolution = "provider is unavailable"
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+
+    response = await handle_control_command(
+        manager, "model", "openai/gpt-5.6-sol", envelope(), current
+    )
+
+    assert response == "provider is unavailable"
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_model_runtime_is_rejected_before_persist(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+
+    async def shared_runtime(_model_id: str | None = None) -> Any:
+        return core.model_config, core.api_client
+
+    core.resolve_request_runtime = shared_runtime
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+
+    response = await handle_control_command(
+        manager, "model", "openai/gpt-5.6-sol", envelope(), current
+    )
+
+    assert response == "Penguin returned a shared runtime for that model."
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_locked_direct_setting_rejects_without_persisting(tmp_path) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+    gate = process_lifecycle.get_session_request_gate(core, "session-one")
+    await gate.acquire()
+    try:
+        response = await handle_control_command(
+            manager, "fast", "on", envelope(), current
+        )
+    finally:
+        gate.release()
+
+    assert "busy" in str(response).lower()
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences is not None
+    assert preferences.service_tier is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_setting_waits_for_thread_write_before_releasing_gate(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    started = threading.Event()
+    release = threading.Event()
+    persisted = threading.Event()
+    real_update = _controls.update_session_runtime_preferences
+
+    def delayed_update(*args: Any, **kwargs: Any) -> Any:
+        started.set()
+        assert release.wait(timeout=2)
+        result = real_update(*args, **kwargs)
+        persisted.set()
+        return result
+
+    monkeypatch.setattr(_controls, "update_session_runtime_preferences", delayed_update)
+    task = asyncio.create_task(
+        handle_control_command(manager, "fast", "on", envelope(), current)
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+    gate = process_lifecycle.get_session_request_gate(core, "session-one")
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    assert gate.locked()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert persisted.is_set()
+    assert not gate.locked()
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences is not None
+    assert preferences.service_tier == "priority"
+
+
+@pytest.mark.asyncio
+async def test_model_picker_persists_only_bounded_connected_ids(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+
+    assert (
+        await handle_control_command(manager, "model", "", envelope(), current) is None
+    )
+
+    projection = manager.projections[-1]
+    payload = projection["callback_payload"]
+    assert payload["kind"] == "control"
+    assert payload["session_id"] == "session-one"
+    assert payload["binding_version"] == current.version
+    assert payload["session_revision"] == _controls._preferences_revision(
+        SessionRuntimePreferences()
+    )
+    assert payload["choices"] == [
+        "reset",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-sonnet-4-6",
+    ]
+    assert "hidden" not in repr(projection)
+    assert "api_client" not in repr(payload)
+    assert all(len(value) <= 512 for value in payload["choices"])
+
+
+@pytest.mark.asyncio
+async def test_model_picker_pages_reach_every_connected_model(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(
+        _controls, "_build_provider_payload", lambda _core: model_catalog(61)
+    )
+
+    assert (
+        await handle_control_command(manager, "model", "", envelope(), current) is None
+    )
+
+    seen: set[str] = set()
+    for page in range(3):
+        projection = manager.projections[-1]
+        payload = projection["callback_payload"]
+        choices = payload["choices"]
+        page_models = {value for value in choices if value.startswith("openai/model-")}
+        seen.update(page_models)
+        assert len(page_models) <= 25
+        assert len(choices) <= 28
+        assert all(
+            len(button[0]["data"].encode("utf-8")) < 64
+            for button in projection["buttons"]
+        )
+        assert f"page {page + 1}/3" in projection["text"]
+        if page < 2:
+            result = await resolve_control_callback(
+                manager,
+                envelope(),
+                payload,
+                f"c{choices.index(f'page:{page + 1}')}",
+            )
+            assert result.resolved is True
+            assert result.label == f"Opened model page {page + 2}"
+
+    payload = manager.projections[-1]["callback_payload"]
+    result = await resolve_control_callback(
+        manager,
+        envelope(),
+        payload,
+        f"c{payload['choices'].index('openai/model-60')}",
+    )
+
+    assert result.resolved is True
+    assert seen == {f"openai/model-{index:02d}" for index in range(61)}
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences(provider_id="openai", model_id="model-60")
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_page_navigation_revalidates_catalog(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    current_catalog = model_catalog(40)
+    monkeypatch.setattr(
+        _controls, "_build_provider_payload", lambda _core: current_catalog
+    )
+    await handle_control_command(manager, "model", "", envelope(), current)
+    payload = manager.projections[-1]["callback_payload"]
+    action = f"c{payload['choices'].index('page:1')}"
+    projection_count = len(manager.projections)
+
+    current_catalog["all"][0]["models"] = model_catalog(5)["all"][0]["models"]
+    result = await resolve_control_callback(manager, envelope(), payload, action)
+
+    assert result.resolved is False
+    assert result.label == "Unavailable"
+    assert "catalog changed" in result.answer.lower()
+    assert len(manager.projections) == projection_count
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+
+
+@pytest.mark.asyncio
+async def test_control_callback_rejects_stale_binding_before_mutation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+    changed = store.upsert_binding(
+        current.address_key,
+        current.session_id,
+        directory=current.directory,
+        agent_mode="plan",
+        settings=current.settings,
+        expected_version=current.version,
+    )
+
+    result = await resolve_control_callback(
+        manager,
+        envelope(),
+        {
+            "kind": "control",
+            "control": "model",
+            "session_id": current.session_id,
+            "binding_version": current.version,
+            "choices": ["openai/gpt-5.6-sol"],
+        },
+        "c0",
+    )
+
+    assert result.resolved is False
+    assert result.label == "Stale"
+    assert store.get_binding(current.address_key) == changed
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("control", "selection"),
+    (
+        ("model", "openai/gpt-5.6-sol"),
+        ("reasoning", "medium"),
+        ("fast", "on"),
+    ),
+)
+async def test_session_callback_rechecks_binding_inside_gate(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    control: str,
+    selection: str,
+) -> None:
+    core = ControlCore("session-one", "session-two")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+    await handle_control_command(manager, control, "", envelope(), current)
+    payload = manager.projections[-1]["callback_payload"]
+    real_gate = process_lifecycle.get_session_request_gate(core, "session-one")
+    acquire_started = asyncio.Event()
+    resume = asyncio.Event()
+
+    class BlockingGate:
+        def locked(self) -> bool:
+            return real_gate.locked()
+
+        async def acquire(self) -> bool:
+            acquire_started.set()
+            await resume.wait()
+            return await real_gate.acquire()
+
+        def release(self) -> None:
+            real_gate.release()
+
+    monkeypatch.setattr(
+        _controls.process_lifecycle,
+        "get_session_request_gate",
+        lambda _core, _session_id: BlockingGate(),
+    )
+    callback = asyncio.create_task(
+        resolve_control_callback(
+            manager,
+            envelope(),
+            payload,
+            f"c{payload['choices'].index(selection)}",
+        )
+    )
+    await asyncio.wait_for(acquire_started.wait(), timeout=1)
+    changed = store.upsert_binding(
+        current.address_key,
+        "session-two",
+        directory=current.directory,
+        agent_mode=current.agent_mode,
+        settings=current.settings,
+        expected_version=current.version,
+    )
+    resume.set()
+
+    result = await callback
+
+    assert result.resolved is False
+    assert result.label == "Stale"
+    assert store.get_binding(current.address_key) == changed
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+    assert load_session_runtime_preferences(core, "session-two") == (
+        SessionRuntimePreferences()
+    )
+    assert core.resolved == []
+    assert not real_gate.locked()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "value"),
+    (
+        ("model", "openai/gpt-5.6-sol"),
+        ("reasoning", "medium"),
+        ("fast", "on"),
+    ),
+)
+async def test_direct_session_setting_rechecks_binding_inside_gate(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    value: str,
+) -> None:
+    core = ControlCore("session-one", "session-two")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+    real_gate = process_lifecycle.get_session_request_gate(core, "session-one")
+    acquire_started = asyncio.Event()
+    resume = asyncio.Event()
+
+    class BlockingGate:
+        def locked(self) -> bool:
+            return real_gate.locked()
+
+        async def acquire(self) -> bool:
+            acquire_started.set()
+            await resume.wait()
+            return await real_gate.acquire()
+
+        def release(self) -> None:
+            real_gate.release()
+
+    monkeypatch.setattr(
+        _controls.process_lifecycle,
+        "get_session_request_gate",
+        lambda _core, _session_id: BlockingGate(),
+    )
+    setting = asyncio.create_task(
+        handle_control_command(manager, command, value, envelope(), current)
+    )
+    await asyncio.wait_for(acquire_started.wait(), timeout=1)
+    changed = store.upsert_binding(
+        current.address_key,
+        "session-two",
+        directory=current.directory,
+        agent_mode=current.agent_mode,
+        settings=current.settings,
+        expected_version=current.version,
+    )
+    resume.set()
+
+    response = await setting
+
+    assert response == "Settings changed. Reopen the control and try again."
+    assert store.get_binding(current.address_key) == changed
+    assert load_session_runtime_preferences(core, "session-one") == (
+        SessionRuntimePreferences()
+    )
+    assert load_session_runtime_preferences(core, "session-two") == (
+        SessionRuntimePreferences()
+    )
+    assert core.resolved == []
+    assert not real_gate.locked()
+
+
+@pytest.mark.asyncio
+async def test_control_callback_rejects_gate_locked_session(tmp_path) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+    gate = process_lifecycle.get_session_request_gate(core, "session-one")
+    await gate.acquire()
+    try:
+        result = await resolve_control_callback(
+            manager,
+            envelope(),
+            {
+                "kind": "control",
+                "control": "fast",
+                "session_id": current.session_id,
+                "binding_version": current.version,
+                "session_revision": _controls._preferences_revision(
+                    SessionRuntimePreferences(
+                        provider_id="openai", model_id="gpt-5.6-sol"
+                    )
+                ),
+                "choices": ["on"],
+            },
+            "c0",
+        )
+    finally:
+        gate.release()
+
+    assert result.resolved is False
+    assert result.label == "Busy"
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences is not None
+    assert preferences.service_tier is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("control", "selection", "direct_command", "direct_value", "large_models"),
+    (
+        ("model", "page:1", "fast", "on", True),
+        ("reasoning", "medium", "fast", "on", False),
+        ("fast", "off", "reasoning", "medium", False),
+    ),
+)
+async def test_session_control_picker_rejects_change_after_open(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    control: str,
+    selection: str,
+    direct_command: str,
+    direct_value: str,
+    large_models: bool,
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(
+        _controls,
+        "_build_provider_payload",
+        lambda _core: model_catalog(30) if large_models else catalog(),
+    )
+    await handle_control_command(manager, control, "", envelope(), current)
+    payload = manager.projections[-1]["callback_payload"]
+    projection_count = len(manager.projections)
+
+    response = await handle_control_command(
+        manager, direct_command, direct_value, envelope(), current
+    )
+    assert response is not None and "set to" in response
+    expected = load_session_runtime_preferences(core, "session-one")
+    result = await resolve_control_callback(
+        manager,
+        envelope(),
+        payload,
+        f"c{payload['choices'].index(selection)}",
+    )
+
+    assert result.resolved is False
+    assert result.label == "Stale"
+    assert "session settings changed" in result.answer.lower()
+    assert load_session_runtime_preferences(core, "session-one") == expected
+    assert len(manager.projections) == projection_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "value", "expected_response"),
+    (
+        ("reasoning", "medium", "Session reasoning set to medium."),
+        ("fast", "on", "Session fast mode set to on."),
+    ),
+)
+async def test_session_setting_holds_gate_across_validation_and_persist(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    value: str,
+    expected_response: str,
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+    validation_started = asyncio.Event()
+    finish_validation = asyncio.Event()
+    real_preferences = _controls._preferences
+    first_call = True
+
+    async def delayed_preferences(manager_arg: Any, session_id: str) -> Any:
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            validation_started.set()
+            await finish_validation.wait()
+        return await real_preferences(manager_arg, session_id)
+
+    monkeypatch.setattr(_controls, "_preferences", delayed_preferences)
+    setting = asyncio.create_task(
+        handle_control_command(manager, command, value, envelope(), current)
+    )
+    await asyncio.wait_for(validation_started.wait(), timeout=1)
+    gate = process_lifecycle.get_session_request_gate(core, "session-one")
+    assert gate.locked()
+
+    raced_model = await handle_control_command(
+        manager,
+        "model",
+        "anthropic/claude-sonnet-4-6",
+        envelope(),
+        current,
+    )
+    assert "busy" in str(raced_model).lower()
+    finish_validation.set()
+    assert await setting == expected_response
+
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences is not None
+    assert preferences.provider_id == "openai"
+    assert preferences.model_id == "gpt-5.6-sol"
+    assert core.resolved == []
+
+
+@pytest.mark.asyncio
+async def test_reasoning_fast_and_streaming_are_curated_and_scoped(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    monkeypatch.setattr(_controls, "_build_provider_payload", lambda _core: catalog())
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+
+    assert (
+        await handle_control_command(
+            manager, "reasoning", "medium", envelope(), current
+        )
+        == "Session reasoning set to medium."
+    )
+    assert (
+        await handle_control_command(manager, "fast", "on", envelope(), current)
+        == "Session fast mode set to on."
+    )
+    assert (
+        await handle_control_command(manager, "fast", "off", envelope(), current)
+        == "Session fast mode set to off."
+    )
+    assert (
+        await handle_control_command(manager, "fast", "reset", envelope(), current)
+        == "Session fast mode set to inherited."
+    )
+    assert (
+        await handle_control_command(
+            manager, "settings", "streaming progress", envelope(), current
+        )
+        == "Telegram streaming set to progress."
+    )
+
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences == SessionRuntimePreferences(
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+    )
+    updated = store.get_binding(current.address_key)
+    assert updated is not None
+    assert updated.settings["streaming_mode"] == "progress"
+    assert updated.settings[RECENT_SESSIONS_KEY] == ["session-one"]
+
+
+@pytest.mark.asyncio
+async def test_fast_reset_remains_available_after_effective_provider_changes(
+    tmp_path,
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(store)
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        service_tier="priority",
+    )
+    core.model_config.provider = "anthropic"
+    core.model_config.model = "claude-sonnet-4-6"
+    core.get_current_model = lambda: {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+    }
+
+    response = await handle_control_command(
+        manager, "fast", "reset", envelope(), current
+    )
+
+    assert response == "Session fast mode set to inherited."
+    preferences = load_session_runtime_preferences(core, "session-one")
+    assert preferences is not None
+    assert preferences.service_tier is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_settings_picker_seeds_current_session_once(tmp_path) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    legacy = binding(store, settings={"prompt": "keep"})
+
+    assert (
+        await handle_control_command(manager, "settings", "", envelope(), legacy)
+        is None
+    )
+
+    seeded = store.get_binding(legacy.address_key)
+    assert seeded is not None
+    assert seeded.settings == {
+        "prompt": "keep",
+        RECENT_SESSIONS_KEY: ["session-one"],
+    }
+    assert manager.projections[-1]["callback_payload"]["binding_version"] == (
+        seeded.version
+    )
+
+
+@pytest.mark.asyncio
+async def test_sessions_direct_rebind_is_limited_to_lane_history(tmp_path) -> None:
+    core = ControlCore("session-one", "session-two")
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = ProjectionManager(core, store)
+    current = binding(
+        store,
+        settings={RECENT_SESSIONS_KEY: ["session-one", "session-two"]},
+    )
+
+    response = await handle_control_command(
+        manager, "sessions", "session-two", envelope(), current
+    )
+
+    assert response == ("Telegram is now bound to Penguin session session-two.")
+    rebound = store.get_binding(current.address_key)
+    assert rebound is not None
+    assert rebound.session_id == "session-two"
+    assert rebound.settings[RECENT_SESSIONS_KEY] == [
+        "session-two",
+        "session-one",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_configured_new_binding_preserves_older_recent_history(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    core = ControlCore("older", "current")
+    core.create_conversation = lambda: "new-session"
+    store = ChannelStore(tmp_path / "channel.db")
+    address = ChannelAddress("telegram", "bot", "-100")
+    current = store.upsert_binding(
+        address.lane_key,
+        "current",
+        directory=str(project),
+        agent_mode="build",
+        settings={
+            "prompt": "old prompt",
+            RECENT_SESSIONS_KEY: ["current", "older"],
+        },
+        expected_version=0,
+    )
+    policy = TelegramBindingPolicy.from_mapping(
+        {
+            "-100": {
+                "prompt": "configured prompt",
+                "directory": str(project),
+                "history_limit": 7,
+            }
+        }
+    )
+    manager = TelegramManager(
+        core,
+        TelegramConfig(binding_policy=policy),
+        store=store,
+        bot=TurnBot(),
+    )
+
+    updated = await manager._new_binding(address, current)
+
+    assert updated.session_id == "new-session"
+    assert updated.settings["prompt"] == "configured prompt"
+    assert updated.settings["history_limit"] == 7
+    assert updated.settings[RECENT_SESSIONS_KEY] == [
+        "new-session",
+        "current",
+        "older",
+    ]
+
+
+class TurnBot:
+    async def send_chat_action(self, **kwargs: Any) -> None:
+        del kwargs
+
+
+@pytest.mark.asyncio
+async def test_turn_uses_fresh_session_runtime_and_binding_streaming_mode(
+    tmp_path,
+) -> None:
+    core = ControlCore("session-one")
+    store = ChannelStore(tmp_path / "channel.db")
+    current = binding(store, settings={"streaming_mode": "off"})
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+        service_tier="priority",
+    )
+    manager = TelegramManager(
+        core,
+        TelegramConfig(streaming_mode="edit"),
+        store=store,
+        bot=TurnBot(),
+    )
+
+    result, preview_id = await manager._execute_turn(
+        envelope(),
+        current,
+        image_paths=[],
+        document_inputs=[],
+        group_history=[],
+        directory=str(tmp_path),
+    )
+
+    assert result["status"] == "ok"
+    assert preview_id is None
+    assert len(core.calls) == 1
+    call = core.calls[0]
+    assert call["streaming"] is False
+    assert call["stream_callback"] is None
+    assert call["model_config_override"] is not core.model_config
+    assert call["model_config_override"].reasoning_effort == "medium"
+    assert call["model_config_override"].service_tier == "priority"
+    assert call["api_client_override"] is not core.api_client
+
+
+@pytest.mark.asyncio
+async def test_turn_runtime_resolution_failure_is_visible_and_leaks_no_targets(
+    tmp_path,
+) -> None:
+    core = ControlCore("session-one")
+    core.fail_resolution = "bad session model"
+    store = ChannelStore(tmp_path / "channel.db")
+    current = binding(store, settings={"streaming_mode": "off"})
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+    manager = TelegramManager(
+        core,
+        TelegramConfig(streaming_mode="off"),
+        store=store,
+        bot=TurnBot(),
+    )
+
+    result, preview_id = await manager._execute_turn(
+        envelope(),
+        current,
+        image_paths=[],
+        document_inputs=[],
+        group_history=[],
+        directory=str(tmp_path),
+    )
+
+    assert result == {
+        "status": "error",
+        "error": {"message": "Session model settings are invalid: bad session model"},
+    }
+    assert preview_id is None
+    assert manager._request_targets == {}
+    assert manager._session_targets == {}
+    assert core.calls == []

--- a/tests/integrations/telegram/test_manager.py
+++ b/tests/integrations/telegram/test_manager.py
@@ -17,7 +17,10 @@ from penguin.channels.store import (
     LeaseLostError,
     PollerLeaseConflictError,
 )
-from penguin.integrations.telegram import manager as manager_module
+from penguin.integrations.telegram import (
+    _callback_resolution,
+    manager as manager_module,
+)
 from penguin.integrations.telegram._artifacts import artifact_paths
 from penguin.integrations.telegram.binding_policy import TelegramBindingPolicy
 from penguin.integrations.telegram.config import TelegramConfig
@@ -372,6 +375,12 @@ class FakeCore:
             "action_results": [],
             "status": "ok",
         }
+
+
+class ConfiguredAgentCore(FakeCore):
+    def create_agent_conversation(self, agent_id: str) -> str:
+        self.session_number += 1
+        return f"session-{agent_id}-{self.session_number}"
 
 
 class MediaCore(FakeCore):
@@ -746,6 +755,83 @@ async def test_webhook_dm_round_trip_is_durable_and_reuses_binding(
         )
         assert manager.status()["username"] == "@Penguin_agent_bot"
         assert "token" not in repr(manager.status()).lower()
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_progress_runtime_resolution_error_replaces_working_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_runtime(_core: Any, _session_id: str) -> Any:
+        raise ValueError("bad session model")
+
+    monkeypatch.setattr(
+        manager_module,
+        "resolve_session_request_runtime",
+        fail_runtime,
+    )
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="progress"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(3, "hello"))
+        await _wait_for(lambda: len(bot.edits) == 1)
+
+        assert [message["text"] for message in bot.messages] == ["Penguin is working…"]
+        assert bot.edits[0]["message_id"] == 1
+        assert "Penguin error" in bot.edits[0]["text"]
+        assert "bad session model" in bot.edits[0]["text"]
+        assert core.calls == []
+        assert manager._request_targets == {}
+        assert manager._session_targets == {}
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_new_session_agent_failure_is_visible_and_keeps_binding(
+    tmp_path: Path,
+) -> None:
+    bot = FakeBot()
+    core = FakeCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    original = store.upsert_binding(
+        "telegram\x1f867\x1f42\x1f",
+        "session-existing",
+        agent_id="missing-agent",
+        expected_version=0,
+    )
+    manager = TelegramManager(
+        core,
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(4, "/new"))
+        await _wait_for(lambda: len(bot.messages) == 1)
+
+        assert bot.messages[0]["text"] == (
+            "Penguin session unavailable: Cannot create a session for "
+            "agent 'missing-agent'."
+        )
+        assert store.get_binding(original.address_key) == original
+        ingress = store.get_ingress(
+            "telegram:867:4", platform="telegram", account_id="867"
+        )
+        assert ingress is not None and ingress.state == "completed"
     finally:
         await manager.stop()
 
@@ -2624,6 +2710,253 @@ async def test_restart_terminalizes_orphaned_prompt_before_ttl(
 
 
 @pytest.mark.asyncio
+async def test_control_picker_survives_restart_and_completes_once(
+    tmp_path: Path,
+) -> None:
+    store = ChannelStore(tmp_path / "channel.db")
+    core = FakeCore()
+    config = _config(streaming_mode="off")
+    first_bot = FakeBot()
+    first_manager = TelegramManager(core, config, bot=first_bot, store=store)
+
+    await first_manager.start()
+    try:
+        assert await first_manager.admit_webhook_update(_update(256, "/mode"))
+        await _wait_for(
+            lambda: any(
+                message.get("text") == "Choose plan or build mode:"
+                for message in first_bot.messages
+            )
+        )
+        prompt = next(
+            message
+            for message in first_bot.messages
+            if message.get("text") == "Choose plan or build mode:"
+        )
+        callback_data = _callback_data(prompt["reply_markup"], text="Plan")
+        callback_id = callback_data.split(":", 2)[1]
+        projection_id = f"telegram:control:{callback_id}"
+
+        def projection_delivered() -> bool:
+            with store._read() as conn:
+                row = conn.execute(
+                    """
+                    SELECT state, external_message_id
+                    FROM channel_deliveries
+                    WHERE delivery_id = ?
+                    """,
+                    (projection_id,),
+                ).fetchone()
+            return bool(
+                row is not None
+                and row["state"] == "delivered"
+                and row["external_message_id"] == "1"
+            )
+
+        await _wait_for(projection_delivered)
+    finally:
+        await first_manager.stop()
+
+    with store._read() as conn:
+        state = conn.execute(
+            "SELECT state FROM channel_callbacks WHERE callback_id = ?",
+            (callback_id,),
+        ).fetchone()[0]
+    assert state == "pending"
+
+    second_bot = FakeBot()
+    second_manager = TelegramManager(core, config, bot=second_bot, store=store)
+    callback_message = {
+        "message_id": 1,
+        "chat": {"id": 42, "type": "private"},
+        "from": {"id": 867, "username": "Penguin_agent_bot"},
+    }
+
+    await second_manager.start()
+    try:
+        assert second_bot.edits == []
+        assert await second_manager.admit_webhook_update(
+            {
+                "update_id": 257,
+                "callback_query": {
+                    "id": "control-after-restart",
+                    "from": {"id": 42},
+                    "data": callback_data,
+                    "message": callback_message,
+                },
+            }
+        )
+        await _wait_for(
+            lambda: (
+                (binding := store.get_binding("telegram\x1f867\x1f42\x1f")) is not None
+                and binding.agent_mode == "plan"
+            )
+        )
+
+        def callback_completed() -> bool:
+            with store._read() as conn:
+                row = conn.execute(
+                    "SELECT state FROM channel_callbacks WHERE callback_id = ?",
+                    (callback_id,),
+                ).fetchone()
+            return row is not None and row["state"] == "completed"
+
+        await _wait_for(callback_completed)
+        await _wait_for(lambda: len(second_bot.edits) == 1)
+        assert second_bot.callback_answers == [
+            {
+                "callback_query_id": "control-after-restart",
+                "text": "Updated.",
+            }
+        ]
+        assert second_bot.edits[0]["reply_markup"] is None
+
+        assert await second_manager.admit_webhook_update(
+            {
+                "update_id": 258,
+                "callback_query": {
+                    "id": "control-replay",
+                    "from": {"id": 42},
+                    "data": callback_data,
+                    "message": callback_message,
+                },
+            }
+        )
+        await _wait_for(lambda: len(second_bot.callback_answers) == 2)
+
+        assert second_bot.callback_answers[-1] == {
+            "callback_query_id": "control-replay",
+            "text": "This action is unavailable.",
+        }
+        assert len(second_bot.edits) == 1
+        assert callback_completed()
+    finally:
+        await second_manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_slow_control_resolution_renews_callback_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_callback_resolution, "_CALLBACK_LEASE_SECONDS", 1.0)
+    monkeypatch.setattr(manager_module, "_RECOVERY_INTERVAL_SECONDS", 0.02)
+    original_resolver = _callback_resolution.resolve_control_callback
+    resolution_started = asyncio.Event()
+    release_resolution = asyncio.Event()
+
+    async def slow_resolver(*args: Any, **kwargs: Any) -> Any:
+        resolution_started.set()
+        await release_resolution.wait()
+        return await original_resolver(*args, **kwargs)
+
+    monkeypatch.setattr(
+        _callback_resolution,
+        "resolve_control_callback",
+        slow_resolver,
+    )
+    store = ChannelStore(tmp_path / "channel.db")
+    bot = FakeBot()
+    manager = TelegramManager(
+        FakeCore(),
+        _config(streaming_mode="off"),
+        bot=bot,
+        store=store,
+    )
+
+    await manager.start()
+    try:
+        assert await manager.admit_webhook_update(_update(259, "/mode"))
+        await _wait_for(
+            lambda: any(
+                message.get("text") == "Choose plan or build mode:"
+                for message in bot.messages
+            )
+        )
+        prompt = next(
+            message
+            for message in bot.messages
+            if message.get("text") == "Choose plan or build mode:"
+        )
+        callback_data = _callback_data(prompt["reply_markup"], text="Plan")
+        callback_id = callback_data.split(":", 2)[1]
+        callback_message = {
+            "message_id": 1,
+            "chat": {"id": 42, "type": "private"},
+            "from": {"id": 867, "username": "Penguin_agent_bot"},
+        }
+        assert await manager.admit_webhook_update(
+            {
+                "update_id": 260,
+                "callback_query": {
+                    "id": "slow-control",
+                    "from": {"id": 42},
+                    "data": callback_data,
+                    "message": callback_message,
+                },
+            }
+        )
+        await asyncio.wait_for(resolution_started.wait(), timeout=1.0)
+        await asyncio.sleep(1.4)
+
+        with store._read() as conn:
+            claimed = conn.execute(
+                """
+                SELECT state, lease_expires_at
+                FROM channel_callbacks WHERE callback_id = ?
+                """,
+                (callback_id,),
+            ).fetchone()
+        assert claimed is not None and claimed["state"] == "claimed"
+        assert claimed["lease_expires_at"] > time.time()
+
+        release_resolution.set()
+        await _wait_for(
+            lambda: (
+                (binding := store.get_binding("telegram\x1f867\x1f42\x1f")) is not None
+                and binding.agent_mode == "plan"
+            )
+        )
+
+        def callback_completed() -> bool:
+            with store._read() as conn:
+                row = conn.execute(
+                    "SELECT state FROM channel_callbacks WHERE callback_id = ?",
+                    (callback_id,),
+                ).fetchone()
+            return row is not None and row["state"] == "completed"
+
+        await _wait_for(callback_completed)
+        await _wait_for(lambda: len(bot.edits) == 1)
+        assert bot.callback_answers == [
+            {"callback_query_id": "slow-control", "text": "Updated."}
+        ]
+        assert bot.edits[0]["reply_markup"] is None
+
+        assert await manager.admit_webhook_update(
+            {
+                "update_id": 261,
+                "callback_query": {
+                    "id": "slow-control-replay",
+                    "from": {"id": 42},
+                    "data": callback_data,
+                    "message": callback_message,
+                },
+            }
+        )
+        await _wait_for(lambda: len(bot.callback_answers) == 2)
+        assert bot.callback_answers[-1] == {
+            "callback_query_id": "slow-control-replay",
+            "text": "This action is unavailable.",
+        }
+        assert len(bot.edits) == 1
+        assert callback_completed()
+    finally:
+        release_resolution.set()
+        await manager.stop()
+
+
+@pytest.mark.asyncio
 async def test_approval_callback_resumes_once_and_duplicate_is_inert(
     tmp_path: Path,
 ) -> None:
@@ -2754,7 +3087,7 @@ async def test_group_topic_policy_seeds_and_scopes_execution(
             }
         }
     )
-    core = FakeCore()
+    core = ConfiguredAgentCore()
     store = ChannelStore(tmp_path / "channel.db")
     manager = TelegramManager(
         core,
@@ -2809,7 +3142,9 @@ async def test_group_topic_policy_seeds_and_scopes_execution(
         assert binding.directory == str(project.resolve())
         assert binding.agent_id == "configured-agent"
         assert binding.agent_mode == "plan"
+        assert binding.session_id == "session-configured-agent-1"
         assert binding.settings == {
+            "_telegram_recent_sessions_v1": ["session-configured-agent-1"],
             "activation": "mention",
             "history_limit": 1,
             "prompt": "Answer for the release team.",
@@ -2825,6 +3160,55 @@ async def test_group_topic_policy_seeds_and_scopes_execution(
         assert execution.require_registered_agent is True
     finally:
         await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_configured_agent_new_session_preserves_agent_and_history(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "configured-project"
+    project.mkdir()
+    policy = TelegramBindingPolicy.from_mapping(
+        {
+            "-100": {
+                "directory": str(project),
+                "agent_id": "configured-agent",
+            }
+        }
+    )
+    core = ConfiguredAgentCore()
+    store = ChannelStore(tmp_path / "channel.db")
+    manager = TelegramManager(
+        core,
+        _config(binding_policy=policy),
+        bot=FakeBot(),
+        store=store,
+    )
+    normalized = normalize_update(
+        {
+            "update_id": 1,
+            "message": {
+                "message_id": 1,
+                "chat": {"id": -100, "type": "supergroup"},
+                "from": {"id": 42},
+                "text": "/new",
+            },
+        },
+        account_id="867",
+    )
+    assert normalized is not None
+    address = normalized.address
+
+    first = await manager._binding_for(address)
+    second = await manager._new_binding(address, first)
+
+    assert first.session_id == "session-configured-agent-1"
+    assert second.session_id == "session-configured-agent-2"
+    assert second.agent_id == "configured-agent"
+    assert second.settings["_telegram_recent_sessions_v1"] == [
+        "session-configured-agent-2",
+        "session-configured-agent-1",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/telegram/test_session_runtime.py
+++ b/tests/integrations/telegram/test_session_runtime.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from penguin.core_runtime.opencode_bridge import (
+    SESSION_MODEL_ID_KEY,
+    SESSION_PROVIDER_ID_KEY,
+    SESSION_VARIANT_KEY,
+)
+from penguin.integrations.telegram._session_runtime import (
+    SESSION_SERVICE_TIER_KEY,
+    SessionRuntimePreferences,
+    load_session_runtime_preferences,
+    resolve_session_request_runtime,
+    update_session_runtime_preferences,
+)
+from penguin.system.session_manager import SessionManager
+from penguin.system.state import Session
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _SessionManager:
+    def __init__(self, *session_ids: str) -> None:
+        self.sessions = {
+            session_id: (SimpleNamespace(id=session_id, metadata={}), False)
+            for session_id in session_ids
+        }
+        self.marked: list[str] = []
+        self.saved: list[str] = []
+        self.session_index: dict[str, Any] = {}
+
+    def mark_session_modified(self, session_id: str) -> None:
+        self.marked.append(session_id)
+
+    def save_session(self, session: Any) -> bool:
+        self.saved.append(session.id)
+        return True
+
+
+def _core(*session_ids: str) -> tuple[Any, _SessionManager]:
+    manager = _SessionManager(*session_ids)
+    core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=manager,
+            agent_session_managers={},
+        )
+    )
+    return core, manager
+
+
+def test_session_runtime_preferences_persist_on_the_target_session() -> None:
+    core, manager = _core("session-one")
+
+    updated = update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id=" OpenAI ",
+        model_id="openai/gpt-5.6-sol",
+        reasoning_variant=" Medium ",
+        service_tier=" PRIORITY ",
+    )
+
+    assert updated == SessionRuntimePreferences(
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+        service_tier="priority",
+    )
+    assert load_session_runtime_preferences(core, "session-one") == updated
+    assert manager.marked == ["session-one"]
+    assert manager.saved == ["session-one"]
+
+
+def test_session_runtime_preferences_are_isolated_between_sessions() -> None:
+    core, _manager = _core("session-one", "session-two")
+
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+    )
+    update_session_runtime_preferences(
+        core,
+        "session-two",
+        provider_id="anthropic",
+        model_id="claude-sonnet-4-6",
+    )
+
+    assert load_session_runtime_preferences(
+        core, "session-one"
+    ) == SessionRuntimePreferences(provider_id="openai", model_id="gpt-5.6-sol")
+    assert load_session_runtime_preferences(
+        core, "session-two"
+    ) == SessionRuntimePreferences(
+        provider_id="anthropic",
+        model_id="claude-sonnet-4-6",
+    )
+
+
+def test_runtime_update_distinguishes_unchanged_from_clear() -> None:
+    core, manager = _core("session-one")
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="high",
+        service_tier="priority",
+    )
+
+    reasoning_cleared = update_session_runtime_preferences(
+        core,
+        "session-one",
+        reasoning_variant=None,
+    )
+
+    assert reasoning_cleared == SessionRuntimePreferences(
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        service_tier="priority",
+    )
+    reset = update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id=None,
+        model_id=None,
+        service_tier=None,
+    )
+    assert reset == SessionRuntimePreferences()
+    assert load_session_runtime_preferences(core, "session-one") == reset
+    assert manager.saved == ["session-one", "session-one", "session-one"]
+
+
+def test_model_provider_pair_invariant_rejects_partial_updates() -> None:
+    core, manager = _core("session-one")
+
+    try:
+        update_session_runtime_preferences(
+            core,
+            "session-one",
+            model_id="gpt-5.6-sol",
+        )
+    except ValueError as exc:
+        assert "provider_id and model_id" in str(exc)
+    else:
+        raise AssertionError("A model without its provider must be rejected")
+
+    assert (
+        load_session_runtime_preferences(core, "session-one")
+        == SessionRuntimePreferences()
+    )
+    assert manager.marked == []
+    assert manager.saved == []
+
+
+def test_missing_session_fails_closed_without_persisting() -> None:
+    core, manager = _core("known-session")
+
+    assert load_session_runtime_preferences(core, "missing-session") is None
+    assert (
+        update_session_runtime_preferences(
+            core,
+            "missing-session",
+            reasoning_variant="high",
+        )
+        is None
+    )
+    assert manager.marked == []
+    assert manager.saved == []
+
+
+@pytest.mark.parametrize("failure", ["false", "exception"])
+def test_runtime_update_rolls_back_exact_session_state_on_save_failure(
+    failure: str,
+) -> None:
+    core, manager = _core("session-one")
+    session = manager.sessions["session-one"][0]
+    original_metadata = {"nested": {"keep": [1, 2, 3]}}
+    session.metadata = original_metadata
+    session.last_active = "2026-08-11T12:00:00"
+
+    def fail_save(candidate: Any) -> bool:
+        candidate.metadata["nested"]["keep"].append(4)
+        candidate.metadata["save-side-effect"] = True
+        candidate.last_active = "changed-by-save"
+        if failure == "exception":
+            raise OSError("disk failed")
+        return False
+
+    manager.save_session = fail_save
+
+    expected = OSError if failure == "exception" else RuntimeError
+    with pytest.raises(expected):
+        update_session_runtime_preferences(
+            core,
+            "session-one",
+            reasoning_variant="medium",
+        )
+
+    assert session.metadata is original_metadata
+    assert session.metadata == {"nested": {"keep": [1, 2, 3]}}
+    assert session.last_active == "2026-08-11T12:00:00"
+    assert manager.sessions["session-one"] == (session, False)
+
+
+@pytest.mark.parametrize("failure", ["false", "exception"])
+@pytest.mark.parametrize("had_entry", [False, True])
+def test_runtime_update_rolls_back_only_target_session_index_entry(
+    failure: str,
+    had_entry: bool,
+) -> None:
+    core, manager = _core("session-one")
+    original_entry = {"nested": {"keep": [1, 2, 3]}}
+    if had_entry:
+        manager.session_index["session-one"] = original_entry
+    unrelated = {"title": "leave alone"}
+    manager.session_index["unrelated"] = unrelated
+
+    def fail_save(candidate: Any) -> bool:
+        manager.session_index["session-one"] = {
+            "ghost": candidate.metadata.get(SESSION_VARIANT_KEY)
+        }
+        manager.session_index["unrelated"]["title"] = "mutated externally"
+        if failure == "exception":
+            raise OSError("disk failed")
+        return False
+
+    manager.save_session = fail_save
+
+    expected = OSError if failure == "exception" else RuntimeError
+    with pytest.raises(expected):
+        update_session_runtime_preferences(
+            core,
+            "session-one",
+            reasoning_variant="medium",
+        )
+
+    if had_entry:
+        assert manager.session_index["session-one"] == {"nested": {"keep": [1, 2, 3]}}
+        assert manager.session_index["session-one"] is not original_entry
+    else:
+        assert "session-one" not in manager.session_index
+    assert manager.session_index["unrelated"] == {"title": "mutated externally"}
+
+
+def test_runtime_update_rejects_cached_session_with_mismatched_exact_id() -> None:
+    core, manager = _core("requested")
+    manager.sessions["requested"] = (
+        SimpleNamespace(id="different", metadata={}, last_active="unchanged"),
+        False,
+    )
+
+    assert load_session_runtime_preferences(core, "requested") is None
+    assert (
+        update_session_runtime_preferences(
+            core,
+            "requested",
+            reasoning_variant="medium",
+        )
+        is None
+    )
+    assert manager.marked == []
+    assert manager.saved == []
+
+
+def test_uncached_runtime_preferences_use_file_without_activating_manager(
+    tmp_path: Path,
+) -> None:
+    session = Session(
+        id="persisted-session",
+        metadata={"directory": "/tmp/project", "agent_id": "default"},
+    )
+    session_path = tmp_path / "persisted-session.json"
+    session_path.write_text(session.to_json(), encoding="utf-8")
+    active = SimpleNamespace(id="active-session")
+
+    class DiskManager:
+        def __init__(self) -> None:
+            self.base_path = tmp_path
+            self.format = "json"
+            self.sessions: dict[str, Any] = {}
+            self.session_index = {session.id: {}}
+            self.current_session = active
+            self.saved: list[str] = []
+
+        def load_session(self, session_id: str) -> Any:
+            raise AssertionError(f"activating loader called for {session_id}")
+
+        def mark_session_modified(self, session_id: str) -> None:
+            assert session_id == session.id
+
+        def save_session(self, candidate: Session) -> bool:
+            self.saved.append(candidate.id)
+            session_path.write_text(candidate.to_json(), encoding="utf-8")
+            return True
+
+    manager = DiskManager()
+    core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=manager,
+            agent_session_managers={},
+        )
+    )
+
+    updated = update_session_runtime_preferences(
+        core,
+        session.id,
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+    )
+
+    assert updated == SessionRuntimePreferences(
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+    )
+    assert load_session_runtime_preferences(core, session.id) == updated
+    assert manager.current_session is active
+    assert manager.sessions == {}
+    assert manager.saved == [session.id]
+
+
+@pytest.mark.parametrize("had_primary", [False, True])
+def test_real_session_manager_disk_state_rolls_back_after_index_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    had_primary: bool,
+) -> None:
+    manager = SessionManager(base_path=str(tmp_path), auto_save_interval=0)
+    session = manager.create_session()
+    session.metadata["owner"] = "original"
+    if had_primary:
+        assert manager.save_session(session) is True
+        original_primary = (tmp_path / f"{session.id}.json").read_bytes()
+        original_backup = tmp_path / f"{session.id}.json.bak"
+        original_backup_state = (
+            original_backup.read_bytes() if original_backup.exists() else None
+        )
+    else:
+        primary = tmp_path / f"{session.id}.json"
+        assert not primary.exists()
+        original_primary = None
+        original_backup_state = None
+    original_index_entry = deepcopy(manager.session_index[session.id])
+    core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=manager,
+            agent_session_managers={},
+        )
+    )
+
+    def fail_index(_index: Any) -> None:
+        raise OSError("index persistence failed")
+
+    monkeypatch.setattr(manager, "_save_index", fail_index)
+
+    with pytest.raises(RuntimeError, match="Unable to persist"):
+        update_session_runtime_preferences(
+            core,
+            session.id,
+            provider_id="openai",
+            model_id="gpt-5.6-sol",
+            reasoning_variant="medium",
+        )
+
+    primary = tmp_path / f"{session.id}.json"
+    backup = tmp_path / f"{session.id}.json.bak"
+    assert manager.session_index[session.id] == original_index_entry
+    if had_primary:
+        assert primary.read_bytes() == original_primary
+        restored = Session.from_json(primary.read_text(encoding="utf-8"))
+        assert restored.metadata["owner"] == "original"
+        assert SESSION_PROVIDER_ID_KEY not in restored.metadata
+        assert SESSION_MODEL_ID_KEY not in restored.metadata
+        assert SESSION_VARIANT_KEY not in restored.metadata
+        if original_backup_state is None:
+            assert not backup.exists()
+        else:
+            assert backup.read_bytes() == original_backup_state
+    else:
+        assert not primary.exists()
+        assert not backup.exists()
+
+
+def test_runtime_update_prefers_uncached_live_current_session_over_disk(
+    tmp_path: Path,
+) -> None:
+    manager = SessionManager(base_path=str(tmp_path), auto_save_interval=0)
+    live = manager.create_session()
+    live.metadata["owner"] = "live"
+    assert manager.save_session(live) is True
+    manager.sessions.pop(live.id)
+    assert manager.current_session is live
+    core = SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=manager,
+            agent_session_managers={},
+        )
+    )
+
+    updated = update_session_runtime_preferences(
+        core,
+        live.id,
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+    )
+
+    assert updated == SessionRuntimePreferences(
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+    )
+    assert live.metadata[SESSION_PROVIDER_ID_KEY] == "openai"
+    assert live.metadata[SESSION_MODEL_ID_KEY] == "gpt-5.6-sol"
+    assert live.metadata[SESSION_VARIANT_KEY] == "medium"
+    assert manager.current_session is live
+
+    assert manager.save_session(live) is True
+    reloaded = Session.from_json(
+        (tmp_path / f"{live.id}.json").read_text(encoding="utf-8")
+    )
+    assert reloaded.metadata[SESSION_PROVIDER_ID_KEY] == "openai"
+    assert reloaded.metadata[SESSION_MODEL_ID_KEY] == "gpt-5.6-sol"
+    assert reloaded.metadata[SESSION_VARIANT_KEY] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_request_runtime_is_fresh_and_does_not_mutate_global_runtime() -> None:
+    core, manager = _core("session-one")
+    global_config = SimpleNamespace(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        reasoning_enabled=False,
+        reasoning_effort=None,
+        reasoning_max_tokens=2048,
+        reasoning_exclude=False,
+        service_tier=None,
+    )
+    global_client = SimpleNamespace(name="global-client")
+    core.model_config = global_config
+    core.api_client = global_client
+    requested_models: list[str | None] = []
+
+    async def resolve_request_runtime(model_id: str | None = None):
+        requested_models.append(model_id)
+        request_config = deepcopy(global_config)
+        request_config.provider = "openai"
+        request_config.model = "gpt-5.6-sol"
+        request_config.supported_reasoning_levels = [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        ]
+        request_config.api_key = "request-only-secret"
+        return request_config, SimpleNamespace(model_config=request_config)
+
+    core.resolve_request_runtime = resolve_request_runtime
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        provider_id="openai",
+        model_id="gpt-5.6-sol",
+        reasoning_variant="medium",
+        service_tier="priority",
+    )
+
+    first = await resolve_session_request_runtime(core, "session-one")
+    second = await resolve_session_request_runtime(core, "session-one")
+
+    assert first is not None
+    assert second is not None
+    first_config, first_client = first
+    second_config, second_client = second
+    assert requested_models == ["openai/gpt-5.6-sol", "openai/gpt-5.6-sol"]
+    assert first_config is not second_config
+    assert first_client is not second_client
+    assert first_config.reasoning_enabled is True
+    assert first_config.reasoning_effort == "medium"
+    assert first_config.reasoning_max_tokens is None
+    assert first_config.service_tier == "priority"
+    assert global_config.reasoning_enabled is False
+    assert global_config.reasoning_effort is None
+    assert global_config.reasoning_max_tokens == 2048
+    assert global_config.service_tier is None
+    assert core.api_client is global_client
+
+    session = manager.sessions["session-one"][0]
+    assert session.metadata == {
+        SESSION_PROVIDER_ID_KEY: "openai",
+        SESSION_MODEL_ID_KEY: "gpt-5.6-sol",
+        SESSION_VARIANT_KEY: "medium",
+        SESSION_SERVICE_TIER_KEY: "priority",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fast_mode_rejects_a_non_openai_effective_runtime() -> None:
+    core, _manager = _core("session-one")
+    core.model_config = SimpleNamespace(provider="anthropic")
+    core.api_client = SimpleNamespace(name="global-client")
+
+    async def resolve_request_runtime(_model_id: str | None = None):
+        return (
+            SimpleNamespace(provider="anthropic", service_tier=None),
+            SimpleNamespace(name="request-client"),
+        )
+
+    core.resolve_request_runtime = resolve_request_runtime
+    update_session_runtime_preferences(
+        core,
+        "session-one",
+        service_tier="priority",
+    )
+
+    with pytest.raises(ValueError, match="only for OpenAI"):
+        await resolve_session_request_runtime(core, "session-one")

--- a/tests/integrations/telegram/test_sessions.py
+++ b/tests/integrations/telegram/test_sessions.py
@@ -1,0 +1,651 @@
+"""Owner-scoped Telegram session history and rebinding tests."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from penguin.channels.store import ChannelStore, CompareAndSwapError
+from penguin.core_runtime import process_lifecycle
+from penguin.integrations.telegram._sessions import (
+    RECENT_SESSIONS_KEY,
+    SessionAccessError,
+    SessionBusyError,
+    create_bound_session,
+    list_recent_sessions,
+    rebind_session,
+    with_recent_session,
+    with_session_transition,
+)
+from penguin.system.state import Session
+
+
+def _session(
+    session_id: str,
+    *,
+    title: str | None = None,
+    last_active: str = "2026-08-11T12:00:00",
+    directory: str | None = None,
+    agent_id: str | None = None,
+) -> SimpleNamespace:
+    metadata: dict[str, Any] = {}
+    if title is not None:
+        metadata["title"] = title
+    if directory is not None:
+        metadata["directory"] = directory
+    if agent_id is not None:
+        metadata["agent_id"] = agent_id
+    return SimpleNamespace(
+        id=session_id,
+        metadata=metadata,
+        messages=[],
+        last_active=last_active,
+    )
+
+
+def _core(*sessions: SimpleNamespace) -> SimpleNamespace:
+    manager = SimpleNamespace(
+        sessions={session.id: (session, False) for session in sessions},
+        session_index={},
+    )
+    return SimpleNamespace(
+        conversation_manager=SimpleNamespace(
+            session_manager=manager,
+            agent_session_managers={},
+        )
+    )
+
+
+def _binding(
+    store: ChannelStore,
+    *,
+    current: str,
+    directory: str,
+    agent_id: str = "build-agent",
+    history: list[str] | None = None,
+) -> Any:
+    settings: dict[str, Any] = {"prompt": "Stay concise", "streaming": "live"}
+    if history is not None:
+        settings[RECENT_SESSIONS_KEY] = history
+    return store.upsert_binding(
+        "telegram\x1fbot\x1f42\x1f",
+        current,
+        directory=directory,
+        agent_id=agent_id,
+        agent_mode="plan",
+        settings=settings,
+        expected_version=0,
+    )
+
+
+def _write_primary_session(
+    manager: Any,
+    root: Any,
+    requested_id: str,
+    *,
+    stored_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    last_active: str | None = None,
+) -> None:
+    manager.base_path = root
+    manager.format = "json"
+    session = Session(id=stored_id or requested_id, metadata=metadata or {})
+    if last_active is not None:
+        session.last_active = last_active
+    (root / f"{requested_id}.json").write_text(
+        session.to_json(),
+        encoding="utf-8",
+    )
+
+
+def test_recent_history_preserves_settings_dedupes_and_caps() -> None:
+    settings: dict[str, Any] = {
+        "prompt": "Keep me",
+        RECENT_SESSIONS_KEY: ["session-2", "session-1", "session-2", 7, ""],
+    }
+
+    updated = settings
+    for index in range(25):
+        updated = with_recent_session(updated, f"session-{index}")
+
+    assert updated["prompt"] == "Keep me"
+    assert updated[RECENT_SESSIONS_KEY] == [
+        f"session-{index}" for index in range(24, 4, -1)
+    ]
+    assert settings[RECENT_SESSIONS_KEY] == [
+        "session-2",
+        "session-1",
+        "session-2",
+        7,
+        "",
+    ]
+
+
+def test_transition_records_target_then_current_without_losing_settings() -> None:
+    updated = with_session_transition(
+        {"activation": "mention", RECENT_SESSIONS_KEY: ["older", "target"]},
+        current_session_id="current",
+        target_session_id="target",
+    )
+
+    assert updated == {
+        "activation": "mention",
+        RECENT_SESSIONS_KEY: ["target", "current", "older"],
+    }
+
+
+def test_create_bound_session_uses_configured_agent_without_switching_global() -> None:
+    calls: list[tuple[str, str | None]] = []
+    core = SimpleNamespace(current_agent_id="default")
+
+    def create_agent_conversation(agent_id: str) -> str:
+        calls.append(("agent", agent_id))
+        return " session-agent "
+
+    def create_conversation() -> str:
+        calls.append(("default", None))
+        return "session-default"
+
+    core.create_agent_conversation = create_agent_conversation
+    core.create_conversation = create_conversation
+
+    assert create_bound_session(core, " worker ") == "session-agent"
+    assert calls == [("agent", "worker")]
+    assert core.current_agent_id == "default"
+
+
+def test_create_bound_session_uses_explicit_default_without_switching_global() -> None:
+    calls: list[tuple[str, str | None]] = []
+    core = SimpleNamespace(
+        current_agent_id="worker",
+        create_conversation=lambda: calls.append(("legacy", None)) or "session-legacy",
+        create_agent_conversation=lambda agent: (
+            calls.append(("agent", agent)) or "session-default"
+        ),
+    )
+
+    assert create_bound_session(core, None) == "session-default"
+    assert create_bound_session(core, "  ") == "session-default"
+    assert calls == [("agent", "default"), ("agent", "default")]
+    assert core.current_agent_id == "worker"
+
+
+def test_create_bound_session_legacy_default_compatibility() -> None:
+    calls: list[str] = []
+    core = SimpleNamespace(
+        create_conversation=lambda: calls.append("legacy") or "session-default"
+    )
+
+    assert create_bound_session(core, None) == "session-default"
+    assert calls == ["legacy"]
+
+
+def test_create_bound_session_fails_closed_when_agent_seam_is_missing() -> None:
+    default_calls: list[str] = []
+    core = SimpleNamespace(
+        create_conversation=lambda: default_calls.append("default") or "session-default"
+    )
+
+    with pytest.raises(SessionAccessError, match="agent 'worker'"):
+        create_bound_session(core, "worker")
+
+    assert default_calls == []
+
+
+@pytest.mark.parametrize("result", [None, "", "   ", 123])
+def test_create_bound_session_rejects_invalid_session_id(result: Any) -> None:
+    core = SimpleNamespace(create_conversation=lambda: result)
+
+    with pytest.raises(SessionAccessError, match="valid session ID"):
+        create_bound_session(core, None)
+
+
+def test_list_recent_sessions_only_hydrates_owned_history(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session(
+        "current",
+        title="Current work",
+        last_active="2026-08-11T12:02:00",
+        directory=str(project),
+        agent_id="build-agent",
+    )
+    target = _session(
+        "target",
+        title="Earlier work",
+        last_active="2026-08-11T11:59:00",
+        directory=str(project),
+        agent_id="build-agent",
+    )
+    globally_visible_but_unowned = _session(
+        "not-in-history",
+        title="Someone else's session",
+        directory=str(project),
+        agent_id="build-agent",
+    )
+    mismatched = _session(
+        "wrong-project",
+        directory=str(tmp_path),
+        agent_id="build-agent",
+    )
+    core = _core(current, target, globally_visible_but_unowned, mismatched)
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "missing", "wrong-project", "current"],
+    )
+
+    summaries = list_recent_sessions(core, binding)
+
+    assert [
+        (item.session_id, item.title, item.last_active, item.current)
+        for item in summaries
+    ] == [
+        ("target", "Earlier work", "2026-08-11T11:59:00", False),
+        ("current", "Current work", "2026-08-11T12:02:00", True),
+    ]
+
+
+def test_list_recent_sessions_prefers_uncached_live_current_over_stale_index(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    live = _session(
+        "current",
+        title="Live current",
+        directory=str(project),
+        agent_id="build-agent",
+    )
+    core = _core()
+    manager = core.conversation_manager.session_manager
+    manager.current_session = live
+    manager.session_index = {
+        live.id: {
+            "title": "Stale index",
+            "directory": str(tmp_path),
+            "agent_id": "other-agent",
+        }
+    }
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current=live.id,
+        directory=str(project),
+        history=[live.id],
+    )
+
+    summaries = list_recent_sessions(core, binding)
+
+    assert len(summaries) == 1
+    assert summaries[0].title == "Live current"
+    assert summaries[0].current is True
+    assert manager.current_session is live
+    assert manager.sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_index_session_view_never_calls_activating_loader_or_moves_pointer(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    core = _core(current)
+    manager = core.conversation_manager.session_manager
+    manager.current_session = current
+    _write_primary_session(
+        manager,
+        tmp_path,
+        "target",
+        metadata={
+            "title": "Persisted target",
+            "directory": str(project),
+            "agent_id": "build-agent",
+        },
+        last_active="2026-08-11T11:58:00",
+    )
+    manager.session_index = {
+        "target": {
+            "title": "Persisted target",
+            "last_active": "2026-08-11T11:58:00",
+            "directory": str(project),
+            "agent_id": "build-agent",
+        }
+    }
+
+    def activating_loader(session_id: str) -> Any:
+        raise AssertionError(f"activating loader called for {session_id}")
+
+    manager.load_session = activating_loader
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+
+    summaries = list_recent_sessions(core, binding)
+    rebound = await rebind_session(core, store, binding, "target")
+
+    assert [summary.session_id for summary in summaries] == ["target", "current"]
+    assert summaries[0].title == "Persisted target"
+    assert rebound.session_id == "target"
+    assert manager.current_session is current
+    assert set(manager.sessions) == {"current"}
+
+
+@pytest.mark.asyncio
+async def test_index_session_view_rejects_mismatched_embedded_id(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    core = _core(current)
+    manager = core.conversation_manager.session_manager
+    _write_primary_session(manager, tmp_path, "target")
+    manager.session_index = {
+        "target": {
+            "id": "different",
+            "directory": str(project),
+            "agent_id": "build-agent",
+        }
+    }
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+
+    assert [item.session_id for item in list_recent_sessions(core, binding)] == [
+        "current"
+    ]
+    with pytest.raises(SessionAccessError, match="not available"):
+        await rebind_session(core, store, binding, "target")
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mismatch", ["directory", "agent"])
+async def test_index_claim_cannot_override_primary_session_owner(
+    tmp_path,
+    mismatch: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    other_project = tmp_path / "other"
+    other_project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    core = _core(current)
+    manager = core.conversation_manager.session_manager
+    primary_metadata = {
+        "directory": str(other_project) if mismatch == "directory" else str(project),
+        "agent_id": "other-agent" if mismatch == "agent" else "build-agent",
+    }
+    _write_primary_session(
+        manager,
+        tmp_path,
+        "target",
+        metadata=primary_metadata,
+    )
+    manager.session_index = {
+        "target": {
+            "directory": str(project),
+            "agent_id": "build-agent",
+        }
+    }
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+
+    assert [item.session_id for item in list_recent_sessions(core, binding)] == [
+        "current"
+    ]
+    with pytest.raises(SessionAccessError, match="not available"):
+        await rebind_session(core, store, binding, "target")
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["missing", "corrupt", "embedded-id"])
+async def test_index_session_view_requires_valid_exact_primary_file(
+    tmp_path,
+    failure: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    core = _core(current)
+    manager = core.conversation_manager.session_manager
+    manager.base_path = tmp_path
+    manager.format = "json"
+    manager.session_index = {
+        "target": {
+            "directory": str(project),
+            "agent_id": "build-agent",
+        }
+    }
+    if failure == "corrupt":
+        (tmp_path / "target.json").write_text("{not-json", encoding="utf-8")
+    elif failure == "embedded-id":
+        _write_primary_session(
+            manager,
+            tmp_path,
+            "target",
+            stored_id="different",
+        )
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+
+    assert [item.session_id for item in list_recent_sessions(core, binding)] == [
+        "current"
+    ]
+    with pytest.raises(SessionAccessError, match="not available"):
+        await rebind_session(core, store, binding, "target")
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+async def test_rebind_denies_guessed_session_id_even_when_it_exists(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    guessed = _session("guessed", directory=str(project), agent_id="build-agent")
+    core = _core(current, guessed)
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["current"],
+    )
+
+    with pytest.raises(SessionAccessError, match="not available"):
+        await rebind_session(core, store, binding, "guessed")
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["missing", "directory", "agent"])
+async def test_rebind_denies_missing_or_mismatched_history_target(
+    tmp_path,
+    failure: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    other_project = tmp_path / "other"
+    other_project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    target: SimpleNamespace | None = None
+    if failure == "directory":
+        target = _session(
+            "target", directory=str(other_project), agent_id="build-agent"
+        )
+    elif failure == "agent":
+        target = _session("target", directory=str(project), agent_id="other-agent")
+    core = _core(current, *([target] if target is not None else []))
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+
+    with pytest.raises(SessionAccessError, match="not available"):
+        await rebind_session(core, store, binding, "target")
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("busy_session_id", ["current", "target"])
+async def test_rebind_rejects_busy_current_or_target_session(
+    tmp_path,
+    busy_session_id: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    target = _session("target", directory=str(project), agent_id="build-agent")
+    core = _core(current, target)
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+    gate = process_lifecycle.get_session_request_gate(core, busy_session_id)
+    await gate.acquire()
+    try:
+        with pytest.raises(SessionBusyError, match=busy_session_id):
+            await rebind_session(core, store, binding, "target")
+    finally:
+        gate.release()
+
+    assert store.get_binding(binding.address_key) == binding
+
+
+@pytest.mark.asyncio
+async def test_rebind_preserves_binding_and_records_transition(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    target = _session("target", directory=str(project), agent_id="build-agent")
+    core = _core(current, target)
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["older", "target", "current"],
+    )
+
+    rebound = await rebind_session(core, store, binding, "target")
+
+    assert rebound.session_id == "target"
+    assert rebound.directory == binding.directory
+    assert rebound.agent_id == binding.agent_id
+    assert rebound.agent_mode == binding.agent_mode
+    assert rebound.settings["prompt"] == "Stay concise"
+    assert rebound.settings["streaming"] == "live"
+    assert rebound.settings[RECENT_SESSIONS_KEY] == ["target", "current", "older"]
+    assert rebound.version == binding.version + 1
+
+
+@pytest.mark.asyncio
+async def test_rebind_fails_closed_when_binding_version_changed(tmp_path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    target = _session("target", directory=str(project), agent_id="build-agent")
+    core = _core(current, target)
+    store = ChannelStore(tmp_path / "channel.db")
+    stale = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+    changed = store.upsert_binding(
+        stale.address_key,
+        stale.session_id,
+        directory=stale.directory,
+        agent_id=stale.agent_id,
+        agent_mode="build",
+        settings=stale.settings,
+        expected_version=stale.version,
+    )
+
+    with pytest.raises(CompareAndSwapError):
+        await rebind_session(core, store, stale, "target")
+
+    assert store.get_binding(stale.address_key) == changed
+
+
+@pytest.mark.asyncio
+async def test_cancelled_rebind_waits_for_threaded_cas_before_releasing_gates(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    current = _session("current", directory=str(project), agent_id="build-agent")
+    target = _session("target", directory=str(project), agent_id="build-agent")
+    core = _core(current, target)
+    store = ChannelStore(tmp_path / "channel.db")
+    binding = _binding(
+        store,
+        current="current",
+        directory=str(project),
+        history=["target", "current"],
+    )
+    original_upsert = store.upsert_binding
+    entered = threading.Event()
+    release = threading.Event()
+
+    def delayed_upsert(*args: Any, **kwargs: Any) -> Any:
+        entered.set()
+        assert release.wait(timeout=5)
+        return original_upsert(*args, **kwargs)
+
+    store.upsert_binding = delayed_upsert
+    task = asyncio.create_task(rebind_session(core, store, binding, "target"))
+    assert await asyncio.to_thread(entered.wait, 5)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert task.done() is False
+    assert process_lifecycle.get_session_request_gate(core, "current").locked()
+    assert process_lifecycle.get_session_request_gate(core, "target").locked()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    rebound = store.get_binding(binding.address_key)
+    assert rebound is not None
+    assert rebound.session_id == "target"
+    assert not process_lifecycle.get_session_request_gate(core, "current").locked()
+    assert not process_lifecycle.get_session_request_gate(core, "target").locked()


### PR DESCRIPTION
## Summary

Adds the curated Telegram controls requested after the live smoke test, stacked on #87.

- add session-scoped `/model`, `/reasoning`, and `/fast` controls with direct commands and durable inline pickers
- add bounded owner-lane `/sessions` history and safe one-tap rebinding
- add curated `/settings` for model, reasoning, fast mode, plan/build mode, session, permissions, and per-binding streaming
- resolve a fresh request-owned runtime inside the session gate; never mutate process-global model state or expose credentials
- keep control callbacks recipient-scoped, restart-safe, replay-safe, lease-renewed, paginated, and stale/busy fail-closed
- preserve configured-agent ownership and make failed session preference saves transactional across memory, index, primary file, and backup
- document the controls and intentionally omit arbitrary Telegram YAML editing

## Why

The first Telegram smoke test showed that approvals worked but also highlighted the need for TUI-style model/session controls. These controls belong to the Penguin session or Telegram binding, not the server-wide configuration, so switching a Telegram lane cannot race or reconfigure unrelated clients.

## Validation

- `TELEGRAM_BOT_TOKEN=test-only-token uv run pytest -q tests/channels tests/integrations/telegram tests/core_runtime/test_process_lifecycle.py` — 235 passed
- Ruff check and format check across channel and Telegram source/tests
- Python 3.9 byte-compilation of all changed runtime modules
- credential-pattern scan clean
- `manager.py` and `store.py` remain below 2,000 lines

## Stack

- Base: #87 (`codex/penguin-telegram-phases-0-5`)
- This PR contains only the Telegram controls follow-up.