### PR TITLE
feat: add opt-in OpenCode V2 TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,70 @@ jobs:
             tests/api/test_sse_and_status_scoping.py \
             tests/api/test_session_view_service.py
 
+  opencode-v2-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.9"
+            pydantic-spec: "pydantic==1.10.24"
+          - python-version: "3.12"
+            pydantic-spec: "pydantic>=2,<3"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install Penguin development dependencies
+        run: python -m pip install -e '.[dev]' '${{ matrix.pydantic-spec }}'
+      - name: Check V2 compatibility and launcher modules
+        run: |
+          ruff check \
+            penguin/cli/opencode_launcher.py \
+            penguin/web/opencode_v2_routes.py \
+            penguin/web/services/link_inference.py \
+            penguin/web/services/opencode_v2.py \
+            penguin/web/services/opencode_v2_events.py \
+            penguin/web/services/opencode_v2_interactions.py \
+            tests/test_opencode_launcher.py \
+            tests/test_opencode_v2_plugin.py \
+            tests/api/test_opencode_v2_routes.py \
+            tests/api/test_opencode_v2_events.py \
+            tests/web/test_link_inference_service.py
+          ruff check --select E,F,I \
+            penguin/web/middleware/auth.py \
+            tests/api/test_web_auth_hardening.py
+          ruff format --check \
+            penguin/cli/opencode_launcher.py \
+            penguin/web/middleware/auth.py \
+            penguin/web/opencode_v2_routes.py \
+            penguin/web/services/link_inference.py \
+            penguin/web/services/opencode_v2.py \
+            penguin/web/services/opencode_v2_events.py \
+            penguin/web/services/opencode_v2_interactions.py \
+            tests/test_opencode_launcher.py \
+            tests/test_opencode_v2_plugin.py \
+            tests/api/test_web_auth_hardening.py \
+            tests/api/test_opencode_v2_routes.py \
+            tests/api/test_opencode_v2_events.py \
+            tests/web/test_link_inference_service.py
+      - name: Run V2 protocol, launcher, and auth contracts
+        run: |
+          pytest -q \
+            tests/api/test_opencode_v2_routes.py \
+            tests/api/test_opencode_v2_events.py \
+            tests/test_opencode_launcher.py \
+            tests/test_opencode_v2_plugin.py \
+            tests/test_cli_entrypoint_dispatcher.py \
+            tests/web/test_link_inference_service.py
+          pytest -q tests/api/test_web_auth_hardening.py \
+            -k 'opencode_basic or startup_token_from_non_loopback or public_endpoint_matching_is_exact_for_sensitive_prefixes'
+
   tui-goal-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/publish-tui-v2.yml
+++ b/.github/workflows/publish-tui-v2.yml
@@ -1,0 +1,481 @@
+name: Publish OpenCode V2 TUI sidecars
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  OPENCODE_V2_VERSION: "0.0.0-next-17220"
+  OPENCODE_V2_UPSTREAM_COMMIT: "b35c5fc98577b77d8d67d298c6254e0cd138c9d5"
+  OPENCODE_V2_PUBLISH_RUN: "17220"
+  OPENCODE_V2_PUBLISHED_AT: "2026-08-11T21:25:30.838Z"
+  OPENCODE_V2_BUN_VERSION: "1.3.14"
+  OPENCODE_V2_WRAPPER_INTEGRITY: "sha512-Gy/CJAoYc+8xm1sgyb7XciWnwc0n7XjDYi01XQqtVH+wO0UAHW+T5FTH9Oh7usku0Cf4XflQieSurpgnMVg3sg=="
+  OPENCODE_V2_MUSL_TEST_IMAGE: "alpine:3.22.5@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce"
+
+jobs:
+  verify-upstream-package-map:
+    name: Verify immutable OpenCode V2 package map
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify wrapper and platform pins
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          spec="@opencode-ai/cli@${OPENCODE_V2_VERSION}"
+          mkdir -p .opencode2-wrapper/pack .opencode2-wrapper/extract
+          pushd .opencode2-wrapper/pack >/dev/null
+          registry_integrity="$(npm view "$spec" dist.integrity)"
+          published_at="$(npm view "$spec" "time[${OPENCODE_V2_VERSION}]")"
+          pack_json="$(npm pack "$spec" --ignore-scripts --json)"
+          tarball="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8"))[0]; process.stdout.write(p.filename)' <<<"$pack_json")"
+          packed_integrity="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8"))[0]; process.stdout.write(p.integrity)' <<<"$pack_json")"
+          test "$OPENCODE_V2_VERSION" = "0.0.0-next-${OPENCODE_V2_PUBLISH_RUN}"
+          test "$published_at" = "$OPENCODE_V2_PUBLISHED_AT"
+          test "$registry_integrity" = "$OPENCODE_V2_WRAPPER_INTEGRITY"
+          test "$packed_integrity" = "$OPENCODE_V2_WRAPPER_INTEGRITY"
+          tar -xzf "$tarball" -C ../extract
+          popd >/dev/null
+
+          WRAPPER_MANIFEST=.opencode2-wrapper/extract/package/package.json \
+            node <<'NODE'
+          const assert = require("node:assert/strict")
+          const manifest = require(`./${process.env.WRAPPER_MANIFEST}`)
+          const expected = [
+            "darwin-arm64",
+            "darwin-x64",
+            "darwin-x64-baseline",
+            "linux-arm64",
+            "linux-arm64-musl",
+            "linux-x64",
+            "linux-x64-baseline",
+            "linux-x64-musl",
+            "linux-x64-baseline-musl",
+            "windows-arm64",
+            "windows-x64",
+            "windows-x64-baseline",
+          ].map((target) => `@opencode-ai/cli-${target}`)
+          const dependencies = manifest.optionalDependencies ?? {}
+
+          assert.equal(manifest.name, "@opencode-ai/cli")
+          assert.equal(manifest.version, process.env.OPENCODE_V2_VERSION)
+          assert.equal(manifest.bin?.opencode2, "./bin/opencode2.exe")
+          assert.equal(manifest.scripts?.postinstall, "node ./postinstall.mjs")
+          assert.deepEqual(Object.keys(dependencies).sort(), expected.sort())
+          for (const name of expected) {
+            assert.equal(dependencies[name], process.env.OPENCODE_V2_VERSION)
+          }
+          NODE
+
+          echo "OpenCode source: ${OPENCODE_V2_UPSTREAM_COMMIT}"
+          echo "OpenCode package: ${spec}"
+
+  verify-plugin-abi:
+    name: Verify Penguin plugin against pinned V2 ABI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Penguin
+        uses: actions/checkout@v4
+
+      - name: Checkout pinned OpenCode ABI
+        uses: actions/checkout@v4
+        with:
+          repository: anomalyco/opencode
+          ref: ${{ env.OPENCODE_V2_UPSTREAM_COMMIT }}
+          path: .opencode2-upstream
+          persist-credentials: false
+
+      - name: Setup pinned Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.OPENCODE_V2_BUN_VERSION }}
+
+      - name: Typecheck, build, and import packaged plugin
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(bun --version)" = "$OPENCODE_V2_BUN_VERSION"
+          test "$(git -C .opencode2-upstream rev-parse HEAD)" = "$OPENCODE_V2_UPSTREAM_COMMIT"
+          cp penguin-tui-v2/plugins/tui/penguin.tsx \
+            .opencode2-upstream/packages/plugin/test/penguin.tsx
+
+          cd .opencode2-upstream
+          bun install --frozen-lockfile --ignore-scripts --filter @opencode-ai/plugin
+          tsc=packages/plugin/node_modules/typescript/bin/tsc
+          test "$(bun "$tsc" --version)" = "Version 5.8.2"
+          bun "$tsc" --noEmit --strict --skipLibCheck \
+            --module preserve --moduleResolution bundler --target ESNext \
+            packages/plugin/test/penguin.tsx
+          mkdir -p .opencode/plugin-abi
+          bun build packages/plugin/test/penguin.tsx --target bun \
+            --outfile .opencode/plugin-abi/penguin.js
+          bun -e '
+            const plugin = (await import("./.opencode/plugin-abi/penguin.js")).default
+            if (plugin.id !== "penguin.product" || typeof plugin.setup !== "function") {
+              process.exit(1)
+            }
+          '
+
+  package-v2-sidecar:
+    name: Package OpenCode V2 (${{ matrix.target }})
+    needs:
+      - verify-upstream-package-map
+      - verify-plugin-abi
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            npm_os: linux
+            cpu: arm64
+            binary: opencode2
+            archive: opencode2-linux-arm64.tar.gz
+            format: tar.gz
+            integrity: "sha512-jBuwFbqoCj5Hql0oaVret7jEzfWvAsUwP4jg1d/fIhdun3N24zK0/a9mGgSvmQ9429JHGE/GF38/Al6ZsKPHzA=="
+          - target: linux-arm64-musl
+            runner: ubuntu-24.04-arm
+            npm_os: linux
+            cpu: arm64
+            binary: opencode2
+            archive: opencode2-linux-arm64-musl.tar.gz
+            format: tar.gz
+            integrity: "sha512-EoZ4bGskz/37vEsI8y9h5Ii08vUkvdFzWDESk93fnT1IDfCdtX89FmMdGH+gyHuvAWO+6P+2wS53hwdXkd/OUA=="
+          - target: linux-x64
+            runner: ubuntu-latest
+            npm_os: linux
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-linux-x64.tar.gz
+            format: tar.gz
+            integrity: "sha512-ErusAreVaFm8RbGWdKBMOwZemn5UurbJdZGATRjjeOtGEG6J4IUU2G6h9AeLwKpVXoVVnYQ4jVbmaMh2NKHrjA=="
+          - target: linux-x64-baseline
+            runner: ubuntu-latest
+            npm_os: linux
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-linux-x64-baseline.tar.gz
+            format: tar.gz
+            integrity: "sha512-oY+vqNvE5+66h5sA9Ab2bI65KjPnQtM8M/s4QoZXwfrpdMChzW1POm9i4yI1degMWi7c7OxceMy6KscUXoN0Dg=="
+          - target: linux-x64-musl
+            runner: ubuntu-latest
+            npm_os: linux
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-linux-x64-musl.tar.gz
+            format: tar.gz
+            integrity: "sha512-aNCpP0G58EGE17LzNcTcAhrgnlVy8OKFPuXnjipp3HHcV2hwmEUDg9nlkK+o79AX6nP+ZXHnp+XQuPdaI8ChJQ=="
+          - target: linux-x64-baseline-musl
+            runner: ubuntu-latest
+            npm_os: linux
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-linux-x64-baseline-musl.tar.gz
+            format: tar.gz
+            integrity: "sha512-wcdS/OzMegT15h0PU2zh6KSn+wVim/ymTc4w3JmDGlLXERobvSSHw91Laq0vRV+0Kox3pZVvolemGQJ4eOcDlw=="
+          - target: darwin-arm64
+            runner: macos-15
+            npm_os: darwin
+            cpu: arm64
+            binary: opencode2
+            archive: opencode2-darwin-arm64.zip
+            format: zip
+            integrity: "sha512-eATJ0ZxA1zVgidDzXjPZ6fYnksHj2u6Mx0nqx2uPXIJeYuGNYsJmR4ufJXaCGm7UicocNrCwt9/yB7j0en5roQ=="
+          - target: darwin-x64
+            runner: macos-15-intel
+            npm_os: darwin
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-darwin-x64.zip
+            format: zip
+            integrity: "sha512-TRuvoJLYLjYBAyegLCxxVJCq1Rmn2yQ05YpF+t812gKcu9klFQ0NxypTZzmLxdZ8kdzcWgGFD7A2bMdlBdTi4w=="
+          - target: darwin-x64-baseline
+            runner: macos-15-intel
+            npm_os: darwin
+            cpu: x64
+            binary: opencode2
+            archive: opencode2-darwin-x64-baseline.zip
+            format: zip
+            integrity: "sha512-4TY+i39Bb8AOpErhttSZkQ4w93q0GPwIGaXUPhfMSyWiYbQ2xBaXF42GWThlNYKgUgNu+dT+LVW690+SV6ffRg=="
+          - target: windows-x64
+            runner: windows-2025
+            npm_os: win32
+            cpu: x64
+            binary: opencode2.exe
+            archive: opencode2-windows-x64.zip
+            format: zip
+            integrity: "sha512-w4oMit599NpQWuTVGlnfb1RHJjv9M1CP0SgmylFcAJ+3qgrV2vZTJSrvD5JDqGVwfVC1+ub/Q24F/9MJKmD4Nw=="
+          - target: windows-x64-baseline
+            runner: windows-2025
+            npm_os: win32
+            cpu: x64
+            binary: opencode2.exe
+            archive: opencode2-windows-x64-baseline.zip
+            format: zip
+            integrity: "sha512-TZhHCXGYipiOwvLO2rXEo6Ad0lca0mPgbyAQMfve/FBnZVZaWZgZIw5omTSq2dQb0gJHTwCSgcRQVh4p9ZbbHg=="
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify and package immutable platform binary
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          NPM_OS: ${{ matrix.npm_os }}
+          CPU: ${{ matrix.cpu }}
+          BINARY_NAME: ${{ matrix.binary }}
+          ASSET_NAME: ${{ matrix.archive }}
+          ARCHIVE_FORMAT: ${{ matrix.format }}
+          EXPECTED_INTEGRITY: ${{ matrix.integrity }}
+        run: |
+          set -euo pipefail
+
+          test -f penguin-tui-v2/plugins/tui/penguin.tsx
+          test -f penguin-tui/LICENSE
+          test "$(node -p 'process.arch')" = "$CPU"
+
+          spec="@opencode-ai/cli-${TARGET}@${OPENCODE_V2_VERSION}"
+          mkdir -p .opencode2-work/pack .opencode2-work/extract
+          mkdir -p .opencode2-work/stage/bin
+          mkdir -p .opencode2-work/stage/plugins/tui
+          mkdir -p .opencode2-work/stage/penguin-tui dist
+
+          pushd .opencode2-work/pack >/dev/null
+          registry_integrity="$(npm view "$spec" dist.integrity)"
+          pack_json="$(npm pack "$spec" --ignore-scripts --json)"
+          tarball="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8"))[0]; process.stdout.write(p.filename)' <<<"$pack_json")"
+          packed_integrity="$(node -e 'const fs=require("node:fs"); const p=JSON.parse(fs.readFileSync(0,"utf8"))[0]; process.stdout.write(p.integrity)' <<<"$pack_json")"
+          test "$registry_integrity" = "$EXPECTED_INTEGRITY"
+          test "$packed_integrity" = "$EXPECTED_INTEGRITY"
+          tar -xzf "$tarball" -C ../extract
+          popd >/dev/null
+
+          PACKAGE_MANIFEST=.opencode2-work/extract/package/package.json \
+          EXPECTED_NAME="@opencode-ai/cli-${TARGET}" \
+            node <<'NODE'
+          const assert = require("node:assert/strict")
+          const manifest = require(`./${process.env.PACKAGE_MANIFEST}`)
+          const os = Array.isArray(manifest.os) ? manifest.os : [manifest.os]
+          const cpu = Array.isArray(manifest.cpu) ? manifest.cpu : [manifest.cpu]
+
+          assert.equal(manifest.name, process.env.EXPECTED_NAME)
+          assert.equal(manifest.version, process.env.OPENCODE_V2_VERSION)
+          assert.ok(os.includes(process.env.NPM_OS))
+          assert.ok(cpu.includes(process.env.CPU))
+          NODE
+
+          package_bin_dir=.opencode2-work/extract/package/bin
+          binary_path="${package_bin_dir}/${BINARY_NAME}"
+          test -f "$binary_path"
+          test "$(find "$package_bin_dir" -maxdepth 1 -type f ! -name '*.map' ! -name "$BINARY_NAME" | wc -l | tr -d ' ')" = "0"
+          if [[ "$TARGET" == *-musl ]]; then
+            readelf -l "$binary_path" | grep -F "/lib/ld-musl-"
+          fi
+          chmod +x "$binary_path"
+          if [[ "$TARGET" == *-musl ]]; then
+            docker_arch="$CPU"
+            if [[ "$docker_arch" == "x64" ]]; then
+              docker_arch=amd64
+            fi
+            version_output="$(
+              docker run --rm --platform "linux/${docker_arch}" \
+                --volume "$PWD:/work:ro" \
+                "$OPENCODE_V2_MUSL_TEST_IMAGE" \
+                sh -c 'apk add --no-cache libstdc++ libgcc >/dev/null && "$1" --version' \
+                sh "/work/${binary_path}"
+            )"
+          else
+            version_output="$("$binary_path" --version 2>&1)"
+          fi
+          version_output="${version_output//$'\r'/}"
+          test "$version_output" = "opencode2 v${OPENCODE_V2_VERSION}"
+
+          cp "$binary_path" ".opencode2-work/stage/bin/${BINARY_NAME}"
+          cp penguin-tui-v2/plugins/tui/penguin.tsx \
+            .opencode2-work/stage/plugins/tui/penguin.tsx
+          cp penguin-tui/LICENSE .opencode2-work/stage/penguin-tui/LICENSE
+
+          python_command=python
+          if ! command -v "$python_command" >/dev/null; then
+            python_command=python3
+          fi
+          STAGE_ROOT=.opencode2-work/stage \
+          ASSET_PATH="dist/${ASSET_NAME}" \
+            "$python_command" - <<'PY'
+          import os
+          import tarfile
+          import zipfile
+          from pathlib import Path
+
+          stage = Path(os.environ["STAGE_ROOT"])
+          asset = Path(os.environ["ASSET_PATH"])
+          names = [
+              f"bin/{os.environ['BINARY_NAME']}",
+              "plugins/tui/penguin.tsx",
+              "penguin-tui/LICENSE",
+          ]
+
+          if os.environ["ARCHIVE_FORMAT"] == "tar.gz":
+              with tarfile.open(asset, "w:gz") as archive:
+                  for name in names:
+                      archive.add(stage / name, arcname=name, recursive=False)
+              with tarfile.open(asset, "r:gz") as archive:
+                  packaged = archive.getnames()
+          else:
+              with zipfile.ZipFile(
+                  asset, "w", compression=zipfile.ZIP_DEFLATED
+              ) as archive:
+                  for name in names:
+                      archive.write(stage / name, arcname=name)
+              with zipfile.ZipFile(asset, "r") as archive:
+                  packaged = archive.namelist()
+
+          if packaged != names:
+              raise SystemExit(f"unexpected archive layout: {packaged}")
+          print(f"packaged {asset}")
+          PY
+
+          echo "OpenCode source: ${OPENCODE_V2_UPSTREAM_COMMIT}"
+          echo "OpenCode package: ${spec}"
+          sha256sum "dist/${ASSET_NAME}" || shasum -a 256 "dist/${ASSET_NAME}"
+
+      - name: Upload packaged sidecar
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode2-v2-${{ matrix.target }}
+          path: dist/${{ matrix.archive }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  assemble-v2-sidecars:
+    name: Assemble OpenCode V2 sidecars
+    needs: package-v2-sidecar
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download packaged sidecars
+        uses: actions/download-artifact@v4
+        with:
+          pattern: opencode2-v2-*
+          path: dist
+          merge-multiple: true
+
+      - name: Verify matrix and write checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected=(
+            opencode2-darwin-arm64.zip
+            opencode2-darwin-x64.zip
+            opencode2-darwin-x64-baseline.zip
+            opencode2-linux-arm64.tar.gz
+            opencode2-linux-arm64-musl.tar.gz
+            opencode2-linux-x64.tar.gz
+            opencode2-linux-x64-baseline.tar.gz
+            opencode2-linux-x64-musl.tar.gz
+            opencode2-linux-x64-baseline-musl.tar.gz
+            opencode2-windows-x64.zip
+            opencode2-windows-x64-baseline.zip
+          )
+
+          test "$(find dist -maxdepth 1 -type f | wc -l | tr -d ' ')" = "${#expected[@]}"
+          for asset in "${expected[@]}"; do
+            test -f "dist/${asset}"
+          done
+          (
+            cd dist
+            sha256sum "${expected[@]}" > opencode2-SHA256SUMS.txt
+          )
+          cat dist/opencode2-SHA256SUMS.txt
+
+      - name: Upload complete V2 sidecar set
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode2-v2-release-assets
+          path: dist
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  publish-release-assets:
+    name: Publish OpenCode V2 release assets
+    needs: assemble-v2-sidecars
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download complete V2 sidecar set
+        uses: actions/download-artifact@v4
+        with:
+          name: opencode2-v2-release-assets
+          path: dist
+
+      - name: Attach V2 assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/opencode2-*.zip
+            dist/opencode2-*.tar.gz
+            dist/opencode2-SHA256SUMS.txt
+          fail_on_unmatched_files: true
+
+      - name: Verify GitHub release digests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            > "$RUNNER_TEMP/release.json"
+          RELEASE_JSON="$RUNNER_TEMP/release.json" node <<'NODE'
+          const assert = require("node:assert/strict")
+          const fs = require("node:fs")
+          const release = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON, "utf8"))
+          const expected = fs.readdirSync("dist").filter((name) =>
+            name === "opencode2-SHA256SUMS.txt" ||
+              name.endsWith(".zip") ||
+              name.endsWith(".tar.gz")
+          )
+          const assets = new Map(release.assets.map((asset) => [asset.name, asset]))
+
+          assert.equal(expected.length, 12)
+          for (const name of expected) {
+            const digest = assets.get(name)?.digest ?? ""
+            assert.match(digest, /^sha256:[0-9a-f]{64}$/)
+          }
+          NODE

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ The Penguin TUI launcher supports both development and packaged installs.
 - In a source checkout, `penguin` prefers local `penguin-tui/packages/opencode` sources.
 - Outside a source checkout, it bootstraps a cached sidecar binary under `~/.cache/penguin/tui`.
 - Stable installs prefer a sidecar that matches the installed Penguin version.
+- OpenCode 2 is available as a parallel beta client. It never replaces the
+  default TUI or its cache.
 - You can override the source or binary path when needed:
 
 ```bash
@@ -235,6 +237,22 @@ export PENGUIN_TUI_BIN_PATH="/path/to/opencode"
 ```
 
 You can also override the release endpoint for staging/testing with `PENGUIN_TUI_RELEASE_URL`.
+
+To try the pinned OpenCode 2 client, opt in explicitly:
+
+```bash
+export PENGUIN_TUI_V2=1
+penguin .
+```
+
+The V2 path uses `opencode2`, `--server`, a separate `~/.cache/penguin/tui/v2`
+cache, and the same Penguin backend data. Unset `PENGUIN_TUI_V2` for immediate
+rollback. For a local V2 artifact, set `PENGUIN_TUI_BIN_PATH` to its
+`opencode2` binary and set `OPENCODE_CONFIG_DIR` to the extracted sidecar root
+that contains `plugins/tui/penguin.tsx`. The launcher preserves an explicit
+`OPENCODE_PASSWORD`; otherwise it uses the first configured `PENGUIN_API_KEYS`
+entry or the local startup token. V2 remains beta: its server, plugin, and
+configuration contracts may change between upstream pins.
 
 ## Common Commands
 

--- a/context/process/release-runbook.md
+++ b/context/process/release-runbook.md
@@ -37,6 +37,13 @@ Run the core launcher/packaging and subagent/TUI parity suites first.
 pytest -q tests/test_opencode_launcher.py tests/test_cli_entrypoint_dispatcher.py
 
 pytest -q \
+  tests/api/test_opencode_v2_routes.py \
+  tests/api/test_opencode_v2_events.py
+
+pytest -q tests/api/test_web_auth_hardening.py \
+  -k 'opencode_basic or startup_token_from_non_loopback'
+
+pytest -q \
   tests/test_core_tool_mapping.py \
   tests/test_action_executor_subagent_events.py \
   tests/tools/test_sub_agent_tools.py \
@@ -68,6 +75,50 @@ What to verify:
 - all expected platform jobs succeed
 - sidecar archives are produced
 - no branch-specific trigger assumptions remain
+
+For an opt-in OpenCode 2 release, dispatch the isolated workflow separately:
+
+```bash
+gh workflow run publish-tui-v2.yml --ref main
+v2_run_id="$(
+  gh run list --workflow publish-tui-v2.yml --event workflow_dispatch \
+    --branch main --limit 1 --json databaseId --jq '.[0].databaseId'
+)"
+gh run watch "$v2_run_id" --exit-status
+```
+
+Verify that every archive is named `opencode2-<platform>`, contains
+`opencode2` (or `opencode2.exe`), reports the pinned prerelease from
+`--version`, and has an entry in `opencode2-SHA256SUMS.txt`. Never accept a
+similarly numbered package that contains the older `lildax` binary.
+
+Download the complete manual-run artifact and smoke the exact sidecar that will
+be attached to the release. This example selects Apple Silicon; choose the
+matching archive on another host.
+
+```bash
+v2_smoke_root="$(mktemp -d)"
+gh run download "$v2_run_id" --name opencode2-v2-release-assets \
+  --dir "$v2_smoke_root/artifacts"
+(
+  cd "$v2_smoke_root/artifacts"
+  shasum -a 256 -c opencode2-SHA256SUMS.txt
+)
+unzip -q "$v2_smoke_root/artifacts/opencode2-darwin-arm64.zip" \
+  -d "$v2_smoke_root/sidecar"
+
+test "$("$v2_smoke_root/sidecar/bin/opencode2" --version)" = \
+  "opencode2 v0.0.0-next-17220"
+test -f "$v2_smoke_root/sidecar/plugins/tui/penguin.tsx"
+
+PENGUIN_TUI_V2=1 \
+PENGUIN_TUI_BIN_PATH="$v2_smoke_root/sidecar/bin/opencode2" \
+OPENCODE_CONFIG_DIR="$v2_smoke_root/sidecar" \
+  penguin .
+```
+
+In the TUI, run `/penguin` and confirm the Penguin status command appears and
+shows the active project. Do not tag unless this extracted-artifact smoke passes.
 
 ### 3b. Python publish workflow sanity check
 
@@ -189,6 +240,23 @@ Verify:
 - cached sidecar exists
 - `current.json` points at the expected tagged release/version metadata
 
+Repeat the packaged smoke with the manual-workflow V2 sidecar from section 3.
+Copy or download that extracted directory into the Codespace, then point the
+launcher at it explicitly:
+
+```bash
+PENGUIN_TUI_V2=1 \
+PENGUIN_TUI_BIN_PATH="/path/to/v2-sidecar/bin/opencode2" \
+OPENCODE_CONFIG_DIR="/path/to/v2-sidecar" \
+  penguin .
+```
+
+Verify Home loads, a text prompt streams to completion, restart reconnects,
+and unsetting `PENGUIN_TUI_V2` immediately launches V1 with its original cache.
+An explicit binary intentionally bypasses the V2 cache marker; automatic V2
+bootstrap and `v2/current.json` are post-tag gates in section 11, after the
+matching release assets exist.
+
 ### 5e. Optional interactive validation
 
 Inside the installed TUI, do one quick smoke test:
@@ -257,6 +325,7 @@ git push origin v0.6.2.2
 This should trigger:
 - `.github/workflows/publish.yml`
 - `.github/workflows/publish-tui.yml`
+- `.github/workflows/publish-tui-v2.yml`
 
 ## 10. Watch Release Workflows
 
@@ -267,7 +336,7 @@ gh run watch
 
 Verify:
 - Python package publishes successfully
-- TUI sidecar assets publish successfully
+- V1 and V2 TUI sidecar workflows publish successfully
 - release assets are attached to the same `v0.6.2.2` GitHub release
 
 ## 11. Post-Tag Verification
@@ -278,8 +347,26 @@ Verify:
 gh release view v0.6.2.2
 gh release download v0.6.2.2 --dir /tmp/penguin-release-assets --pattern "*.zip"
 gh release download v0.6.2.2 --dir /tmp/penguin-release-assets --pattern "*.tar.gz"
+gh release download v0.6.2.2 --dir /tmp/penguin-release-assets \
+  --pattern "opencode2-SHA256SUMS.txt"
 ls -lah /tmp/penguin-release-assets
+(
+  cd /tmp/penguin-release-assets
+  shasum -a 256 -c opencode2-SHA256SUMS.txt
+)
 ```
+
+Confirm all 11 `opencode2-*` archives and the checksum file are present. Then
+run the post-tag automatic-bootstrap gate from a clean installed environment:
+
+```bash
+PENGUIN_TUI_V2=1 penguin .
+cat ~/.cache/penguin/tui/v2/current.json
+```
+
+Verify the marker records protocol generation `v2`, the pinned upstream and
+artifact identities, and the selected platform archive. Unset
+`PENGUIN_TUI_V2` and verify the V1 marker and launcher remain unchanged.
 
 ### PyPI availability
 
@@ -291,7 +378,8 @@ python -m pip index versions penguin-ai | head -40
 
 ### Sidecar workflow fails
 
-- inspect `.github/workflows/publish-tui.yml`
+- inspect `.github/workflows/publish-tui.yml` and
+  `.github/workflows/publish-tui-v2.yml`
 - inspect platform-specific sidecar artifact names vs `_sidecar_platform_candidates()` in
   `penguin/cli/opencode_launcher.py`
 
@@ -306,6 +394,8 @@ python -m pip index versions penguin-ai | head -40
 - confirm the GitHub release tag exists: `v0.6.2.2`
 - confirm sidecar assets were attached to that exact release
 - inspect `~/.cache/penguin/tui/current.json`
+- for V2, inspect `~/.cache/penguin/tui/v2/current.json` and the
+  `opencode2-SHA256SUMS.txt` release asset
 
 ### PyPI package is live but sidecar assets are missing
 
@@ -322,3 +412,5 @@ The release is good when all of the following are true:
 - local macOS clean-venv test passes
 - `v0.6.2.2` tag publishes both Python package and matching sidecar assets
 - the installed launcher pulls a version-matched sidecar by default
+- the opt-in V2 launcher verifies and caches one of the 11 pinned V2 archives
+  without changing the V1 cache or default

--- a/context/tasks/penguin-tui-opencode-v2.md
+++ b/context/tasks/penguin-tui-opencode-v2.md
@@ -1,0 +1,263 @@
+# Penguin TUI OpenCode 2 Sync
+
+## Goal
+
+Adopt OpenCode 2's TUI as a parallel Penguin client without replacing Penguin's
+runtime, provider execution, session storage, permission model, or canonical
+runtime-event ledger. Ship the migration as reversible vertical slices, then
+retire the current OpenCode 1-derived TUI only after parity is proven.
+
+## Pinned Upstream
+
+- Repository: `https://github.com/anomalyco/opencode`
+- Branch: `v2`
+- Commit: `b35c5fc98577b77d8d67d298c6254e0cd138c9d5`
+- Commit date: `2026-08-11T21:05:36Z`
+- CLI source manifest: `1.18.4` (`opencode2`)
+- Immutable binary artifact: `@opencode-ai/cli@0.0.0-next-17220`
+- Bun: `1.3.14`
+- OpenTUI: `0.0.0-20260808-9ecf7c0a`
+
+The pin moves only after its contract fixtures and smoke checks pass. The beta
+branch is not merged or rebased directly into `penguin-tui/`.
+
+OpenCode documents V2 as a beta with three intentional migration breaks: the
+plugin API, server/client contracts, and TUI configuration. It installs as the
+parallel `opencode2` binary. Penguin therefore treats every upstream refresh as
+a protocol migration, never as a routine dependency bump.
+
+The move from the initial audit pin `2b7bd848…` to `b35c5fc…` changed only
+OpenCode core provider/configuration code, skills, and documentation; no TUI,
+generated client, schema, protocol, or CLI contract file changed. The final pin
+is also the source commit for the successful `next-17220` package publish. The
+captured wire fixtures therefore remain the pin gate for Penguin's
+compatibility boundary.
+
+The similarly numbered stable platform package
+`@opencode-ai/cli-<platform>@1.18.4` is not the V2 artifact: registry inspection
+shows it contains `lildax`, not `opencode2`. Release automation must use the
+exact `0.0.0-next-17220` wrapper/platform dependency set and must execute the
+extracted binary's `--version` check before packaging.
+
+### Moving-head observation
+
+The `v2` branch was rechecked on 2026-08-11 at
+`57b636df00d8ff81973f9406df655afea3cc91ab`; this is an observation, not the
+tested artifact pin. The range from `b35c5fc…` changes three adoption contracts:
+
+- the TUI plugin API replaces `ui.slot(name, render)` with a hierarchical slot
+  claim (`prepend`, `append`, `before`, `after`, or `replace`);
+- generated project-copy client paths move from `/experimental/project/*` to
+  `/api/experimental/project/*`; and
+- session interruption gains an optional `continue=true` query that resumes
+  durable pending work after the active execution stops.
+
+Neither change is silently absorbed. Penguin does not expose project-copy in
+the first supported slice, and its plugin remains compiled for `next-17220`.
+The next immutable artifact refresh must port the Penguin slot claim and
+refresh the generated-client fixture before advancing the pin. It must not
+accept `continue=true` until Penguin has the durable queued-work semantics that
+flag promises. Directory autocomplete and experimental per-tab prompt drafts
+are upstream-owned TUI UX that Penguin should adopt unchanged at that refresh.
+Other observed changes in the range (embedded web UI, pair-screen labeling,
+and core import normalization) stay outside Penguin's compatibility boundary.
+
+## Upstream Capability Ledger
+
+The pinned V2 client is a service-driven rewrite, not an incremental update to
+the current OpenCode 1-derived fork. Its useful adoption surface is:
+
+| Capability | V2 surface | Penguin sync decision |
+| --- | --- | --- |
+| Home, project, and session navigation | Location, project, VCS, session catalogs | Adopt through read-only projections |
+| Streaming transcript and composer | Prompt admission plus native session events | Phase 2 tracer bullet |
+| Agent, model, and variant selection | Location catalogs and session-scoped selection | Project Penguin choices; keep execution in Penguin |
+| Permissions, questions, and forms | Session request resources and event updates | Adapt existing approvals/questions; add forms only for real producers |
+| Child, queued, and background sessions | Session families, pending inputs, tabs | Parent/child CRUD first; defer queued/background UX until durable inbox tests |
+| Diffs, snapshots, undo, and redo | Session change/snapshot resources | Defer until Penguin has truthful reversible state |
+| Commands, skills, references, MCP, and integrations | Boot-time capability catalogs | Return valid empty catalogs first; expose only implemented capabilities |
+| Shell and terminal surfaces | Shell catalog and PTY lifecycle | Reuse Penguin PTY ownership after platform smoke tests |
+| Themes, keymaps, editor, clipboard, notifications | OpenTUI-native client features | Keep upstream unless Penguin branding needs a narrow override |
+| TUI plugins, routes, tabs, commands, and slots | V2 plugin ABI | Preferred Phase 4 Penguin extension seam |
+| Mini, debug log, simulations, and story surfaces | Optional development packages | Explicitly outside the first production closure |
+
+The initial source closure, if a branded source build becomes necessary, is the
+TUI, generated promise client, schemas, protocol, theme, and thin TUI plugin
+ABI. OpenCode core, server, database, providers, AI runtime, simulations, and
+browser UI remain outside Penguin.
+
+## Protocol Support Ledger
+
+| Contract group | First supported slice | Later work |
+| --- | --- | --- |
+| Health and connection | `/api/health`; `server.connected` first on `/api/event` | Diagnostics only |
+| Location and project | location, filesystem list, project/current, VCS | Multiple worktrees/workspaces |
+| Sessions | create (including parent), list, active, get, rename, agent/model selection, recursive delete | Fork/share/revert/summarize |
+| Messages and prompt | history and single-flight text admission; reject queue/busy steer | Durable queued input, attachments, and richer input types |
+| Native events | admitted/promoted, execution, step, text, and tool lifecycle | Reasoning, compaction, shell, and snapshot events |
+| Interrupt | Existing Penguin session abort | No second cancellation path |
+| Permissions and forms | Manager-backed approval/question resources, replies, cancellation, and reconnect hydration | Producers beyond Penguin's existing managers |
+| Boot catalogs | Usable agent/model/provider; exact empty envelopes elsewhere | Enable each catalog only with truthful data |
+| Durable replay | Penguin ledger remains canonical; reconnect rehydrates REST | Experimental V2 aggregate log only if the TUI requires it |
+
+Unsupported fields are rejected or omitted; they are never silently accepted.
+
+## Upstream Refresh Procedure
+
+1. Fetch `origin/v2` and record its full commit, CLI version, Bun version, and
+   OpenTUI pin.
+2. Classify the commit range before changing Penguin. Review changes under
+   `packages/tui`, `client`, `schema`, `protocol`, `theme`, the TUI plugin ABI,
+   and the CLI server-connection/argument code. Core-only changes do not enter
+   Penguin's compatibility layer.
+3. Refresh protocol fixtures and run the Python contract suite against both
+   Python 3.9 and 3.12. A schema or generated-client change blocks the pin move
+   until the projector is updated.
+4. Run the pinned `opencode2` artifact against a fake-provider Penguin backend:
+   Home boot, session create, prompt lifecycle, reconnect, interrupt, and reopen.
+5. Publish a separately named, checksummed V2 sidecar. Never overwrite a V1
+   asset or cache marker, and never let the upstream binary auto-update itself.
+6. Land Penguin adapters separately from a mechanical source refresh. If source
+   vendoring becomes necessary, preserve the upstream commit as a distinct
+   commit so the overlay remains reviewable.
+
+Every refresh retains the current V1 launcher as the rollback path.
+
+## Ownership Boundary
+
+| Surface | Owner | Strategy |
+| --- | --- | --- |
+| Reasoning loop, providers, tools, CWM | Penguin | Keep |
+| Sessions, permissions, questions, runtime ledger | Penguin | Keep |
+| `/api/*` OpenCode 2 protocol | Penguin compatibility layer | Project |
+| TUI rendering, navigation, themes, diff UI | OpenCode 2 | Adopt |
+| Penguin commands, themes, task/goal UX | Penguin extension | Isolate |
+| OpenCode core, database, provider runtime | OpenCode | Do not import |
+
+OpenCode payloads are compatibility projections. They are not Penguin's
+internal event or persistence vocabulary.
+
+## Phases
+
+### 1. Pin and classify
+
+- [x] Create an isolated worktree and branch.
+- [x] Pin the current OpenCode 2 commit and dependency baseline.
+- [x] Record the ownership boundary and adoption order.
+- [x] Capture a focused first compatibility fixture manifest from the pin.
+
+Gate status: partially met. The immutable pin, support ledger, and focused
+health/location/session/handshake fixture are in this PR. That fixture is not a
+complete generated-client schema snapshot, so a future pin move still requires
+a fuller decoder fixture and the packaged-client smoke below.
+
+### 2. Backend compatibility slice
+
+- [x] Add thin `/api/health`, `/api/location`, `/api/session`, and `/api/event`
+      routes backed by existing Penguin services.
+- [x] Project V2 session envelopes without changing stored Penguin sessions.
+- [x] Support create, list, get, message history, prompt, and interrupt.
+- [x] Project permission/question requests; add generalized forms only where the
+      V2 TUI requires them.
+- [x] Preserve auth, directory scoping, and structured errors.
+- [x] Rehydrate pending approval/form state from Penguin's existing managers
+      across a new HTTP/SSE connection; do not add a replay ledger.
+
+Gate status: deterministic route/projector tests cover create, successful and
+early-failing prompts, stream terminals, active/idle interrupt, late tool
+terminals, interaction reconnect hydration, and reopenable persisted sessions.
+The single packaged-client create -> prompt -> interrupt -> backend restart ->
+reopen scenario remains a manual pre-release gate.
+
+### 3. Parallel V2 client
+
+- [x] Add an explicit V2 launcher selection without changing the default path.
+- [x] Prefer a pinned upstream binary/build over copying the V2 monorepo.
+- [x] Pass Penguin auth and server endpoint through the narrow launcher boundary.
+- [x] Keep the current TUI as an immediate fallback.
+
+Gate status: the exact pinned packaged binary reaches Home against Penguin and
+loads the typed `/penguin` command from the archive layout. Prompt execution and
+backend-restart reconnect remain required in the extracted-artifact release
+smoke; default V1 behavior is unchanged.
+
+### 4. Penguin extension boundary
+
+- [x] Keep transport/event translation in Penguin's server seam and auth
+      credential bridging in the launcher; add no plugin transport.
+- [x] Put the first Penguin product command in the smallest supported V2
+      plugin/slot surface.
+- [x] Do not fork upstream components for features a plugin can supply.
+
+Gate status: met for the pinned artifact. The plugin is strictly typechecked,
+built, dynamically imported, and packaged against the pinned ABI. A future
+upstream slot-claim API refresh is an explicit port, not a silent update.
+
+### 5. UX adoption
+
+Adopt in dependency order:
+
+1. [x] transcript and single-flight text composer
+2. [x] permissions, questions, and forms backed by existing managers
+3. [x] agent/model/variant selection backed by session metadata
+4. [ ] child/background session UX (parent CRUD and cascade deletion are ready)
+5. [ ] diff and undo/redo
+6. [x] project/session picker boot resources
+7. [ ] session tabs and prefetch
+8. [ ] optional mini/debug/storybook surfaces
+
+Gate: each surface has truthful backend data and a deterministic check before
+the next dependent surface is enabled.
+
+### 6. Verification
+
+- [x] Contract fixtures for supported V2 endpoints and events.
+- [x] Fake-provider create, prompt, stream, and terminal lifecycle tests.
+- [x] Native tool lifecycle, failure, and late-terminal adjacency tests.
+- [x] Duplicate, late, out-of-order, failure, and interleaved-session event tests.
+- [x] REST reconnect hydration from Penguin's canonical session and interaction
+      managers; no event replay identity is claimed.
+- [x] Permission/question reply, cancellation, and new-adapter hydration tests.
+- [x] Connection-local session isolation tests.
+- [ ] Multi-tab hydration and restart tests.
+- [ ] Native tool replay adjacency and CWM category-priority tests.
+- [ ] PTY smoke tests on supported sidecar platforms.
+
+Gate status: Python 3.9/Pydantic 1 and Python 3.12/Pydantic 2 deterministic
+matrices are the proof for the supported slice. Multi-tab restart, native PTY,
+and CWM category-priority coverage remain deferred and are not implied by the
+V2 beta. Live providers remain opt-in smoke tests.
+
+### 7. Rollout
+
+- [x] Put the client behind an explicit opt-in selector; keep V1 as default.
+- [x] Add an isolated workflow that assembles a pinned, checksummed V2 sidecar
+      set for the same Penguin release.
+- [x] Make cache identity include Penguin version, protocol generation, platform,
+      and upstream pin.
+- [x] Document fallback and collect actionable compatibility diagnostics.
+- [x] Keep the default unchanged until packaged-install and upgrade/downgrade
+      checks justify a separate default-switch decision.
+
+Gate status: rollback is one environment change and does not migrate or delete
+user data. Actual release attachment, checksum verification, clean-wheel
+bootstrap, prompt/restart smoke, and cross-platform workflow success remain
+release-time gates; this PR prepares them but does not publish a release.
+
+## Milestone PRs
+
+1. Protocol pin and backend vertical slice (Phases 1-2).
+2. Parallel launcher and first TUI session (Phase 3).
+3. Penguin extensions and prioritized UX (Phases 4-5).
+4. Verification, packaging, and opt-in rollout (Phases 6-7).
+
+PRs may combine adjacent milestones when the smaller split would leave an
+unrunnable intermediate state.
+
+## Explicit Deferrals
+
+- Do not import OpenCode's core/database/provider runtime.
+- Do not promise full API parity before the TUI calls an endpoint.
+- Do not build a second event ledger.
+- Do not switch the default TUI during OpenCode 2 beta.
+- Do not describe Penguin's current CWM trimming as compaction.

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -204,6 +204,22 @@ A single `Esc` should return the session to idle promptly. Capture the web-serve
 
 Penguin prefers local TUI sources in a source checkout and otherwise bootstraps a cached sidecar. Advanced overrides include `PENGUIN_OPENCODE_DIR`, `PENGUIN_TUI_BIN_PATH`, and `PENGUIN_TUI_RELEASE_URL`.
 
+The OpenCode 2 beta is an explicit parallel path:
+
+```bash
+export PENGUIN_TUI_V2=1
+penguin .
+```
+
+It uses an `opencode2` sidecar and a separate `~/.cache/penguin/tui/v2` cache.
+Unset `PENGUIN_TUI_V2` to return to the default TUI without migrating or
+deleting sessions. If testing an unpublished V2 artifact, point
+`PENGUIN_TUI_BIN_PATH` at the pinned `opencode2` binary and
+`OPENCODE_CONFIG_DIR` at the extracted sidecar root containing
+`plugins/tui/penguin.tsx`. An explicit `OPENCODE_PASSWORD` wins; otherwise the
+launcher bridges the first configured Penguin API key or the local startup
+token into OpenCode's Basic-auth password.
+
 ### Configuration or permissions fail
 
 Confirm the configured workspace exists and is writable. Use:

--- a/penguin-tui-v2/README.md
+++ b/penguin-tui-v2/README.md
@@ -1,0 +1,20 @@
+# Penguin OpenCode 2 extension
+
+Penguin runs the pinned upstream `opencode2` binary unchanged. This directory
+contains only Penguin-owned TUI extensions that use OpenCode 2's supported
+plugin and slot API.
+
+Release archives place `plugins/tui/penguin.tsx` next to `bin/opencode2`. The
+Penguin launcher points `OPENCODE_CONFIG_DIR` at that isolated, checksummed
+sidecar root, so OpenCode discovers the extension without writing into a user
+project or global OpenCode configuration. Explicit user configuration always
+wins.
+
+The extension may present Penguin branding and commands. It must not implement
+HTTP transport, authentication, session persistence, provider execution, or
+event translation; those remain in Penguin's server-side compatibility seam.
+If an upstream plugin ABI change breaks this file, V2 can be disabled by
+unsetting `PENGUIN_TUI_V2`, with the default V1 TUI and its cache untouched.
+
+Pinned provenance and refresh checks live in
+`context/tasks/penguin-tui-opencode-v2.md`.

--- a/penguin-tui-v2/plugins/tui/penguin.tsx
+++ b/penguin-tui-v2/plugins/tui/penguin.tsx
@@ -1,0 +1,37 @@
+import type { Plugin } from "@opencode-ai/plugin/tui"
+
+function PenguinCommands(context: Plugin.Context) {
+  context.keymap.layer(() => ({
+    mode: "global",
+    commands: [
+      {
+        id: "penguin.status",
+        title: "Penguin status",
+        description: "Show the active Penguin project and session count",
+        group: "Penguin",
+        palette: true,
+        slash: { name: "penguin" },
+        run() {
+          const directory = context.location?.directory
+          const sessions = context.data.session.list().length
+          const project = directory
+            ? context.ui.format.path(directory)
+            : "project unavailable"
+          context.ui.toast.show({
+            title: "Penguin",
+            message: `${project} · ${sessions} session${sessions === 1 ? "" : "s"}`,
+            variant: "success",
+          })
+        },
+      },
+    ],
+  }))
+  return null
+}
+
+export default {
+  id: "penguin.product",
+  setup(context: Plugin.Context) {
+    context.ui.slot("app", () => PenguinCommands(context))
+  },
+}

--- a/penguin/cli/opencode_launcher.py
+++ b/penguin/cli/opencode_launcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import atexit
+import ctypes
 import hashlib
 import importlib.metadata
 import json
@@ -15,6 +16,7 @@ import os
 import platform
 import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -38,8 +40,16 @@ LOCAL_HOSTS = {"", "localhost", "127.0.0.1", "0.0.0.0", "::1"}
 DEFAULT_TUI_RELEASE_API_ROOT = "https://api.github.com/repos/Maximooch/penguin/releases"
 DEFAULT_TUI_RELEASE_URL = f"{DEFAULT_TUI_RELEASE_API_ROOT}/latest"
 DEFAULT_WEB_URL = f"http://127.0.0.1:{DEFAULT_WEB_PORT}"
+TUI_V2_PROTOCOL_GENERATION = "v2"
+TUI_V2_UPSTREAM_PIN = "b35c5fc98577b77d8d67d298c6254e0cd138c9d5"
+TUI_V2_ARTIFACT_PIN = "@opencode-ai/cli@0.0.0-next-17220"
 _URL_MODE_CAP_CACHE: dict[str, bool] = {}
 _STARTUP_PROFILE_START = time.perf_counter()
+
+
+def _use_opencode_v2() -> bool:
+    """Return whether the parallel OpenCode V2 launcher is enabled."""
+    return os.getenv("PENGUIN_TUI_V2", "").strip() == "1"
 
 
 def _profile_startup(label: str, **details: Any) -> None:
@@ -83,7 +93,7 @@ def _normalize_base_url(raw_url: str) -> str:
 
 
 def _health_url(base_url: str) -> str:
-    """Build the Penguin health endpoint URL.
+    """Build the generation-specific Penguin health endpoint URL.
 
     Args:
         base_url: Normalized Penguin web base URL.
@@ -91,7 +101,8 @@ def _health_url(base_url: str) -> str:
     Returns:
         Health endpoint URL.
     """
-    return f"{base_url.rstrip('/')}/api/v1/health"
+    endpoint = "/api/health" if _use_opencode_v2() else "/api/v1/health"
+    return f"{base_url.rstrip('/')}{endpoint}"
 
 
 def _is_server_running(base_url: str, timeout_seconds: float = 1.0) -> bool:
@@ -102,13 +113,30 @@ def _is_server_running(base_url: str, timeout_seconds: float = 1.0) -> bool:
         timeout_seconds: HTTP timeout for the health check request.
 
     Returns:
-        True if `/api/v1/health` responds with HTTP 200, otherwise False.
+        True if the selected client's health contract is satisfied.
     """
     try:
         with urlopen(_health_url(base_url), timeout=timeout_seconds) as response:
-            status = getattr(response, "status", response.getcode())
-            return status == 200
-    except (URLError, OSError):
+            status = getattr(response, "status", None)
+            if status is None:
+                status = response.getcode()
+            if status != 200:
+                return False
+            if not _use_opencode_v2():
+                return True
+            payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict) or payload.get("healthy") is not True:
+                return False
+            version = payload.get("version")
+            pid = payload.get("pid")
+            return (
+                isinstance(version, str)
+                and bool(version.strip())
+                and isinstance(pid, int)
+                and not isinstance(pid, bool)
+                and pid > 0
+            )
+    except (json.JSONDecodeError, UnicodeDecodeError, URLError, OSError):
         return False
 
 
@@ -330,6 +358,48 @@ def _sync_local_auth_env_from_cache(base_url: str, env: dict[str, str]) -> None:
         env["PENGUIN_LOCAL_AUTH_TOKEN"] = token
 
 
+def _prepare_opencode_v2_env(env: dict[str, str]) -> None:
+    """Configure the opt-in OpenCode V2 client without changing V1."""
+    if not _use_opencode_v2():
+        return
+
+    env["OPENCODE_DISABLE_AUTOUPDATE"] = "1"
+    if env.get("OPENCODE_PASSWORD", "").strip():
+        return
+
+    api_keys = [
+        key.strip() for key in env.get("PENGUIN_API_KEYS", "").split(",") if key.strip()
+    ]
+    if api_keys:
+        env["OPENCODE_PASSWORD"] = api_keys[0]
+        return
+
+    token = env.get("PENGUIN_LOCAL_AUTH_TOKEN", "").strip()
+    if token:
+        env["OPENCODE_PASSWORD"] = token
+
+
+def _prepare_auto_v2_config_env(
+    env: dict[str, str] | None,
+    binary_path: Path,
+) -> None:
+    """Point an auto-resolved V2 client at its bundled extension root."""
+    if env is None or env.get("OPENCODE_CONFIG_DIR", "").strip():
+        return
+
+    install_root = _v2_sidecar_install_root(binary_path)
+    if install_root is None:
+        raise RuntimeError(
+            "Auto-resolved OpenCode V2 sidecar is outside its isolated cache layout"
+        )
+    plugin_path = install_root / "plugins" / "tui" / "penguin.tsx"
+    if not plugin_path.is_file():
+        raise RuntimeError(
+            "Auto-resolved OpenCode V2 sidecar is missing plugins/tui/penguin.tsx"
+        )
+    env["OPENCODE_CONFIG_DIR"] = str(install_root)
+
+
 def _find_local_opencode_dir() -> Path | None:
     """Find local `penguin-tui/packages/opencode` if present.
 
@@ -342,6 +412,9 @@ def _find_local_opencode_dir() -> Path | None:
         if (candidate / "src" / "index.ts").exists():
             return candidate
 
+    if _use_opencode_v2():
+        return None
+
     repo_root = Path(__file__).resolve().parents[2]
     candidate = repo_root / "penguin-tui" / "packages" / "opencode"
     if (candidate / "src" / "index.ts").exists():
@@ -353,11 +426,32 @@ def _sidecar_binary_name() -> str:
     return "opencode.exe" if sys.platform.startswith("win") else "opencode"
 
 
+def _v2_sidecar_binary_name() -> str:
+    return "opencode2.exe" if sys.platform.startswith("win") else "opencode2"
+
+
 def _sidecar_cache_root() -> Path:
     raw = os.getenv("PENGUIN_TUI_CACHE_DIR", "").strip()
     if raw:
         return Path(raw).expanduser().resolve()
     return Path.home() / ".cache" / "penguin" / "tui"
+
+
+def _v2_sidecar_cache_root() -> Path:
+    return _sidecar_cache_root() / TUI_V2_PROTOCOL_GENERATION
+
+
+def _v2_sidecar_install_root(binary_path: Path) -> Path | None:
+    candidate = binary_path.expanduser().resolve()
+    if candidate.name != _v2_sidecar_binary_name() or candidate.parent.name != "bin":
+        return None
+
+    install_root = candidate.parent.parent
+    try:
+        install_root.relative_to(_v2_sidecar_cache_root().resolve())
+    except ValueError:
+        return None
+    return install_root
 
 
 def _sidecar_release_url() -> str:
@@ -430,6 +524,129 @@ def _sidecar_platform_candidates() -> list[str]:
     )
 
 
+def _is_musl_linux() -> bool:
+    """Return whether the current Linux runtime is positively identified as musl."""
+    if not sys.platform.startswith("linux"):
+        return False
+
+    libc_name, _ = platform.libc_ver()
+    if libc_name.strip().lower() == "musl":
+        return True
+    if Path("/etc/alpine-release").is_file():
+        return True
+
+    try:
+        for lib_root in (Path("/lib"), Path("/usr/lib")):
+            if next(lib_root.glob("ld-musl-*.so*"), None) is not None:
+                return True
+    except OSError:
+        pass
+
+    ldd = shutil.which("ldd")
+    if not ldd:
+        return False
+    try:
+        result = subprocess.run(
+            [ldd, "--version"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "musl" in f"{result.stdout}\n{result.stderr}".lower()
+
+
+def _cpu_supports_avx2() -> bool:
+    """Return AVX2 support only when the host reports it explicitly."""
+    machine = platform.machine().strip().lower()
+    if machine not in {"amd64", "x86_64", "x64"}:
+        return False
+
+    if sys.platform.startswith("linux"):
+        try:
+            cpu_info = Path("/proc/cpuinfo").read_text(
+                encoding="utf-8", errors="ignore"
+            )
+        except OSError:
+            return False
+        for line in cpu_info.splitlines():
+            key, separator, value = line.partition(":")
+            if separator and key.strip().lower() in {"flags", "features"}:
+                if "avx2" in value.lower().split():
+                    return True
+        return False
+
+    if sys.platform == "darwin":
+        sysctl = shutil.which("sysctl")
+        if not sysctl:
+            return False
+        try:
+            result = subprocess.run(
+                [sysctl, "-n", "hw.optional.avx2_0"],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0 and result.stdout.strip() == "1"
+
+    if sys.platform.startswith("win"):
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            return bool(kernel32.IsProcessorFeaturePresent(40))
+        except (AttributeError, OSError):
+            return False
+
+    return False
+
+
+def _v2_sidecar_platform_candidates() -> list[str]:
+    """Return compatible V2 release assets in safest-first order."""
+    machine = platform.machine().strip().lower()
+    if machine in {"amd64", "x86_64", "x64"}:
+        arch = "x64"
+    elif machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    else:
+        arch = machine
+
+    prefix = "opencode2"
+    if sys.platform == "darwin":
+        if arch == "arm64":
+            return [f"{prefix}-darwin-arm64.zip"]
+        if arch == "x64":
+            baseline = f"{prefix}-darwin-x64-baseline.zip"
+            if not _cpu_supports_avx2():
+                return [baseline]
+            return [f"{prefix}-darwin-x64.zip", baseline]
+
+    if sys.platform.startswith("linux"):
+        musl = _is_musl_linux()
+        if arch == "arm64":
+            suffix = "-musl" if musl else ""
+            return [f"{prefix}-linux-arm64{suffix}.tar.gz"]
+        if arch == "x64":
+            libc_suffix = "-musl" if musl else ""
+            baseline = f"{prefix}-linux-x64-baseline{libc_suffix}.tar.gz"
+            if not _cpu_supports_avx2():
+                return [baseline]
+            return [f"{prefix}-linux-x64{libc_suffix}.tar.gz", baseline]
+
+    if sys.platform.startswith("win") and arch == "x64":
+        baseline = f"{prefix}-windows-x64-baseline.zip"
+        if not _cpu_supports_avx2():
+            return [baseline]
+        return [f"{prefix}-windows-x64.zip", baseline]
+
+    raise RuntimeError(
+        f"Unsupported OpenCode V2 sidecar platform: {sys.platform}/{machine}"
+    )
+
+
 def _read_json_url(url: str, timeout_seconds: float = 20.0) -> dict[str, Any]:
     request = Request(
         url,
@@ -488,29 +705,64 @@ def _verify_asset_digest(archive_path: Path, digest: str | None) -> None:
 
 def _extract_archive(archive_path: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
+    base = destination.resolve()
+
+    def target_for(member_name: str, archive_kind: str) -> Path:
+        target = (destination / member_name).resolve()
+        if base not in target.parents and target != base:
+            raise RuntimeError(
+                f"Unsafe path in sidecar {archive_kind} archive: {member_name}"
+            )
+        return target
+
     lower_name = archive_path.name.lower()
     if lower_name.endswith(".zip"):
         with zipfile.ZipFile(archive_path, "r") as archive:
-            for member in archive.namelist():
-                target = (destination / member).resolve()
-                if (
-                    destination.resolve() not in target.parents
-                    and target != destination.resolve()
-                ):
-                    raise RuntimeError(f"Unsafe path in sidecar zip archive: {member}")
-            archive.extractall(destination)
+            members = archive.infolist()
+            for member in members:
+                mode = member.external_attr >> 16
+                member_type = stat.S_IFMT(mode)
+                if member_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+                    raise RuntimeError(
+                        f"Unsafe member type in sidecar zip archive: {member.filename}"
+                    )
+                target_for(member.filename, "zip")
+            for member in members:
+                target = target_for(member.filename, "zip")
+                if member.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(member, "r") as source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                mode = member.external_attr >> 16
+                if mode:
+                    target.chmod(stat.S_IMODE(mode))
         return
 
     if lower_name.endswith(".tar.gz") or lower_name.endswith(".tgz"):
         with tarfile.open(archive_path, "r:gz") as archive:
-            base = destination.resolve()
-            for member in archive.getmembers():
-                target = (destination / member.name).resolve()
-                if base not in target.parents and target != base:
+            members = archive.getmembers()
+            for member in members:
+                if not member.isdir() and not member.isreg():
                     raise RuntimeError(
-                        f"Unsafe path in sidecar tar archive: {member.name}"
+                        f"Unsafe member type in sidecar tar archive: {member.name}"
                     )
-            archive.extractall(destination)
+                target_for(member.name, "tar")
+            for member in members:
+                target = target_for(member.name, "tar")
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                source = archive.extractfile(member)
+                if source is None:
+                    raise RuntimeError(
+                        f"Unreadable member in sidecar tar archive: {member.name}"
+                    )
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                target.chmod(stat.S_IMODE(member.mode))
         return
 
     raise RuntimeError(f"Unsupported sidecar archive format: {archive_path.name}")
@@ -533,6 +785,7 @@ def _read_cached_sidecar_marker(
     *,
     release_url: str,
     requested_version: str | None,
+    cache_identity: dict[str, str] | None = None,
 ) -> Path | None:
     marker = cache_root / "current.json"
     if not marker.exists():
@@ -548,6 +801,10 @@ def _read_cached_sidecar_marker(
     marker_release_url = str(data.get("release_url", "")).strip()
     if marker_release_url != release_url:
         return None
+    if cache_identity is not None:
+        for key, expected in cache_identity.items():
+            if data.get(key) != expected:
+                return None
     marker_requested_version = data.get("requested_version")
     if requested_version is not None:
         if not isinstance(marker_requested_version, str):
@@ -571,6 +828,7 @@ def _write_cached_sidecar_marker(
     asset_name: str,
     release_url: str,
     requested_version: str | None,
+    cache_identity: dict[str, str] | None = None,
 ) -> None:
     marker = cache_root / "current.json"
     payload = {
@@ -580,6 +838,8 @@ def _write_cached_sidecar_marker(
         "release_url": release_url,
         "requested_version": requested_version,
     }
+    if cache_identity is not None:
+        payload.update(cache_identity)
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
@@ -607,7 +867,56 @@ def _select_release_asset(release: dict[str, Any]) -> dict[str, Any]:
     )
 
 
-def _resolve_sidecar_binary() -> Path:
+def _select_v2_release_asset(
+    release: dict[str, Any],
+    candidates: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    assets_raw = release.get("assets")
+    assets = assets_raw if isinstance(assets_raw, list) else []
+    compatible_assets = list(candidates or _v2_sidecar_platform_candidates())
+
+    for wanted in compatible_assets:
+        for asset in assets:
+            if not isinstance(asset, dict):
+                continue
+            if str(asset.get("name", "")).strip() == wanted:
+                return asset
+
+    available = [
+        str(asset.get("name", "")).strip()
+        for asset in assets
+        if isinstance(asset, dict) and asset.get("name")
+    ]
+    raise RuntimeError(
+        "No compatible OpenCode V2 sidecar asset found for platform "
+        f"{sys.platform}/{platform.machine()}. Expected one of {compatible_assets}; "
+        f"available assets: {available}"
+    )
+
+
+def _required_v2_sha256_digest(asset: dict[str, Any]) -> str:
+    """Return a validated SHA-256 digest or reject the V2 release asset."""
+    raw_digest = asset.get("digest")
+    if not isinstance(raw_digest, str) or not raw_digest.strip():
+        raise RuntimeError(
+            "OpenCode V2 sidecar assets require a nonempty SHA-256 digest"
+        )
+    value = raw_digest.strip()
+
+    algorithm, separator, expected = value.partition(":")
+    if separator:
+        if algorithm.strip().lower() != "sha256":
+            raise RuntimeError("OpenCode V2 sidecar asset digest must use SHA-256")
+        value = expected.strip()
+
+    if len(value) != 64 or any(
+        character not in "0123456789abcdefABCDEF" for character in value
+    ):
+        raise RuntimeError("OpenCode V2 sidecar asset has an invalid SHA-256 digest")
+    return f"sha256:{value.lower()}"
+
+
+def _resolve_v1_sidecar_binary() -> Path:
     explicit_path = os.getenv("PENGUIN_TUI_BIN_PATH", "").strip()
     if explicit_path:
         candidate = Path(explicit_path).expanduser().resolve()
@@ -717,6 +1026,159 @@ def _resolve_sidecar_binary() -> Path:
     return binary_path
 
 
+def _v2_sidecar_cache_identity(platform_asset: str) -> dict[str, str]:
+    return {
+        "protocol_generation": TUI_V2_PROTOCOL_GENERATION,
+        "upstream_pin": TUI_V2_UPSTREAM_PIN,
+        "artifact_pin": TUI_V2_ARTIFACT_PIN,
+        "platform_asset": platform_asset,
+    }
+
+
+def _resolve_v2_sidecar_binary() -> Path:
+    explicit_path = os.getenv("PENGUIN_TUI_BIN_PATH", "").strip()
+    if explicit_path:
+        candidate = Path(explicit_path).expanduser().resolve()
+        if candidate.exists() and candidate.is_file():
+            return candidate
+        raise RuntimeError(
+            f"Configured PENGUIN_TUI_BIN_PATH does not exist: {candidate}"
+        )
+
+    override_release_url = _sidecar_release_override_url()
+    requested_version = None if override_release_url else _installed_penguin_version()
+    if requested_version is None and override_release_url is None:
+        raise RuntimeError(
+            "Unable to determine installed Penguin version for V2 sidecar lookup"
+        )
+    if override_release_url is not None:
+        release_url = override_release_url
+    else:
+        assert requested_version is not None
+        release_url = _sidecar_release_url_for_version(requested_version)
+
+    platform_candidates = _v2_sidecar_platform_candidates()
+    cache_root = _v2_sidecar_cache_root()
+    cached = None
+    for platform_asset in platform_candidates:
+        cached = _read_cached_sidecar_marker(
+            cache_root,
+            release_url=release_url,
+            requested_version=requested_version,
+            cache_identity=_v2_sidecar_cache_identity(platform_asset),
+        )
+        if cached is not None:
+            break
+    if cached is not None:
+        install_root = _v2_sidecar_install_root(cached)
+        plugin_path = (
+            install_root / "plugins" / "tui" / "penguin.tsx"
+            if install_root is not None
+            else None
+        )
+        license_path = (
+            install_root / "penguin-tui" / "LICENSE"
+            if install_root is not None
+            else None
+        )
+        if (
+            plugin_path is not None
+            and plugin_path.is_file()
+            and license_path is not None
+            and license_path.is_file()
+        ):
+            return cached
+
+    try:
+        release = _read_json_url(release_url)
+    except Exception as exc:
+        if requested_version is not None and override_release_url is None:
+            raise RuntimeError(
+                "No OpenCode V2 sidecar release metadata found for installed "
+                f"Penguin version {requested_version}. Expected GitHub release tag "
+                f"v{requested_version}."
+            ) from exc
+        raise RuntimeError(
+            f"Unable to fetch OpenCode V2 sidecar metadata from {release_url}"
+        ) from exc
+
+    try:
+        asset = _select_v2_release_asset(release, platform_candidates)
+    except RuntimeError as exc:
+        if requested_version is not None and override_release_url is None:
+            raise RuntimeError(
+                "OpenCode V2 sidecar release "
+                f"v{requested_version} does not contain a compatible asset for "
+                f"{sys.platform}/{platform.machine()}: {exc}"
+            ) from exc
+        raise
+
+    asset_name = str(asset.get("name", "")).strip()
+    asset_url = str(asset.get("browser_download_url", "")).strip()
+    if not asset_name or not asset_url:
+        raise RuntimeError(
+            "OpenCode V2 sidecar metadata is missing asset download fields"
+        )
+    digest = _required_v2_sha256_digest(asset)
+    cache_identity = _v2_sidecar_cache_identity(asset_name)
+
+    release_tag = str(release.get("tag_name", "latest")).strip() or "latest"
+    install_root = cache_root / release_tag / asset_name
+    binary_path = install_root / "bin" / _v2_sidecar_binary_name()
+
+    tmp_root = cache_root / ".tmp"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="sidecar-", dir=str(tmp_root)) as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        archive_path = tmp_dir_path / asset_name
+        _download_binary_asset(asset_url, archive_path)
+        _verify_asset_digest(archive_path, digest)
+
+        extracted_dir = tmp_dir_path / "extract"
+        _extract_archive(archive_path, extracted_dir)
+        extracted_binary = extracted_dir / "bin" / _v2_sidecar_binary_name()
+        if not extracted_binary.is_file():
+            raise RuntimeError(
+                "Downloaded OpenCode V2 sidecar archive did not contain "
+                f"'bin/{_v2_sidecar_binary_name()}'"
+            )
+        extracted_plugin = extracted_dir / "plugins" / "tui" / "penguin.tsx"
+        if not extracted_plugin.is_file():
+            raise RuntimeError(
+                "Downloaded OpenCode V2 sidecar archive did not contain "
+                "'plugins/tui/penguin.tsx'"
+            )
+        extracted_license = extracted_dir / "penguin-tui" / "LICENSE"
+        if not extracted_license.is_file():
+            raise RuntimeError(
+                "Downloaded OpenCode V2 sidecar archive did not contain "
+                "'penguin-tui/LICENSE'"
+            )
+
+        shutil.copytree(extracted_dir, install_root, dirs_exist_ok=True)
+
+    if not sys.platform.startswith("win"):
+        mode = binary_path.stat().st_mode
+        binary_path.chmod(mode | 0o755)
+
+    _write_cached_sidecar_marker(
+        cache_root,
+        binary_path=binary_path,
+        release_tag=release_tag,
+        asset_name=asset_name,
+        release_url=release_url,
+        requested_version=requested_version,
+        cache_identity=cache_identity,
+    )
+    return binary_path
+
+
+def _resolve_sidecar_binary() -> Path:
+    if _use_opencode_v2():
+        return _resolve_v2_sidecar_binary()
+    return _resolve_v1_sidecar_binary()
+
+
 def _binary_supports_url_mode(binary: str) -> bool:
     cache_key = str(Path(binary).expanduser())
     cached = _URL_MODE_CAP_CACHE.get(cache_key)
@@ -778,11 +1240,30 @@ def _build_binary_tui_command(
     return cmd
 
 
+def _build_v2_tui_command(
+    *,
+    binary: str,
+    project_dir: Path,
+    base_url: str,
+    extra_args: list[str],
+) -> list[str]:
+    """Build the OpenCode V2 server-mode invocation."""
+    cmd = [binary, str(project_dir)]
+    has_server_arg = any(
+        arg == "--server" or arg.startswith("--server=") for arg in extra_args
+    )
+    if not has_server_arg:
+        cmd.extend(["--server", base_url])
+    cmd.extend(extra_args)
+    return cmd
+
+
 def _build_opencode_command(
     project_dir: Path,
     base_url: str,
     extra_args: Sequence[str],
     use_global_opencode: bool,
+    child_env: dict[str, str] | None = None,
 ) -> tuple[list[str], Path | None]:
     """Resolve the best OpenCode command invocation.
 
@@ -792,6 +1273,8 @@ def _build_opencode_command(
         extra_args: Additional args passed through to OpenCode CLI.
         use_global_opencode: Prefer the global `opencode` binary over local
             source checkout execution.
+        child_env: Optional child environment to configure for an auto-resolved
+            V2 sidecar.
 
     Returns:
         Tuple of command argv and optional cwd for the child process.
@@ -801,11 +1284,23 @@ def _build_opencode_command(
     """
     extra = list(extra_args)
     has_url_arg = "--url" in extra
+    use_v2 = _use_opencode_v2()
     global_error = ""
 
     if use_global_opencode:
-        opencode_bin = shutil.which("opencode")
+        binary_name = "opencode2" if use_v2 else "opencode"
+        opencode_bin = shutil.which(binary_name)
         if opencode_bin:
+            if use_v2:
+                return (
+                    _build_v2_tui_command(
+                        binary=opencode_bin,
+                        project_dir=project_dir,
+                        base_url=base_url,
+                        extra_args=extra,
+                    ),
+                    None,
+                )
             cmd = _build_binary_tui_command(
                 binary=opencode_bin,
                 project_dir=project_dir,
@@ -815,7 +1310,20 @@ def _build_opencode_command(
                 require_url_mode=False,
             )
             return cmd, None
-        global_error = " Global 'opencode' binary was not found."
+        global_error = f" Global '{binary_name}' binary was not found."
+
+    explicit_binary = os.getenv("PENGUIN_TUI_BIN_PATH", "").strip()
+    if use_v2 and not use_global_opencode and explicit_binary:
+        sidecar_bin = _resolve_sidecar_binary()
+        return (
+            _build_v2_tui_command(
+                binary=str(sidecar_bin),
+                project_dir=project_dir,
+                base_url=base_url,
+                extra_args=extra,
+            ),
+            None,
+        )
 
     bun_bin = shutil.which("bun")
     local_dir = _find_local_opencode_dir()
@@ -827,10 +1335,41 @@ def _build_opencode_command(
             "./src/index.ts",
             str(project_dir),
         ]
-        if not has_url_arg:
+        if use_v2:
+            has_server_arg = any(
+                arg == "--server" or arg.startswith("--server=") for arg in extra
+            )
+            if not has_server_arg:
+                cmd.extend(["--server", base_url])
+        elif not has_url_arg:
             cmd.extend(["--url", base_url])
         cmd.extend(extra)
         return cmd, local_dir
+
+    if use_v2:
+        try:
+            sidecar_bin = _resolve_sidecar_binary()
+            if not explicit_binary:
+                _prepare_auto_v2_config_env(child_env, sidecar_bin)
+            return (
+                _build_v2_tui_command(
+                    binary=str(sidecar_bin),
+                    project_dir=project_dir,
+                    base_url=base_url,
+                    extra_args=extra,
+                ),
+                None,
+            )
+        except RuntimeError as exc:
+            sidecar_error = str(exc)
+
+        raise RuntimeError(
+            "OpenCode V2 runtime is not available. Set PENGUIN_TUI_BIN_PATH to "
+            "an 'opencode2' binary, set PENGUIN_OPENCODE_DIR to a V2 source "
+            "checkout, or use --use-global-opencode with an installed "
+            f"'opencode2' binary.{global_error} Sidecar bootstrap error: "
+            f"{sidecar_error}"
+        )
 
     try:
         sidecar_bin = _resolve_sidecar_binary()
@@ -1021,6 +1560,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "launcher.auth_cache.done",
         duration_ms=round((time.perf_counter() - cache_auth_start) * 1000),
     )
+    _prepare_opencode_v2_env(env)
 
     try:
         command_start = time.perf_counter()
@@ -1029,6 +1569,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             base_url,
             extra_args,
             use_global_opencode=args.use_global_opencode,
+            child_env=env,
         )
         _profile_startup(
             "launcher.command.done",

--- a/penguin/web/app.py
+++ b/penguin/web/app.py
@@ -169,12 +169,18 @@ def create_app() -> "FastAPI":
 
     try:
         from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
         from fastapi.responses import FileResponse
         from fastapi.staticfiles import StaticFiles
-        from fastapi.middleware.cors import CORSMiddleware
-        from .routes import router, get_capabilities
+
         from .integrations.github_webhook import router as github_webhook_router
         from .middleware.auth import AuthenticationMiddleware, AuthConfig
+        from .opencode_v2_routes import (
+            OpenCodeV2HTTPError,
+            handle_http_error as handle_opencode_v2_http_error,
+            router as opencode_v2_router,
+        )
+        from .routes import get_capabilities, router
         from .sse_events import router as sse_router, set_core_instance
     except ImportError:
         raise ImportError(
@@ -267,6 +273,7 @@ def create_app() -> "FastAPI":
     except Exception:
         logger.info("Model configs loaded: unknown")
     router.core = core
+    opencode_v2_router.core = core
     github_webhook_router.core = core
 
     # Set core for SSE router
@@ -274,8 +281,10 @@ def create_app() -> "FastAPI":
 
     # Include API routes
     app.include_router(router)
+    app.include_router(opencode_v2_router)
     app.include_router(sse_router)
     app.include_router(github_webhook_router)
+    app.add_exception_handler(OpenCodeV2HTTPError, handle_opencode_v2_http_error)
 
     # Optionally include MCP HTTP router when enabled
     try:

--- a/penguin/web/middleware/auth.py
+++ b/penguin/web/middleware/auth.py
@@ -1,27 +1,29 @@
-from __future__ import annotations
-
 """Authentication middleware and local session helpers for Penguin web API.
 
 Supports API key and JWT authentication for external clients plus a
 startup-token-to-cookie bootstrap flow for local browser sessions.
 """
 
+from __future__ import annotations
+
+import base64
+import binascii
 import logging
 import os
+import re
 import secrets
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from http.cookies import SimpleCookie
 from ipaddress import ip_address
-import re
 from threading import Lock
 from typing import Any, Optional
 
+import jwt
 from fastapi import HTTPException, Request, WebSocket, WebSocketException, status
 from fastapi.responses import JSONResponse
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.middleware.base import BaseHTTPMiddleware
-import jwt
 
 from penguin.local_auth import is_web_auth_enabled
 
@@ -48,6 +50,29 @@ LINK_SERVICE_HTTP_SCOPE = frozenset(
 )
 LINK_SERVICE_FORBIDDEN_DETAIL = (
     "The Link execution credential is not authorized for this endpoint."
+)
+_OPENCODE_V2_ROUTE_ROOTS = frozenset(
+    {
+        "agent",
+        "command",
+        "event",
+        "experimental",
+        "form",
+        "fs",
+        "health",
+        "integration",
+        "location",
+        "mcp",
+        "model",
+        "permission",
+        "project",
+        "provider",
+        "reference",
+        "session",
+        "shell",
+        "skill",
+        "vcs",
+    }
 )
 
 # Security scheme for Bearer token
@@ -127,6 +152,7 @@ class AuthConfig:
             "/api/redoc",
             "/api/openapi.json",
             "/api/v1/health",
+            "/api/health",
             "/api/v1/auth/session",
             "/api/v1/auth/logout",
             "/favicon.ico",
@@ -347,7 +373,8 @@ def build_session_cookie_settings(
     secure = request.url.scheme == "https"
     if not secure and not _is_loopback_host(host):
         raise AuthenticationError(
-            "Browser session cookies are only issued for loopback hosts or HTTPS origins"
+            "Browser session cookies are only issued for loopback hosts or "
+            "HTTPS origins"
         )
 
     return {
@@ -367,7 +394,8 @@ def build_auth_remediation(config: Optional[AuthConfig] = None) -> str:
         return (
             "Use the startup token in an X-API-Key header or authenticate via "
             "POST /api/v1/auth/session, or "
-            "restart local-only without auth using PENGUIN_AUTH_ENABLED=false uv run penguin-web."
+            "restart local-only without auth using PENGUIN_AUTH_ENABLED=false "
+            "uv run penguin-web."
         )
 
     return (
@@ -430,6 +458,42 @@ def extract_bearer_token(connection: Any) -> Optional[str]:
         return None
 
     return parts[1]
+
+
+def _is_opencode_v2_route(connection: Any) -> bool:
+    """Return whether a connection targets an allowlisted V2 route root."""
+    url = getattr(connection, "url", None)
+    path = str(getattr(url, "path", "") or "")
+    parts = path.split("/")
+    return (
+        len(parts) >= 3 and parts[1] == "api" and parts[2] in _OPENCODE_V2_ROUTE_ROOTS
+    )
+
+
+def extract_opencode_basic_password(connection: Any) -> Optional[str]:
+    """Extract a password from OpenCode V2's fixed Basic-auth identity."""
+    if not _is_opencode_v2_route(connection):
+        return None
+
+    auth_header = connection.headers.get("Authorization")
+    if not auth_header:
+        return None
+
+    auth_parts = auth_header.split(None, 1)
+    if len(auth_parts) != 2 or auth_parts[0].lower() != "basic":
+        return None
+
+    try:
+        credentials = base64.b64decode(auth_parts[1].strip(), validate=True).decode(
+            "utf-8"
+        )
+    except (binascii.Error, UnicodeDecodeError):
+        return None
+
+    username, separator, password = credentials.partition(":")
+    if separator != ":" or username != "opencode" or not password:
+        return None
+    return password
 
 
 def extract_session_cookie(
@@ -696,6 +760,22 @@ def authenticate_connection(
             }
 
         if validate_startup_token(api_key, auth_config, connection):
+            return {
+                "method": "startup_token",
+                "subject": "local_bootstrap",
+                "metadata": {"interactive": False},
+            }
+
+    basic_password = extract_opencode_basic_password(connection)
+    if basic_password:
+        if validate_api_key(basic_password, auth_config):
+            return {
+                "method": "api_key",
+                "subject": "api_client",
+                "metadata": {"key_prefix": basic_password[:8] + "..."},
+            }
+
+        if validate_startup_token(basic_password, auth_config, connection):
             return {
                 "method": "startup_token",
                 "subject": "local_bootstrap",

--- a/penguin/web/opencode_v2_routes.py
+++ b/penguin/web/opencode_v2_routes.py
@@ -1,0 +1,1053 @@
+"""Thin OpenCode 2 HTTP compatibility routes."""
+
+# FastAPI evaluates endpoint annotations at runtime on Python 3.9.
+# ruff: noqa: UP045
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import Any, AsyncIterator, Optional, cast
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from penguin.core import PenguinCore  # noqa: TC001
+from penguin.web.services.opencode_events import emit_opencode_event
+from penguin.web.services.opencode_v2 import (
+    OpenCodeV2Error,
+    active_sessions_payload,
+    agent_catalog_payload,
+    create_session_payload,
+    delete_sessions,
+    deletion_order,
+    event_payload,
+    filesystem_list_payload,
+    get_session_payload,
+    health_payload,
+    list_sessions_payload,
+    located_payload,
+    location_payload,
+    messages_payload,
+    model_catalog_payload,
+    project_current_payload,
+    projects_payload,
+    prompt_payload,
+    provider_catalog_payload,
+    rename_session,
+    switch_session_agent,
+    switch_session_model,
+    vcs_payload,
+)
+from penguin.web.services.opencode_v2_events import (
+    OpenCodeV2EventProjector,
+    server_connected_event,
+)
+from penguin.web.services.opencode_v2_interactions import (
+    InteractionNotFoundError,
+    InteractionPayloadError,
+    InteractionSettledError,
+    cancel_form_request,
+    get_form_payload,
+    get_permission_payload,
+    list_form_payloads,
+    list_permission_payloads,
+    reply_form_request,
+    reply_permission_request,
+)
+from penguin.web.services.session_events import (
+    emit_session_created_event,
+    emit_session_deleted_event,
+    emit_session_updated_event,
+)
+from penguin.web.services.session_view import get_session_info
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["OpenCode 2 compatibility"])
+router.core = None  # type: ignore[attr-defined]
+
+_EVENT_QUEUE_SIZE = 4096
+_HEARTBEAT_SECONDS = 15.0
+_NATIVE_LIFECYCLE_SOURCE_TYPES = frozenset(
+    {
+        "message.part.updated",
+        "message.updated",
+        "session.created",
+        "session.execution.interrupted",
+        "session.status",
+    }
+)
+
+
+class OpenCodeV2HTTPError(Exception):
+    """HTTP failure with an exact OpenCode 2 wire payload."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        message = payload.get("message") or payload.get("_tag") or status_code
+        super().__init__(str(message))
+        self.status_code = status_code
+        self.payload = payload
+
+
+async def handle_http_error(
+    _request: Request, exc: OpenCodeV2HTTPError
+) -> JSONResponse:
+    """Render a generated-client-decodable OpenCode 2 error."""
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
+
+
+def get_core() -> PenguinCore:
+    """Return the application-owned Penguin core."""
+    core = getattr(router, "core", None)
+    if core is None:
+        raise RuntimeError("OpenCode 2 router core is not initialized")
+    return cast("PenguinCore", core)
+
+
+def _bad_request(exc: OpenCodeV2Error) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        400,
+        {"_tag": "InvalidRequestError", "message": str(exc)},
+    )
+
+
+def _session_busy(session_id: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        409,
+        {
+            "_tag": "SessionBusyError",
+            "sessionID": session_id,
+            "message": f"Session is already running: {session_id}",
+        },
+    )
+
+
+def _not_found(session_id: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        404,
+        {
+            "_tag": "SessionNotFoundError",
+            "message": f"Session not found: {session_id}",
+            "sessionID": session_id,
+        },
+    )
+
+
+def _permission_not_found(request_id: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        404,
+        {
+            "_tag": "PermissionNotFoundError",
+            "message": f"Permission request not found: {request_id}",
+            "requestID": request_id,
+        },
+    )
+
+
+def _form_not_found(form_id: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        404,
+        {
+            "_tag": "FormNotFoundError",
+            "message": f"Form not found: {form_id}",
+            "id": form_id,
+        },
+    )
+
+
+def _form_settled(form_id: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        409,
+        {
+            "_tag": "FormAlreadySettledError",
+            "message": f"Form already settled: {form_id}",
+            "id": form_id,
+        },
+    )
+
+
+def _form_invalid(form_id: str, message: str) -> OpenCodeV2HTTPError:
+    return OpenCodeV2HTTPError(
+        400,
+        {
+            "_tag": "FormInvalidAnswerError",
+            "message": message,
+            "id": form_id,
+        },
+    )
+
+
+def _located_response(
+    core: PenguinCore,
+    data: Any,
+    *,
+    directory: Optional[str],
+    workspace: Optional[str],
+) -> dict[str, Any]:
+    try:
+        return located_payload(
+            core,
+            data,
+            directory=directory,
+            workspace_id=workspace,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.get("/api/health")
+async def health() -> dict[str, Any]:
+    """Return the OpenCode 2 process health shape."""
+    return health_payload()
+
+
+@router.get("/api/location")
+async def location(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """Resolve a deep-object V2 location query."""
+    try:
+        return location_payload(core, directory=directory, workspace_id=workspace)
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.get("/api/fs/list")
+async def filesystem_list(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+    path: Optional[str] = Query(None),
+) -> dict[str, Any]:
+    """List direct children in the requested location."""
+    try:
+        return filesystem_list_payload(
+            core,
+            directory=directory,
+            workspace_id=workspace,
+            path=path,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.get("/api/vcs")
+async def vcs_get(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """Return the current VCS branch."""
+    try:
+        return vcs_payload(
+            core,
+            directory=directory,
+            workspace_id=workspace,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.get("/api/project/current")
+async def project_current(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, str]:
+    """Resolve the project for a requested location."""
+    try:
+        return project_current_payload(
+            core,
+            directory=directory,
+            workspace_id=workspace,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.get("/api/project")
+async def project_list(
+    core: PenguinCore = Depends(get_core),
+) -> list[dict[str, Any]]:
+    """List the current Penguin project."""
+    return projects_payload(core)
+
+
+@router.get("/api/agent")
+async def agent_list(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """List usable Penguin agents in V2 shape."""
+    return _located_response(
+        core,
+        agent_catalog_payload(core),
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/model")
+async def model_list(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """List the active Penguin model in V2 shape."""
+    return _located_response(
+        core,
+        model_catalog_payload(core),
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/provider")
+async def provider_list(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """List providers referenced by Penguin's model catalog."""
+    return _located_response(
+        core,
+        provider_catalog_payload(core),
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/command")
+@router.get("/api/integration")
+@router.get("/api/mcp")
+@router.get("/api/reference")
+@router.get("/api/skill")
+@router.get("/api/shell")
+async def empty_location_catalog(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """Return an exact empty V2 location catalog for unsupported features."""
+    return _located_response(
+        core,
+        [],
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/permission/request")
+async def permission_requests(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """List pending Penguin approvals for the requested location."""
+    return _located_response(
+        core,
+        list_permission_payloads(),
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/form/request")
+async def form_requests(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """List pending Penguin questions for the requested location."""
+    return _located_response(
+        core,
+        list_form_payloads(),
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/mcp/resource")
+async def mcp_resource_catalog(
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None, alias="location[directory]"),
+    workspace: Optional[str] = Query(None, alias="location[workspace]"),
+) -> dict[str, Any]:
+    """Return the exact empty MCP resource catalog shape."""
+    return _located_response(
+        core,
+        {"resources": [], "templates": []},
+        directory=directory,
+        workspace=workspace,
+    )
+
+
+@router.get("/api/experimental/migration/v1")
+async def migration_v1_status() -> dict[str, str]:
+    """Report that Penguin does not require OpenCode's V1 history migration."""
+    return {"status": "completed"}
+
+
+@router.get("/api/session/active")
+async def session_active(core: PenguinCore = Depends(get_core)) -> dict[str, Any]:
+    """List sessions currently executing in Penguin."""
+    return active_sessions_payload(core)
+
+
+@router.get("/api/session")
+async def session_list(
+    request: Request,
+    core: PenguinCore = Depends(get_core),
+    directory: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    limit: int = Query(50),
+    order: str = Query("desc"),
+    cursor: Optional[str] = Query(None),
+) -> dict[str, Any]:
+    """List the first page of sessions in V2 shape."""
+    if cursor:
+        raise _bad_request(OpenCodeV2Error("Pagination cursors are not supported yet"))
+    parent: Optional[object] = ...
+    if "parentID" in request.query_params:
+        raw_parent = request.query_params.get("parentID")
+        parent = None if raw_parent == "null" else raw_parent
+    try:
+        return list_sessions_payload(
+            core,
+            directory=directory,
+            search=search,
+            parent_id=parent,
+            limit=limit,
+            order=order,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+
+
+@router.post("/api/session")
+async def session_create(
+    payload: Optional[dict[str, Any]] = None,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Create a Penguin-owned session through the V2 contract."""
+    request_payload = payload or {}
+    parent_id = request_payload.get("parentID")
+    if isinstance(parent_id, str) and parent_id in _deleting_sessions(core):
+        raise _session_busy(parent_id)
+    try:
+        default = location_payload(core)["directory"]
+        projected = create_session_payload(
+            core,
+            request_payload,
+            default_directory=default,
+        )
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    info = get_session_info(core, projected["id"])
+    if isinstance(info, dict):
+        await emit_session_created_event(core, info)
+    return {"data": projected}
+
+
+@router.get("/api/session/{session_id}")
+async def session_get(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Get one projected session."""
+    session = get_session_payload(core, session_id)
+    if session is None:
+        raise _not_found(session_id)
+    return {"data": session}
+
+
+@router.delete("/api/session/{session_id}")
+async def session_remove(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Delete one Penguin session and all of its descendants."""
+    deleting = _deleting_sessions(core)
+    if session_id in deleting:
+        raise _session_busy(session_id)
+    try:
+        removed_sessions = deletion_order(core, session_id)
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    if removed_sessions is None:
+        raise _not_found(session_id)
+    removed_ids = {removed["id"] for removed in removed_sessions}
+    if removed_ids & deleting:
+        raise _session_busy(session_id)
+    active = _active_session_ids(core)
+    deleting.update(removed_ids)
+    try:
+        for removed in removed_sessions:
+            removed_id = removed["id"]
+            if removed_id in active:
+                await _interrupt_active_session(core, removed_id)
+            await _await_session_idle(core, removed_id)
+        try:
+            delete_sessions(core, removed_sessions)
+        except OpenCodeV2Error as exc:
+            raise _bad_request(exc) from exc
+        for removed in removed_sessions:
+            await emit_session_deleted_event(core, _v1_session(removed))
+    finally:
+        deleting.difference_update(removed_ids)
+    return Response(status_code=204)
+
+
+@router.post("/api/session/{session_id}/rename")
+async def session_rename(
+    session_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Rename one session."""
+    try:
+        updated = rename_session(core, session_id, payload.get("title"))
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    await _emit_updated_or_404(core, session_id, updated)
+    return Response(status_code=204)
+
+
+@router.post("/api/session/{session_id}/agent")
+async def session_switch_agent(
+    session_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Persist a session-scoped Penguin agent mode."""
+    try:
+        updated = switch_session_agent(core, session_id, payload.get("agent"))
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    if updated is None:
+        raise _not_found(session_id)
+    await emit_opencode_event(
+        core,
+        "session.agent.selected",
+        {
+            "sessionID": session_id,
+            "agent": updated["agent"],
+            "directory": updated["location"]["directory"],
+        },
+    )
+    return Response(status_code=204)
+
+
+@router.post("/api/session/{session_id}/model")
+async def session_switch_model(
+    session_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Persist a session-scoped model selection."""
+    try:
+        updated = switch_session_model(core, session_id, payload.get("model"))
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    if updated is None:
+        raise _not_found(session_id)
+    await emit_opencode_event(
+        core,
+        "session.model.selected",
+        {
+            "sessionID": session_id,
+            "model": updated["model"],
+            "directory": updated["location"]["directory"],
+        },
+    )
+    return Response(status_code=204)
+
+
+@router.get("/api/session/{session_id}/message")
+async def session_messages(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+    limit: int = Query(50),
+    order: str = Query("desc"),
+    cursor: Optional[str] = Query(None),
+) -> dict[str, Any]:
+    """List projected V2 session messages."""
+    if cursor:
+        raise _bad_request(OpenCodeV2Error("Pagination cursors are not supported yet"))
+    try:
+        result = messages_payload(core, session_id, limit=limit, order=order)
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    if result is None:
+        raise _not_found(session_id)
+    return result
+
+
+@router.get("/api/session/{session_id}/pending")
+async def session_pending(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Return pending work; Penguin promotes admitted prompts immediately."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    return {"data": []}
+
+
+@router.get("/api/session/{session_id}/permission")
+async def session_permissions(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """List pending Penguin approvals owned by a session."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    return {"data": list_permission_payloads(session_id)}
+
+
+@router.get("/api/session/{session_id}/permission/{request_id}")
+async def session_permission_get(
+    session_id: str,
+    request_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Get one pending Penguin approval owned by a session."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    permission = get_permission_payload(session_id, request_id)
+    if permission is None:
+        raise _permission_not_found(request_id)
+    return {"data": permission}
+
+
+@router.post("/api/session/{session_id}/permission/{request_id}/reply")
+async def session_permission_reply(
+    session_id: str,
+    request_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Reply to one pending Penguin approval."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    try:
+        reply_permission_request(session_id, request_id, payload)
+    except InteractionPayloadError as exc:
+        raise _bad_request(OpenCodeV2Error(str(exc))) from exc
+    except InteractionNotFoundError as exc:
+        raise _permission_not_found(request_id) from exc
+    return Response(status_code=204)
+
+
+@router.get("/api/session/{session_id}/form")
+async def session_forms(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """List pending Penguin questions projected as V2 forms."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    return {"data": list_form_payloads(session_id)}
+
+
+@router.get("/api/session/{session_id}/form/{form_id}")
+async def session_form_get(
+    session_id: str,
+    form_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Get one Penguin question projected as a V2 form."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    form = get_form_payload(session_id, form_id)
+    if form is None:
+        raise _form_not_found(form_id)
+    return {"data": form}
+
+
+@router.post("/api/session/{session_id}/form/{form_id}/reply")
+async def session_form_reply(
+    session_id: str,
+    form_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Translate a V2 form answer into ordered Penguin question answers."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    try:
+        reply_form_request(session_id, form_id, payload)
+    except InteractionNotFoundError as exc:
+        raise _form_not_found(form_id) from exc
+    except InteractionSettledError as exc:
+        raise _form_settled(form_id) from exc
+    except InteractionPayloadError as exc:
+        raise _form_invalid(form_id, str(exc)) from exc
+    return Response(status_code=204)
+
+
+@router.post("/api/session/{session_id}/form/{form_id}/cancel")
+async def session_form_cancel(
+    session_id: str,
+    form_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Cancel one pending Penguin question through the V2 form contract."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    try:
+        cancel_form_request(session_id, form_id)
+    except InteractionNotFoundError as exc:
+        raise _form_not_found(form_id) from exc
+    except InteractionSettledError as exc:
+        raise _form_settled(form_id) from exc
+    return Response(status_code=204)
+
+
+@router.post("/api/session/{session_id}/prompt")
+async def session_prompt(
+    session_id: str,
+    payload: dict[str, Any],
+    core: PenguinCore = Depends(get_core),
+) -> dict[str, Any]:
+    """Admit a text prompt and run it through Penguin's existing chat path."""
+    try:
+        admitted = prompt_payload(core, session_id, payload)
+    except OpenCodeV2Error as exc:
+        raise _bad_request(exc) from exc
+    if admitted is None:
+        raise _not_found(session_id)
+    reservations = _prompt_reservations(core)
+    if session_id in _active_session_ids(core):
+        raise _session_busy(session_id)
+    reservations.add(session_id)
+    pending, request_payload = admitted
+    task = asyncio.create_task(_run_prompt(core, request_payload))
+    _prompt_tasks(core)[session_id] = task
+    return {"data": pending}
+
+
+@router.post("/api/session/{session_id}/interrupt")
+async def session_interrupt(
+    session_id: str,
+    core: PenguinCore = Depends(get_core),
+) -> Response:
+    """Interrupt a running Penguin session; idle interruption is a no-op."""
+    if get_session_payload(core, session_id) is None:
+        raise _not_found(session_id)
+    if session_id not in _active_session_ids(core):
+        return Response(status_code=204)
+    await _interrupt_active_session(core, session_id)
+    return Response(status_code=204)
+
+
+@router.get("/api/event")
+async def event_stream(core: PenguinCore = Depends(get_core)) -> StreamingResponse:
+    """Expose a volatile V2 event projection over Penguin's existing EventBus."""
+    return StreamingResponse(
+        _events(core),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+async def _emit_updated_or_404(
+    core: PenguinCore,
+    session_id: str,
+    updated: Optional[dict[str, Any]],
+) -> None:
+    if updated is None:
+        raise _not_found(session_id)
+    info = get_session_info(core, session_id)
+    if isinstance(info, dict):
+        await emit_session_updated_event(core, info)
+
+
+async def _run_prompt(core: PenguinCore, payload: dict[str, Any]) -> None:
+    from penguin.web.routes import MessageRequest, handle_chat_message
+
+    try:
+        await handle_chat_message(
+            MessageRequest(**payload), core=core, http_request=None
+        )
+    except Exception as exc:
+        logger.exception("OpenCode 2 background prompt failed")
+        await _emit_prompt_failure(core, payload, exc)
+    finally:
+        session_id = payload.get("session_id")
+        if isinstance(session_id, str):
+            _prompt_reservations(core).discard(session_id)
+            current = asyncio.current_task()
+            if _prompt_tasks(core).get(session_id) is current:
+                _prompt_tasks(core).pop(session_id, None)
+
+
+async def _emit_prompt_failure(
+    core: PenguinCore,
+    payload: dict[str, Any],
+    exc: Exception,
+) -> None:
+    """Terminate a V2 run when the shared chat path fails before streaming."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return
+
+    detail = getattr(exc, "detail", None)
+    message = detail if isinstance(detail, str) and detail else str(exc)
+    if not message:
+        message = "Penguin prompt failed before execution"
+    error_data: dict[str, Any] = {"message": message}
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int) and not isinstance(status_code, bool):
+        error_data["statusCode"] = status_code
+
+    model = payload.get("model")
+    provider_id = "penguin"
+    model_id = "penguin-default"
+    if isinstance(model, str) and "/" in model:
+        provider_id, model_id = model.split("/", 1)
+    created = int(time.time() * 1000)
+    message_id = payload.get("client_message_id")
+    part_id = payload.get("client_part_id")
+    if isinstance(message_id, str) and isinstance(part_id, str):
+        await emit_opencode_event(
+            core,
+            "message.updated",
+            {
+                "id": message_id,
+                "sessionID": session_id,
+                "role": "user",
+                "directory": payload.get("directory"),
+                "metadata": payload.get("context"),
+                "delivery": "steer",
+                "time": {"created": created},
+            },
+        )
+        await emit_opencode_event(
+            core,
+            "message.part.updated",
+            {
+                "part": {
+                    "id": part_id,
+                    "messageID": message_id,
+                    "sessionID": session_id,
+                    "type": "text",
+                    "text": payload.get("text") or "",
+                }
+            },
+        )
+    await emit_opencode_event(
+        core,
+        "message.updated",
+        {
+            "id": f"msg_{uuid.uuid4().hex}",
+            "sessionID": session_id,
+            "role": "assistant",
+            "agent": payload.get("agent_id") or "build",
+            "providerID": provider_id,
+            "modelID": model_id,
+            "directory": payload.get("directory"),
+            "time": {"created": created, "completed": created},
+            "error": {"name": "APIError", "data": error_data},
+        },
+    )
+
+
+async def _events(core: PenguinCore) -> AsyncIterator[str]:
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_EVENT_QUEUE_SIZE)
+    overflowed = asyncio.Event()
+    event_bus = getattr(core, "event_bus", None)
+    projector = OpenCodeV2EventProjector()
+    durable_sequences: dict[str, int] = {}
+
+    def handler(event_type: str, data: Any) -> None:
+        if event_type != "opencode_event" or not isinstance(data, dict):
+            return
+        source = _interrupt_source(core, data)
+        projected = projector.project(source)
+        if not projected and source.get("type") not in _NATIVE_LIFECYCLE_SOURCE_TYPES:
+            fallback = event_payload(source)
+            if fallback is not None:
+                projected = [fallback]
+        for projected_item in projected:
+            item = _sequence_durable_event(projected_item, durable_sequences)
+            try:
+                queue.put_nowait(item)
+            except asyncio.QueueFull:
+                logger.warning("OpenCode 2 event subscriber overflowed")
+                overflowed.set()
+                break
+
+    subscribe = getattr(event_bus, "subscribe", None)
+    unsubscribe = getattr(event_bus, "unsubscribe", None)
+    if callable(subscribe):
+        subscribe("opencode_event", handler)
+    try:
+        yield _frame(server_connected_event(uuid.uuid4().hex))
+        while True:
+            queued = asyncio.create_task(queue.get())
+            failed = asyncio.create_task(overflowed.wait())
+            done, pending = await asyncio.wait(
+                {queued, failed},
+                timeout=_HEARTBEAT_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            if failed in done:
+                if queued in done:
+                    queued.result()
+                return
+            if queued in done:
+                yield _frame(queued.result())
+            else:
+                yield ": heartbeat\n\n"
+    except asyncio.CancelledError:
+        return
+    finally:
+        if callable(unsubscribe):
+            unsubscribe("opencode_event", handler)
+
+
+def _interrupt_intents(core: PenguinCore) -> set[str]:
+    intents = getattr(core, "_opencode_v2_interrupt_intents", None)
+    if not isinstance(intents, set):
+        intents = set()
+        setattr(core, "_opencode_v2_interrupt_intents", intents)
+    return cast("set[str]", intents)
+
+
+def _prompt_reservations(core: PenguinCore) -> set[str]:
+    reservations = getattr(core, "_opencode_v2_prompt_reservations", None)
+    if not isinstance(reservations, set):
+        reservations = set()
+        setattr(core, "_opencode_v2_prompt_reservations", reservations)
+    return cast("set[str]", reservations)
+
+
+def _prompt_tasks(core: PenguinCore) -> dict[str, asyncio.Task[None]]:
+    tasks = getattr(core, "_opencode_v2_prompt_tasks", None)
+    if not isinstance(tasks, dict):
+        tasks = {}
+        setattr(core, "_opencode_v2_prompt_tasks", tasks)
+    return cast("dict[str, asyncio.Task[None]]", tasks)
+
+
+def _deleting_sessions(core: PenguinCore) -> set[str]:
+    sessions = getattr(core, "_opencode_v2_deleting_sessions", None)
+    if not isinstance(sessions, set):
+        sessions = set()
+        setattr(core, "_opencode_v2_deleting_sessions", sessions)
+    return cast("set[str]", sessions)
+
+
+def _active_session_ids(core: PenguinCore) -> set[str]:
+    active = active_sessions_payload(core).get("data", {})
+    return set(active) if isinstance(active, dict) else set()
+
+
+async def _interrupt_active_session(core: PenguinCore, session_id: str) -> None:
+    """Route V2 interruption through Penguin and settle its admitted task."""
+    intents = _interrupt_intents(core)
+    intents.add(session_id)
+    task = _prompt_tasks(core).get(session_id)
+    interrupted = False
+    try:
+        handler = getattr(core, "abort_session", None)
+        if callable(handler):
+            interrupted = await handler(session_id) is not False
+        if task is not None and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            interrupted = True
+        if interrupted:
+            await emit_opencode_event(
+                core,
+                "session.execution.interrupted",
+                {"sessionID": session_id, "reason": "user"},
+            )
+    finally:
+        intents.discard(session_id)
+        _prompt_reservations(core).discard(session_id)
+
+
+async def _await_session_idle(core: PenguinCore, session_id: str) -> None:
+    """Wait for Penguin's existing request tasks to settle after cancellation."""
+    tasks_map = getattr(core, "_opencode_process_tasks", None)
+    tasks = tasks_map.get(session_id, set()) if isinstance(tasks_map, dict) else set()
+    pending = [task for task in tasks if isinstance(task, asyncio.Task)]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    _prompt_reservations(core).discard(session_id)
+
+
+def _sequence_durable_event(
+    event: dict[str, Any],
+    sequences: dict[str, int],
+) -> dict[str, Any]:
+    """Assign one connection-local contiguous sequence to every durable event."""
+    durable = event.get("durable")
+    if not isinstance(durable, dict):
+        return event
+    aggregate_id = durable.get("aggregateID")
+    if not isinstance(aggregate_id, str) or not aggregate_id:
+        return event
+    sequence = sequences.get(aggregate_id, 0)
+    sequences[aggregate_id] = sequence + 1
+    normalized = dict(event)
+    normalized["durable"] = {**durable, "seq": sequence}
+    return normalized
+
+
+def _interrupt_source(core: PenguinCore, data: dict[str, Any]) -> dict[str, Any]:
+    """Translate the legacy idle emitted during a V2 cancel into interruption."""
+    if data.get("type") != "session.status":
+        return data
+    properties = data.get("properties")
+    if not isinstance(properties, dict):
+        return data
+    status = properties.get("status")
+    session_id = properties.get("sessionID")
+    if (
+        not isinstance(status, dict)
+        or status.get("type") != "idle"
+        or not isinstance(session_id, str)
+        or session_id not in _interrupt_intents(core)
+    ):
+        return data
+    translated = dict(data)
+    translated["type"] = "session.execution.interrupted"
+    translated["properties"] = {
+        "sessionID": session_id,
+        "reason": "user",
+        "directory": properties.get("directory"),
+    }
+    return translated
+
+
+def _frame(event: dict[str, Any]) -> str:
+    return f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
+
+
+def _v1_session(projected: dict[str, Any]) -> dict[str, Any]:
+    """Build the minimum legacy info needed by the shared delete emitter."""
+    return {
+        "id": projected["id"],
+        "title": projected.get("title", ""),
+        "directory": projected["location"]["directory"],
+    }
+
+
+__all__ = ["OpenCodeV2HTTPError", "get_core", "handle_http_error", "router"]

--- a/penguin/web/services/link_inference.py
+++ b/penguin/web/services/link_inference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import replace
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, PositiveInt
 
@@ -20,13 +20,15 @@ class LinkExecutionRequest(BaseModel):
     user_id: str
     # Omitted together for transient Link conversations that have no durable
     # Link session/agent-instance identity.
-    session_id: str | None = None
-    agent_id: str | None = None
+    # Pydantic 1 evaluates these annotations on Python 3.9, where ``T | None``
+    # is not a runtime expression.
+    session_id: Optional[str] = None  # noqa: UP045
+    agent_id: Optional[str] = None  # noqa: UP045
     run_id: str
     requested_model_id: str
     # Optional for rolling compatibility with Link versions that predate the
     # explicit per-invocation spend bound.
-    max_output_tokens: PositiveInt | None = None
+    max_output_tokens: Optional[PositiveInt] = None  # noqa: UP045
     execution_source: Literal["link_gateway"]
     provider_state_owner: Literal["link_managed"]
     settlement_mode: Literal["debit_link_credits"]

--- a/penguin/web/services/opencode_v2.py
+++ b/penguin/web/services/opencode_v2.py
@@ -1,0 +1,1005 @@
+"""OpenCode 2 protocol projections backed by Penguin-owned state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from penguin import __version__
+from penguin.web.services.opencode_v2_interactions import (
+    interaction_event_projection,
+)
+from penguin.web.services.provider_catalog import canonical_model_id, provider_name
+from penguin.web.services.session_view import (
+    create_session_info,
+    get_session_info,
+    get_session_messages,
+    list_session_infos,
+    list_session_statuses,
+    remove_session_info,
+    update_session_info,
+)
+from penguin.web.services.system_status import get_path_info, get_vcs_info
+
+UPSTREAM_V2_COMMIT = "b35c5fc98577b77d8d67d298c6254e0cd138c9d5"
+PROJECT_ID = "penguin"
+
+_EMPTY_TOKENS = {
+    "input": 0,
+    "output": 0,
+    "reasoning": 0,
+    "cache": {"read": 0, "write": 0},
+}
+_FINISH_REASONS = {
+    "stop",
+    "length",
+    "tool-calls",
+    "content-filter",
+    "error",
+    "unknown",
+}
+
+
+class OpenCodeV2Error(ValueError):
+    """Raised when a V2 request cannot be represented safely by Penguin."""
+
+
+def health_payload() -> dict[str, Any]:
+    """Return the pinned OpenCode 2 health contract."""
+    import os
+
+    return {"healthy": True, "version": __version__, "pid": os.getpid()}
+
+
+def location_payload(
+    core: Any,
+    *,
+    directory: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Resolve one OpenCode 2 location without changing Penguin runtime state."""
+    if directory:
+        try:
+            candidate = Path(directory).expanduser().resolve()
+        except (OSError, RuntimeError) as exc:
+            raise OpenCodeV2Error(f"Invalid directory: {directory}") from exc
+        if not candidate.is_dir():
+            raise OpenCodeV2Error(f"Directory does not exist: {directory}")
+        requested = str(candidate)
+    else:
+        requested = None
+
+    path = get_path_info(core, directory=requested)
+    resolved = str(Path(path["directory"]).resolve())
+    canonical = str(Path(path["worktree"]).resolve())
+    payload: dict[str, Any] = {
+        "directory": resolved,
+        "project": {
+            "id": PROJECT_ID,
+            "directory": canonical,
+            "canonical": canonical,
+        },
+    }
+    if workspace_id:
+        payload["workspaceID"] = workspace_id
+    return payload
+
+
+def located_payload(
+    core: Any,
+    data: Any,
+    *,
+    directory: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Wrap data in the OpenCode 2 location response contract."""
+    return {
+        "location": location_payload(
+            core,
+            directory=directory,
+            workspace_id=workspace_id,
+        ),
+        "data": data,
+    }
+
+
+def filesystem_list_payload(
+    core: Any,
+    *,
+    directory: str | None = None,
+    workspace_id: str | None = None,
+    path: str | None = None,
+) -> dict[str, Any]:
+    """List direct filesystem children without escaping the requested location."""
+    location = location_payload(
+        core,
+        directory=directory,
+        workspace_id=workspace_id,
+    )
+    base = Path(location["directory"]).resolve()
+    relative = Path(path or ".")
+    if relative.is_absolute():
+        raise OpenCodeV2Error("path must be relative")
+    try:
+        target = (base / relative).resolve()
+        target.relative_to(base)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise OpenCodeV2Error("path escapes the requested location") from exc
+    if not target.is_dir():
+        raise OpenCodeV2Error(f"Directory does not exist: {path or '.'}")
+
+    entries: list[dict[str, str]] = []
+    try:
+        children = target.iterdir()
+        for child in children:
+            if child.is_symlink():
+                continue
+            if child.is_dir():
+                entry_type = "directory"
+            elif child.is_file():
+                entry_type = "file"
+            else:
+                continue
+            entry_path = child.relative_to(base).as_posix()
+            if entry_type == "directory":
+                entry_path += "/"
+            entries.append({"path": entry_path, "type": entry_type})
+    except OSError as exc:
+        raise OpenCodeV2Error(f"Unable to list directory: {path or '.'}") from exc
+    entries.sort(key=lambda entry: (entry["type"] != "directory", entry["path"]))
+    return {"location": location, "data": entries}
+
+
+def vcs_payload(
+    core: Any,
+    *,
+    directory: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the current branch in OpenCode 2's location response shape."""
+    location = location_payload(
+        core,
+        directory=directory,
+        workspace_id=workspace_id,
+    )
+    vcs = get_vcs_info(core, directory=location["directory"], emit_events=False)
+    branch: dict[str, str] = {}
+    current = _string(vcs.get("branch"))
+    if current:
+        branch["current"] = current
+    return {"location": location, "data": {"branch": branch}}
+
+
+def project_current_payload(
+    core: Any,
+    *,
+    directory: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, str]:
+    """Resolve the current project for a location."""
+    location = location_payload(
+        core,
+        directory=directory,
+        workspace_id=workspace_id,
+    )
+    project = location["project"]
+    return {
+        "id": str(project["id"]),
+        "directory": str(project["directory"]),
+        "canonical": str(project["canonical"]),
+    }
+
+
+def projects_payload(core: Any) -> list[dict[str, Any]]:
+    """Return Penguin's current project as the minimum V2 project catalog."""
+    current = project_current_payload(core)
+    canonical = Path(current["canonical"])
+    now = int(time.time() * 1000)
+    try:
+        stat = canonical.stat()
+        created = max(int(stat.st_ctime * 1000), 0)
+        updated = max(int(stat.st_mtime * 1000), 0)
+    except OSError:
+        created = now
+        updated = now
+    vcs = get_vcs_info(core, directory=current["directory"], emit_events=False)
+    result: dict[str, Any] = {
+        "id": current["id"],
+        "canonical": current["canonical"],
+        "name": canonical.name or PROJECT_ID,
+        "time": {"created": created, "updated": updated},
+        "sandboxes": [],
+    }
+    if vcs.get("vcs") == "git":
+        result["vcs"] = "git"
+    return [result]
+
+
+def model_catalog_payload(core: Any) -> list[dict[str, Any]]:
+    """Return the active Penguin model as a usable V2 model catalog."""
+    model_config = getattr(core, "model_config", None)
+    current = core.get_current_model() if hasattr(core, "get_current_model") else None
+    current = current if isinstance(current, dict) else {}
+    raw_model_id = (
+        _string(current.get("model"))
+        or _string(getattr(model_config, "model", None))
+        or "penguin-default"
+    )
+    provider_id = _string(current.get("provider")) or _string(
+        getattr(model_config, "provider", None)
+    )
+    if not provider_id:
+        provider_id = (
+            raw_model_id.split("/", 1)[0] if "/" in raw_model_id else "penguin"
+        )
+    model_id = canonical_model_id(provider_id, raw_model_id)
+    context_limit = _positive_integer(
+        current.get("context_window") or getattr(model_config, "context_window", None),
+        128_000,
+    )
+    output_limit = _positive_integer(
+        current.get("max_output_tokens")
+        or current.get("max_tokens")
+        or getattr(model_config, "max_output_tokens", None),
+        8_192,
+    )
+    vision = bool(
+        current.get("vision_enabled") or getattr(model_config, "vision_enabled", False)
+    )
+    inputs = ["text", "image"] if vision else ["text"]
+    return [
+        {
+            "id": model_id,
+            "modelID": model_id,
+            "providerID": provider_id,
+            "name": model_id,
+            "capabilities": {
+                "tools": True,
+                "input": inputs,
+                "output": ["text"],
+            },
+            "variants": [],
+            "time": {"released": 0},
+            "cost": [],
+            "status": "active",
+            "enabled": True,
+            "limit": {"context": context_limit, "output": output_limit},
+        }
+    ]
+
+
+def provider_catalog_payload(core: Any) -> list[dict[str, Any]]:
+    """Return providers referenced by the minimum V2 model catalog."""
+    providers = {
+        str(model["providerID"])
+        for model in model_catalog_payload(core)
+        if model.get("providerID")
+    }
+    return [
+        {
+            "id": provider_id,
+            "name": provider_name(provider_id),
+            "package": "",
+        }
+        for provider_id in sorted(providers)
+    ]
+
+
+def agent_catalog_payload(core: Any) -> list[dict[str, Any]]:
+    """Expose Penguin's supported build and plan modes as V2 agents."""
+    model = model_catalog_payload(core)[0]
+    model_ref = {"providerID": model["providerID"], "id": model["id"]}
+    return [
+        {
+            "id": agent_id,
+            "name": name,
+            "model": model_ref,
+            "request": {"settings": {}, "headers": {}, "body": {}},
+            "mode": "primary",
+            "hidden": False,
+            "permissions": [],
+        }
+        for agent_id, name in (("build", "Build"), ("plan", "Plan"))
+    ]
+
+
+def session_payload(info: dict[str, Any]) -> dict[str, Any]:
+    """Project a V1-shaped Penguin session into OpenCode 2 Session.Info."""
+    directory = str(Path(str(info.get("directory") or Path.cwd())).resolve())
+    payload: dict[str, Any] = {
+        "id": str(info["id"]),
+        "projectID": str(info.get("projectID") or PROJECT_ID),
+        "cost": _non_negative_number(info.get("cost")),
+        "tokens": _tokens(info.get("tokens")),
+        "time": _session_time(info.get("time")),
+        "location": {"directory": directory},
+    }
+
+    title = _string(info.get("title"))
+    if title:
+        payload["title"] = title
+    parent_id = _string(info.get("parentID"))
+    if parent_id:
+        payload["parentID"] = parent_id
+    agent = _string(info.get("agent_id")) or _string(info.get("agent_mode"))
+    if agent:
+        payload["agent"] = agent
+    model = _model_ref(info)
+    if model:
+        payload["model"] = model
+    archived = payload["time"].get("archived")
+    if archived is None:
+        payload["time"].pop("archived", None)
+
+    revert = info.get("revert")
+    if isinstance(revert, dict) and _string(revert.get("messageID")):
+        projected_revert = {"messageID": str(revert["messageID"])}
+        for key in ("partID", "snapshot"):
+            value = _string(revert.get(key))
+            if value:
+                projected_revert[key] = value
+        payload["revert"] = projected_revert
+    return payload
+
+
+def list_sessions_payload(
+    core: Any,
+    *,
+    directory: str | None = None,
+    search: str | None = None,
+    parent_id: str | object | None = ...,  # ``None`` means roots only.
+    limit: int = 50,
+    order: str = "desc",
+) -> dict[str, Any]:
+    """Return the first V2 session page using Penguin's existing session view."""
+    if limit < 1 or limit > 200:
+        raise OpenCodeV2Error("limit must be between 1 and 200")
+    if order not in {"asc", "desc"}:
+        raise OpenCodeV2Error("order must be asc or desc")
+
+    rows = list_session_infos(
+        core,
+        directory=directory,
+        search=search,
+        roots=parent_id is None,
+        limit=None,
+    )
+    if parent_id is not ... and parent_id is not None:
+        rows = [row for row in rows if row.get("parentID") == parent_id]
+    if order == "asc":
+        rows.reverse()
+    return {"data": [session_payload(row) for row in rows[:limit]], "cursor": {}}
+
+
+def get_session_payload(core: Any, session_id: str) -> dict[str, Any] | None:
+    """Return one V2 session projection."""
+    info = get_session_info(core, session_id)
+    return session_payload(info) if isinstance(info, dict) else None
+
+
+def create_session_payload(
+    core: Any,
+    payload: dict[str, Any],
+    *,
+    default_directory: str,
+) -> dict[str, Any]:
+    """Create a Penguin session from the supported V2 creation fields."""
+    if payload.get("id") is not None:
+        raise OpenCodeV2Error("Client-selected session ids are not supported")
+    location = payload.get("location")
+    if location is not None and not isinstance(location, dict):
+        raise OpenCodeV2Error("location must be an object")
+    location = location if isinstance(location, dict) else {}
+    directory = _string(location.get("directory")) or default_directory
+    resolved = location_payload(core, directory=directory)["directory"]
+
+    model = payload.get("model")
+    if model is not None and not isinstance(model, dict):
+        raise OpenCodeV2Error("model must be an object")
+    model = model if isinstance(model, dict) else {}
+    parent_id = _optional_string_field(payload, "parentID")
+    deleting = getattr(core, "_opencode_v2_deleting_sessions", None)
+    if parent_id and isinstance(deleting, set) and parent_id in deleting:
+        raise OpenCodeV2Error(f"Parent session is being deleted: {parent_id}")
+    if parent_id and get_session_payload(core, parent_id) is None:
+        raise OpenCodeV2Error(f"Parent session not found: {parent_id}")
+    info = create_session_info(
+        core,
+        title=_optional_string_field(payload, "title"),
+        parent_id=parent_id,
+        directory=resolved,
+        agent_mode=_optional_agent(payload.get("agent")),
+        provider_id=_optional_string_field(model, "providerID"),
+        model_id=_optional_string_field(model, "id"),
+        variant=_optional_string_field(model, "variant"),
+    )
+    return session_payload(info)
+
+
+def rename_session(core: Any, session_id: str, title: Any) -> dict[str, Any] | None:
+    """Rename one session and return its V2 projection."""
+    if not isinstance(title, str) or not title.strip():
+        raise OpenCodeV2Error("title must be a non-empty string")
+    updated = update_session_info(core, session_id, title=title.strip())
+    return session_payload(updated) if isinstance(updated, dict) else None
+
+
+def switch_session_agent(
+    core: Any, session_id: str, agent: Any
+) -> dict[str, Any] | None:
+    """Persist the V2 agent selection through Penguin's existing mode field."""
+    normalized = _optional_agent(agent)
+    if normalized is None:
+        raise OpenCodeV2Error("agent must be one of: build, plan")
+    updated = update_session_info(core, session_id, agent_mode=normalized)
+    return session_payload(updated) if isinstance(updated, dict) else None
+
+
+def switch_session_model(
+    core: Any, session_id: str, model: Any
+) -> dict[str, Any] | None:
+    """Persist the V2 model selection without mutating the shared runtime model."""
+    if not isinstance(model, dict):
+        raise OpenCodeV2Error("model must be an object")
+    provider_id = _required_string_field(model, "providerID")
+    model_id = _required_string_field(model, "id")
+    updated = update_session_info(
+        core,
+        session_id,
+        provider_id=provider_id,
+        model_id=model_id,
+        variant=_optional_string_field(model, "variant") or "",
+    )
+    return session_payload(updated) if isinstance(updated, dict) else None
+
+
+def deletion_order(core: Any, session_id: str) -> list[dict[str, Any]] | None:
+    """Return an existing session subtree in children-first removal order."""
+    existing = get_session_payload(core, session_id)
+    if existing is None:
+        return None
+
+    sessions = {
+        projected["id"]: projected
+        for info in list_session_infos(core, limit=None)
+        if (projected := session_payload(info))
+    }
+    sessions.setdefault(session_id, existing)
+    children: dict[str, list[str]] = {}
+    for candidate in sessions.values():
+        parent_id = _string(candidate.get("parentID"))
+        if parent_id:
+            children.setdefault(parent_id, []).append(candidate["id"])
+
+    order: list[str] = []
+    visited: set[str] = set()
+
+    def visit(candidate_id: str) -> None:
+        if candidate_id in visited:
+            return
+        visited.add(candidate_id)
+        for child_id in children.get(candidate_id, []):
+            visit(child_id)
+        order.append(candidate_id)
+
+    visit(session_id)
+    return [sessions[candidate_id] for candidate_id in order]
+
+
+def delete_sessions(core: Any, sessions: list[dict[str, Any]]) -> None:
+    """Remove a previously resolved children-first session subtree."""
+    for candidate in sessions:
+        candidate_id = candidate["id"]
+        if not remove_session_info(core, candidate_id):
+            raise OpenCodeV2Error(f"Failed to delete session {candidate_id}")
+
+
+def active_sessions_payload(core: Any) -> dict[str, Any]:
+    """Return sessions with an active Penguin request in the V2 active shape."""
+    active = {
+        session_id: {"type": "running"}
+        for session_id, status in list_session_statuses(core).items()
+        if status.get("type") == "busy"
+    }
+    reservations = getattr(core, "_opencode_v2_prompt_reservations", None)
+    if isinstance(reservations, set):
+        for session_id in reservations:
+            if isinstance(session_id, str):
+                active[session_id] = {"type": "running"}
+    tasks = getattr(core, "_opencode_v2_prompt_tasks", None)
+    if isinstance(tasks, dict):
+        for session_id, task in tasks.items():
+            done = getattr(task, "done", None)
+            if isinstance(session_id, str) and callable(done) and not done():
+                active[session_id] = {"type": "running"}
+    deleting = getattr(core, "_opencode_v2_deleting_sessions", None)
+    if isinstance(deleting, set):
+        for session_id in deleting:
+            if isinstance(session_id, str):
+                active[session_id] = {"type": "running"}
+    return {"data": active}
+
+
+def messages_payload(
+    core: Any,
+    session_id: str,
+    *,
+    limit: int = 50,
+    order: str = "desc",
+) -> dict[str, Any] | None:
+    """Return projected V2 messages for one Penguin session."""
+    if limit < 1 or limit > 200:
+        raise OpenCodeV2Error("limit must be between 1 and 200")
+    if order not in {"asc", "desc"}:
+        raise OpenCodeV2Error("order must be asc or desc")
+    rows = get_session_messages(core, session_id)
+    if rows is None:
+        return None
+    projected = [item for row in rows if (item := message_payload(row)) is not None]
+    if order == "desc":
+        projected.reverse()
+    return {"data": projected[:limit], "cursor": {}}
+
+
+def prompt_payload(
+    core: Any,
+    session_id: str,
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Validate a V2 prompt and build its pending and Penguin request payloads."""
+    session = get_session_payload(core, session_id)
+    if session is None:
+        return None
+    text = payload.get("text")
+    if not isinstance(text, str):
+        raise OpenCodeV2Error("text must be a string")
+    for field in ("files", "agents", "skills"):
+        value = payload.get(field)
+        if value not in (None, []):
+            raise OpenCodeV2Error(f"{field} attachments are not supported yet")
+    if payload.get("resume") is False:
+        raise OpenCodeV2Error("resume=false admission is not supported yet")
+    delivery = payload.get("delivery", "steer")
+    if delivery not in {"steer", "queue"}:
+        raise OpenCodeV2Error("delivery must be steer or queue")
+    if delivery == "queue":
+        raise OpenCodeV2Error("queue delivery is not supported yet")
+    message_id = payload.get("id") or f"msg_{uuid.uuid4().hex}"
+    if not isinstance(message_id, str) or not message_id.startswith("msg_"):
+        raise OpenCodeV2Error("id must start with msg_")
+    metadata = payload.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise OpenCodeV2Error("metadata must be an object")
+
+    data: dict[str, Any] = {"text": text}
+    if metadata:
+        data["metadata"] = metadata
+    pending = {
+        "id": message_id,
+        "sessionID": session_id,
+        "timeCreated": int(time.time() * 1000),
+        "type": "user",
+        "data": data,
+        "delivery": delivery,
+    }
+    model = session.get("model")
+    model_ref = None
+    variant = None
+    if isinstance(model, dict):
+        provider_id = _string(model.get("providerID"))
+        model_id = _string(model.get("id"))
+        if provider_id and model_id:
+            model_ref = f"{provider_id}/{model_id}"
+        variant = _string(model.get("variant"))
+    request = {
+        "text": text,
+        "session_id": session_id,
+        "conversation_id": session_id,
+        "client_message_id": message_id,
+        "client_part_id": f"part_{uuid.uuid4().hex}",
+        "context": metadata,
+        "streaming": True,
+        "agent_id": session.get("agent"),
+        "agent_mode": session.get("agent"),
+        "directory": session["location"]["directory"],
+        "model": model_ref,
+        "variant": variant,
+    }
+    return pending, request
+
+
+def message_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Project one OpenCode 1 WithParts row into an OpenCode 2 message."""
+    info = row.get("info")
+    if not isinstance(info, dict):
+        return None
+    message_id = _string(info.get("id"))
+    role = _string(info.get("role"))
+    if not message_id or role not in {"user", "assistant"}:
+        return None
+    parts = [part for part in row.get("parts", []) if isinstance(part, dict)]
+    created = _message_time(info.get("time"))["created"]
+
+    if role == "user":
+        return {
+            "id": message_id,
+            "type": "user",
+            "text": "".join(
+                str(part.get("text") or "")
+                for part in parts
+                if part.get("type") == "text"
+            ),
+            "time": {"created": created},
+        }
+
+    model = _model_ref(info) or {"providerID": "penguin", "id": "penguin-default"}
+    result: dict[str, Any] = {
+        "id": message_id,
+        "type": "assistant",
+        "agent": _string(info.get("agent")) or "build",
+        "model": model,
+        "content": [content for part in parts if (content := _content(part))],
+        "cost": _non_negative_number(info.get("cost")),
+        "tokens": _tokens(info.get("tokens")),
+        "time": _message_time(info.get("time")),
+    }
+    finish = _string(info.get("finish"))
+    if finish in _FINISH_REASONS:
+        result["finish"] = finish
+    error = info.get("error")
+    if isinstance(error, dict):
+        result["error"] = _error(error)
+    if result["time"].get("completed") is None:
+        result["time"].pop("completed", None)
+    return result
+
+
+def event_payload(
+    data: dict[str, Any],
+    *,
+    suffix: str = "event",
+) -> dict[str, Any] | None:
+    """Project non-stream V1 lifecycle events consumed during V2 hydration."""
+    event_type = _string(data.get("type"))
+    properties = data.get("properties")
+    if not event_type or not isinstance(properties, dict):
+        return None
+    runtime = data.get("runtime_event")
+    runtime = runtime if isinstance(runtime, dict) else {}
+    created = _integer(
+        data.get("time"), _integer(runtime.get("time"), int(time.time() * 1000))
+    )
+    session_id = _event_session(properties)
+    directory = _event_directory(properties)
+
+    projected_type = event_type
+    projected_data: dict[str, Any]
+    durable_version: int | None = None
+    interaction = interaction_event_projection(event_type, properties)
+    if interaction is not None:
+        projected_type, projected_data = interaction
+    elif event_type == "session.created":
+        info = properties.get("info")
+        if not isinstance(info, dict) or not session_id:
+            return None
+        session = session_payload(info)
+        projected_data = {
+            "sessionID": session_id,
+            "projectID": session["projectID"],
+            "location": session["location"],
+            "slug": session_id,
+            "title": session.get("title"),
+            "agent": session.get("agent"),
+            "model": session.get("model"),
+            "version": __version__,
+        }
+        projected_data = {
+            key: value for key, value in projected_data.items() if value is not None
+        }
+        durable_version = 1
+    elif event_type == "session.updated":
+        info = properties.get("info")
+        if not isinstance(info, dict) or not session_id:
+            return None
+        projected_type = "session.renamed"
+        projected_data = {
+            "sessionID": session_id,
+            "title": str(info.get("title") or ""),
+        }
+        durable_version = 1
+    elif event_type == "session.agent.selected":
+        agent = _string(properties.get("agent"))
+        if not session_id or not agent:
+            return None
+        projected_data = {"sessionID": session_id, "agent": agent}
+        previous = _string(properties.get("previous"))
+        if previous:
+            projected_data["previous"] = previous
+        durable_version = 1
+    elif event_type == "session.model.selected":
+        model = _model_ref({"model": properties.get("model")})
+        if not session_id or model is None:
+            return None
+        projected_data = {"sessionID": session_id, "model": model}
+        previous = _model_ref({"model": properties.get("previous")})
+        if previous:
+            projected_data["previous"] = previous
+        durable_version = 1
+    elif event_type == "session.deleted":
+        if not session_id:
+            return None
+        projected_data = {"sessionID": session_id}
+        durable_version = 2
+    elif event_type == "vcs.branch.updated":
+        projected_data = {"branch": _string(properties.get("branch")) or ""}
+    else:
+        return None
+
+    source_id = _string(data.get("id")) or _string(runtime.get("id")) or event_type
+    result: dict[str, Any] = {
+        "id": _event_id(source_id, suffix),
+        "created": created,
+        "type": projected_type,
+        "data": projected_data,
+    }
+    if directory:
+        result["location"] = {"directory": directory}
+    if durable_version is not None and session_id:
+        sequence = _integer(runtime.get("sequence"), _integer(data.get("order"), 1))
+        result["durable"] = {
+            "aggregateID": session_id,
+            "seq": max(sequence, 0),
+            "version": durable_version,
+        }
+    return result
+
+
+def _content(part: dict[str, Any]) -> dict[str, Any] | None:
+    part_type = _string(part.get("type"))
+    if part_type == "text":
+        return {"type": "text", "text": str(part.get("text") or "")}
+    if part_type == "reasoning":
+        result: dict[str, Any] = {
+            "type": "reasoning",
+            "text": str(part.get("text") or ""),
+        }
+        time_data = part.get("time")
+        if isinstance(time_data, dict):
+            result["time"] = _message_time(time_data)
+        return result
+    if part_type != "tool":
+        return None
+
+    state = part.get("state")
+    state = state if isinstance(state, dict) else {}
+    status = _string(state.get("status")) or "running"
+    input_data = state.get("input") if isinstance(state.get("input"), dict) else {}
+    metadata = state.get("metadata") if isinstance(state.get("metadata"), dict) else {}
+    if status == "completed":
+        output = state.get("output")
+        rendered = (
+            output if isinstance(output, str) else json.dumps(output, default=str)
+        )
+        projected_state: dict[str, Any] = {
+            "status": "completed",
+            "input": input_data,
+            "content": [{"type": "text", "text": rendered or "(no output)"}],
+        }
+        if metadata:
+            projected_state["metadata"] = metadata
+    elif status == "error":
+        projected_state = {
+            "status": "error",
+            "input": input_data,
+            "error": {
+                "type": "tool.error",
+                "message": str(state.get("error") or "Tool execution failed"),
+            },
+        }
+        if metadata:
+            projected_state["metadata"] = metadata
+    else:
+        projected_state = {
+            "status": "running",
+            "input": input_data,
+            "metadata": metadata,
+        }
+
+    time_data = state.get("time") if isinstance(state.get("time"), dict) else {}
+    created = _integer(time_data.get("start"), int(time.time() * 1000))
+    result = {
+        "type": "tool",
+        "id": _string(part.get("callID")) or _string(part.get("id")) or "tool",
+        "name": _string(part.get("tool")) or "tool",
+        "state": projected_state,
+        "time": {"created": created},
+    }
+    completed = time_data.get("end")
+    if isinstance(completed, (int, float)):
+        result["time"]["completed"] = int(completed)
+    return result
+
+
+def _model_ref(value: dict[str, Any]) -> dict[str, Any] | None:
+    provider_id = _string(value.get("providerID"))
+    model_id = _string(value.get("modelID"))
+    nested = value.get("model")
+    if isinstance(nested, dict):
+        provider_id = provider_id or _string(nested.get("providerID"))
+        model_id = (
+            model_id or _string(nested.get("id")) or _string(nested.get("modelID"))
+        )
+    if not provider_id or not model_id:
+        return None
+    result = {"providerID": provider_id, "id": model_id}
+    variant = _string(value.get("variant")) or (
+        _string(nested.get("variant")) if isinstance(nested, dict) else None
+    )
+    if variant:
+        result["variant"] = variant
+    return result
+
+
+def _tokens(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {**_EMPTY_TOKENS, "cache": dict(_EMPTY_TOKENS["cache"])}
+    cache = value.get("cache") if isinstance(value.get("cache"), dict) else {}
+    return {
+        "input": _non_negative_number(value.get("input")),
+        "output": _non_negative_number(value.get("output")),
+        "reasoning": _non_negative_number(value.get("reasoning")),
+        "cache": {
+            "read": _non_negative_number(cache.get("read")),
+            "write": _non_negative_number(cache.get("write")),
+        },
+    }
+
+
+def _session_time(value: Any) -> dict[str, int]:
+    value = value if isinstance(value, dict) else {}
+    created = _integer(value.get("created"), int(time.time() * 1000))
+    result = {
+        "created": created,
+        "updated": _integer(value.get("updated"), created),
+    }
+    archived = _optional_integer(value.get("archived"))
+    if archived is not None:
+        result["archived"] = archived
+    return result
+
+
+def _message_time(value: Any) -> dict[str, int]:
+    value = value if isinstance(value, dict) else {}
+    result = {
+        "created": _integer(value.get("created"), int(time.time() * 1000)),
+    }
+    completed = _optional_integer(value.get("completed"))
+    if completed is not None:
+        result["completed"] = completed
+    return result
+
+
+def _error(value: dict[str, Any]) -> dict[str, Any]:
+    data = value.get("data") if isinstance(value.get("data"), dict) else {}
+    result: dict[str, Any] = {
+        "type": _string(value.get("type"))
+        or _string(value.get("name"))
+        or "provider.error",
+        "message": _string(value.get("message"))
+        or _string(data.get("message"))
+        or "Provider request failed",
+    }
+    status = value.get("status") or data.get("statusCode")
+    if isinstance(status, int):
+        result["status"] = status
+    return result
+
+
+def _event_session(properties: dict[str, Any]) -> str | None:
+    direct = _string(properties.get("sessionID")) or _string(
+        properties.get("session_id")
+    )
+    info = properties.get("info")
+    return direct or (_string(info.get("id")) if isinstance(info, dict) else None)
+
+
+def _event_directory(properties: dict[str, Any]) -> str | None:
+    direct = _string(properties.get("directory"))
+    info = properties.get("info")
+    return direct or (
+        _string(info.get("directory")) if isinstance(info, dict) else None
+    )
+
+
+def _event_id(source: str, suffix: str) -> str:
+    digest = hashlib.sha256(f"{source}:{suffix}".encode()).hexdigest()[:24]
+    return f"evt_{digest}"
+
+
+def _string(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_string_field(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise OpenCodeV2Error(f"{key} must be a string")
+    return value.strip() or None
+
+
+def _required_string_field(payload: dict[str, Any], key: str) -> str:
+    value = _optional_string_field(payload, key)
+    if value is None:
+        raise OpenCodeV2Error(f"{key} must be a non-empty string")
+    return value
+
+
+def _optional_agent(value: Any) -> str | None:
+    if value is None:
+        return None
+    agent = _string(value)
+    if agent not in {"build", "plan"}:
+        raise OpenCodeV2Error("agent must be one of: build, plan")
+    return agent
+
+
+def _integer(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return int(value)
+    return default
+
+
+def _positive_integer(value: Any, default: int) -> int:
+    parsed = _integer(value, default)
+    return parsed if parsed > 0 else default
+
+
+def _optional_integer(value: Any) -> int | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _integer(value, 0)
+    return None
+
+
+def _non_negative_number(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return max(float(value), 0)
+
+
+__all__ = [
+    "PROJECT_ID",
+    "UPSTREAM_V2_COMMIT",
+    "OpenCodeV2Error",
+    "active_sessions_payload",
+    "agent_catalog_payload",
+    "create_session_payload",
+    "delete_sessions",
+    "deletion_order",
+    "event_payload",
+    "filesystem_list_payload",
+    "get_session_payload",
+    "health_payload",
+    "list_sessions_payload",
+    "located_payload",
+    "location_payload",
+    "message_payload",
+    "messages_payload",
+    "model_catalog_payload",
+    "project_current_payload",
+    "projects_payload",
+    "prompt_payload",
+    "provider_catalog_payload",
+    "rename_session",
+    "session_payload",
+    "switch_session_agent",
+    "switch_session_model",
+    "vcs_payload",
+]

--- a/penguin/web/services/opencode_v2_events.py
+++ b/penguin/web/services/opencode_v2_events.py
@@ -1,0 +1,1144 @@
+"""Deterministic OpenCode 2 event projection for Penguin prompt streams.
+
+The projector owns only connection-local reconstruction state. It translates the
+small OpenCode 1 event subset Penguin already emits without persisting a second
+event log or reading mutable application state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from penguin import __version__
+
+__all__ = ["OpenCodeV2EventProjector", "server_connected_event"]
+
+
+_FINISH_REASONS = {
+    "stop",
+    "length",
+    "tool-calls",
+    "content-filter",
+    "error",
+    "unknown",
+}
+
+
+@dataclass
+class _TextState:
+    """One assistant text segment reconstructed from V1 part updates."""
+
+    ordinal: int
+    text: str = ""
+    started: bool = False
+    ended: bool = False
+
+
+@dataclass
+class _ToolState:
+    """One Penguin tool part projected into a native V2 tool lifecycle."""
+
+    part_id: str
+    name: str
+    input: dict[str, Any]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    settled: bool = False
+
+
+@dataclass
+class _AssistantState:
+    """Connection-local state for one assistant step."""
+
+    message_id: str
+    agent: str
+    model: dict[str, Any]
+    cost: int | float = 0
+    finish: str = "stop"
+    tokens: dict[str, Any] = field(default_factory=lambda: _tokens(None))
+    text: dict[str, _TextState] = field(default_factory=dict)
+    tools: dict[str, _ToolState] = field(default_factory=dict)
+    step_started: bool = False
+    completion_requested: bool = False
+    completed: bool = False
+
+
+@dataclass
+class _SessionState:
+    """Connection-local state for one V2 aggregate."""
+
+    next_durable_sequence: int = 0
+    location: dict[str, str] | None = None
+    busy_requested: bool = False
+    execution_started: bool = False
+    execution_failed: bool = False
+    pending_idle_completion: bool = False
+    created: bool = False
+    promoted_inputs: set[str] = field(default_factory=set)
+    user_messages: dict[str, dict[str, Any]] = field(default_factory=dict)
+    assistants: dict[str, _AssistantState] = field(default_factory=dict)
+    active_assistant_id: str | None = None
+
+
+class OpenCodeV2EventProjector:
+    """Project an ordered V1 event stream into native OpenCode 2 events.
+
+    Create one instance per SSE connection. Given the same ordered inputs and
+    ``default_delivery``, separate instances produce identical outputs. The
+    default is required because current V1 user-message events omit delivery.
+    """
+
+    def __init__(self, *, default_delivery: str = "steer") -> None:
+        if default_delivery not in {"steer", "queue"}:
+            raise ValueError("default_delivery must be steer or queue")
+        self._default_delivery = default_delivery
+        self._sessions: dict[str, _SessionState] = {}
+        self._seen_source_ids: set[str] = set()
+        self._input_index = 0
+        self._output_index = 0
+
+    def project(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
+        """Translate one canonical Penguin event into zero or more V2 events."""
+        self._input_index += 1
+        event_type = _string(event.get("type"))
+        properties = event.get("properties")
+        if not event_type or not isinstance(properties, Mapping):
+            return []
+
+        props = dict(properties)
+        source = _source_id(event, event_type, self._input_index)
+        if source in self._seen_source_ids:
+            return []
+        self._seen_source_ids.add(source)
+        created = _event_time(event, props)
+
+        if event_type == "session.created":
+            return self._project_session_created(props, source, created)
+        if event_type == "session.status":
+            return self._project_session_status(props, source, created)
+        if event_type == "session.execution.interrupted":
+            return self._project_execution_interrupted(props, source, created)
+        if event_type == "message.updated":
+            return self._project_message_updated(props, source, created)
+        if event_type == "message.part.updated":
+            return self._project_part_updated(props, source, created)
+        return []
+
+    def _project_session_created(
+        self,
+        properties: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        raw_info = properties.get("info")
+        info = dict(raw_info) if isinstance(raw_info, Mapping) else properties
+        session_id = _session_id(properties, info=info)
+        location = _location(properties, info)
+        if not session_id or not location:
+            return []
+
+        state = self._state(session_id)
+        state.location = location
+        if state.created:
+            return []
+        state.created = True
+
+        data: dict[str, Any] = {
+            "sessionID": session_id,
+            "projectID": _string(info.get("projectID")) or "penguin",
+            "location": location,
+            "slug": _string(info.get("slug")) or session_id,
+            "version": _string(info.get("version")) or __version__,
+        }
+        for key in ("parentID", "subpath", "title"):
+            value = _string(info.get(key))
+            if value:
+                data[key] = value
+        agent = (
+            _string(info.get("agent"))
+            or _string(info.get("agent_id"))
+            or _string(info.get("agent_mode"))
+        )
+        if agent:
+            data["agent"] = agent
+        model = _model(info)
+        if model:
+            data["model"] = model
+
+        return [
+            self._emit(
+                session_id,
+                source=source,
+                created=created,
+                event_type="session.created",
+                data=data,
+                durable_version=1,
+            )
+        ]
+
+    def _project_session_status(
+        self,
+        properties: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        session_id = _session_id(properties)
+        status = properties.get("status")
+        status_type = (
+            _string(status.get("type")) if isinstance(status, Mapping) else None
+        )
+        if not session_id or status_type not in {"busy", "idle"}:
+            return []
+
+        state = self._state(session_id)
+        self._remember_location(state, properties)
+        if status_type == "busy":
+            # The V1 busy event precedes its user message. Buffer it so V2 keeps
+            # the durable admission -> promotion -> execution ordering.
+            state.busy_requested = True
+            state.pending_idle_completion = False
+            return []
+
+        output: list[dict[str, Any]] = []
+        active_id = state.active_assistant_id
+        assistant = state.assistants.get(active_id) if active_id else None
+        if assistant and not assistant.completed:
+            if _has_unsettled_tools(assistant):
+                state.pending_idle_completion = True
+                return []
+            output.extend(
+                self._finish_assistant(
+                    session_id,
+                    state,
+                    assistant,
+                    source=source,
+                    created=created,
+                )
+            )
+        if state.execution_started:
+            output.append(
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.execution.succeeded",
+                    data={"sessionID": session_id},
+                    durable_version=1,
+                )
+            )
+        state.busy_requested = False
+        state.execution_started = False
+        state.pending_idle_completion = False
+        state.active_assistant_id = None
+        return output
+
+    def _project_execution_interrupted(
+        self,
+        properties: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        session_id = _session_id(properties)
+        reason = _string(properties.get("reason"))
+        if not session_id or reason not in {"user", "shutdown", "superseded"}:
+            return []
+
+        state = self._state(session_id)
+        self._remember_location(state, properties)
+        if state.execution_failed:
+            return []
+
+        state.busy_requested = False
+        state.execution_started = False
+        state.execution_failed = True
+        state.pending_idle_completion = False
+        state.active_assistant_id = None
+        return [
+            self._emit(
+                session_id,
+                source=source,
+                created=created,
+                event_type="session.execution.interrupted",
+                data={"sessionID": session_id, "reason": reason},
+                durable_version=1,
+            )
+        ]
+
+    def _project_message_updated(
+        self,
+        properties: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        raw_info = properties.get("info")
+        info = dict(raw_info) if isinstance(raw_info, Mapping) else properties
+        role = _string(info.get("role"))
+        message_id = _message_id(info)
+        session_id = _session_id(properties, info=info)
+        if not session_id or not message_id or role not in {"user", "assistant"}:
+            return []
+
+        state = self._state(session_id)
+        self._remember_location(state, properties, info)
+        if role == "user":
+            state.user_messages[message_id] = dict(info)
+            return []
+        if state.execution_failed:
+            return []
+
+        assistant = state.assistants.get(message_id)
+        if assistant is None:
+            assistant = _AssistantState(
+                message_id=message_id,
+                agent=_string(info.get("agent")) or "build",
+                model=_model(info)
+                or {"providerID": "penguin", "id": "penguin-default"},
+            )
+            state.assistants[message_id] = assistant
+        else:
+            assistant.agent = _string(info.get("agent")) or assistant.agent
+            assistant.model = _model(info) or assistant.model
+
+        if assistant.completed:
+            return []
+
+        assistant.cost = _number(info.get("cost"))
+        assistant.tokens = _tokens(info.get("tokens"))
+        finish = _string(info.get("finish"))
+        if finish in _FINISH_REASONS:
+            assistant.finish = finish
+        error = _session_error(info.get("error"))
+
+        output: list[dict[str, Any]] = []
+        output.extend(
+            self._ensure_execution_started(
+                session_id,
+                state,
+                source=source,
+                created=created,
+            )
+        )
+        if not assistant.step_started:
+            assistant.step_started = True
+            state.active_assistant_id = message_id
+            output.append(
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.step.started",
+                    data={
+                        "sessionID": session_id,
+                        "assistantMessageID": message_id,
+                        "agent": assistant.agent,
+                        "model": assistant.model,
+                    },
+                    durable_version=1,
+                )
+            )
+
+        if error:
+            output.extend(
+                self._fail_assistant(
+                    session_id,
+                    state,
+                    assistant,
+                    error=error,
+                    source=source,
+                    created=created,
+                )
+            )
+            return output
+
+        time_data = info.get("time")
+        completed = (
+            time_data.get("completed") is not None
+            if isinstance(time_data, Mapping)
+            else False
+        )
+        if completed and not assistant.completed:
+            assistant.completion_requested = True
+            if not _has_unsettled_tools(assistant):
+                output.extend(
+                    self._finish_assistant(
+                        session_id,
+                        state,
+                        assistant,
+                        source=source,
+                        created=created,
+                    )
+                )
+        return output
+
+    def _project_part_updated(
+        self,
+        properties: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        raw_part = properties.get("part")
+        if not isinstance(raw_part, Mapping):
+            return []
+        part = dict(raw_part)
+        part_type = _string(part.get("type"))
+        if part_type == "tool":
+            return self._project_tool_part_updated(
+                properties,
+                part,
+                source=source,
+                created=created,
+            )
+        if part_type != "text":
+            return []
+        session_id = _session_id(properties, part=part)
+        message_id = _string(part.get("messageID"))
+        part_id = _string(part.get("id"))
+        if not session_id or not message_id or not part_id:
+            return []
+
+        state = self._state(session_id)
+        self._remember_location(state, properties, part)
+        if message_id in state.user_messages:
+            if message_id in state.promoted_inputs:
+                return []
+            state.promoted_inputs.add(message_id)
+            state.execution_failed = False
+            info = state.user_messages[message_id]
+            data: dict[str, Any] = {"text": str(part.get("text") or "")}
+            metadata = info.get("metadata")
+            if isinstance(metadata, Mapping) and metadata:
+                data["metadata"] = dict(metadata)
+            delivery = _string(info.get("delivery"))
+            if delivery not in {"steer", "queue"}:
+                delivery = self._default_delivery
+
+            output = [
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.input.admitted",
+                    data={
+                        "sessionID": session_id,
+                        "inputID": message_id,
+                        "input": {
+                            "type": "user",
+                            "data": data,
+                            "delivery": delivery,
+                        },
+                    },
+                    durable_version=1,
+                ),
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.input.promoted",
+                    data={"sessionID": session_id, "inputID": message_id},
+                    durable_version=1,
+                ),
+            ]
+            output.extend(
+                self._ensure_execution_started(
+                    session_id,
+                    state,
+                    source=source,
+                    created=created,
+                )
+            )
+            return output
+
+        assistant = state.assistants.get(message_id)
+        if assistant is None or assistant.completed:
+            return []
+        text = assistant.text.get(part_id)
+        if text is None:
+            text = _TextState(ordinal=len(assistant.text))
+            assistant.text[part_id] = text
+        if text.ended:
+            return []
+
+        output: list[dict[str, Any]] = []
+        if not text.started:
+            text.started = True
+            output.append(
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.text.started",
+                    data={
+                        "sessionID": session_id,
+                        "assistantMessageID": message_id,
+                        "ordinal": text.ordinal,
+                    },
+                    durable_version=1,
+                )
+            )
+
+        full_text = str(part.get("text") or "")
+        raw_delta = properties.get("delta")
+        delta = (
+            raw_delta
+            if isinstance(raw_delta, str)
+            else _text_delta(text.text, full_text)
+        )
+        if full_text:
+            text.text = full_text
+        elif delta:
+            text.text += delta
+        if delta:
+            output.append(
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.text.delta",
+                    data={
+                        "sessionID": session_id,
+                        "assistantMessageID": message_id,
+                        "ordinal": text.ordinal,
+                        "delta": delta,
+                    },
+                )
+            )
+        return output
+
+    def _project_tool_part_updated(
+        self,
+        properties: dict[str, Any],
+        part: dict[str, Any],
+        *,
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        """Project Penguin's running/terminal tool-part snapshots."""
+        session_id = _session_id(properties, part=part)
+        message_id = _string(part.get("messageID"))
+        part_id = _string(part.get("id"))
+        call_id = _string(part.get("callID"))
+        name = _string(part.get("tool"))
+        raw_state = part.get("state")
+        if (
+            not session_id
+            or not message_id
+            or not part_id
+            or not call_id
+            or not name
+            or not isinstance(raw_state, Mapping)
+        ):
+            return []
+
+        status = _string(raw_state.get("status"))
+        raw_input = raw_state.get("input")
+        if status not in {"running", "completed", "error"} or not isinstance(
+            raw_input, Mapping
+        ):
+            return []
+        tool_input = _json_record(raw_input)
+        if tool_input is None:
+            return []
+
+        state = self._state(session_id)
+        self._remember_location(state, properties, part)
+        assistant = state.assistants.get(message_id)
+        if assistant is None or assistant.completed or state.execution_failed:
+            return []
+
+        metadata = _json_metadata(raw_state.get("metadata"))
+        tool = assistant.tools.get(call_id)
+        if tool is None:
+            if status != "running":
+                return []
+            tool = _ToolState(
+                part_id=part_id,
+                name=name,
+                input=tool_input,
+                metadata=metadata,
+            )
+            assistant.tools[call_id] = tool
+            output = self._end_texts(
+                session_id,
+                assistant,
+                source=source,
+                created=created,
+            )
+            output.extend(
+                [
+                    self._emit(
+                        session_id,
+                        source=source,
+                        created=created,
+                        event_type="session.tool.input.started",
+                        data={
+                            "sessionID": session_id,
+                            "assistantMessageID": message_id,
+                            "id": call_id,
+                            "name": name,
+                        },
+                        durable_version=1,
+                    ),
+                    self._emit(
+                        session_id,
+                        source=source,
+                        created=created,
+                        event_type="session.tool.input.ended",
+                        data={
+                            "sessionID": session_id,
+                            "assistantMessageID": message_id,
+                            "id": call_id,
+                            "text": _canonical_json(tool_input),
+                        },
+                        durable_version=1,
+                    ),
+                    self._emit(
+                        session_id,
+                        source=source,
+                        created=created,
+                        event_type="session.tool.called",
+                        data={
+                            "sessionID": session_id,
+                            "assistantMessageID": message_id,
+                            "id": call_id,
+                            "input": tool_input,
+                            "executed": False,
+                        },
+                        durable_version=1,
+                    ),
+                ]
+            )
+            if metadata:
+                output.append(
+                    self._tool_progress(
+                        session_id,
+                        message_id,
+                        call_id,
+                        metadata,
+                        source=source,
+                        created=created,
+                    )
+                )
+            return output
+
+        if (
+            tool.part_id != part_id
+            or tool.name != name
+            or tool.input != tool_input
+            or tool.settled
+        ):
+            return []
+        if status == "running":
+            if not metadata or metadata == tool.metadata:
+                return []
+            tool.metadata = metadata
+            return [
+                self._tool_progress(
+                    session_id,
+                    message_id,
+                    call_id,
+                    metadata,
+                    source=source,
+                    created=created,
+                )
+            ]
+
+        terminal_metadata = metadata or tool.metadata
+        if status == "completed":
+            if "output" not in raw_state:
+                return []
+            terminal_type = "session.tool.success"
+            terminal_data: dict[str, Any] = {
+                "sessionID": session_id,
+                "assistantMessageID": message_id,
+                "id": call_id,
+                "content": [
+                    {"type": "text", "text": _tool_output_text(raw_state["output"])}
+                ],
+                "executed": False,
+            }
+        else:
+            error = _string(raw_state.get("error"))
+            if not error:
+                return []
+            terminal_type = "session.tool.failed"
+            terminal_data = {
+                "sessionID": session_id,
+                "assistantMessageID": message_id,
+                "id": call_id,
+                "error": {"type": "tool.execution", "message": error},
+                "executed": False,
+            }
+        if terminal_metadata:
+            terminal_data["metadata"] = terminal_metadata
+
+        tool.settled = True
+        tool.metadata = terminal_metadata
+        output = [
+            self._emit(
+                session_id,
+                source=source,
+                created=created,
+                event_type=terminal_type,
+                data=terminal_data,
+                durable_version=2,
+            )
+        ]
+        tools_settled = not _has_unsettled_tools(assistant)
+        if tools_settled and (
+            assistant.completion_requested or state.pending_idle_completion
+        ):
+            output.extend(
+                self._finish_assistant(
+                    session_id,
+                    state,
+                    assistant,
+                    source=source,
+                    created=created,
+                )
+            )
+        if tools_settled and state.pending_idle_completion:
+            if state.execution_started and not state.execution_failed:
+                output.append(
+                    self._emit(
+                        session_id,
+                        source=source,
+                        created=created,
+                        event_type="session.execution.succeeded",
+                        data={"sessionID": session_id},
+                        durable_version=1,
+                    )
+                )
+            state.busy_requested = False
+            state.execution_started = False
+            state.pending_idle_completion = False
+            state.active_assistant_id = None
+        return output
+
+    def _tool_progress(
+        self,
+        session_id: str,
+        message_id: str,
+        call_id: str,
+        metadata: dict[str, Any],
+        *,
+        source: str,
+        created: int,
+    ) -> dict[str, Any]:
+        return self._emit(
+            session_id,
+            source=source,
+            created=created,
+            event_type="session.tool.progress",
+            data={
+                "sessionID": session_id,
+                "assistantMessageID": message_id,
+                "id": call_id,
+                "metadata": metadata,
+            },
+        )
+
+    def _ensure_execution_started(
+        self,
+        session_id: str,
+        state: _SessionState,
+        *,
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        if state.execution_started:
+            return []
+        state.execution_started = True
+        state.busy_requested = False
+        state.pending_idle_completion = False
+        return [
+            self._emit(
+                session_id,
+                source=source,
+                created=created,
+                event_type="session.execution.started",
+                data={"sessionID": session_id},
+                durable_version=1,
+            )
+        ]
+
+    def _finish_assistant(
+        self,
+        session_id: str,
+        state: _SessionState,
+        assistant: _AssistantState,
+        *,
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        if assistant.completed:
+            return []
+        output = self._end_texts(
+            session_id,
+            assistant,
+            source=source,
+            created=created,
+        )
+        assistant.completed = True
+        output.append(
+            self._emit(
+                session_id,
+                source=source,
+                created=created,
+                event_type="session.step.ended",
+                data={
+                    "sessionID": session_id,
+                    "assistantMessageID": assistant.message_id,
+                    "finish": assistant.finish,
+                    "cost": assistant.cost,
+                    "tokens": assistant.tokens,
+                },
+                durable_version=1,
+            )
+        )
+        if state.active_assistant_id == assistant.message_id:
+            state.active_assistant_id = None
+        return output
+
+    def _fail_assistant(
+        self,
+        session_id: str,
+        state: _SessionState,
+        assistant: _AssistantState,
+        *,
+        error: dict[str, Any],
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        if assistant.completed:
+            return []
+        output = self._end_texts(
+            session_id,
+            assistant,
+            source=source,
+            created=created,
+        )
+        assistant.completed = True
+        output.extend(
+            [
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.step.failed",
+                    data={
+                        "sessionID": session_id,
+                        "assistantMessageID": assistant.message_id,
+                        "error": dict(error),
+                    },
+                    durable_version=1,
+                ),
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.execution.failed",
+                    data={"sessionID": session_id, "error": dict(error)},
+                    durable_version=1,
+                ),
+            ]
+        )
+        state.busy_requested = False
+        state.execution_started = False
+        state.execution_failed = True
+        state.pending_idle_completion = False
+        if state.active_assistant_id == assistant.message_id:
+            state.active_assistant_id = None
+        return output
+
+    def _end_texts(
+        self,
+        session_id: str,
+        assistant: _AssistantState,
+        *,
+        source: str,
+        created: int,
+    ) -> list[dict[str, Any]]:
+        output: list[dict[str, Any]] = []
+        for text in sorted(assistant.text.values(), key=lambda item: item.ordinal):
+            if not text.started or text.ended:
+                continue
+            text.ended = True
+            output.append(
+                self._emit(
+                    session_id,
+                    source=source,
+                    created=created,
+                    event_type="session.text.ended",
+                    data={
+                        "sessionID": session_id,
+                        "assistantMessageID": assistant.message_id,
+                        "ordinal": text.ordinal,
+                        "text": text.text,
+                    },
+                    durable_version=1,
+                )
+            )
+        return output
+
+    def _state(self, session_id: str) -> _SessionState:
+        return self._sessions.setdefault(session_id, _SessionState())
+
+    @staticmethod
+    def _remember_location(
+        state: _SessionState,
+        properties: Mapping[str, Any],
+        info: Mapping[str, Any] | None = None,
+    ) -> None:
+        location = _location(properties, info or {})
+        if location:
+            state.location = location
+
+    def _emit(
+        self,
+        session_id: str,
+        *,
+        source: str,
+        created: int,
+        event_type: str,
+        data: dict[str, Any],
+        durable_version: int | None = None,
+    ) -> dict[str, Any]:
+        self._output_index += 1
+        state = self._state(session_id)
+        event: dict[str, Any] = {
+            "id": _event_id(source, event_type, self._output_index),
+            "created": created,
+            "type": event_type,
+            "data": data,
+        }
+        if state.location:
+            event["location"] = dict(state.location)
+        if durable_version is not None:
+            event["durable"] = {
+                "aggregateID": session_id,
+                "seq": state.next_durable_sequence,
+                "version": durable_version,
+            }
+            state.next_durable_sequence += 1
+        return event
+
+
+def server_connected_event(connection_id: str = "connection") -> dict[str, Any]:
+    """Return the exact deterministic V2 event-stream handshake."""
+    source = _string(connection_id) or "connection"
+    return {
+        "id": _event_id(source, "server.connected", 0),
+        "type": "server.connected",
+        "data": {},
+    }
+
+
+def _source_id(event: Mapping[str, Any], event_type: str, index: int) -> str:
+    direct = _string(event.get("id"))
+    runtime = event.get("runtime_event")
+    runtime_id = _string(runtime.get("id")) if isinstance(runtime, Mapping) else None
+    return direct or runtime_id or f"{event_type}:{index}"
+
+
+def _event_time(event: Mapping[str, Any], properties: Mapping[str, Any]) -> int:
+    direct = _integer(event.get("time"))
+    if direct is not None:
+        return direct
+    runtime = event.get("runtime_event")
+    if isinstance(runtime, Mapping):
+        runtime_time = _integer(runtime.get("time"))
+        if runtime_time is not None:
+            return runtime_time
+    info = properties.get("info")
+    if not isinstance(info, Mapping):
+        info = properties
+    time_data = info.get("time") if isinstance(info, Mapping) else None
+    if isinstance(time_data, Mapping):
+        created = _integer(time_data.get("created"))
+        if created is not None:
+            return created
+    return 0
+
+
+def _session_id(
+    properties: Mapping[str, Any],
+    *,
+    info: Mapping[str, Any] | None = None,
+    part: Mapping[str, Any] | None = None,
+) -> str | None:
+    for candidate in (
+        properties.get("sessionID"),
+        properties.get("session_id"),
+        info.get("sessionID") if info else None,
+        info.get("session_id") if info else None,
+        part.get("sessionID") if part else None,
+        part.get("session_id") if part else None,
+    ):
+        value = _string(candidate)
+        if value:
+            return value
+    if info:
+        return _string(info.get("id"))
+    return None
+
+
+def _message_id(info: Mapping[str, Any]) -> str | None:
+    value = _string(info.get("id"))
+    return value if value and value.startswith("msg_") else None
+
+
+def _location(
+    properties: Mapping[str, Any], info: Mapping[str, Any]
+) -> dict[str, str] | None:
+    raw_location = info.get("location")
+    if not isinstance(raw_location, Mapping):
+        raw_location = properties.get("location")
+    directory = (
+        _string(raw_location.get("directory"))
+        if isinstance(raw_location, Mapping)
+        else None
+    )
+    directory = (
+        directory
+        or _string(info.get("directory"))
+        or _string(properties.get("directory"))
+    )
+    path = info.get("path")
+    if not directory and isinstance(path, Mapping):
+        directory = _string(path.get("cwd"))
+    if not directory:
+        return None
+    result = {"directory": directory}
+    if isinstance(raw_location, Mapping):
+        workspace_id = _string(raw_location.get("workspaceID"))
+        if workspace_id:
+            result["workspaceID"] = workspace_id
+    return result
+
+
+def _model(info: Mapping[str, Any]) -> dict[str, Any] | None:
+    nested = info.get("model")
+    nested = nested if isinstance(nested, Mapping) else {}
+    provider_id = _string(info.get("providerID")) or _string(nested.get("providerID"))
+    model_id = (
+        _string(info.get("modelID"))
+        or _string(nested.get("id"))
+        or _string(nested.get("modelID"))
+    )
+    if not provider_id or not model_id:
+        return None
+    result: dict[str, Any] = {"providerID": provider_id, "id": model_id}
+    variant = _string(info.get("variant")) or _string(nested.get("variant"))
+    if variant:
+        result["variant"] = variant
+    return result
+
+
+def _tokens(value: Any) -> dict[str, Any]:
+    source = value if isinstance(value, Mapping) else {}
+    cache = source.get("cache")
+    cache = cache if isinstance(cache, Mapping) else {}
+    return {
+        "input": _number(source.get("input")),
+        "output": _number(source.get("output")),
+        "reasoning": _number(source.get("reasoning")),
+        "cache": {
+            "read": _number(cache.get("read")),
+            "write": _number(cache.get("write")),
+        },
+    }
+
+
+def _session_error(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    data = value.get("data")
+    data = data if isinstance(data, Mapping) else {}
+    error_type = _string(value.get("type")) or _string(value.get("name"))
+    message = data.get("message")
+    if not isinstance(message, str):
+        message = value.get("message")
+    if not error_type or not isinstance(message, str):
+        return None
+
+    result: dict[str, Any] = {"type": error_type, "message": message}
+    status = data.get("statusCode", data.get("status", value.get("status")))
+    if (
+        isinstance(status, int)
+        and not isinstance(status, bool)
+        and 100 <= status <= 599
+    ):
+        result["status"] = status
+    return result
+
+
+def _has_unsettled_tools(assistant: _AssistantState) -> bool:
+    return any(not tool.settled for tool in assistant.tools.values())
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _tool_output_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return _canonical_json(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _json_metadata(value: Any) -> dict[str, Any]:
+    return _json_record(value) or {}
+
+
+def _json_record(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        return None
+    try:
+        decoded = json.loads(_canonical_json(dict(value)))
+    except (TypeError, ValueError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _number(value: Any) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    if not math.isfinite(value):
+        return 0
+    return max(value, 0)
+
+
+def _integer(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value):
+        return None
+    return max(int(value), 0)
+
+
+def _text_delta(previous: str, current: str) -> str:
+    if current.startswith(previous):
+        return current[len(previous) :]
+    return current if current != previous else ""
+
+
+def _event_id(source: str, event_type: str, index: int) -> str:
+    digest = hashlib.sha256(f"{source}:{event_type}:{index}".encode()).hexdigest()
+    return f"evt_{digest[:24]}"
+
+
+def _string(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/penguin/web/services/opencode_v2_interactions.py
+++ b/penguin/web/services/opencode_v2_interactions.py
@@ -1,0 +1,508 @@
+"""OpenCode 2 projections for Penguin approvals and questions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from penguin.security.approval import (
+    ApprovalRequest,
+    ApprovalScope,
+    ApprovalStatus,
+    get_approval_manager,
+)
+from penguin.security.question import (
+    QuestionRequest,
+    QuestionStatus,
+    get_question_manager,
+)
+
+__all__ = [
+    "InteractionNotFoundError",
+    "InteractionPayloadError",
+    "InteractionSettledError",
+    "cancel_form_request",
+    "form_id_for_question",
+    "get_form_payload",
+    "get_permission_payload",
+    "interaction_event_projection",
+    "list_form_payloads",
+    "list_permission_payloads",
+    "permission_id_for_approval",
+    "reply_form_request",
+    "reply_permission_request",
+]
+
+
+_PERMISSION_ACTIONS = {
+    "apply_diff": "edit",
+    "code_execution": "shell",
+    "create_file": "edit",
+    "create_folder": "edit",
+    "delegate": "subagent",
+    "delegate_explore_task": "subagent",
+    "delete_lines": "edit",
+    "edit_with_pattern": "edit",
+    "enhanced_read": "read",
+    "enhanced_write": "edit",
+    "execute_command": "shell",
+    "find_file": "glob",
+    "get_file_map": "list",
+    "grep_search": "grep",
+    "insert_lines": "edit",
+    "list_files": "list",
+    "multiedit_apply": "edit",
+    "patch_file": "edit",
+    "patch_files": "edit",
+    "read_file": "read",
+    "replace_lines": "edit",
+    "spawn_sub_agent": "subagent",
+    "webfetch": "webfetch",
+    "write_file": "edit",
+    "write_to_file": "edit",
+}
+_PERMISSION_REPLIES = {"once", "always", "reject"}
+
+
+class InteractionPayloadError(ValueError):
+    """Raised when an interaction payload cannot satisfy the V2 contract."""
+
+
+class InteractionNotFoundError(LookupError):
+    """Raised when a session does not own the requested interaction."""
+
+
+class InteractionSettledError(RuntimeError):
+    """Raised when a form has already been answered or cancelled."""
+
+
+def permission_id_for_approval(request_id: str) -> str:
+    """Return the stable V2 permission ID for a Penguin approval ID."""
+    return f"per_{request_id}"
+
+
+def form_id_for_question(request_id: str) -> str:
+    """Return the stable V2 form ID for a Penguin question ID."""
+    return f"frm_{request_id}"
+
+
+def list_permission_payloads(session_id: str | None = None) -> list[dict[str, Any]]:
+    """List pending Penguin approvals in V2 Permission.Request shape."""
+    manager = get_approval_manager()
+    return [
+        _approval_payload(request)
+        for request in manager.get_pending(session_id=session_id)
+    ]
+
+
+def get_permission_payload(session_id: str, request_id: str) -> dict[str, Any] | None:
+    """Return one pending V2 permission owned by ``session_id``."""
+    request = _approval_for_id(session_id, request_id)
+    return _approval_payload(request) if request else None
+
+
+def reply_permission_request(
+    session_id: str,
+    request_id: str,
+    payload: Mapping[str, Any],
+) -> None:
+    """Resolve one Penguin approval through the V2 reply contract."""
+    reply = _string(payload.get("reply"))
+    if reply not in _PERMISSION_REPLIES:
+        raise InteractionPayloadError("reply must be one of: once, always, reject")
+    message = payload.get("message")
+    if message is not None and not isinstance(message, str):
+        raise InteractionPayloadError("message must be a string")
+
+    request = _approval_for_id(session_id, request_id)
+    if request is None:
+        raise InteractionNotFoundError(request_id)
+    manager = get_approval_manager()
+    if reply == "reject":
+        resolved = manager.deny(request.id)
+        if resolved and isinstance(message, str) and message.strip():
+            resolved.context["message"] = message.strip()
+    elif reply == "once":
+        resolved = manager.approve(request.id, scope=ApprovalScope.ONCE)
+    else:
+        resolved = manager.approve(
+            request.id,
+            scope=ApprovalScope.PATTERN,
+            pattern=_string(request.resource) or "*",
+        )
+    if resolved is None:
+        raise InteractionNotFoundError(request_id)
+
+
+def list_form_payloads(session_id: str | None = None) -> list[dict[str, Any]]:
+    """List valid pending Penguin questions as V2 forms."""
+    manager = get_question_manager()
+    return [
+        form
+        for request in manager.list_pending(session_id=session_id)
+        if (form := _question_form(request)) is not None
+    ]
+
+
+def get_form_payload(session_id: str, form_id: str) -> dict[str, Any] | None:
+    """Return one pending or retained V2 form owned by ``session_id``."""
+    request = _question_for_id(session_id, form_id)
+    return _question_form(request) if request else None
+
+
+def reply_form_request(
+    session_id: str,
+    form_id: str,
+    payload: Mapping[str, Any],
+) -> None:
+    """Translate a V2 answer object into ordered Penguin question answers."""
+    request = _question_for_id(session_id, form_id)
+    if request is None:
+        raise InteractionNotFoundError(form_id)
+    if request.status != QuestionStatus.PENDING:
+        raise InteractionSettledError(form_id)
+    answer = payload.get("answer")
+    if not isinstance(answer, Mapping):
+        raise InteractionPayloadError("answer must be an object")
+    answers = _ordered_question_answers(request, answer)
+    if get_question_manager().reply(request.id, answers) is None:
+        raise InteractionSettledError(form_id)
+
+
+def cancel_form_request(session_id: str, form_id: str) -> None:
+    """Cancel a pending V2 form through Penguin's question manager."""
+    request = _question_for_id(session_id, form_id)
+    if request is None:
+        raise InteractionNotFoundError(form_id)
+    if request.status != QuestionStatus.PENDING:
+        raise InteractionSettledError(form_id)
+    if get_question_manager().reject(request.id) is None:
+        raise InteractionSettledError(form_id)
+
+
+def interaction_event_projection(
+    event_type: str,
+    properties: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    """Translate legacy approval/question properties into V2 event data."""
+    try:
+        if event_type == "permission.asked":
+            request = _permission_event_payload(properties)
+            return (event_type, request) if request else None
+        if event_type == "permission.replied":
+            request_id = _string(properties.get("requestID"))
+            session_id = _string(properties.get("sessionID"))
+            reply = _string(properties.get("reply"))
+            if not request_id or not session_id or reply not in _PERMISSION_REPLIES:
+                return None
+            return (
+                event_type,
+                {
+                    "sessionID": session_id,
+                    "requestID": permission_id_for_approval(request_id),
+                    "reply": reply,
+                },
+            )
+        if event_type == "question.asked":
+            form = _question_form_from_mapping(properties)
+            return ("form.created", {"form": form}) if form else None
+        if event_type == "question.replied":
+            request_id = _string(properties.get("requestID"))
+            session_id = _string(properties.get("sessionID"))
+            answers = properties.get("answers")
+            if not request_id or not session_id or not isinstance(answers, list):
+                return None
+            request = get_question_manager().get_request(request_id)
+            if request is None or request.session_id != session_id:
+                return None
+            answer = _form_answer_from_ordered(request, answers)
+            return (
+                "form.replied",
+                {
+                    "id": form_id_for_question(request_id),
+                    "sessionID": session_id,
+                    "answer": answer,
+                },
+            )
+        if event_type == "question.rejected":
+            request_id = _string(properties.get("requestID"))
+            session_id = _string(properties.get("sessionID"))
+            if not request_id or not session_id:
+                return None
+            return (
+                "form.cancelled",
+                {
+                    "id": form_id_for_question(request_id),
+                    "sessionID": session_id,
+                },
+            )
+    except InteractionPayloadError:
+        return None
+    return None
+
+
+def _approval_for_id(session_id: str, request_id: str) -> ApprovalRequest | None:
+    raw_id = _legacy_id(request_id, "per_")
+    if raw_id is None:
+        return None
+    request = get_approval_manager().get_request(raw_id)
+    if (
+        request is None
+        or request.session_id != session_id
+        or request.status != ApprovalStatus.PENDING
+    ):
+        return None
+    return request
+
+
+def _approval_payload(request: ApprovalRequest) -> dict[str, Any]:
+    resource = _string(request.resource) or "*"
+    context = request.context if isinstance(request.context, dict) else {}
+    metadata: dict[str, Any] = {
+        "reason": request.reason,
+        "operation": request.operation,
+        "tool_name": request.tool_name,
+        "resource": request.resource,
+    }
+    tool_input = context.get("tool_input")
+    if isinstance(tool_input, dict):
+        metadata.update(tool_input)
+    payload: dict[str, Any] = {
+        "id": permission_id_for_approval(request.id),
+        "sessionID": request.session_id or "",
+        "action": _permission_action(request.tool_name, request.operation),
+        "resources": [resource],
+        "save": [resource],
+        "metadata": metadata,
+    }
+    source = _tool_source(context.get("tool"))
+    if source:
+        payload["source"] = source
+    return payload
+
+
+def _permission_event_payload(properties: Mapping[str, Any]) -> dict[str, Any] | None:
+    request_id = _string(properties.get("id"))
+    session_id = _string(properties.get("sessionID"))
+    action = _string(properties.get("permission"))
+    resources = _string_list(properties.get("patterns"))
+    if not request_id or not session_id or not action:
+        return None
+    payload: dict[str, Any] = {
+        "id": permission_id_for_approval(request_id),
+        "sessionID": session_id,
+        "action": _native_permission_action(action),
+        "resources": resources or ["*"],
+    }
+    save = _string_list(properties.get("always"))
+    if save:
+        payload["save"] = save
+    metadata = properties.get("metadata")
+    if isinstance(metadata, Mapping):
+        payload["metadata"] = dict(metadata)
+    source = _tool_source(properties.get("tool"))
+    if source:
+        payload["source"] = source
+    return payload
+
+
+def _permission_action(tool_name: str, operation: str) -> str:
+    tool = _string(tool_name)
+    if tool and tool in _PERMISSION_ACTIONS:
+        return _PERMISSION_ACTIONS[tool]
+    normalized = (_string(operation) or "").lower()
+    if normalized.startswith("filesystem.read"):
+        return "read"
+    if normalized.startswith("filesystem.list"):
+        return "list"
+    if normalized.startswith("filesystem"):
+        return "edit"
+    if normalized.startswith("process"):
+        return "shell"
+    if normalized.startswith("network.fetch"):
+        return "webfetch"
+    return "tool"
+
+
+def _native_permission_action(action: str) -> str:
+    return {"bash": "shell", "task": "subagent"}.get(action, action)
+
+
+def _tool_source(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, Mapping):
+        return None
+    message_id = _string(value.get("messageID"))
+    call_id = _string(value.get("callID")) or _string(value.get("id"))
+    if not message_id or not call_id:
+        return None
+    return {"type": "tool", "messageID": message_id, "id": call_id}
+
+
+def _question_for_id(session_id: str, form_id: str) -> QuestionRequest | None:
+    raw_id = _legacy_id(form_id, "frm_")
+    if raw_id is None:
+        return None
+    request = get_question_manager().get_request(raw_id)
+    if request is None or request.session_id != session_id:
+        return None
+    return request
+
+
+def _question_form(request: QuestionRequest) -> dict[str, Any] | None:
+    return _question_form_from_mapping(request.to_dict())
+
+
+def _question_form_from_mapping(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    request_id = _string(value.get("id"))
+    session_id = _string(value.get("sessionID"))
+    questions = value.get("questions")
+    if (
+        not request_id
+        or not session_id
+        or not isinstance(questions, list)
+        or not questions
+    ):
+        return None
+    fields: list[dict[str, Any]] = []
+    for index, question in enumerate(questions):
+        field = _question_field(index, question)
+        if field is None:
+            return None
+        fields.append(field)
+    first_title = (
+        _string(questions[0].get("header"))
+        if isinstance(questions[0], Mapping)
+        else None
+    )
+    return {
+        "id": form_id_for_question(request_id),
+        "sessionID": session_id,
+        "title": first_title if len(fields) == 1 and first_title else "Questions",
+        "fields": fields,
+    }
+
+
+def _question_field(index: int, value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    question = _string(value.get("question"))
+    header = _string(value.get("header"))
+    raw_options = value.get("options")
+    if not question or not header or not isinstance(raw_options, list):
+        return None
+    options: list[dict[str, Any]] = []
+    for raw_option in raw_options:
+        if not isinstance(raw_option, Mapping):
+            return None
+        label = _string(raw_option.get("label"))
+        if not label:
+            return None
+        option: dict[str, Any] = {"value": label, "label": label}
+        description = _string(raw_option.get("description"))
+        if description:
+            option["description"] = description
+        options.append(option)
+    if not options:
+        return None
+    common: dict[str, Any] = {
+        "key": _question_key(index),
+        "title": header,
+        "description": question,
+        "required": True,
+        "options": options,
+        "custom": value.get("custom")
+        if isinstance(value.get("custom"), bool)
+        else True,
+    }
+    if value.get("multiple") is True:
+        return {**common, "type": "multiselect"}
+    return {**common, "type": "string"}
+
+
+def _ordered_question_answers(
+    request: QuestionRequest,
+    answer: Mapping[str, Any],
+) -> list[list[str]]:
+    expected = {_question_key(index) for index in range(len(request.questions))}
+    if set(answer) != expected:
+        unknown = sorted(set(answer) - expected)
+        missing = sorted(expected - set(answer))
+        detail = (
+            f"unknown fields: {', '.join(unknown)}"
+            if unknown
+            else f"missing fields: {', '.join(missing)}"
+        )
+        raise InteractionPayloadError(detail)
+
+    ordered: list[list[str]] = []
+    for index, question in enumerate(request.questions):
+        if not isinstance(question, Mapping):
+            raise InteractionPayloadError("question request is malformed")
+        value = answer[_question_key(index)]
+        multiple = question.get("multiple") is True
+        if multiple:
+            if (
+                not isinstance(value, list)
+                or not value
+                or not all(isinstance(item, str) and item for item in value)
+            ):
+                raise InteractionPayloadError(
+                    f"expected a non-empty string array for {_question_key(index)}"
+                )
+            selected = list(value)
+        else:
+            if not isinstance(value, str) or not value:
+                raise InteractionPayloadError(
+                    f"expected a non-empty string for {_question_key(index)}"
+                )
+            selected = [value]
+        if question.get("custom") is False:
+            labels = {
+                item.get("label")
+                for item in question.get("options", [])
+                if isinstance(item, Mapping)
+            }
+            if any(item not in labels for item in selected):
+                raise InteractionPayloadError(
+                    f"invalid option for {_question_key(index)}"
+                )
+        ordered.append(selected)
+    return ordered
+
+
+def _form_answer_from_ordered(
+    request: QuestionRequest,
+    answers: list[Any],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for index, question in enumerate(request.questions):
+        values = answers[index] if index < len(answers) else []
+        values = values if isinstance(values, list) else []
+        strings = [item for item in values if isinstance(item, str)]
+        if isinstance(question, Mapping) and question.get("multiple") is True:
+            result[_question_key(index)] = strings
+        else:
+            result[_question_key(index)] = strings[0] if strings else ""
+    return result
+
+
+def _question_key(index: int) -> str:
+    return f"question_{index}"
+
+
+def _legacy_id(value: str, prefix: str) -> str | None:
+    return (
+        value[len(prefix) :]
+        if value.startswith(prefix) and len(value) > len(prefix)
+        else None
+    )
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _string(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/tests/api/test_opencode_v2_events.py
+++ b/tests/api/test_opencode_v2_events.py
@@ -1,0 +1,825 @@
+from __future__ import annotations
+
+from typing import Any
+
+from penguin.web.services.opencode_v2_events import (
+    OpenCodeV2EventProjector,
+    server_connected_event,
+)
+
+SESSION_ID = "session_prompt"
+USER_ID = "msg_user"
+ASSISTANT_ID = "msg_assistant"
+
+
+def _source_events(directory: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "source-session",
+            "time": 1,
+            "type": "session.created",
+            "properties": {
+                "sessionID": SESSION_ID,
+                "info": {
+                    "id": SESSION_ID,
+                    "projectID": "penguin",
+                    "directory": directory,
+                    "title": "Prompt contract",
+                    "agent": "build",
+                    "providerID": "openai",
+                    "modelID": "gpt-test",
+                    "version": "2.0-test",
+                },
+            },
+        },
+        {
+            "id": "source-busy",
+            "time": 2,
+            "type": "session.status",
+            "properties": {
+                "sessionID": SESSION_ID,
+                "status": {"type": "busy"},
+            },
+        },
+        {
+            "id": "source-user",
+            "time": 3,
+            "type": "message.updated",
+            "properties": {
+                "id": USER_ID,
+                "sessionID": SESSION_ID,
+                "role": "user",
+                "time": {"created": 3},
+            },
+        },
+        {
+            "id": "source-user-part",
+            "time": 4,
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "id": "part_user",
+                    "messageID": USER_ID,
+                    "sessionID": SESSION_ID,
+                    "type": "text",
+                    "text": "Say hello",
+                }
+            },
+        },
+        {
+            "id": "source-assistant",
+            "time": 5,
+            "type": "message.updated",
+            "properties": {
+                "id": ASSISTANT_ID,
+                "sessionID": SESSION_ID,
+                "role": "assistant",
+                "agent": "build",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": {"created": 5, "completed": None},
+                "cost": 0,
+                "tokens": {},
+            },
+        },
+        {
+            "id": "source-delta-1",
+            "time": 6,
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "id": "part_assistant",
+                    "messageID": ASSISTANT_ID,
+                    "sessionID": SESSION_ID,
+                    "type": "text",
+                    "text": "Hel",
+                },
+                "delta": "Hel",
+            },
+        },
+        {
+            "id": "source-delta-2",
+            "time": 7,
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "id": "part_assistant",
+                    "messageID": ASSISTANT_ID,
+                    "sessionID": SESSION_ID,
+                    "type": "text",
+                    "text": "Hello",
+                },
+                "delta": "lo",
+            },
+        },
+        {
+            "id": "source-assistant-complete",
+            "time": 8,
+            "type": "message.updated",
+            "properties": {
+                "id": ASSISTANT_ID,
+                "sessionID": SESSION_ID,
+                "role": "assistant",
+                "agent": "build",
+                "providerID": "openai",
+                "modelID": "gpt-test",
+                "time": {"created": 5, "completed": 8},
+                "finish": "stop",
+                "cost": 0.25,
+                "tokens": {
+                    "input": 4,
+                    "output": 2,
+                    "reasoning": 1,
+                    "cache": {"read": 3, "write": 0},
+                },
+            },
+        },
+        {
+            "id": "source-idle",
+            "time": 9,
+            "type": "session.status",
+            "properties": {
+                "sessionID": SESSION_ID,
+                "status": {"type": "idle"},
+            },
+        },
+    ]
+
+
+def _project(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    projector = OpenCodeV2EventProjector()
+    return [projected for source in events for projected in projector.project(source)]
+
+
+def _tool_part_event(
+    source_id: str,
+    status: str,
+    *,
+    call_id: str = "call_read",
+    part_id: str = "part_tool_read",
+    name: str = "read",
+    tool_input: dict[str, Any] | None = None,
+    output: Any = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    created: int = 7,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "status": status,
+        "input": tool_input or {"path": "README.md"},
+        "time": {"start": 7},
+    }
+    if status == "completed":
+        state["output"] = output
+        state["time"]["end"] = created
+    if status == "error":
+        state["error"] = error
+        state["time"]["end"] = created
+    if metadata is not None:
+        state["metadata"] = metadata
+    return {
+        "id": source_id,
+        "time": created,
+        "type": "message.part.updated",
+        "properties": {
+            "part": {
+                "id": part_id,
+                "messageID": ASSISTANT_ID,
+                "sessionID": SESSION_ID,
+                "type": "tool",
+                "callID": call_id,
+                "tool": name,
+                "state": state,
+            }
+        },
+    }
+
+
+def _retarget(
+    value: Any,
+    *,
+    session_id: str,
+    user_id: str,
+    assistant_id: str,
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _retarget(
+                item,
+                session_id=session_id,
+                user_id=user_id,
+                assistant_id=assistant_id,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _retarget(
+                item,
+                session_id=session_id,
+                user_id=user_id,
+                assistant_id=assistant_id,
+            )
+            for item in value
+        ]
+    replacements = {
+        SESSION_ID: session_id,
+        USER_ID: user_id,
+        ASSISTANT_ID: assistant_id,
+    }
+    if isinstance(value, str) and value.startswith("source-"):
+        return f"{value}-{session_id}"
+    return replacements.get(value, value)
+
+
+def test_prompt_events_match_native_v2_lifecycle(tmp_path: Any) -> None:
+    output = _project(_source_events(str(tmp_path)))
+
+    assert [event["type"] for event in output] == [
+        "session.created",
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+        "session.step.started",
+        "session.text.started",
+        "session.text.delta",
+        "session.text.delta",
+        "session.text.ended",
+        "session.step.ended",
+        "session.execution.succeeded",
+    ]
+    admitted = output[1]
+    assert admitted["data"] == {
+        "sessionID": SESSION_ID,
+        "inputID": USER_ID,
+        "input": {
+            "type": "user",
+            "data": {"text": "Say hello"},
+            "delivery": "steer",
+        },
+    }
+    assert output[4]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "agent": "build",
+        "model": {"providerID": "openai", "id": "gpt-test"},
+    }
+    assert [event["data"]["delta"] for event in output[6:8]] == ["Hel", "lo"]
+    assert output[8]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "ordinal": 0,
+        "text": "Hello",
+    }
+    assert output[9]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "finish": "stop",
+        "cost": 0.25,
+        "tokens": {
+            "input": 4,
+            "output": 2,
+            "reasoning": 1,
+            "cache": {"read": 3, "write": 0},
+        },
+    }
+
+    assert all(event["id"].startswith("evt_") for event in output)
+    assert len({event["id"] for event in output}) == len(output)
+    durable = [event["durable"] for event in output if "durable" in event]
+    assert durable == [
+        {"aggregateID": SESSION_ID, "seq": sequence, "version": 1}
+        for sequence in range(9)
+    ]
+    assert all(
+        "durable" not in event for event in output if event["type"].endswith(".delta")
+    )
+
+
+def test_projection_is_deterministic_and_sequences_are_per_session(
+    tmp_path: Any,
+) -> None:
+    events = _source_events(str(tmp_path))
+    assert _project(events) == _project(events)
+
+    projector = OpenCodeV2EventProjector()
+    first = projector.project(events[0])[0]
+    second_source = {
+        **events[0],
+        "id": "source-other-session",
+        "properties": {
+            **events[0]["properties"],
+            "sessionID": "session_other",
+            "info": {
+                **events[0]["properties"]["info"],
+                "id": "session_other",
+            },
+        },
+    }
+    second = projector.project(second_source)[0]
+
+    assert first["durable"]["seq"] == 0
+    assert second["durable"]["seq"] == 0
+
+
+def test_duplicate_terminal_events_do_not_restart_execution(tmp_path: Any) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    output = [event for source in events for event in projector.project(source)]
+
+    assert projector.project(events[3]) == []
+    assert projector.project(events[7]) == []
+    assert projector.project(events[8]) == []
+    assert projector.project({"type": "unknown", "properties": {}}) == []
+    assert output[-1]["type"] == "session.execution.succeeded"
+
+
+def test_interleaved_sessions_keep_state_and_sequences_isolated(tmp_path: Any) -> None:
+    first = _retarget(
+        _source_events(str(tmp_path / "first")),
+        session_id="session_first",
+        user_id="msg_user_first",
+        assistant_id="msg_assistant_first",
+    )
+    second = _retarget(
+        _source_events(str(tmp_path / "second")),
+        session_id="session_second",
+        user_id="msg_user_second",
+        assistant_id="msg_assistant_second",
+    )
+    interleaved = [source for pair in zip(first, second) for source in pair]
+
+    output = _project(interleaved)
+
+    for session_id, assistant_id, directory in (
+        ("session_first", "msg_assistant_first", str(tmp_path / "first")),
+        ("session_second", "msg_assistant_second", str(tmp_path / "second")),
+    ):
+        session_events = [
+            event for event in output if event["data"]["sessionID"] == session_id
+        ]
+        durable = [event["durable"] for event in session_events if "durable" in event]
+        assert [item["seq"] for item in durable] == list(range(9))
+        assert all(item["aggregateID"] == session_id for item in durable)
+        assert all(
+            event["location"]["directory"] == directory for event in session_events
+        )
+        assert all(
+            event["data"].get("assistantMessageID", assistant_id) == assistant_id
+            for event in session_events
+        )
+
+
+def test_duplicate_late_and_out_of_order_inputs_are_ignored(tmp_path: Any) -> None:
+    events = _source_events(str(tmp_path))
+    out_of_order = OpenCodeV2EventProjector()
+
+    assert out_of_order.project(events[3]) == []
+    assert out_of_order.project(events[6]) == []
+    assert out_of_order.project(events[8]) == []
+
+    projector = OpenCodeV2EventProjector()
+    initial = [event for source in events[:6] for event in projector.project(source)]
+    assert initial[-1]["type"] == "session.text.delta"
+    assert projector.project(events[5]) == []
+
+    terminal = projector.project(events[8])
+    assert [event["type"] for event in terminal] == [
+        "session.text.ended",
+        "session.step.ended",
+        "session.execution.succeeded",
+    ]
+    assert terminal[0]["data"]["text"] == "Hel"
+    assert projector.project(events[6]) == []
+    assert projector.project(events[7]) == []
+    assert projector.project(events[8]) == []
+
+
+def test_idle_closes_an_incomplete_text_boundary(tmp_path: Any) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    for source in events[:6]:
+        projector.project(source)
+
+    output = projector.project(events[8])
+
+    assert [event["type"] for event in output] == [
+        "session.text.ended",
+        "session.step.ended",
+        "session.execution.succeeded",
+    ]
+    assert output[0]["data"]["text"] == "Hel"
+
+
+def test_completion_closes_an_empty_text_boundary(tmp_path: Any) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    for source in events[:5]:
+        projector.project(source)
+    empty_part = {
+        "id": "source-empty-text",
+        "time": 6,
+        "type": "message.part.updated",
+        "properties": {
+            "part": {
+                "id": "part_empty",
+                "messageID": ASSISTANT_ID,
+                "sessionID": SESSION_ID,
+                "type": "text",
+                "text": "",
+            }
+        },
+    }
+
+    started = projector.project(empty_part)
+    completed = projector.project(events[7])
+
+    assert [event["type"] for event in started] == ["session.text.started"]
+    assert [event["type"] for event in completed] == [
+        "session.text.ended",
+        "session.step.ended",
+    ]
+    assert completed[0]["data"]["text"] == ""
+
+
+def test_provider_error_emits_failed_boundaries_without_late_success(
+    tmp_path: Any,
+) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    output = [event for source in events[:6] for event in projector.project(source)]
+    provider_error = {
+        **events[7],
+        "id": "source-provider-error",
+        "properties": {
+            **events[7]["properties"],
+            "error": {
+                "name": "APIError",
+                "data": {
+                    "message": "Provider unavailable",
+                    "isRetryable": True,
+                    "statusCode": 503,
+                    "metadata": {"provider": "openai"},
+                },
+            },
+        },
+    }
+
+    failed = projector.project(provider_error)
+    output.extend(failed)
+
+    assert [event["type"] for event in failed] == [
+        "session.text.ended",
+        "session.step.failed",
+        "session.execution.failed",
+    ]
+    error = {"type": "APIError", "message": "Provider unavailable", "status": 503}
+    assert failed[1]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "error": error,
+    }
+    assert failed[2]["data"] == {"sessionID": SESSION_ID, "error": error}
+    assert [event["durable"]["seq"] for event in output if "durable" in event] == list(
+        range(9)
+    )
+    assert all(event["type"] != "session.execution.succeeded" for event in output)
+
+    late_completion = {**events[7], "id": "source-late-success"}
+    stale_other_completion = {
+        **events[7],
+        "id": "source-stale-other-success",
+        "properties": {
+            **events[7]["properties"],
+            "id": "msg_stale_assistant",
+        },
+    }
+    second_idle = {**events[8], "id": "source-idle-again", "time": 10}
+    assert projector.project(late_completion) == []
+    assert projector.project(stale_other_completion) == []
+    assert projector.project(events[8]) == []
+    assert projector.project(second_idle) == []
+
+    retry_user = {
+        **events[2],
+        "id": "source-retry-user",
+        "properties": {**events[2]["properties"], "id": "msg_retry_user"},
+    }
+    retry_part = {
+        **events[3],
+        "id": "source-retry-part",
+        "properties": {
+            "part": {
+                **events[3]["properties"]["part"],
+                "id": "part_retry_user",
+                "messageID": "msg_retry_user",
+            }
+        },
+    }
+    assert projector.project(retry_user) == []
+    retry = projector.project(retry_part)
+    assert [event["type"] for event in retry] == [
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+    ]
+    assert [event["durable"]["seq"] for event in retry] == [9, 10, 11]
+
+
+def test_missing_legacy_delivery_uses_explicit_projector_default(
+    tmp_path: Any,
+) -> None:
+    projector = OpenCodeV2EventProjector(default_delivery="queue")
+    output = [
+        event
+        for source in _source_events(str(tmp_path))[:4]
+        for event in projector.project(source)
+    ]
+
+    assert output[1]["type"] == "session.input.admitted"
+    assert output[1]["data"]["input"]["delivery"] == "queue"
+
+
+def test_tool_success_projects_exact_native_boundaries_after_adjacent_text(
+    tmp_path: Any,
+) -> None:
+    projector = OpenCodeV2EventProjector()
+    output = [
+        event
+        for source in _source_events(str(tmp_path))[:6]
+        for event in projector.project(source)
+    ]
+    running = projector.project(
+        _tool_part_event(
+            "source-tool-running",
+            "running",
+            metadata={"title": "Read README"},
+        )
+    )
+    succeeded = projector.project(
+        _tool_part_event(
+            "source-tool-completed",
+            "completed",
+            output="Penguin docs",
+            metadata={"title": "Read README", "lines": 1},
+            created=8,
+        )
+    )
+    completed = projector.project(_source_events(str(tmp_path))[7])
+    idle = projector.project(_source_events(str(tmp_path))[8])
+    output.extend([*running, *succeeded, *completed, *idle])
+
+    assert [event["type"] for event in running] == [
+        "session.text.ended",
+        "session.tool.input.started",
+        "session.tool.input.ended",
+        "session.tool.called",
+        "session.tool.progress",
+    ]
+    assert running[0]["data"]["text"] == "Hel"
+    assert running[1]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "id": "call_read",
+        "name": "read",
+    }
+    assert running[2]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "id": "call_read",
+        "text": '{"path":"README.md"}',
+    }
+    assert running[3]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "id": "call_read",
+        "input": {"path": "README.md"},
+        "executed": False,
+    }
+    assert running[4]["data"]["metadata"] == {"title": "Read README"}
+    assert "durable" not in running[4]
+    assert [event["type"] for event in succeeded] == ["session.tool.success"]
+    assert succeeded[0]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "id": "call_read",
+        "content": [{"type": "text", "text": "Penguin docs"}],
+        "executed": False,
+        "metadata": {"lines": 1, "title": "Read README"},
+    }
+    assert succeeded[0]["durable"]["version"] == 2
+    assert [event["type"] for event in completed] == ["session.step.ended"]
+    assert [event["type"] for event in idle] == ["session.execution.succeeded"]
+    assert [event["durable"]["seq"] for event in output if "durable" in event] == list(
+        range(13)
+    )
+
+
+def test_tool_error_is_terminal_without_fabricated_success(tmp_path: Any) -> None:
+    projector = OpenCodeV2EventProjector()
+    output = [
+        event
+        for source in _source_events(str(tmp_path))[:5]
+        for event in projector.project(source)
+    ]
+    running_event = _tool_part_event("source-tool-error-running", "running")
+    failed_event = _tool_part_event(
+        "source-tool-error",
+        "error",
+        error="README.md is unavailable",
+        metadata={"path": "README.md"},
+        created=8,
+    )
+    late_success = _tool_part_event(
+        "source-tool-late-success",
+        "completed",
+        output="should be ignored",
+        created=9,
+    )
+    output.extend(projector.project(running_event))
+    failed = projector.project(failed_event)
+    output.extend(failed)
+
+    assert [event["type"] for event in failed] == ["session.tool.failed"]
+    assert failed[0]["data"] == {
+        "sessionID": SESSION_ID,
+        "assistantMessageID": ASSISTANT_ID,
+        "id": "call_read",
+        "error": {
+            "type": "tool.execution",
+            "message": "README.md is unavailable",
+        },
+        "executed": False,
+        "metadata": {"path": "README.md"},
+    }
+    assert failed[0]["durable"]["version"] == 2
+    assert projector.project({**failed_event, "id": "source-tool-error-again"}) == []
+    assert projector.project(late_success) == []
+
+    completed = projector.project(_source_events(str(tmp_path))[7])
+    idle = projector.project(_source_events(str(tmp_path))[8])
+    output.extend([*completed, *idle])
+    assert [event["type"] for event in completed] == ["session.step.ended"]
+    assert [event["type"] for event in idle] == ["session.execution.succeeded"]
+    assert all(event["type"] != "session.tool.success" for event in output)
+    assert all(event["type"] != "session.execution.failed" for event in output)
+
+
+def test_multiple_tools_keep_call_identity_and_sequence_isolated(tmp_path: Any) -> None:
+    projector = OpenCodeV2EventProjector()
+    output = [
+        event
+        for source in _source_events(str(tmp_path))[:5]
+        for event in projector.project(source)
+    ]
+    sources = [
+        _tool_part_event("source-tool-one-running", "running"),
+        _tool_part_event(
+            "source-tool-two-running",
+            "running",
+            call_id="call_bash",
+            part_id="part_tool_bash",
+            name="bash",
+            tool_input={"command": "pytest -q"},
+        ),
+        _tool_part_event(
+            "source-tool-two-success",
+            "completed",
+            call_id="call_bash",
+            part_id="part_tool_bash",
+            name="bash",
+            tool_input={"command": "pytest -q"},
+            output="2 passed",
+            created=8,
+        ),
+        _tool_part_event(
+            "source-tool-one-failed",
+            "error",
+            error="missing file",
+            created=9,
+        ),
+    ]
+    output.extend(event for source in sources for event in projector.project(source))
+
+    called = [event for event in output if event["type"] == "session.tool.called"]
+    terminal = [
+        event
+        for event in output
+        if event["type"] in {"session.tool.success", "session.tool.failed"}
+    ]
+    assert [event["data"]["id"] for event in called] == [
+        "call_read",
+        "call_bash",
+    ]
+    assert [(event["type"], event["data"]["id"]) for event in terminal] == [
+        ("session.tool.success", "call_bash"),
+        ("session.tool.failed", "call_read"),
+    ]
+    assert all(
+        event["data"]["assistantMessageID"] == ASSISTANT_ID
+        for event in [*called, *terminal]
+    )
+    assert [event["durable"]["seq"] for event in output if "durable" in event] == list(
+        range(13)
+    )
+
+
+def test_late_tool_terminal_completes_a_prior_pending_idle(tmp_path: Any) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    output = [event for source in events[:5] for event in projector.project(source)]
+    output.extend(
+        projector.project(_tool_part_event("source-tool-late-running", "running"))
+    )
+
+    assert projector.project(events[7]) == []
+    assert projector.project(events[8]) == []
+    late_terminal_source = _tool_part_event(
+        "source-tool-late-terminal",
+        "completed",
+        output="done after idle",
+        created=10,
+    )
+    terminal = projector.project(late_terminal_source)
+    output.extend(terminal)
+
+    assert [event["type"] for event in terminal] == [
+        "session.tool.success",
+        "session.step.ended",
+        "session.execution.succeeded",
+    ]
+    assert terminal[0]["data"]["content"] == [
+        {"type": "text", "text": "done after idle"}
+    ]
+    assert terminal[2]["data"] == {"sessionID": SESSION_ID}
+    assert all(event["created"] == 10 for event in terminal)
+    assert [event["durable"]["seq"] for event in output if "durable" in event] == list(
+        range(11)
+    )
+    assert (
+        projector.project(
+            {**late_terminal_source, "id": "source-tool-late-terminal-duplicate"}
+        )
+        == []
+    )
+    assert projector.project({**events[8], "id": "source-idle-after-terminal"}) == []
+
+
+def test_unsettled_tool_blocks_success_and_provider_failure_wins(
+    tmp_path: Any,
+) -> None:
+    events = _source_events(str(tmp_path))
+    projector = OpenCodeV2EventProjector()
+    output = [event for source in events[:5] for event in projector.project(source)]
+    output.extend(
+        projector.project(_tool_part_event("source-tool-provider-running", "running"))
+    )
+
+    assert projector.project(events[8]) == []
+    provider_error = {
+        **events[7],
+        "id": "source-provider-error-with-tool",
+        "properties": {
+            **events[7]["properties"],
+            "error": {
+                "name": "APIError",
+                "data": {
+                    "message": "Provider unavailable",
+                    "isRetryable": False,
+                    "statusCode": 503,
+                },
+            },
+        },
+    }
+    failed = projector.project(provider_error)
+    output.extend(failed)
+
+    assert [event["type"] for event in failed] == [
+        "session.step.failed",
+        "session.execution.failed",
+    ]
+    assert (
+        projector.project(
+            _tool_part_event(
+                "source-tool-after-provider-failure",
+                "completed",
+                output="late",
+                created=10,
+            )
+        )
+        == []
+    )
+    assert projector.project({**events[8], "id": "source-idle-after-failure"}) == []
+    assert all(event["type"] != "session.execution.succeeded" for event in output)
+    assert all(event["type"] != "session.tool.success" for event in output)
+
+
+def test_server_connected_handshake_is_exact_and_deterministic() -> None:
+    connected = server_connected_event("connection-1")
+
+    assert connected == server_connected_event("connection-1")
+    assert connected["id"].startswith("evt_")
+    assert connected["type"] == "server.connected"
+    assert connected["data"] == {}
+    assert set(connected) == {"id", "type", "data"}
+    assert connected["id"] != server_connected_event("connection-2")["id"]

--- a/tests/api/test_opencode_v2_routes.py
+++ b/tests/api/test_opencode_v2_routes.py
@@ -1,0 +1,1628 @@
+"""Contract tests for Penguin's pinned OpenCode 2 compatibility slice."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from penguin.security.approval import get_approval_manager
+from penguin.security.question import get_question_manager
+from penguin.system.state import Session
+from penguin.web import opencode_v2_routes as routes
+from penguin.web.services.opencode_events import emit_opencode_event
+from penguin.web.services.opencode_v2 import (
+    UPSTREAM_V2_COMMIT,
+    active_sessions_payload,
+    create_session_payload,
+    event_payload,
+    prompt_payload,
+)
+from penguin.web.services.opencode_v2_interactions import (
+    form_id_for_question,
+    permission_id_for_approval,
+)
+from penguin.web.services.session_view import TRANSCRIPT_KEY
+
+
+class _EventBus:
+    def __init__(self) -> None:
+        self.handlers: dict[str, list[Any]] = {}
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def subscribe(self, event_type: str, handler: Any) -> None:
+        self.handlers.setdefault(event_type, []).append(handler)
+
+    def unsubscribe(self, event_type: str, handler: Any) -> None:
+        self.handlers.get(event_type, []).remove(handler)
+
+    async def emit(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+        for handler in list(self.handlers.get(event_type, [])):
+            handler(event_type, data)
+
+
+class _Manager:
+    def __init__(self) -> None:
+        self.sessions: dict[str, tuple[Session, bool]] = {}
+        self.session_index: dict[str, dict[str, Any]] = {}
+        self.current_session: Session | None = None
+
+    def create_session(self) -> Session:
+        session = Session()
+        self.sessions[session.id] = (session, True)
+        self.current_session = session
+        self.save_session(session)
+        return session
+
+    def load_session(self, session_id: str) -> Session | None:
+        row = self.sessions.get(session_id)
+        return row[0] if row else None
+
+    def mark_session_modified(self, session_id: str) -> None:
+        session = self.load_session(session_id)
+        if session:
+            self.sessions[session_id] = (session, True)
+
+    def save_session(self, session: Session) -> bool:
+        self.sessions[session.id] = (session, False)
+        self.session_index[session.id] = {
+            "created_at": session.created_at,
+            "last_active": session.last_active,
+            "message_count": len(session.messages),
+            "title": session.metadata.get("title", ""),
+            "directory": session.metadata.get("directory", ""),
+        }
+        return True
+
+    def delete_session(self, session_id: str) -> bool:
+        existed = session_id in self.sessions
+        self.sessions.pop(session_id, None)
+        self.session_index.pop(session_id, None)
+        return existed
+
+
+class _Core:
+    def __init__(self, workspace: Path) -> None:
+        manager = _Manager()
+        self.runtime_config = SimpleNamespace(
+            workspace_root=str(workspace),
+            project_root=str(workspace),
+            active_root=str(workspace),
+        )
+        self.model_config = SimpleNamespace(provider="openai", model="gpt-5")
+        self.conversation_manager = SimpleNamespace(
+            session_manager=manager,
+            current_agent_id="default",
+            agent_session_managers={"default": manager},
+        )
+        self.event_bus = _EventBus()
+        self._opencode_session_directories: dict[str, str] = {}
+        self._opencode_stream_states: dict[str, dict[str, Any]] = {}
+        self.abort_session = AsyncMock(return_value=True)
+
+
+def _client(core: _Core) -> TestClient:
+    routes.router.core = cast("Any", core)
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.add_exception_handler(routes.OpenCodeV2HTTPError, routes.handle_http_error)
+    return TestClient(app)
+
+
+def _fixture() -> dict[str, Any]:
+    path = (
+        Path(__file__).parents[1] / "fixtures" / "opencode_v2" / "core_contracts.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_interaction_managers() -> Any:
+    approval = get_approval_manager()
+    question = get_question_manager()
+    approval.reset()
+    question.reset()
+    yield
+    approval.reset()
+    question.reset()
+
+
+def test_pinned_fixture_matches_implementation() -> None:
+    assert _fixture()["upstream"]["commit"] == UPSTREAM_V2_COMMIT
+
+
+def test_health_and_deep_location_contract(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        health = client.get("/api/health")
+        location = client.get(
+            "/api/location",
+            params={"location[directory]": str(tmp_path)},
+        )
+
+    assert health.status_code == 200
+    assert set(_fixture()["health_required"]) <= health.json().keys()
+    assert health.json()["healthy"] is True
+    assert health.json()["pid"] > 0
+    assert location.status_code == 200
+    assert location.json() == {
+        "directory": str(tmp_path.resolve()),
+        "project": {
+            "id": "penguin",
+            "directory": str(tmp_path.resolve()),
+            "canonical": str(tmp_path.resolve()),
+        },
+    }
+
+
+def test_filesystem_vcs_and_project_boot_contract(tmp_path: Path) -> None:
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "note.txt").write_text("hello", encoding="utf-8")
+    core = _Core(tmp_path)
+    params = {"location[directory]": str(tmp_path)}
+
+    with _client(core) as client:
+        filesystem = client.get("/api/fs/list", params=params)
+        vcs = client.get("/api/vcs", params=params)
+        current = client.get("/api/project/current", params=params)
+        projects = client.get("/api/project")
+        escaped = client.get("/api/fs/list", params={**params, "path": ".."})
+
+    expected_location = {
+        "directory": str(tmp_path.resolve()),
+        "project": {
+            "id": "penguin",
+            "directory": str(tmp_path.resolve()),
+            "canonical": str(tmp_path.resolve()),
+        },
+    }
+    assert filesystem.status_code == 200
+    assert filesystem.json() == {
+        "location": expected_location,
+        "data": [
+            {"path": "alpha/", "type": "directory"},
+            {"path": "note.txt", "type": "file"},
+        ],
+    }
+    assert vcs.status_code == 200
+    assert vcs.json() == {
+        "location": expected_location,
+        "data": {"branch": {}},
+    }
+    assert current.json() == {
+        "id": "penguin",
+        "directory": str(tmp_path.resolve()),
+        "canonical": str(tmp_path.resolve()),
+    }
+    project = projects.json()[0]
+    assert project["id"] == "penguin"
+    assert project["canonical"] == str(tmp_path.resolve())
+    assert project["name"] == tmp_path.name
+    assert project["sandboxes"] == []
+    assert set(project["time"]) == {"created", "updated"}
+    assert escaped.status_code == 400
+    assert escaped.json() == {
+        "_tag": "InvalidRequestError",
+        "message": "path escapes the requested location",
+    }
+
+
+def test_location_catalogs_are_complete_and_exactly_shaped(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    params = {
+        "location[directory]": str(tmp_path),
+        "location[workspace]": "workspace_one",
+    }
+    empty_paths = [
+        "/api/command",
+        "/api/integration",
+        "/api/mcp",
+        "/api/reference",
+        "/api/skill",
+        "/api/shell",
+        "/api/form/request",
+    ]
+
+    with _client(core) as client:
+        agents = client.get("/api/agent", params=params)
+        models = client.get("/api/model", params=params)
+        providers = client.get("/api/provider", params=params)
+        empty = {path: client.get(path, params=params) for path in empty_paths}
+        resources = client.get("/api/mcp/resource", params=params)
+        migration = client.get("/api/experimental/migration/v1")
+
+    expected_location = {
+        "directory": str(tmp_path.resolve()),
+        "workspaceID": "workspace_one",
+        "project": {
+            "id": "penguin",
+            "directory": str(tmp_path.resolve()),
+            "canonical": str(tmp_path.resolve()),
+        },
+    }
+    for response in empty.values():
+        assert response.status_code == 200
+        assert response.json() == {"location": expected_location, "data": []}
+
+    model = models.json()["data"][0]
+    assert model == {
+        "id": "gpt-5",
+        "modelID": "gpt-5",
+        "providerID": "openai",
+        "name": "gpt-5",
+        "capabilities": {
+            "tools": True,
+            "input": ["text"],
+            "output": ["text"],
+        },
+        "variants": [],
+        "time": {"released": 0},
+        "cost": [],
+        "status": "active",
+        "enabled": True,
+        "limit": {"context": 128000, "output": 8192},
+    }
+    assert providers.json() == {
+        "location": expected_location,
+        "data": [{"id": "openai", "name": "OpenAI", "package": ""}],
+    }
+    assert agents.json() == {
+        "location": expected_location,
+        "data": [
+            {
+                "id": agent_id,
+                "name": name,
+                "model": {"providerID": "openai", "id": "gpt-5"},
+                "request": {"settings": {}, "headers": {}, "body": {}},
+                "mode": "primary",
+                "hidden": False,
+                "permissions": [],
+            }
+            for agent_id, name in (("build", "Build"), ("plan", "Plan"))
+        ],
+    }
+    assert resources.json() == {
+        "location": expected_location,
+        "data": {"resources": [], "templates": []},
+    }
+    assert migration.json() == {"status": "completed"}
+
+
+def test_session_permission_and_form_hydration_are_empty(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={}).json()["data"]["id"]
+        permissions = client.get(f"/api/session/{session_id}/permission")
+        forms = client.get(f"/api/session/{session_id}/form")
+        missing_permissions = client.get("/api/session/session_missing/permission")
+        missing_forms = client.get("/api/session/session_missing/form")
+
+    assert permissions.json() == {"data": []}
+    assert forms.json() == {"data": []}
+    assert missing_permissions.status_code == 404
+    assert missing_permissions.json()["_tag"] == "SessionNotFoundError"
+    assert missing_forms.status_code == 404
+    assert missing_forms.json()["_tag"] == "SessionNotFoundError"
+
+
+def test_pending_interactions_rehydrate_from_managers_after_disconnect(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={}).json()["data"]["id"]
+
+    approval = get_approval_manager().create_request(
+        tool_name="execute_command",
+        operation="process.execute",
+        resource="pytest -q",
+        reason="Run tests",
+        session_id=session_id,
+    )
+    question = get_question_manager().create_request(
+        session_id=session_id,
+        questions=[
+            {
+                "question": "Run the suite?",
+                "header": "Tests",
+                "options": [{"label": "Run", "description": "Run now"}],
+            }
+        ],
+    )
+
+    with _client(core) as reconnected:
+        permissions = reconnected.get(f"/api/session/{session_id}/permission")
+        forms = reconnected.get(f"/api/session/{session_id}/form")
+
+    assert [item["id"] for item in permissions.json()["data"]] == [
+        permission_id_for_approval(approval.id)
+    ]
+    assert [item["id"] for item in forms.json()["data"]] == [
+        form_id_for_question(question.id)
+    ]
+
+
+def test_permission_list_get_reply_reject_and_session_isolation(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    manager = get_approval_manager()
+    with _client(core) as client:
+        first_session = client.post("/api/session", json={}).json()["data"]["id"]
+        second_session = client.post("/api/session", json={}).json()["data"]["id"]
+        first = manager.create_request(
+            tool_name="write_to_file",
+            operation="filesystem.write",
+            resource="src/app.py",
+            reason="Write requires approval",
+            session_id=first_session,
+            context={
+                "tool_input": {"path": "src/app.py"},
+                "tool": {"messageID": "msg_1", "callID": "call_1"},
+            },
+        )
+        manager.create_request(
+            tool_name="execute_command",
+            operation="process.execute",
+            resource="pytest -q",
+            reason="Command requires approval",
+            session_id=second_session,
+        )
+        permission_id = permission_id_for_approval(first.id)
+
+        listed = client.get(f"/api/session/{first_session}/permission")
+        fetched = client.get(f"/api/session/{first_session}/permission/{permission_id}")
+        global_list = client.get(
+            "/api/permission/request",
+            params={"location[directory]": str(tmp_path)},
+        )
+        wrong_session = client.get(
+            f"/api/session/{second_session}/permission/{permission_id}"
+        )
+        malformed = client.post(
+            f"/api/session/{first_session}/permission/{permission_id}/reply",
+            json={"reply": "maybe"},
+        )
+        replied = client.post(
+            f"/api/session/{first_session}/permission/{permission_id}/reply",
+            json={"reply": "once"},
+        )
+
+        rejected_request = manager.create_request(
+            tool_name="execute_command",
+            operation="process.execute",
+            resource="rm build.txt",
+            reason="Delete generated output",
+            session_id=first_session,
+        )
+        rejected = client.post(
+            f"/api/session/{first_session}/permission/"
+            f"{permission_id_for_approval(rejected_request.id)}/reply",
+            json={"reply": "reject", "message": "Keep the artifact"},
+        )
+
+    expected = {
+        "id": permission_id,
+        "sessionID": first_session,
+        "action": "edit",
+        "resources": ["src/app.py"],
+        "save": ["src/app.py"],
+        "metadata": {
+            "reason": "Write requires approval",
+            "operation": "filesystem.write",
+            "tool_name": "write_to_file",
+            "resource": "src/app.py",
+            "path": "src/app.py",
+        },
+        "source": {"type": "tool", "messageID": "msg_1", "id": "call_1"},
+    }
+    assert listed.json() == {"data": [expected]}
+    assert fetched.json() == {"data": expected}
+    assert len(global_list.json()["data"]) == 2
+    assert {
+        item["sessionID"]: item["action"] for item in global_list.json()["data"]
+    } == {first_session: "edit", second_session: "shell"}
+    assert wrong_session.status_code == 404
+    assert wrong_session.json()["_tag"] == "PermissionNotFoundError"
+    assert malformed.status_code == 400
+    assert malformed.json() == {
+        "_tag": "InvalidRequestError",
+        "message": "reply must be one of: once, always, reject",
+    }
+    assert replied.status_code == 204
+    assert manager.get_request(first.id).status.value == "approved"
+    assert rejected.status_code == 204
+    resolved_rejection = manager.get_request(rejected_request.id)
+    assert resolved_rejection is not None
+    assert resolved_rejection.status.value == "denied"
+    assert resolved_rejection.context["message"] == "Keep the artifact"
+
+
+def test_permission_events_project_exact_v2_request_and_reply() -> None:
+    asked = event_payload(
+        {
+            "id": "legacy-permission-asked",
+            "time": 10,
+            "type": "permission.asked",
+            "properties": {
+                "id": "legacy_permission",
+                "sessionID": "session_one",
+                "permission": "bash",
+                "patterns": ["pytest -q"],
+                "always": ["pytest -q"],
+                "metadata": {"reason": "Run tests"},
+                "tool": {"messageID": "msg_1", "callID": "call_1"},
+            },
+        }
+    )
+    replied = event_payload(
+        {
+            "id": "legacy-permission-replied",
+            "time": 11,
+            "type": "permission.replied",
+            "properties": {
+                "sessionID": "session_one",
+                "requestID": "legacy_permission",
+                "reply": "always",
+            },
+        }
+    )
+
+    assert asked is not None
+    assert asked["type"] == "permission.asked"
+    assert asked["data"] == {
+        "id": "per_legacy_permission",
+        "sessionID": "session_one",
+        "action": "shell",
+        "resources": ["pytest -q"],
+        "save": ["pytest -q"],
+        "metadata": {"reason": "Run tests"},
+        "source": {"type": "tool", "messageID": "msg_1", "id": "call_1"},
+    }
+    assert "durable" not in asked
+    assert replied is not None
+    assert replied["type"] == "permission.replied"
+    assert replied["data"] == {
+        "sessionID": "session_one",
+        "requestID": "per_legacy_permission",
+        "reply": "always",
+    }
+
+    delegated = event_payload(
+        {
+            "id": "legacy-permission-task",
+            "type": "permission.asked",
+            "properties": {
+                "id": "legacy_task_permission",
+                "sessionID": "session_one",
+                "permission": "task",
+                "patterns": ["explore"],
+            },
+        }
+    )
+    assert delegated is not None
+    assert delegated["data"]["action"] == "subagent"
+
+
+def test_question_forms_list_get_reply_and_validate_ordered_answers(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    manager = get_question_manager()
+    with _client(core) as client:
+        first_session = client.post("/api/session", json={}).json()["data"]["id"]
+        second_session = client.post("/api/session", json={}).json()["data"]["id"]
+        request = manager.create_request(
+            session_id=first_session,
+            questions=[
+                {
+                    "question": "Proceed with migration?",
+                    "header": "Migration",
+                    "options": [
+                        {"label": "Yes", "description": "Continue"},
+                        {"label": "No", "description": "Stop"},
+                    ],
+                    "custom": False,
+                },
+                {
+                    "question": "Which checks should run?",
+                    "header": "Checks",
+                    "options": [
+                        {"label": "Unit", "description": "Unit tests"},
+                        {"label": "API", "description": "API tests"},
+                    ],
+                    "multiple": True,
+                    "custom": False,
+                },
+            ],
+        )
+        form_id = form_id_for_question(request.id)
+
+        listed = client.get(f"/api/session/{first_session}/form")
+        fetched = client.get(f"/api/session/{first_session}/form/{form_id}")
+        global_list = client.get(
+            "/api/form/request",
+            params={"location[directory]": str(tmp_path)},
+        )
+        wrong_session = client.get(f"/api/session/{second_session}/form/{form_id}")
+        malformed = client.post(
+            f"/api/session/{first_session}/form/{form_id}/reply",
+            json={"answer": {"question_0": "Yes"}},
+        )
+        replied = client.post(
+            f"/api/session/{first_session}/form/{form_id}/reply",
+            json={
+                "answer": {
+                    "question_1": ["API", "Unit"],
+                    "question_0": "Yes",
+                }
+            },
+        )
+        retained = client.get(f"/api/session/{first_session}/form/{form_id}")
+        pending_after = client.get(f"/api/session/{first_session}/form")
+        repeated = client.post(
+            f"/api/session/{first_session}/form/{form_id}/reply",
+            json={
+                "answer": {
+                    "question_0": "Yes",
+                    "question_1": ["Unit"],
+                }
+            },
+        )
+
+    form = listed.json()["data"][0]
+    assert form["id"] == form_id
+    assert form["sessionID"] == first_session
+    assert form["title"] == "Questions"
+    assert form["fields"] == [
+        {
+            "key": "question_0",
+            "title": "Migration",
+            "description": "Proceed with migration?",
+            "required": True,
+            "options": [
+                {"value": "Yes", "label": "Yes", "description": "Continue"},
+                {"value": "No", "label": "No", "description": "Stop"},
+            ],
+            "custom": False,
+            "type": "string",
+        },
+        {
+            "key": "question_1",
+            "title": "Checks",
+            "description": "Which checks should run?",
+            "required": True,
+            "options": [
+                {"value": "Unit", "label": "Unit", "description": "Unit tests"},
+                {"value": "API", "label": "API", "description": "API tests"},
+            ],
+            "custom": False,
+            "type": "multiselect",
+        },
+    ]
+    assert fetched.json() == {"data": form}
+    assert global_list.json()["data"] == [form]
+    assert wrong_session.status_code == 404
+    assert wrong_session.json()["_tag"] == "FormNotFoundError"
+    assert malformed.status_code == 400
+    assert malformed.json() == {
+        "_tag": "FormInvalidAnswerError",
+        "id": form_id,
+        "message": "missing fields: question_1",
+    }
+    assert replied.status_code == 204
+    resolved = manager.get_request(request.id)
+    assert resolved is not None
+    assert resolved.status.value == "answered"
+    assert resolved.answers == [["Yes"], ["API", "Unit"]]
+    assert retained.json() == {"data": form}
+    assert pending_after.json() == {"data": []}
+    assert repeated.status_code == 409
+    assert repeated.json()["_tag"] == "FormAlreadySettledError"
+
+
+def test_question_form_cancel_is_session_scoped_and_idempotently_terminal(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    manager = get_question_manager()
+    with _client(core) as client:
+        owner = client.post("/api/session", json={}).json()["data"]["id"]
+        other = client.post("/api/session", json={}).json()["data"]["id"]
+        request = manager.create_request(
+            session_id=owner,
+            questions=[
+                {
+                    "question": "Apply patch?",
+                    "header": "Patch",
+                    "options": [
+                        {"label": "Apply", "description": "Apply now"},
+                        {"label": "Skip", "description": "Skip it"},
+                    ],
+                }
+            ],
+        )
+        form_id = form_id_for_question(request.id)
+
+        wrong_session = client.post(f"/api/session/{other}/form/{form_id}/cancel")
+        cancelled = client.post(f"/api/session/{owner}/form/{form_id}/cancel")
+        repeated = client.post(f"/api/session/{owner}/form/{form_id}/cancel")
+
+    assert wrong_session.status_code == 404
+    assert cancelled.status_code == 204
+    resolved = manager.get_request(request.id)
+    assert resolved is not None
+    assert resolved.status.value == "rejected"
+    assert repeated.status_code == 409
+    assert repeated.json()["_tag"] == "FormAlreadySettledError"
+
+
+def test_question_events_project_to_created_replied_and_cancelled_forms() -> None:
+    manager = get_question_manager()
+    request = manager.create_request(
+        session_id="session_form_events",
+        questions=[
+            {
+                "question": "Pick one",
+                "header": "Pick",
+                "options": [
+                    {"label": "A", "description": "First"},
+                    {"label": "B", "description": "Second"},
+                ],
+                "custom": False,
+            }
+        ],
+    )
+    created = event_payload(
+        {
+            "id": "legacy-question-created",
+            "type": "question.asked",
+            "properties": request.to_dict(),
+        }
+    )
+    manager.reply(request.id, [["A"]])
+    replied = event_payload(
+        {
+            "id": "legacy-question-replied",
+            "type": "question.replied",
+            "properties": {
+                "sessionID": request.session_id,
+                "requestID": request.id,
+                "answers": [["A"]],
+            },
+        }
+    )
+
+    cancelled_request = manager.create_request(
+        session_id="session_form_events",
+        questions=[
+            {
+                "question": "Continue?",
+                "header": "Continue",
+                "options": [{"label": "Yes", "description": "Continue"}],
+            }
+        ],
+    )
+    manager.reject(cancelled_request.id)
+    cancelled = event_payload(
+        {
+            "id": "legacy-question-cancelled",
+            "type": "question.rejected",
+            "properties": {
+                "sessionID": cancelled_request.session_id,
+                "requestID": cancelled_request.id,
+            },
+        }
+    )
+
+    assert created is not None
+    assert created["type"] == "form.created"
+    form = created["data"]["form"]
+    assert form["id"] == form_id_for_question(request.id)
+    assert form["fields"][0]["key"] == "question_0"
+    assert replied is not None
+    assert replied["type"] == "form.replied"
+    assert replied["data"] == {
+        "id": form_id_for_question(request.id),
+        "sessionID": request.session_id,
+        "answer": {"question_0": "A"},
+    }
+    assert cancelled is not None
+    assert cancelled["type"] == "form.cancelled"
+    assert cancelled["data"] == {
+        "id": form_id_for_question(cancelled_request.id),
+        "sessionID": cancelled_request.session_id,
+    }
+    assert "durable" not in created
+    assert "durable" not in replied
+    assert "durable" not in cancelled
+
+
+def test_malformed_question_request_is_not_exposed_as_a_v2_form(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    manager = get_question_manager()
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={}).json()["data"]["id"]
+        malformed = manager.create_request(session_id=session_id, questions=[])
+        listed = client.get(f"/api/session/{session_id}/form")
+        fetched = client.get(
+            f"/api/session/{session_id}/form/{form_id_for_question(malformed.id)}"
+        )
+
+    assert listed.json() == {"data": []}
+    assert fetched.status_code == 404
+    assert (
+        event_payload(
+            {
+                "type": "question.asked",
+                "properties": malformed.to_dict(),
+            }
+        )
+        is None
+    )
+
+
+def test_session_crud_selection_and_exact_error_shape(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        created_response = client.post(
+            "/api/session",
+            json={
+                "title": "V2 session",
+                "agent": "build",
+                "model": {"providerID": "openai", "id": "gpt-5"},
+                "location": {"directory": str(tmp_path)},
+            },
+        )
+        created = created_response.json()["data"]
+        session_id = created["id"]
+
+        listed = client.get("/api/session", params={"order": "desc"})
+        fetched = client.get(f"/api/session/{session_id}")
+        renamed = client.post(
+            f"/api/session/{session_id}/rename", json={"title": "Renamed"}
+        )
+        switched_agent = client.post(
+            f"/api/session/{session_id}/agent", json={"agent": "plan"}
+        )
+        switched_model = client.post(
+            f"/api/session/{session_id}/model",
+            json={
+                "model": {
+                    "providerID": "anthropic",
+                    "id": "claude-sonnet",
+                    "variant": "high",
+                }
+            },
+        )
+        selected = client.get(f"/api/session/{session_id}").json()["data"]
+        removed = client.delete(f"/api/session/{session_id}")
+        missing = client.get(f"/api/session/{session_id}")
+
+    assert created_response.status_code == 200
+    assert set(_fixture()["session_required"]) <= created.keys()
+    assert created["agent"] == "build"
+    assert listed.json()["data"][0]["id"] == session_id
+    assert listed.json()["cursor"] == {}
+    assert fetched.json()["data"] == created
+    assert renamed.status_code == 204
+    assert switched_agent.status_code == 204
+    assert switched_model.status_code == 204
+    assert selected["title"] == "Renamed"
+    assert selected["agent"] == "plan"
+    assert selected["model"] == {
+        "providerID": "anthropic",
+        "id": "claude-sonnet",
+        "variant": "high",
+    }
+    assert removed.status_code == 204
+    assert missing.status_code == 404
+    assert missing.json() == {
+        "_tag": "SessionNotFoundError",
+        "message": f"Session not found: {session_id}",
+        "sessionID": session_id,
+    }
+    emitted_types = [
+        event["type"]
+        for channel, event in core.event_bus.events
+        if channel == "opencode_event"
+    ]
+    assert emitted_types == [
+        "session.created",
+        "session.updated",
+        "session.agent.selected",
+        "session.model.selected",
+        "session.deleted",
+    ]
+
+
+def test_delete_parent_removes_descendants_children_first(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        parent = client.post("/api/session", json={}).json()["data"]
+        child = client.post("/api/session", json={"parentID": parent["id"]}).json()[
+            "data"
+        ]
+        grandchild = client.post("/api/session", json={"parentID": child["id"]}).json()[
+            "data"
+        ]
+        unrelated = client.post("/api/session", json={}).json()["data"]
+
+        removed = client.delete(f"/api/session/{parent['id']}")
+        remaining = client.get("/api/session").json()["data"]
+
+    assert child["parentID"] == parent["id"]
+    assert grandchild["parentID"] == child["id"]
+    assert removed.status_code == 204
+    assert [item["id"] for item in remaining] == [unrelated["id"]]
+    deleted = [
+        event["properties"]["info"]["id"]
+        for channel, event in core.event_bus.events
+        if channel == "opencode_event" and event["type"] == "session.deleted"
+    ]
+    assert deleted == [grandchild["id"], child["id"], parent["id"]]
+
+
+@pytest.mark.asyncio
+async def test_delete_active_session_interrupts_and_awaits_its_task(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    created = create_session_payload(core, {}, default_directory=str(tmp_path))
+    session_id = created["id"]
+    settled = asyncio.Event()
+
+    async def worker() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            settled.set()
+
+    task = asyncio.create_task(worker())
+    await asyncio.sleep(0)
+    core._opencode_active_requests = {session_id: 1}
+    core._opencode_process_tasks = {session_id: {task}}
+
+    async def abort(active_session_id: str) -> bool:
+        assert active_session_id == session_id
+        task.cancel()
+        return True
+
+    core.abort_session = abort
+    response = await routes.session_remove(session_id, core=cast("Any", core))
+
+    assert response.status_code == 204
+    assert settled.is_set()
+    assert task.done()
+    assert core.conversation_manager.session_manager.load_session(session_id) is None
+    emitted = [
+        event["type"]
+        for channel, event in core.event_bus.events
+        if channel == "opencode_event"
+    ]
+    assert emitted[-2:] == ["session.execution.interrupted", "session.deleted"]
+
+
+@pytest.mark.asyncio
+async def test_delete_reservation_rejects_prompt_and_new_child(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    ancestor = create_session_payload(core, {}, default_directory=str(tmp_path))
+    parent = create_session_payload(
+        core,
+        {"parentID": ancestor["id"]},
+        default_directory=str(tmp_path),
+    )
+    session_id = parent["id"]
+    core._opencode_active_requests = {session_id: 1}
+    interrupt_started = asyncio.Event()
+    release_interrupt = asyncio.Event()
+
+    async def abort(active_session_id: str) -> bool:
+        assert active_session_id == session_id
+        interrupt_started.set()
+        await release_interrupt.wait()
+        return True
+
+    core.abort_session = abort
+    deleting = asyncio.create_task(
+        routes.session_remove(session_id, core=cast("Any", core))
+    )
+    await asyncio.wait_for(interrupt_started.wait(), timeout=1)
+
+    with pytest.raises(routes.OpenCodeV2HTTPError) as prompt_error:
+        await routes.session_prompt(
+            session_id,
+            {"text": "too late"},
+            core=cast("Any", core),
+        )
+    with pytest.raises(routes.OpenCodeV2HTTPError) as child_error:
+        await routes.session_create(
+            {"parentID": session_id},
+            core=cast("Any", core),
+        )
+    with pytest.raises(routes.OpenCodeV2HTTPError) as ancestor_error:
+        await routes.session_remove(ancestor["id"], core=cast("Any", core))
+
+    assert prompt_error.value.status_code == 409
+    assert prompt_error.value.payload["_tag"] == "SessionBusyError"
+    assert child_error.value.status_code == 409
+    assert child_error.value.payload["_tag"] == "SessionBusyError"
+    assert ancestor_error.value.status_code == 409
+    assert ancestor_error.value.payload["_tag"] == "SessionBusyError"
+
+    release_interrupt.set()
+    response = await asyncio.wait_for(deleting, timeout=1)
+    assert response.status_code == 204
+    assert routes._deleting_sessions(cast("Any", core)) == set()
+    assert set(core.conversation_manager.session_manager.sessions) == {ancestor["id"]}
+
+
+def test_message_projection_returns_flat_v2_union(tmp_path: Path) -> None:
+    core = _Core(tmp_path)
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={}).json()["data"]["id"]
+        session = core.conversation_manager.session_manager.load_session(session_id)
+        assert session is not None
+        session.metadata[TRANSCRIPT_KEY] = {
+            "order": ["msg_user", "msg_assistant"],
+            "messages": {
+                "msg_user": {
+                    "info": {
+                        "id": "msg_user",
+                        "sessionID": session_id,
+                        "role": "user",
+                        "time": {"created": 10},
+                    },
+                    "part_order": ["part_user"],
+                    "parts": {
+                        "part_user": {
+                            "id": "part_user",
+                            "type": "text",
+                            "text": "hello",
+                        }
+                    },
+                },
+                "msg_assistant": {
+                    "info": {
+                        "id": "msg_assistant",
+                        "sessionID": session_id,
+                        "role": "assistant",
+                        "agent": "build",
+                        "providerID": "openai",
+                        "modelID": "gpt-5",
+                        "time": {"created": 20, "completed": 30},
+                    },
+                    "part_order": ["part_assistant"],
+                    "parts": {
+                        "part_assistant": {
+                            "id": "part_assistant",
+                            "type": "text",
+                            "text": "hi",
+                        }
+                    },
+                },
+            },
+        }
+
+        response = client.get(
+            f"/api/session/{session_id}/message",
+            params={"limit": 200, "order": "desc"},
+        )
+
+    assert response.status_code == 200
+    assistant, user = response.json()["data"]
+    assert assistant["type"] == "assistant"
+    assert assistant["content"] == [{"type": "text", "text": "hi"}]
+    assert assistant["model"] == {"providerID": "openai", "id": "gpt-5"}
+    assert user == {
+        "id": "msg_user",
+        "type": "user",
+        "text": "hello",
+        "time": {"created": 10},
+    }
+
+
+def test_prompt_admission_reuses_background_chat_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = _Core(tmp_path)
+    runner = AsyncMock()
+    monkeypatch.setattr(routes, "_run_prompt", runner)
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={"agent": "build"}).json()[
+            "data"
+        ]["id"]
+        response = client.post(
+            f"/api/session/{session_id}/prompt",
+            json={"id": "msg_client", "text": "ship it", "delivery": "steer"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "id": "msg_client",
+        "sessionID": session_id,
+        "timeCreated": response.json()["data"]["timeCreated"],
+        "type": "user",
+        "data": {"text": "ship it"},
+        "delivery": "steer",
+    }
+    runner.assert_awaited_once()
+    request_payload = runner.await_args.args[1]
+    assert request_payload["session_id"] == session_id
+    assert request_payload["client_message_id"] == "msg_client"
+
+
+def test_prompt_rejects_queue_and_busy_steer_without_scheduling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = _Core(tmp_path)
+    runner = AsyncMock()
+    monkeypatch.setattr(routes, "_run_prompt", runner)
+    with _client(core) as client:
+        session_id = client.post("/api/session", json={}).json()["data"]["id"]
+        core._opencode_active_requests = {session_id: 1}
+        queued = client.post(
+            f"/api/session/{session_id}/prompt",
+            json={"text": "later", "delivery": "queue"},
+        )
+        busy = client.post(
+            f"/api/session/{session_id}/prompt",
+            json={"text": "now", "delivery": "steer"},
+        )
+
+    assert queued.status_code == 400
+    assert queued.json() == {
+        "_tag": "InvalidRequestError",
+        "message": "queue delivery is not supported yet",
+    }
+    assert busy.status_code == 409
+    assert busy.json() == {
+        "_tag": "SessionBusyError",
+        "sessionID": session_id,
+        "message": f"Session is already running: {session_id}",
+    }
+    runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prompt_reservation_rejects_a_concurrent_second_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = _Core(tmp_path)
+    created = create_session_payload(core, {}, default_directory=str(tmp_path))
+    session_id = created["id"]
+    started = asyncio.Event()
+    release = asyncio.Event()
+    requests: list[Any] = []
+
+    async def blocking_chat(request: Any, **_kwargs: Any) -> None:
+        requests.append(request)
+        started.set()
+        await release.wait()
+
+    import penguin.web.routes as legacy_routes
+
+    monkeypatch.setattr(legacy_routes, "handle_chat_message", blocking_chat)
+    first = await routes.session_prompt(
+        session_id,
+        {"id": "msg_first", "text": "first"},
+        core=cast("Any", core),
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    with pytest.raises(routes.OpenCodeV2HTTPError) as raised:
+        await routes.session_prompt(
+            session_id,
+            {"id": "msg_second", "text": "second"},
+            core=cast("Any", core),
+        )
+
+    assert first["data"]["id"] == "msg_first"
+    assert active_sessions_payload(core) == {"data": {session_id: {"type": "running"}}}
+    assert raised.value.status_code == 409
+    assert raised.value.payload["_tag"] == "SessionBusyError"
+    assert [request.client_message_id for request in requests] == ["msg_first"]
+
+    release.set()
+    await asyncio.wait_for(routes._prompt_tasks(cast("Any", core))[session_id], 1)
+    assert routes._prompt_reservations(cast("Any", core)) == set()
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_prompt_stream_reaches_native_terminal_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prove the create -> admit -> Penguin chat -> V2 stream seam end to end."""
+    core = _Core(tmp_path)
+    created = create_session_payload(
+        core,
+        {
+            "agent": "build",
+            "model": {"providerID": "openai", "id": "gpt-test"},
+        },
+        default_directory=str(tmp_path),
+    )
+    session_id = created["id"]
+    admitted = prompt_payload(
+        core,
+        session_id,
+        {"id": "msg_user", "text": "Say hello", "delivery": "steer"},
+    )
+    assert admitted is not None
+    _, request_payload = admitted
+    received: list[Any] = []
+
+    async def fake_handle_chat_message(
+        request: Any, *, core: Any, http_request: Any
+    ) -> None:
+        received.append(request)
+        source_events = [
+            (
+                "session.created",
+                {
+                    "sessionID": session_id,
+                    "info": {
+                        "id": session_id,
+                        "projectID": "penguin",
+                        "directory": str(tmp_path),
+                        "agent": "build",
+                        "providerID": "openai",
+                        "modelID": "gpt-test",
+                    },
+                },
+            ),
+            ("session.status", {"sessionID": session_id, "status": {"type": "busy"}}),
+            (
+                "message.updated",
+                {
+                    "id": "msg_user",
+                    "sessionID": session_id,
+                    "role": "user",
+                    "time": {"created": 1},
+                },
+            ),
+            (
+                "message.part.updated",
+                {
+                    "part": {
+                        "id": "part_user",
+                        "messageID": "msg_user",
+                        "sessionID": session_id,
+                        "type": "text",
+                        "text": "Say hello",
+                    }
+                },
+            ),
+            (
+                "message.updated",
+                {
+                    "id": "msg_assistant",
+                    "sessionID": session_id,
+                    "role": "assistant",
+                    "agent": "build",
+                    "providerID": "openai",
+                    "modelID": "gpt-test",
+                    "time": {"created": 2, "completed": None},
+                },
+            ),
+            (
+                "message.part.updated",
+                {
+                    "part": {
+                        "id": "part_assistant",
+                        "messageID": "msg_assistant",
+                        "sessionID": session_id,
+                        "type": "text",
+                        "text": "Hello",
+                    },
+                    "delta": "Hello",
+                },
+            ),
+            (
+                "message.updated",
+                {
+                    "id": "msg_assistant",
+                    "sessionID": session_id,
+                    "role": "assistant",
+                    "agent": "build",
+                    "providerID": "openai",
+                    "modelID": "gpt-test",
+                    "time": {"created": 2, "completed": 3},
+                    "finish": "stop",
+                },
+            ),
+            ("session.status", {"sessionID": session_id, "status": {"type": "idle"}}),
+        ]
+        for event_type, properties in source_events:
+            await emit_opencode_event(core, event_type, properties)
+
+    import penguin.web.routes as legacy_routes
+
+    monkeypatch.setattr(legacy_routes, "handle_chat_message", fake_handle_chat_message)
+    stream = routes._events(cast("Any", core))
+    connected = json.loads((await stream.__anext__()).split("data: ", 1)[1])
+    assert connected["type"] == "server.connected"
+
+    try:
+        await routes._run_prompt(cast("Any", core), request_payload)
+        projected = []
+        while not projected or projected[-1]["type"] != "session.execution.succeeded":
+            frame = await asyncio.wait_for(stream.__anext__(), timeout=1)
+            projected.append(json.loads(frame.split("data: ", 1)[1]))
+    finally:
+        await stream.aclose()
+
+    assert received[0].client_message_id == "msg_user"
+    assert [event["type"] for event in projected] == [
+        "session.created",
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+        "session.step.started",
+        "session.text.started",
+        "session.text.delta",
+        "session.text.ended",
+        "session.step.ended",
+        "session.execution.succeeded",
+    ]
+    assert projected[7]["data"]["text"] == "Hello"
+    assert [
+        event["durable"]["seq"] for event in projected if "durable" in event
+    ] == list(range(9))
+
+
+@pytest.mark.asyncio
+async def test_background_prompt_failure_synthesizes_native_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = _Core(tmp_path)
+    created = create_session_payload(core, {}, default_directory=str(tmp_path))
+    admitted = prompt_payload(
+        core,
+        created["id"],
+        {"id": "msg_user", "text": "fail early", "delivery": "steer"},
+    )
+    assert admitted is not None
+    _, request_payload = admitted
+
+    async def fail_before_streaming(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("model runtime unavailable")
+
+    import penguin.web.routes as legacy_routes
+
+    monkeypatch.setattr(legacy_routes, "handle_chat_message", fail_before_streaming)
+    stream = routes._events(cast("Any", core))
+    await stream.__anext__()
+    try:
+        await routes._run_prompt(cast("Any", core), request_payload)
+        projected = []
+        while not projected or projected[-1]["type"] != "session.execution.failed":
+            frame = await asyncio.wait_for(stream.__anext__(), timeout=1)
+            projected.append(json.loads(frame.split("data: ", 1)[1]))
+    finally:
+        await stream.aclose()
+
+    assert [event["type"] for event in projected] == [
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+        "session.step.started",
+        "session.step.failed",
+        "session.execution.failed",
+    ]
+    assert projected[0]["data"]["input"]["data"]["text"] == "fail early"
+    assert projected[-1]["data"]["error"] == {
+        "type": "APIError",
+        "message": "model runtime unavailable",
+    }
+    assert [event["durable"]["seq"] for event in projected] == list(range(6))
+
+
+@pytest.mark.asyncio
+async def test_interrupt_projects_user_terminal_and_idle_is_noop(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    created = create_session_payload(core, {}, default_directory=str(tmp_path))
+    session_id = created["id"]
+    core._opencode_active_requests = {session_id: 1}
+    abort_calls: list[str] = []
+
+    async def abort(active_session_id: str) -> bool:
+        abort_calls.append(active_session_id)
+        await emit_opencode_event(
+            core,
+            "session.status",
+            {"sessionID": active_session_id, "status": {"type": "idle"}},
+        )
+        return True
+
+    core.abort_session = abort
+    stream = routes._events(cast("Any", core))
+    await stream.__anext__()
+    await emit_opencode_event(
+        core,
+        "message.updated",
+        {
+            "id": "msg_interrupt",
+            "sessionID": session_id,
+            "role": "user",
+            "time": {"created": 1},
+        },
+    )
+    await emit_opencode_event(
+        core,
+        "message.part.updated",
+        {
+            "part": {
+                "id": "part_interrupt",
+                "messageID": "msg_interrupt",
+                "sessionID": session_id,
+                "type": "text",
+                "text": "stop",
+            }
+        },
+    )
+
+    try:
+        response = await routes.session_interrupt(session_id, core=cast("Any", core))
+        projected = []
+        while not projected or projected[-1]["type"] != "session.execution.interrupted":
+            frame = await asyncio.wait_for(stream.__anext__(), timeout=1)
+            projected.append(json.loads(frame.split("data: ", 1)[1]))
+    finally:
+        await stream.aclose()
+
+    assert response.status_code == 204
+    assert abort_calls == [session_id]
+    assert [event["type"] for event in projected] == [
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+        "session.execution.interrupted",
+    ]
+    assert projected[-1]["data"] == {"sessionID": session_id, "reason": "user"}
+    assert all(event["type"] != "session.execution.succeeded" for event in projected)
+
+    core._opencode_active_requests = {}
+    idle_response = await routes.session_interrupt(session_id, core=cast("Any", core))
+    assert idle_response.status_code == 204
+    assert abort_calls == [session_id]
+
+
+@pytest.mark.asyncio
+async def test_event_stream_terminates_on_subscriber_overflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = _Core(tmp_path)
+    monkeypatch.setattr(routes, "_EVENT_QUEUE_SIZE", 1)
+    stream = routes._events(cast("Any", core))
+    await stream.__anext__()
+    await emit_opencode_event(
+        core,
+        "message.updated",
+        {
+            "id": "msg_overflow",
+            "sessionID": "session_overflow",
+            "role": "user",
+            "time": {"created": 1},
+        },
+    )
+    await emit_opencode_event(
+        core,
+        "message.part.updated",
+        {
+            "part": {
+                "id": "part_overflow",
+                "messageID": "msg_overflow",
+                "sessionID": "session_overflow",
+                "type": "text",
+                "text": "too much",
+            }
+        },
+    )
+
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(stream.__anext__(), timeout=1)
+    assert core.event_bus.handlers["opencode_event"] == []
+
+
+@pytest.mark.asyncio
+async def test_event_stream_uses_one_durable_sequence_for_projected_and_fallback(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    session_id = "session_mixed_sequence"
+    stream = routes._events(cast("Any", core))
+    await stream.__anext__()
+    source_events = [
+        (
+            "message.updated",
+            {
+                "id": "msg_sequence_user",
+                "sessionID": session_id,
+                "role": "user",
+                "time": {"created": 1},
+            },
+        ),
+        (
+            "message.part.updated",
+            {
+                "part": {
+                    "id": "part_sequence_user",
+                    "messageID": "msg_sequence_user",
+                    "sessionID": session_id,
+                    "type": "text",
+                    "text": "sequence me",
+                }
+            },
+        ),
+        (
+            "message.updated",
+            {
+                "id": "msg_sequence_assistant",
+                "sessionID": session_id,
+                "role": "assistant",
+                "time": {"created": 2},
+            },
+        ),
+        (
+            "message.part.updated",
+            {
+                "part": {
+                    "id": "part_sequence_tool",
+                    "messageID": "msg_sequence_assistant",
+                    "sessionID": session_id,
+                    "type": "tool",
+                    "callID": "call_sequence",
+                    "tool": "read",
+                    "state": {"status": "running", "input": {"path": "README.md"}},
+                }
+            },
+        ),
+        (
+            "session.updated",
+            {
+                "sessionID": session_id,
+                "info": {
+                    "id": session_id,
+                    "title": "Mixed sequence",
+                    "directory": str(tmp_path),
+                    "time": {"created": 1, "updated": 3},
+                },
+            },
+        ),
+        (
+            "session.deleted",
+            {
+                "sessionID": session_id,
+                "info": {"id": session_id, "directory": str(tmp_path)},
+            },
+        ),
+    ]
+    for event_type, properties in source_events:
+        await emit_opencode_event(core, event_type, properties)
+
+    expected_types = [
+        "session.input.admitted",
+        "session.input.promoted",
+        "session.execution.started",
+        "session.step.started",
+        "session.tool.input.started",
+        "session.tool.input.ended",
+        "session.tool.called",
+        "session.renamed",
+        "session.deleted",
+    ]
+    projected = []
+    try:
+        for _ in expected_types:
+            frame = await asyncio.wait_for(stream.__anext__(), timeout=1)
+            projected.append(json.loads(frame.split("data: ", 1)[1]))
+    finally:
+        await stream.aclose()
+
+    assert [event["type"] for event in projected] == expected_types
+    assert [event["durable"]["seq"] for event in projected] == list(
+        range(len(expected_types))
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_stream_handshake_is_first_and_fallback_events_use_data(
+    tmp_path: Path,
+) -> None:
+    core = _Core(tmp_path)
+    stream = routes._events(cast("Any", core))
+    connected = json.loads((await stream.__anext__()).split("data: ", 1)[1])
+
+    assert connected["id"].startswith(_fixture()["connected"]["id_prefix"])
+    assert connected["type"] == "server.connected"
+    assert connected["data"] == {}
+
+    await core.event_bus.emit(
+        "opencode_event",
+        {
+            "type": "session.updated",
+            "properties": {
+                "sessionID": "session_one",
+                "info": {
+                    "id": "session_one",
+                    "title": "Renamed",
+                    "directory": str(tmp_path),
+                    "time": {"created": 1, "updated": 10},
+                },
+            },
+            "runtime_event": {"id": "evt:source:1", "time": 10, "sequence": 1},
+        },
+    )
+    renamed = json.loads((await stream.__anext__()).split("data: ", 1)[1])
+    assert renamed["type"] == "session.renamed"
+    assert renamed["data"] == {
+        "sessionID": "session_one",
+        "title": "Renamed",
+    }
+    assert renamed["location"] == {"directory": str(tmp_path)}
+    await stream.aclose()
+
+
+def test_event_projector_maps_legacy_session_update_to_v2_rename() -> None:
+    projected = event_payload(
+        {
+            "type": "session.updated",
+            "properties": {
+                "sessionID": "session_one",
+                "info": {
+                    "id": "session_one",
+                    "title": "New title",
+                    "directory": "/tmp",
+                    "time": {"created": 1, "updated": 2},
+                },
+            },
+            "runtime_event": {"id": "evt:source:2", "time": 2, "sequence": 2},
+        }
+    )
+
+    assert projected is not None
+    assert projected["type"] == "session.renamed"
+    assert projected["data"] == {"sessionID": "session_one", "title": "New title"}
+    assert projected["id"].startswith("evt_")
+
+
+def test_event_projector_preserves_native_session_selection_events() -> None:
+    agent = event_payload(
+        {
+            "type": "session.agent.selected",
+            "properties": {"sessionID": "session_one", "agent": "plan"},
+        }
+    )
+    model = event_payload(
+        {
+            "type": "session.model.selected",
+            "properties": {
+                "sessionID": "session_one",
+                "model": {"providerID": "openai", "id": "gpt-5"},
+            },
+        }
+    )
+
+    assert agent is not None
+    assert agent["type"] == "session.agent.selected"
+    assert agent["data"] == {"sessionID": "session_one", "agent": "plan"}
+    assert model is not None
+    assert model["type"] == "session.model.selected"
+    assert model["data"] == {
+        "sessionID": "session_one",
+        "model": {"providerID": "openai", "id": "gpt-5"},
+    }

--- a/tests/api/test_web_auth_hardening.py
+++ b/tests/api/test_web_auth_hardening.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import io
 import json
 import logging
@@ -10,9 +11,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from PIL import Image
 from fastapi import FastAPI, WebSocketException
 from fastapi.testclient import TestClient
+from PIL import Image
 from starlette.requests import Request
 from starlette.websockets import WebSocketDisconnect
 
@@ -25,8 +26,8 @@ from penguin.web.middleware.auth import (
     require_websocket_auth,
 )
 from penguin.web.routes import ALLOWED_UPLOAD_CONTENT_TYPES, router
-from penguin.web.sse_events import router as sse_router, set_core_instance
 from penguin.web.services import provider_credentials as provider_credentials_service
+from penguin.web.sse_events import router as sse_router, set_core_instance
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +59,11 @@ def _loopback_client(
     app: FastAPI, base_url: str = "http://127.0.0.1:9000"
 ) -> TestClient:
     return TestClient(app, base_url=base_url, client=("127.0.0.1", 50000))
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {credentials}"
 
 
 @pytest.fixture
@@ -125,6 +131,111 @@ def test_authenticate_connection_rejects_startup_token_from_non_loopback_client(
         authenticate_connection(connection, AuthConfig())
 
 
+def test_authenticate_connection_accepts_opencode_basic_api_key(
+    auth_config: AuthConfig,
+) -> None:
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.25"),
+        headers={"Authorization": _basic_auth_header("opencode", "test-key-123")},
+        query_params={},
+        url=SimpleNamespace(path="/api/session"),
+    )
+
+    result = authenticate_connection(connection, auth_config)
+
+    assert result["method"] == "api_key"
+    assert result["subject"] == "api_client"
+
+
+def test_authenticate_connection_accepts_opencode_basic_permission_bootstrap(
+    auth_config: AuthConfig,
+) -> None:
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.25"),
+        headers={"Authorization": _basic_auth_header("opencode", "test-key-123")},
+        query_params={},
+        url=SimpleNamespace(path="/api/permission/request"),
+    )
+
+    result = authenticate_connection(connection, auth_config)
+
+    assert result["method"] == "api_key"
+
+
+def test_authenticate_connection_accepts_opencode_basic_startup_token_on_loopback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={
+            "Authorization": _basic_auth_header(
+                "opencode",
+                "startup-token-123",
+            )
+        },
+        query_params={},
+        url=SimpleNamespace(path="/api/session"),
+    )
+
+    result = authenticate_connection(connection, AuthConfig())
+
+    assert result["method"] == "startup_token"
+    assert result["subject"] == "local_bootstrap"
+
+
+def test_authenticate_connection_rejects_opencode_basic_startup_token_remotely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
+    monkeypatch.setenv("PENGUIN_AUTH_STARTUP_TOKEN", "startup-token-123")
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="203.0.113.25"),
+        headers={
+            "Authorization": _basic_auth_header(
+                "opencode",
+                "startup-token-123",
+            )
+        },
+        query_params={},
+        url=SimpleNamespace(path="/api/session"),
+    )
+
+    with pytest.raises(AuthenticationError, match="No valid authentication"):
+        authenticate_connection(connection, AuthConfig())
+
+
+def test_authenticate_connection_rejects_non_opencode_basic_username(
+    auth_config: AuthConfig,
+) -> None:
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={"Authorization": _basic_auth_header("penguin", "test-key-123")},
+        query_params={},
+        url=SimpleNamespace(path="/api/session"),
+    )
+
+    with pytest.raises(AuthenticationError, match="No valid authentication"):
+        authenticate_connection(connection, auth_config)
+
+
+@pytest.mark.parametrize("path", ["/api/v1/sessions", "/api/docs", "/dashboard"])
+def test_authenticate_connection_rejects_opencode_basic_outside_v2_routes(
+    auth_config: AuthConfig,
+    path: str,
+) -> None:
+    connection = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={"Authorization": _basic_auth_header("opencode", "test-key-123")},
+        query_params={},
+        url=SimpleNamespace(path=path),
+    )
+
+    with pytest.raises(AuthenticationError, match="No valid authentication"):
+        authenticate_connection(connection, auth_config)
+
+
 def test_build_session_cookie_settings_rejects_non_loopback_http_client() -> None:
     request = Request(
         {
@@ -143,7 +254,10 @@ def test_build_session_cookie_settings_rejects_non_loopback_http_client() -> Non
 
     with pytest.raises(
         AuthenticationError,
-        match="Browser session cookies are only issued for loopback hosts or HTTPS origins",
+        match=(
+            "Browser session cookies are only issued for loopback hosts or HTTPS "
+            "origins"
+        ),
     ):
         build_session_cookie_settings(request, AuthConfig())
 

--- a/tests/fixtures/opencode_v2/core_contracts.json
+++ b/tests/fixtures/opencode_v2/core_contracts.json
@@ -1,0 +1,22 @@
+{
+  "upstream": {
+    "repository": "https://github.com/anomalyco/opencode",
+    "branch": "v2",
+    "commit": "b35c5fc98577b77d8d67d298c6254e0cd138c9d5"
+  },
+  "health_required": ["healthy", "version", "pid"],
+  "location_required": ["directory", "project"],
+  "session_required": [
+    "id",
+    "projectID",
+    "cost",
+    "tokens",
+    "time",
+    "location"
+  ],
+  "connected": {
+    "id_prefix": "evt_",
+    "type": "server.connected",
+    "data": {}
+  }
+}

--- a/tests/llm/test_link_provider.py
+++ b/tests/llm/test_link_provider.py
@@ -454,7 +454,7 @@ async def test_stream_http_error_reads_link_error_body_before_reporting() -> Non
     provider = _provider(handler)
     with pytest.raises(
         LLMProviderError,
-        match="The selected model rejected this request.",
+        match=r"The selected model rejected this request\.",
     ) as raised:
         await provider.get_response(
             [{"role": "user", "content": "hi"}],

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import subprocess
 import tarfile
 import zipfile
@@ -15,6 +16,12 @@ from penguin.cli import opencode_launcher
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _default_to_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep existing launcher tests on the default V1 path."""
+    monkeypatch.delenv("PENGUIN_TUI_V2", raising=False)
 
 
 class _FakeProcess:
@@ -40,20 +47,76 @@ class _FakeProcess:
         self._running = False
 
 
-def _build_archive_bytes(asset_name: str, binary_name: str) -> bytes:
+class _FakeHTTPResponse:
+    def __init__(self, payload: bytes, *, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self) -> bytes:
+        return self.payload
+
+
+def _build_archive_bytes(
+    asset_name: str,
+    binary_name: str,
+    *,
+    v2_bundle: bool = False,
+) -> bytes:
+    members = {binary_name: b"#!/bin/sh\necho sidecar\n"}
+    if v2_bundle:
+        members = {
+            f"bin/{binary_name}": b"#!/bin/sh\necho sidecar\n",
+            "plugins/tui/penguin.tsx": b"export const Penguin = true\n",
+            "penguin-tui/LICENSE": b"Penguin TUI license\n",
+        }
+
     if asset_name.endswith(".zip"):
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-            archive.writestr(binary_name, "#!/bin/sh\necho sidecar\n")
+            for member_name, payload in members.items():
+                archive.writestr(member_name, payload)
         return buf.getvalue()
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as archive:
-        payload = b"#!/bin/sh\necho sidecar\n"
-        info = tarfile.TarInfo(name=binary_name)
-        info.size = len(payload)
-        archive.addfile(info, io.BytesIO(payload))
+        for member_name, payload in members.items():
+            info = tarfile.TarInfo(name=member_name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
     return buf.getvalue()
+
+
+@pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+def test_extract_archive_rejects_tar_links(
+    tmp_path: Path,
+    link_type: bytes,
+) -> None:
+    archive_path = tmp_path / "sidecar.tar.gz"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = tarfile.TarInfo("pivot")
+    link.type = link_type
+    link.linkname = str(outside / "target")
+    payload = b"must stay contained"
+    nested = tarfile.TarInfo("pivot/pwned.txt")
+    nested.size = len(payload)
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.addfile(link)
+        archive.addfile(nested, io.BytesIO(payload))
+
+    with pytest.raises(RuntimeError, match="Unsafe member type"):
+        opencode_launcher._extract_archive(archive_path, tmp_path / "extract")
+
+    assert not (outside / "pwned.txt").exists()
 
 
 def test_default_release_url_points_to_penguin_repo(
@@ -64,6 +127,60 @@ def test_default_release_url_points_to_penguin_repo(
         opencode_launcher._sidecar_release_url()
         == "https://api.github.com/repos/Maximooch/penguin/releases/latest"
     )
+
+
+def test_server_health_probe_uses_generation_specific_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str] = []
+
+    def _open(url: str, timeout: float) -> _FakeHTTPResponse:
+        del timeout
+        requested.append(url)
+        if url.endswith("/api/health"):
+            return _FakeHTTPResponse(b'{"healthy":true,"version":"test","pid":1}')
+        return _FakeHTTPResponse(b'{"status":"ok"}')
+
+    monkeypatch.setattr(opencode_launcher, "urlopen", _open)
+
+    assert opencode_launcher._is_server_running("http://127.0.0.1:9000") is True
+    assert requested[-1].endswith("/api/v1/health")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    assert opencode_launcher._is_server_running("http://127.0.0.1:9000") is True
+    assert requested[-1].endswith("/api/health")
+
+
+def test_v2_health_probe_rejects_a_v1_only_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str] = []
+
+    def _open(url: str, timeout: float) -> _FakeHTTPResponse:
+        del timeout
+        requested.append(url)
+        if url.endswith("/api/v1/health"):
+            return _FakeHTTPResponse(b'{"status":"ok"}')
+        raise opencode_launcher.URLError("V2 route is absent")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setattr(opencode_launcher, "urlopen", _open)
+
+    assert opencode_launcher._is_server_running("http://127.0.0.1:9000") is False
+    assert requested == ["http://127.0.0.1:9000/api/health"]
+
+
+def test_v2_health_probe_rejects_an_unexpected_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setattr(
+        opencode_launcher,
+        "urlopen",
+        lambda *_args, **_kwargs: _FakeHTTPResponse(b'{"status":"ok"}'),
+    )
+
+    assert opencode_launcher._is_server_running("http://127.0.0.1:9000") is False
 
 
 def test_sidecar_release_url_for_version_uses_tag_endpoint() -> None:
@@ -84,6 +201,160 @@ def test_installed_penguin_version_falls_back_to_package_version(
         opencode_launcher._installed_penguin_version()
         == opencode_launcher.PENGUIN_VERSION
     )
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "musl", "avx2", "expected"),
+    [
+        ("darwin", "arm64", False, False, ["opencode2-darwin-arm64.zip"]),
+        (
+            "darwin",
+            "x86_64",
+            False,
+            True,
+            [
+                "opencode2-darwin-x64.zip",
+                "opencode2-darwin-x64-baseline.zip",
+            ],
+        ),
+        (
+            "darwin",
+            "x86_64",
+            False,
+            False,
+            ["opencode2-darwin-x64-baseline.zip"],
+        ),
+        (
+            "linux",
+            "aarch64",
+            False,
+            False,
+            ["opencode2-linux-arm64.tar.gz"],
+        ),
+        (
+            "linux",
+            "aarch64",
+            True,
+            False,
+            ["opencode2-linux-arm64-musl.tar.gz"],
+        ),
+        (
+            "linux",
+            "x86_64",
+            False,
+            True,
+            [
+                "opencode2-linux-x64.tar.gz",
+                "opencode2-linux-x64-baseline.tar.gz",
+            ],
+        ),
+        (
+            "linux",
+            "x86_64",
+            False,
+            False,
+            ["opencode2-linux-x64-baseline.tar.gz"],
+        ),
+        (
+            "linux",
+            "x86_64",
+            True,
+            True,
+            [
+                "opencode2-linux-x64-musl.tar.gz",
+                "opencode2-linux-x64-baseline-musl.tar.gz",
+            ],
+        ),
+        (
+            "linux",
+            "x86_64",
+            True,
+            False,
+            ["opencode2-linux-x64-baseline-musl.tar.gz"],
+        ),
+        (
+            "win32",
+            "AMD64",
+            False,
+            True,
+            [
+                "opencode2-windows-x64.zip",
+                "opencode2-windows-x64-baseline.zip",
+            ],
+        ),
+        (
+            "win32",
+            "AMD64",
+            False,
+            False,
+            ["opencode2-windows-x64-baseline.zip"],
+        ),
+    ],
+)
+def test_v2_sidecar_platform_candidates_choose_compatible_variant_first(
+    monkeypatch: pytest.MonkeyPatch,
+    system: str,
+    machine: str,
+    musl: bool,
+    avx2: bool,
+    expected: list[str],
+) -> None:
+    monkeypatch.setattr(opencode_launcher.sys, "platform", system)
+    monkeypatch.setattr(opencode_launcher.platform, "machine", lambda: machine)
+    monkeypatch.setattr(opencode_launcher, "_is_musl_linux", lambda: musl)
+    monkeypatch.setattr(opencode_launcher, "_cpu_supports_avx2", lambda: avx2)
+
+    assert opencode_launcher._v2_sidecar_platform_candidates() == expected
+    expected_binary = "opencode2.exe" if system.startswith("win") else "opencode2"
+    assert opencode_launcher._v2_sidecar_binary_name() == expected_binary
+
+
+def test_musl_detection_requires_positive_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(opencode_launcher.sys, "platform", "linux")
+    monkeypatch.setattr(
+        opencode_launcher.platform,
+        "libc_ver",
+        lambda: ("musl", "1.2.5"),
+    )
+
+    assert opencode_launcher._is_musl_linux() is True
+
+    monkeypatch.setattr(opencode_launcher.platform, "libc_ver", lambda: ("", ""))
+    monkeypatch.setattr(opencode_launcher.Path, "is_file", lambda _path: False)
+    monkeypatch.setattr(
+        opencode_launcher.Path,
+        "glob",
+        lambda _path, _pattern: iter(()),
+    )
+    monkeypatch.setattr(opencode_launcher.shutil, "which", lambda _name: None)
+
+    assert opencode_launcher._is_musl_linux() is False
+
+
+def test_avx2_detection_defaults_to_baseline_without_cpu_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(opencode_launcher.sys, "platform", "linux")
+    monkeypatch.setattr(
+        opencode_launcher.platform,
+        "machine",
+        lambda: "x86_64",
+    )
+    monkeypatch.setattr(
+        opencode_launcher.Path,
+        "read_text",
+        lambda _path, **_kwargs: "flags : sse4_2 avx avx2",
+    )
+    assert opencode_launcher._cpu_supports_avx2() is True
+
+    monkeypatch.setattr(
+        opencode_launcher.Path,
+        "read_text",
+        lambda _path, **_kwargs: "flags : sse4_2 avx",
+    )
+    assert opencode_launcher._cpu_supports_avx2() is False
 
 
 def test_binary_supports_url_mode_from_help_output(
@@ -244,6 +515,213 @@ def test_build_command_uses_global_before_local_source_when_requested(
     assert cmd == [global_bin, str(project_dir), "--url", "http://127.0.0.1:9000"]
 
 
+def test_v2_build_command_prefers_explicit_binary_over_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    source_dir = tmp_path / "opencode-v2"
+    (source_dir / "src").mkdir(parents=True)
+    (source_dir / "src" / "index.ts").write_text("", encoding="utf-8")
+    binary = tmp_path / "opencode2"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_BIN_PATH", str(binary))
+    monkeypatch.setenv("PENGUIN_OPENCODE_DIR", str(source_dir))
+    monkeypatch.setattr(
+        opencode_launcher.shutil,
+        "which",
+        lambda name: "/usr/local/bin/bun" if name == "bun" else None,
+    )
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_binary_supports_url_mode",
+        lambda _binary: pytest.fail("V2 must not probe the V1 --url interface"),
+    )
+
+    child_env: dict[str, str] = {}
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        ["--session", "abc123"],
+        use_global_opencode=False,
+        child_env=child_env,
+    )
+
+    assert cwd is None
+    assert cmd == [
+        str(binary.resolve()),
+        str(project_dir),
+        "--server",
+        "http://127.0.0.1:9000",
+        "--session",
+        "abc123",
+    ]
+    assert "OPENCODE_CONFIG_DIR" not in child_env
+
+
+def test_v2_build_command_uses_explicit_source_with_server_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    source_dir = tmp_path / "opencode-v2"
+    (source_dir / "src").mkdir(parents=True)
+    (source_dir / "src" / "index.ts").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_OPENCODE_DIR", str(source_dir))
+    monkeypatch.delenv("PENGUIN_TUI_BIN_PATH", raising=False)
+    monkeypatch.setattr(
+        opencode_launcher.shutil,
+        "which",
+        lambda name: "/usr/local/bin/bun" if name == "bun" else None,
+    )
+
+    child_env: dict[str, str] = {}
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        ["--session", "abc123"],
+        use_global_opencode=False,
+        child_env=child_env,
+    )
+
+    assert cwd == source_dir.resolve()
+    assert cmd == [
+        "/usr/local/bin/bun",
+        "run",
+        "--conditions=browser",
+        "./src/index.ts",
+        str(project_dir),
+        "--server",
+        "http://127.0.0.1:9000",
+        "--session",
+        "abc123",
+    ]
+    assert "OPENCODE_CONFIG_DIR" not in child_env
+
+
+def test_v2_build_command_uses_global_opencode2_and_preserves_explicit_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    global_bin = "/usr/local/bin/opencode2"
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setattr(
+        opencode_launcher.shutil,
+        "which",
+        lambda name: global_bin if name == "opencode2" else None,
+    )
+
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        ["--server=http://127.0.0.1:9010"],
+        use_global_opencode=True,
+    )
+
+    assert cwd is None
+    assert cmd == [
+        global_bin,
+        str(project_dir),
+        "--server=http://127.0.0.1:9010",
+    ]
+
+
+def test_v2_global_fallback_keeps_explicit_binary_user_managed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    binary = tmp_path / "opencode2"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_BIN_PATH", str(binary))
+    monkeypatch.setattr(opencode_launcher.shutil, "which", lambda _name: None)
+
+    child_env: dict[str, str] = {}
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        [],
+        use_global_opencode=True,
+        child_env=child_env,
+    )
+
+    assert cwd is None
+    assert cmd == [
+        str(binary.resolve()),
+        str(project_dir),
+        "--server",
+        "http://127.0.0.1:9000",
+    ]
+    assert "OPENCODE_CONFIG_DIR" not in child_env
+
+
+def test_v2_build_command_sets_bundled_config_for_auto_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    cache_root = tmp_path / "cache"
+    install_root = cache_root / "v2" / "v-test" / "asset"
+    sidecar_bin = install_root / "bin" / "opencode2"
+    sidecar_bin.parent.mkdir(parents=True)
+    sidecar_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    plugin_path = install_root / "plugins" / "tui" / "penguin.tsx"
+    plugin_path.parent.mkdir(parents=True)
+    plugin_path.write_text("export const Penguin = true\n", encoding="utf-8")
+
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_CACHE_DIR", str(cache_root))
+    monkeypatch.delenv("PENGUIN_TUI_BIN_PATH", raising=False)
+    monkeypatch.delenv("PENGUIN_OPENCODE_DIR", raising=False)
+    monkeypatch.setattr(opencode_launcher.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_resolve_sidecar_binary",
+        lambda: sidecar_bin,
+    )
+
+    child_env = {"OPENCODE_CONFIG_DIR": "  "}
+    cmd, cwd = opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        [],
+        use_global_opencode=False,
+        child_env=child_env,
+    )
+
+    assert cwd is None
+    assert cmd == [
+        str(sidecar_bin),
+        str(project_dir),
+        "--server",
+        "http://127.0.0.1:9000",
+    ]
+    assert child_env["OPENCODE_CONFIG_DIR"] == str(install_root)
+
+    explicit_env = {"OPENCODE_CONFIG_DIR": "/custom/opencode"}
+    opencode_launcher._build_opencode_command(
+        project_dir,
+        "http://127.0.0.1:9000",
+        [],
+        use_global_opencode=False,
+        child_env=explicit_env,
+    )
+    assert explicit_env["OPENCODE_CONFIG_DIR"] == "/custom/opencode"
+
+
 def test_build_command_error_surfaces_sidecar_bootstrap_detail(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -318,6 +796,8 @@ def test_sidecar_bootstrap_downloads_verifies_and_caches(
     first = opencode_launcher._resolve_sidecar_binary()
     assert first.exists()
     assert first.is_file()
+    assert (cache_root / "current.json").is_file()
+    assert not (cache_root / "v2").exists()
     assert len(calls) == 1
     assert release_calls == [
         opencode_launcher._sidecar_release_url_for_version("0.6.0")
@@ -372,6 +852,219 @@ def test_sidecar_bootstrap_rejects_checksum_mismatch(
         opencode_launcher._resolve_sidecar_binary()
 
     assert "checksum verification" in str(exc.value)
+
+
+def test_v2_sidecar_bootstrap_isolates_and_pins_cache_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_CACHE_DIR", str(cache_root))
+    monkeypatch.delenv("PENGUIN_TUI_RELEASE_URL", raising=False)
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_installed_penguin_version",
+        lambda: "0.6.0",
+    )
+    asset_name = "opencode2-linux-x64-baseline.tar.gz"
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_v2_sidecar_platform_candidates",
+        lambda: ["opencode2-linux-x64.tar.gz", asset_name],
+    )
+    archive_bytes = _build_archive_bytes(
+        asset_name,
+        "opencode2",
+        v2_bundle=True,
+    )
+    digest = opencode_launcher.hashlib.sha256(archive_bytes).hexdigest()
+    release_doc = {
+        "tag_name": "v-test",
+        "assets": [
+            {
+                "name": asset_name,
+                "browser_download_url": "https://example.invalid/opencode2",
+                "digest": f"sha256:{digest}",
+            }
+        ],
+    }
+    release_url = opencode_launcher._sidecar_release_url_for_version("0.6.0")
+
+    v1_binary = cache_root / "v-test" / "asset" / "bin" / "opencode"
+    v1_binary.parent.mkdir(parents=True)
+    v1_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    opencode_launcher._write_cached_sidecar_marker(
+        cache_root,
+        binary_path=v1_binary,
+        release_tag="v-test",
+        asset_name="asset",
+        release_url=release_url,
+        requested_version="0.6.0",
+    )
+    outside_v2_binary = v1_binary.with_name("opencode2")
+    outside_v2_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    opencode_launcher._write_cached_sidecar_marker(
+        cache_root / "v2",
+        binary_path=outside_v2_binary,
+        release_tag="v-test",
+        asset_name="asset",
+        release_url=release_url,
+        requested_version="0.6.0",
+        cache_identity=opencode_launcher._v2_sidecar_cache_identity(asset_name),
+    )
+
+    release_calls: list[str] = []
+    download_calls: list[str] = []
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_read_json_url",
+        lambda url: release_calls.append(url) or release_doc,
+    )
+
+    def _download(url: str, destination: Path, timeout_seconds: float = 120.0) -> None:
+        del timeout_seconds
+        download_calls.append(url)
+        destination.write_bytes(archive_bytes)
+
+    monkeypatch.setattr(opencode_launcher, "_download_binary_asset", _download)
+
+    first = opencode_launcher._resolve_sidecar_binary()
+
+    expected = cache_root / "v2" / "v-test" / asset_name / "bin" / "opencode2"
+    assert first == expected
+    assert first.is_file()
+    install_root = first.parent.parent
+    plugin_path = install_root / "plugins" / "tui" / "penguin.tsx"
+    license_path = install_root / "penguin-tui" / "LICENSE"
+    assert plugin_path.read_text(encoding="utf-8") == "export const Penguin = true\n"
+    assert license_path.read_text(encoding="utf-8") == "Penguin TUI license\n"
+    assert release_calls == [release_url]
+    assert download_calls == ["https://example.invalid/opencode2"]
+    assert (cache_root / "current.json").is_file()
+
+    marker_path = cache_root / "v2" / "current.json"
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert marker["protocol_generation"] == "v2"
+    assert marker["upstream_pin"] == "b35c5fc98577b77d8d67d298c6254e0cd138c9d5"
+    assert marker["artifact_pin"] == "@opencode-ai/cli@0.0.0-next-17220"
+    assert marker["platform_asset"] == asset_name
+
+    plugin_path.unlink()
+    second = opencode_launcher._resolve_sidecar_binary()
+    assert second == first
+    assert len(release_calls) == 2
+    assert len(download_calls) == 2
+    assert plugin_path.is_file()
+
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    marker["upstream_pin"] = "stale-pin"
+    marker_path.write_text(json.dumps(marker), encoding="utf-8")
+    third = opencode_launcher._resolve_sidecar_binary()
+    assert third == first
+    assert len(release_calls) == 3
+    assert len(download_calls) == 3
+
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_read_json_url",
+        lambda _url: pytest.fail("valid V2 marker should avoid release lookup"),
+    )
+    fourth = opencode_launcher._resolve_sidecar_binary()
+    assert fourth == first
+    assert len(download_calls) == 3
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [None, "", "sha512:" + ("0" * 128), "sha256:not-a-digest"],
+)
+def test_v2_sidecar_bootstrap_requires_valid_sha256_digest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    digest: str | None,
+) -> None:
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_installed_penguin_version",
+        lambda: "0.6.0",
+    )
+    asset_name = "opencode2-linux-x64-baseline.tar.gz"
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_v2_sidecar_platform_candidates",
+        lambda: [asset_name],
+    )
+    asset = {
+        "name": asset_name,
+        "browser_download_url": "https://example.invalid/opencode2",
+    }
+    if digest is not None:
+        asset["digest"] = digest
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_read_json_url",
+        lambda _url: {"tag_name": "v-test", "assets": [asset]},
+    )
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_download_binary_asset",
+        lambda *_args, **_kwargs: pytest.fail("invalid digest must fail first"),
+    )
+
+    with pytest.raises(RuntimeError, match="SHA-256"):
+        opencode_launcher._resolve_sidecar_binary()
+
+
+def test_v2_sidecar_bootstrap_rejects_archive_without_penguin_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    monkeypatch.setenv("PENGUIN_TUI_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_installed_penguin_version",
+        lambda: "0.6.0",
+    )
+    asset_name = "opencode2-linux-x64-baseline.tar.gz"
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_v2_sidecar_platform_candidates",
+        lambda: [asset_name],
+    )
+    archive_bytes = _build_archive_bytes(asset_name, "bin/opencode2")
+    digest = opencode_launcher.hashlib.sha256(archive_bytes).hexdigest()
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_read_json_url",
+        lambda _url: {
+            "tag_name": "v-test",
+            "assets": [
+                {
+                    "name": asset_name,
+                    "browser_download_url": "https://example.invalid/opencode2",
+                    "digest": f"sha256:{digest}",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        opencode_launcher,
+        "_download_binary_asset",
+        lambda _url, destination, timeout_seconds=120.0: destination.write_bytes(
+            archive_bytes
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match=r"plugins/tui/penguin\.tsx"):
+        opencode_launcher._resolve_sidecar_binary()
+
+    assert not (cache_root / "v2" / "current.json").exists()
 
 
 def test_sidecar_cache_invalidates_when_installed_version_changes(
@@ -644,6 +1337,70 @@ def test_prepare_local_auth_env_reads_existing_local_token_file(
     assert "PENGUIN_AUTH_STARTUP_TOKEN" not in env
 
 
+def test_prepare_opencode_v2_env_bridges_auth_and_disables_updater(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    env = {"PENGUIN_LOCAL_AUTH_TOKEN": "startup-token"}
+
+    opencode_launcher._prepare_opencode_v2_env(env)
+
+    assert env["OPENCODE_PASSWORD"] == "startup-token"
+    assert env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+
+
+def test_prepare_opencode_v2_env_preserves_explicit_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    env = {
+        "PENGUIN_LOCAL_AUTH_TOKEN": "startup-token",
+        "OPENCODE_PASSWORD": "explicit-password",
+    }
+
+    opencode_launcher._prepare_opencode_v2_env(env)
+
+    assert env["OPENCODE_PASSWORD"] == "explicit-password"
+    assert env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+
+
+def test_prepare_opencode_v2_env_bridges_configured_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    env = {
+        "PENGUIN_API_KEYS": "primary-key, fallback-key",
+        "PENGUIN_LOCAL_AUTH_TOKEN": "stale-startup-token",
+    }
+
+    opencode_launcher._prepare_opencode_v2_env(env)
+
+    assert env["OPENCODE_PASSWORD"] == "primary-key"
+    assert env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+
+
+def test_prepare_opencode_v2_env_replaces_blank_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
+    env = {
+        "PENGUIN_LOCAL_AUTH_TOKEN": "startup-token",
+        "OPENCODE_PASSWORD": "  ",
+    }
+
+    opencode_launcher._prepare_opencode_v2_env(env)
+
+    assert env["OPENCODE_PASSWORD"] == "startup-token"
+
+
+def test_prepare_opencode_v2_env_is_noop_for_v1() -> None:
+    env = {"PENGUIN_LOCAL_AUTH_TOKEN": "startup-token"}
+
+    opencode_launcher._prepare_opencode_v2_env(env)
+
+    assert env == {"PENGUIN_LOCAL_AUTH_TOKEN": "startup-token"}
+
+
 def test_main_reuses_cached_local_auth_token_for_running_server(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -773,6 +1530,7 @@ def test_main_refreshes_local_auth_token_from_running_server_cache(
     health_checks = iter([False, True])
 
     monkeypatch.setenv("PENGUIN_LOCAL_AUTH_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("PENGUIN_TUI_V2", "1")
     monkeypatch.setenv("PENGUIN_AUTH_ENABLED", "true")
     monkeypatch.delenv("PENGUIN_API_KEYS", raising=False)
     monkeypatch.delenv("PENGUIN_AUTH_STARTUP_TOKEN", raising=False)
@@ -822,6 +1580,8 @@ def test_main_refreshes_local_auth_token_from_running_server_cache(
 
     assert exit_code == 0
     assert captured_run_env["PENGUIN_LOCAL_AUTH_TOKEN"] == "running-server-token"
+    assert captured_run_env["OPENCODE_PASSWORD"] == "running-server-token"
+    assert captured_run_env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
 
 
 def test_main_returns_error_when_autostart_health_never_recovers(

--- a/tests/test_opencode_v2_plugin.py
+++ b/tests/test_opencode_v2_plugin.py
@@ -1,0 +1,28 @@
+"""Boundary checks for Penguin's native OpenCode 2 TUI extension."""
+
+from pathlib import Path
+
+PLUGIN = (
+    Path(__file__).parents[1] / "penguin-tui-v2" / "plugins" / "tui" / "penguin.tsx"
+)
+
+
+def test_v2_extension_uses_only_the_native_tui_plugin_seam() -> None:
+    source = PLUGIN.read_text(encoding="utf-8")
+
+    assert 'import type { Plugin } from "@opencode-ai/plugin/tui"' in source
+    assert "context: Plugin.Context" in source
+    assert 'id: "penguin.product"' in source
+    assert 'id: "penguin.status"' in source
+    assert 'context.ui.slot("app"' in source
+
+    forbidden_transport = (
+        "fetch(",
+        "axios",
+        "/api/",
+        "OPENCODE_PASSWORD",
+        "PENGUIN_LOCAL_AUTH_TOKEN",
+        "react/jsx",
+        "@opentui/solid",
+    )
+    assert all(token not in source for token in forbidden_transport)


### PR DESCRIPTION
## Summary

- Pin the tested OpenCode 2 beta artifact to `b35c5fc98577b77d8d67d298c6254e0cd138c9d5` / `@opencode-ai/cli@0.0.0-next-17220`, document the upstream ownership boundary, and record the moving-head refresh procedure.
- Add a Penguin-owned `/api/*` compatibility seam backed by Penguin sessions, execution, approvals, questions, and runtime events. It covers Home boot, session CRUD, single-flight text prompts, interruption, native text/tool lifecycle projection, reconnect hydration, and strict failure/concurrency handling without adding a second runtime or event ledger.
- Add the reversible `PENGUIN_TUI_V2=1` launcher path, strict OpenCode Basic-auth bridge, isolated V2 cache/provenance, pinned plugin ABI, and an independent 11-platform sidecar workflow. V1 remains the default and its launcher, cache, and release workflow stay intact.

The full phase 1–7 ledger, supported surface, explicit deferrals, and refresh procedure live in [`context/tasks/penguin-tui-opencode-v2.md`](../blob/codex/opencode-v2-sync/context/tasks/penguin-tui-opencode-v2.md).

## Supported beta slice

- Home/project/session catalogs and persisted session reopen
- Agent/model/variant selection backed by Penguin session metadata
- Single-flight text prompt admission and transcript streaming
- Native admitted/promoted, execution, step, text, and tool events
- Active/idle interruption and children-first recursive deletion
- Manager-backed permissions, questions/forms, replies, cancellation, and REST rehydration
- Generation-aware readiness probing, API-key/startup-token auth, and immediate V1 rollback

Unsupported behavior is rejected or truthfully empty. Queue delivery, busy steer, attachments, durable replay, background/multi-tab session UX, PTY, diffs, snapshots, and undo/redo remain deferred. This PR does not switch the default client.

## Verification

- Python 3.12 / Pydantic 2: `124 passed` plus `9 passed` auth-hardening slice
- Python 3.9 / Pydantic 1: `124 passed` plus `9 passed` auth-hardening slice
- Focused launcher + dispatcher: `73 passed` on each runtime
- Ruff check/format: passed for the full V2 CI file set
- actionlint 1.7.12: passed for CI and V2 publish workflows
- Python 3.9 wheel build: verified all four V2 server modules are packaged
- Pinned plugin ABI: strict TypeScript check, Bun build, and dynamic import passed
- Native pinned Darwin artifact smoke: Home loaded and `/penguin` appeared and ran
- Independent blocker audit: no remaining P1/P2 correctness, security, protocol, launcher, or release blockers

## Why draft

The implementation and deterministic gates are complete, but release-time gates still require the GitHub-hosted 11-platform packaging matrix, checksum verification, clean-wheel extracted-artifact prompt/interrupt/restart smoke, and an actual tag attachment. Those gates are documented in the release runbook; no release is published by this PR.
